### PR TITLE
Fix "memcached: Message from memcached has been truncated." error message

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -357,7 +357,7 @@ static void submit_gauge2 (const char *type, const char *type_inst,
 
 static int memcached_read (void) /* {{{ */
 {
-	char buf[1024];
+	char buf[2048];
 	char *fields[3];
 	char *ptr;
 	char *line;


### PR DESCRIPTION
Typical stats answer has ~1900 bytes length.
$ memcached-tool localhost:11211 stats | wc -c
1863
But buffer for this answer was only 1024 bytes length.
