### PR TITLE
swap plugin: Don't report an error if there is no swap space on Linux.

### DIFF
--- a/src/swap.c
+++ b/src/swap.c
@@ -239,7 +239,7 @@ static int swap_read (void) /* {{{ */
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 	}
 
-	if ((swap_total == 0LL) || ((swap_free + swap_cached) > swap_total))
+	if ((swap_free + swap_cached) > swap_total)
 		return (-1);
 
 	swap_used = swap_total - (swap_free + swap_cached);


### PR DESCRIPTION
… rather, simply record zeros in that case. Swap may be switched on and off at
arbitrary times and/or might be added at "later" times. Thus, storing zero in
case the swap plugin is enabled sounds like the best approach to me.
