### PR TITLE
Remove use of "et" in PyArg_Parse*() to avoid leaking memory

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -529,7 +529,7 @@ static PyObject *cpy_register_generic(cpy_callback_t **list_head, PyObject *args
 	PyObject *callback = NULL, *data = NULL, *mod = NULL;
 	static char *kwlist[] = {"callback", "data", "name", NULL};
 	
-	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|Oet", kwlist, &callback, &data, NULL, &name) == 0) return NULL;
+	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|Os", kwlist, &callback, &data, &name) == 0) return NULL;
 	if (PyCallable_Check(callback) == 0) {
 		PyErr_SetString(PyExc_TypeError, "callback needs a be a callable object.");
 		return NULL;
@@ -553,7 +553,7 @@ static PyObject *cpy_flush(cpy_callback_t **list_head, PyObject *args, PyObject 
 	const char *plugin = NULL, *identifier = NULL;
 	static char *kwlist[] = {"plugin", "timeout", "identifier", NULL};
 	
-	if (PyArg_ParseTupleAndKeywords(args, kwds, "|etiet", kwlist, NULL, &plugin, &timeout, NULL, &identifier) == 0) return NULL;
+	if (PyArg_ParseTupleAndKeywords(args, kwds, "|sis", kwlist, &plugin, &timeout, &identifier) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_flush(plugin, timeout, identifier);
 	Py_END_ALLOW_THREADS
@@ -579,7 +579,7 @@ static PyObject *cpy_register_generic_userdata(void *reg, void *handler, PyObjec
 	PyObject *callback = NULL, *data = NULL;
 	static char *kwlist[] = {"callback", "data", "name", NULL};
 	
-	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|Oet", kwlist, &callback, &data, NULL, &name) == 0) return NULL;
+	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|Os", kwlist, &callback, &data, &name) == 0) return NULL;
 	if (PyCallable_Check(callback) == 0) {
 		PyErr_SetString(PyExc_TypeError, "callback needs a be a callable object.");
 		return NULL;
@@ -610,7 +610,7 @@ static PyObject *cpy_register_read(PyObject *self, PyObject *args, PyObject *kwd
 	struct timespec ts;
 	static char *kwlist[] = {"callback", "interval", "data", "name", NULL};
 	
-	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|dOet", kwlist, &callback, &interval, &data, NULL, &name) == 0) return NULL;
+	if (PyArg_ParseTupleAndKeywords(args, kwds, "O|dOs", kwlist, &callback, &interval, &data, &name) == 0) return NULL;
 	if (PyCallable_Check(callback) == 0) {
 		PyErr_SetString(PyExc_TypeError, "callback needs a be a callable object.");
 		return NULL;
@@ -660,7 +660,7 @@ static PyObject *cpy_register_shutdown(PyObject *self, PyObject *args, PyObject 
 
 static PyObject *cpy_error(PyObject *self, PyObject *args) {
 	const char *text;
-	if (PyArg_ParseTuple(args, "et", NULL, &text) == 0) return NULL;
+	if (PyArg_ParseTuple(args, "s", &text) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_log(LOG_ERR, "%s", text);
 	Py_END_ALLOW_THREADS
@@ -669,7 +669,7 @@ static PyObject *cpy_error(PyObject *self, PyObject *args) {
 
 static PyObject *cpy_warning(PyObject *self, PyObject *args) {
 	const char *text;
-	if (PyArg_ParseTuple(args, "et", NULL, &text) == 0) return NULL;
+	if (PyArg_ParseTuple(args, "s", &text) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_log(LOG_WARNING, "%s", text);
 	Py_END_ALLOW_THREADS
@@ -678,7 +678,7 @@ static PyObject *cpy_warning(PyObject *self, PyObject *args) {
 
 static PyObject *cpy_notice(PyObject *self, PyObject *args) {
 	const char *text;
-	if (PyArg_ParseTuple(args, "et", NULL, &text) == 0) return NULL;
+	if (PyArg_ParseTuple(args, "s", &text) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_log(LOG_NOTICE, "%s", text);
 	Py_END_ALLOW_THREADS
@@ -687,7 +687,7 @@ static PyObject *cpy_notice(PyObject *self, PyObject *args) {
 
 static PyObject *cpy_info(PyObject *self, PyObject *args) {
 	const char *text;
-	if (PyArg_ParseTuple(args, "et", NULL, &text) == 0) return NULL;
+	if (PyArg_ParseTuple(args, "s", &text) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_log(LOG_INFO, "%s", text);
 	Py_END_ALLOW_THREADS
@@ -697,7 +697,7 @@ static PyObject *cpy_info(PyObject *self, PyObject *args) {
 static PyObject *cpy_debug(PyObject *self, PyObject *args) {
 #ifdef COLLECT_DEBUG
 	const char *text;
-	if (PyArg_ParseTuple(args, "et", NULL, &text) == 0) return NULL;
+	if (PyArg_ParseTuple(args, "s", &text) == 0) return NULL;
 	Py_BEGIN_ALLOW_THREADS
 	plugin_log(LOG_DEBUG, "%s", text);
 	Py_END_ALLOW_THREADS

--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -147,8 +147,8 @@ static int PluginData_init(PyObject *s, PyObject *args, PyObject *kwds) {
 	static char *kwlist[] = {"type", "plugin_instance", "type_instance",
 			"plugin", "host", "time", NULL};
 	
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etetetetetd", kwlist, NULL, &type,
-			NULL, &plugin_instance, NULL, &type_instance, NULL, &plugin, NULL, &host, &time))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sssssd", kwlist, &type,
+			&plugin_instance, &type_instance, &plugin, &host, &time))
 		return -1;
 	
 	if (type[0] != 0 && plugin_get_ds(type) == NULL) {
@@ -357,9 +357,9 @@ static int Values_init(PyObject *s, PyObject *args, PyObject *kwds) {
 	static char *kwlist[] = {"type", "values", "plugin_instance", "type_instance",
 			"plugin", "host", "time", "interval", "meta", NULL};
 	
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etOetetetetddO", kwlist,
-			NULL, &type, &values, NULL, &plugin_instance, NULL, &type_instance,
-			NULL, &plugin, NULL, &host, &time, &interval, &meta))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sOssssddO", kwlist,
+			&type, &values, &plugin_instance, &type_instance,
+			&plugin, &host, &time, &interval, &meta))
 		return -1;
 	
 	if (type[0] != 0 && plugin_get_ds(type) == NULL) {
@@ -498,9 +498,9 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 	
 	static char *kwlist[] = {"type", "values", "plugin_instance", "type_instance",
 			"plugin", "host", "time", "interval", "meta", NULL};
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etOetetetetddO", kwlist,
-			NULL, &type, &values, NULL, &plugin_instance, NULL, &type_instance,
-			NULL, &plugin, NULL, &host, &time, &interval, &meta))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sOssssddO", kwlist,
+			&type, &values, &plugin_instance, &type_instance,
+			&plugin, &host, &time, &interval, &meta))
 		return NULL;
 
 	if (type[0] == 0) {
@@ -610,9 +610,9 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
 	
 	static char *kwlist[] = {"destination", "type", "values", "plugin_instance", "type_instance",
 			"plugin", "host", "time", "interval", "meta", NULL};
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etOetetetetddO", kwlist,
-			NULL, &type, &values, NULL, &plugin_instance, NULL, &type_instance,
-			NULL, &plugin, NULL, &host, &time, &interval, &meta))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sOssssddO", kwlist,
+			&type, &values, &plugin_instance, &type_instance,
+			&plugin, &host, &time, &interval, &meta))
 		return NULL;
 
 	if (type[0] == 0) {
@@ -832,9 +832,9 @@ static int Notification_init(PyObject *s, PyObject *args, PyObject *kwds) {
 	static char *kwlist[] = {"type", "message", "plugin_instance", "type_instance",
 			"plugin", "host", "time", "severity", NULL};
 	
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etetetetetetdi", kwlist,
-			NULL, &type, NULL, &message, NULL, &plugin_instance, NULL, &type_instance,
-			NULL, &plugin, NULL, &host, &time, &severity))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ssssssdi", kwlist,
+			&type, &message, &plugin_instance, &type_instance,
+			&plugin, &host, &time, &severity))
 		return -1;
 	
 	if (type[0] != 0 && plugin_get_ds(type) == NULL) {
@@ -869,9 +869,9 @@ static PyObject *Notification_dispatch(Notification *self, PyObject *args, PyObj
 	
 	static char *kwlist[] = {"type", "message", "plugin_instance", "type_instance",
 			"plugin", "host", "time", "severity", NULL};
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|etetetetetetdi", kwlist,
-			NULL, &type, NULL, &message, NULL, &plugin_instance, NULL, &type_instance,
-			NULL, &plugin, NULL, &host, &t, &severity))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ssssssdi", kwlist,
+			&type, &message, &plugin_instance, &type_instance,
+			&plugin, &host, &t, &severity))
 		return NULL;
 
 	if (type[0] == 0) {


### PR DESCRIPTION
Memory is allocated when calling PyArg_Parse*() with "et" strings. That has to be freed by PyMem_Free(). As we are not dealing with exotic encodings (the encoding argument is ignored in all cases anyway,) just switch to "s" which returns a pointer to Python-internal storage.

See http://docs.python.org/c-api/arg.html
