### PR TITLE
Set license info line to ”GPLv2 or newer”

### DIFF
--- a/contrib/collectd_network.py
+++ b/contrib/collectd_network.py
@@ -4,7 +4,7 @@
 #
 # Copyright © 2009 Adrian Perez <aperez@igalia.com>
 #
-# Distributed under terms of the GPLv2 license.
+# Distributed under terms of the GPLv2 license or newer.
 # 
 # Frank Marien (frank@apsu.be) 6 Sep 2012
 # - quick fixes for 5.1 binary protocol


### PR DESCRIPTION
Recently I had a request to change the licensing of this file to use it in a GPLv3 application. This change would make it easier, while retaining GPLv2 to make the license still match the one in collectd.
