### PR TITLE
rrdtool bug fix to out-of-bounds array reference

### DIFF
--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -185,7 +185,7 @@ static int srrd_update (char *filename, char *template,
 	if (status != 0)
 	{
 		WARNING ("rrdtool plugin: rrd_update_r failed: %s: %s",
-				argv[1], rrd_get_error ());
+				filename, rrd_get_error ());
 	}
 
 	sfree (new_argv);


### PR DESCRIPTION
Fix a reference to argv[1] that is (always?)
outside the bounds of the argv array. It happens
during a log statement that seems to want
to actually refer to the rrd filename.
