### PR TITLE
network.c: call gcry_check_version() as required by library. Closes #88

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -3355,9 +3355,17 @@ static int network_init (void)
 	have_init = 1;
 
 #if HAVE_LIBGCRYPT
-	gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-	gcry_control (GCRYCTL_INIT_SECMEM, 32768, 0);
-	gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+    /* http://lists.gnupg.org/pipermail/gcrypt-devel/2003-August/000458.html
+     * Because you can't know in a library whether another library has
+     * already initialized the library
+     */
+    if (!gcry_control (GCRYCTL_ANY_INITIALIZATION_P))
+    {
+        gcry_check_version(NULL); /* before calling any other functions */
+        gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+        gcry_control (GCRYCTL_INIT_SECMEM, 32768, 0);
+        gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+    }
 #endif
 
 	if (network_config_stats != 0)


### PR DESCRIPTION
I was unable to test this issue for two reasons:
- I don't have a debian environment at the moment.
- I can't build master as the "buildperl" directory doesn't seem to be there? I tried git bisect without luck
  exact error I see is:

```
Making all in bindings
cd buildperl && /opt/local/bin/perl Makefile.PL INSTALL_BASE=/opt/collectd 
/bin/sh: line 0: cd: buildperl: No such file or directory
```

It is quite possibly an environment issue. I am perplexed because it was building the other day.

closes https://github.com/collectd/collectd/issues/88

Adds changes detailed by the github issue above. Should fix gcrypt issues on Debian Lenny 6.0.x
