### PR TITLE
Increase size of AVL tree even on first insertion.

### DIFF
--- a/src/utils_avltree.c
+++ b/src/utils_avltree.c
@@ -512,6 +512,7 @@ int c_avl_insert (c_avl_tree_t *t, void *key, void *value)
 	{
 		new->parent = NULL;
 		t->root = new;
+		++t->size;
 		return (0);
 	}
 


### PR DESCRIPTION
t->size should be increased in all sensible return paths of c_avl_insert(). If I interpreted the code correctly, the root node is just another node and should count towards the tree size.

The size of the tree doesn't seem to be used anywhere except threshold.c, so this probably doesn't matter that much in practice.
