### PR TITLE
fixed link of varnish.so module when --with-varnishlib is used

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -4060,7 +4060,7 @@ AC_ARG_WITH(libvarnish, [AS_HELP_STRING([--with-libvarnish@<:@=PREFIX@:>@], [Pat
 	then
 		AC_MSG_NOTICE([Not checking for libvarnish: Manually configured])
 		with_libvarnish_cflags="-I$withval/include"
-		with_libvarnish_libs="-L$withval/lib -lvarnish -lvarnishcompat -lvarnishapi"
+		with_libvarnish_libs="-L$withval/lib -lvarnishapi"
 		with_libvarnish="yes"
 	fi; fi; fi
 ],


### PR DESCRIPTION
Module varnish.so need to be linked to libvarnishapi.so only.

However, depending if you use the ./configure --with-varnishlib option, you'll get two more libs linked to varnish.so : libvarnish.so and libvarnishcompat.so; but they must be used only for varnishd binary.
If you're not using this --with-varnishlib option, the varnish.so will be correctly linked only to libvarnishapi.so (thanks to pkg-config)
