### PR TITLE
Fix configure script generation in AIX

### DIFF
--- a/version-gen.sh
+++ b/version-gen.sh
@@ -10,8 +10,4 @@ fi
 
 VERSION="`echo \"$VERSION\" | sed -e 's/-/./g'`"
 
-if test "x`uname -s`" = "xAIX" ; then
-	echo "$VERSION\c"
-else 
-	echo -n "$VERSION"
-fi
+echo -n "$VERSION"


### PR DESCRIPTION
The commit 3bda88e change the shell from sh to bash.

To fix the configure script generation error: remove the echo whith \c used in sh.

Note: bash is not installed in AIX by default.
