### PR TITLE
check for iptc_init in both iptc and ip4tc

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1854,9 +1854,10 @@ then
 	AC_CHECK_TYPES([iptc_handle_t, ip6tc_handle_t], [], [])
 fi
 # Check for the iptc_init symbol in the library.
+# This could be in iptc or ip4tc
 if test "x$with_libiptc" = "xpkgconfig"
 then
-	AC_CHECK_LIB(iptc, iptc_init,
+	AC_SEARCH_LIBS(iptc_init, [iptc ip4tc],
 			[with_libiptc="pkgconfig"],
 			[with_libiptc="no"],
 			[$with_libiptc_libs])


### PR DESCRIPTION
./configure --enable-iptables was failing on fedora as iptc_init
wasn't found. This patches configure.in to also look in ip4tc
