### PR TITLE
Change the libnetlink function used to query link statistics

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -223,7 +223,7 @@ static int link_filter (const struct sockaddr_nl __attribute__((unused)) *sa,
 
   msg = NLMSG_DATA (nmh);
 
-  msg_len = nmh->nlmsg_len - sizeof (struct ifinfomsg);
+  msg_len = nmh->nlmsg_len - NLMSG_LENGTH(sizeof (struct ifinfomsg));
   if (msg_len < 0)
   {
     ERROR ("netlink plugin: link_filter: msg_len = %i < 0;", msg_len);
@@ -554,19 +554,15 @@ static int ir_init (void)
 
 static int ir_read (void)
 {
-  struct ifinfomsg im;
   struct tcmsg tm;
   int ifindex;
 
   static const int type_id[] = { RTM_GETQDISC, RTM_GETTCLASS, RTM_GETTFILTER };
   static const char *type_name[] = { "qdisc", "class", "filter" };
 
-  memset (&im, '\0', sizeof (im));
-  im.ifi_type = AF_UNSPEC;
-
-  if (rtnl_dump_request (&rth, RTM_GETLINK, &im, sizeof (im)) < 0)
+  if (rtnl_wilddump_request (&rth, AF_UNSPEC, RTM_GETLINK) < 0)
   {
-    ERROR ("netlink plugin: ir_read: rtnl_dump_request failed.");
+    ERROR ("netlink plugin: ir_read: rtnl_wilddump_request failed.");
     return (-1);
   }
 


### PR DESCRIPTION
Change the libnetlink function used to query link statistics to match
iproute2's behavior and thus not trip on the kernel's new parsing of
optional attributes for RTM_GETLINK.

Starting with linux-3.3-rc5 kernel at each interval netlink plugin triggers
three lines of kernel log:
  netlink: 12 bytes leftover after parsing attributes.
