### PR TITLE
Fix for config file parsing ("memcachec plugin: Option `Server' not allowed here.")

### DIFF
--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -328,7 +328,7 @@ static int cmc_config_add_page (oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp ("Server", child->key) == 0)
       status = cmc_config_add_string ("Server", &page->server, child);
-    if (strcasecmp ("Key", child->key) == 0)
+    else if (strcasecmp ("Key", child->key) == 0)
       status = cmc_config_add_string ("Key", &page->key, child);
     else if (strcasecmp ("Match", child->key) == 0)
       /* Be liberal with failing matches => don't set `status'. */


### PR DESCRIPTION
There was a else missing in memcachec-plugin. Seems like no-one ever used it - It was not possible to provide a valid config...
