### PR TITLE
configure: Define _REENTRANT when compiling on Solaris.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -91,6 +91,7 @@ fi
 if test "x$ac_system" = "xSolaris"
 then
 	AC_DEFINE(_POSIX_PTHREAD_SEMANTICS, 1, [Define to enforce POSIX thread semantics under Solaris.])
+	AC_DEFINE(_REENTRANT,               1, [Define to enable reentrancy interfaces.])
 fi
 if test "x$ac_system" = "xAIX"
 then


### PR DESCRIPTION
On Wed, Mar 16, 2011 at 10:35:07AM +0100, Mathijs Möhlmann wrote:

> I'm using collectd 4.10.2 on Solaris 10 (gcc 3.4.6). Sometimes when I
> start with a clean rrd directory or add a host the .rrd file (rrdtools
> plugin) don't get created and I get the following message:
> 
> collectd[2996]: [ID 702911 daemon.error] stat(/usr/local/var/lib/collectd/rrd/asterix/load/load.rrd) failed: Bad file number

This patch fixes this.

Signed-off-by: Sebastian Harl sh@teamix.net
