### PR TITLE
Fix SEGV/SIGBUS crash on Solaris, build fail with -Werror

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1230,9 +1230,7 @@ static int ps_read_process(int pid, procstat_t *ps, char *state)
 {
 	char filename[64];
 	char f_psinfo[64], f_usage[64];
-	int i;
 	char *buffer;
-
 
 	pstatus_t *myStatus;
 	psinfo_t *myInfo;
@@ -2080,7 +2078,7 @@ static int ps_read (void)
 	procstat_t *ps_ptr;
 	char state;
 
-	char cmdline[ARG_MAX];
+	char cmdline[PRARGSZ];
 
 	ps_list_reset ();
 


### PR DESCRIPTION
ARG_MAX is way too large to use in a stack variable in a thread on Solaris.  Use PRARGSZ, which is the actual size of the "cmdline" buffer in /proc.

Also removed 'int i', which is an unused variable and breaks building with --enable-debug.
