### PR TITLE
src/common.c: get_kstat_value: Check the arguments and return error codes.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -637,7 +637,7 @@ long long get_kstat_value (kstat_t *ksp, char *name)
 
 	if (ksp == NULL)
 	{
-		ERROR ("get_kstat_value (\"%s\"): ksp is NULL.", name)
+		ERROR ("get_kstat_value (\"%s\"): ksp is NULL.", name);
 		return (-1LL);
 	}
 	else if (ksp->ks_type != KSTAT_TYPE_NAMED)


### PR DESCRIPTION
Rather than asserting that an argument is not NULL, check this condition
and return an error code.

This should fix Github issue #71.
