### PR TITLE
Fixed bugs that prevented to "make distcheck"

### DIFF
--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -10,28 +10,55 @@ EXTRA_DIST = perl/Makefile.PL \
 	     perl/lib/Collectd/Plugins/Monitorus.pm \
 	     perl/lib/Collectd/Plugins/OpenVZ.pm
 
+CLEANFILES = \
+	buildperl/Collectd.pm \
+	buildperl/Collectd/Plugins/OpenVZ.pm \
+	buildperl/Collectd/Unixsock.pm \
+	buildperl/Makefile.PL \
+	.perl-directory-stamp
+
+DISTCLEANFILES = \
+	buildperl/Collectd.pm \
+	buildperl/Collectd/Plugins/OpenVZ.pm \
+	buildperl/Collectd/Unixsock.pm \
+	buildperl/Makefile.PL \
+	.perl-directory-stamp
+
 all-local: @PERL_BINDINGS@
 
+
 install-exec-local:
-	[ ! -f perl/Makefile ] || ( cd perl && $(MAKE) install )
+	[ ! -f buildperl/Makefile ] || ( cd buildperl && $(MAKE) install )
+
+# Perl 'make uninstall' does not work as well as wanted.
+# So we do the work here.
+uninstall-local:
+	rm -f $(DESTDIR)$(mandir)/man3/Collectd::Unixsock.3pm
+	rm -f $(DESTDIR)$(datarootdir)/perl5/Collectd.pm
+	rm -f $(DESTDIR)$(datarootdir)/perl5/Collectd/Plugins/OpenVZ.pm
+	rm -f $(DESTDIR)$(datarootdir)/perl5/Collectd/Unixsock.pm
+	rm -f $(DESTDIR)$(prefix)/lib64/perl5/perllocal.pod
+	rm -f $(DESTDIR)$(prefix)/lib64/perl5/auto/Collectd/.packlist
 
 clean-local:
-	[ ! -f perl/Makefile ] || ( cd perl && $(MAKE) realclean )
+	rm -rf buildperl
 
-perl: perl/Makefile
-	cd perl && $(MAKE)
+perl: buildperl/Makefile
+	cd buildperl && $(MAKE)
 
-perl/Makefile: .perl-directory-stamp perl/Makefile.PL \
+buildperl/Makefile: .perl-directory-stamp buildperl/Makefile.PL \
 	$(top_builddir)/config.status
-	cd perl && @PERL@ Makefile.PL PREFIX=$(prefix) @PERL_BINDINGS_OPTIONS@
+	cd buildperl && @PERL@ Makefile.PL PREFIX=$(prefix) @PERL_BINDINGS_OPTIONS@
+
+buildperl/Makefile.PL: .perl-directory-stamp $(top_builddir)/config.status
 
 .perl-directory-stamp:
-	if test ! -d perl; then \
-	  mkdir -p perl/Collectd/Plugins; \
-	  cp $(srcdir)/perl/Collectd.pm perl/; \
-	  cp $(srcdir)/perl/Makefile.PL perl/; \
-	  cp $(srcdir)/perl/Collectd/Unixsock.pm perl/Collectd/; \
-	  cp $(srcdir)/perl/Collectd/Plugins/OpenVZ.pm perl/Collectd/Plugins/; \
+	if test ! -d buildperl; then \
+	  mkdir -p buildperl/Collectd/Plugins; \
+	  cp $(srcdir)/perl/lib/Collectd.pm buildperl/; \
+	  cp $(srcdir)/perl/Makefile.PL buildperl/; \
+	  cp $(srcdir)/perl/lib/Collectd/Unixsock.pm buildperl/Collectd/; \
+	  cp $(srcdir)/perl/lib/Collectd/Plugins/OpenVZ.pm buildperl/Collectd/Plugins/; \
 	fi
 	touch $@
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1385,3 +1385,9 @@ install-exec-hook:
 	$(INSTALL) -m 0644 $(srcdir)/types.db $(DESTDIR)$(pkgdatadir)/types.db;
 	$(INSTALL) -m 0644 $(srcdir)/postgresql_default.conf \
 		$(DESTDIR)$(pkgdatadir)/postgresql_default.conf;
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(pkgdatadir)/types.db;
+	rm -f $(DESTDIR)$(sysconfdir)/collectd.conf
+	rm -f $(DESTDIR)$(pkgdatadir)/postgresql_default.conf;
+


### PR DESCRIPTION
Hello,

I noticed that "make distcheck" does not work.
I fixed some Makefile.am do have it work.

Now you can create the release files (like collected-5.1.0.tar.gz) with "make distcheck".

Regards,
Yves Mettier
