### PR TITLE
autoconf cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I libltdl/m4
 
-SUBDIRS = libltdl src bindings
+SUBDIRS = libltdl src bindings .
 
 INCLUDES = $(LTDLINCL)
 
@@ -10,3 +10,8 @@ install-exec-hook:
 	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run
 	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/lib/$(PACKAGE_NAME)
 	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/log
+
+maintainer-clean-local:
+	-rm -f -r libltdl
+	-rm -f INSTALL
+	-rm -f aclocal.m4

--- a/configure.in
+++ b/configure.in
@@ -2466,21 +2466,20 @@ then
 #include <asm/types.h>
 #include <sys/socket.h>])
 
-	AC_COMPILE_IFELSE(
-[#include <stdio.h>
-#include <sys/types.h>
-#include <asm/types.h>
-#include <sys/socket.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
-
-int main (void)
-{
-	int retval = TCA_STATS2;
-	return (retval);
-}],
-	[AC_DEFINE([HAVE_TCA_STATS2], 1, [True if the enum-member TCA_STATS2 exists])]
-	[]);
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                           [
+                            #include <stdio.h>
+                            #include <sys/types.h>
+                            #include <asm/types.h>
+                            #include <sys/socket.h>
+                            #include <linux/netlink.h>
+                            #include <linux/rtnetlink.h>
+                            ], [
+                                int retval = TCA_STATS2;
+                                return (retval);
+                                ]
+                            )],
+                            [AC_DEFINE([HAVE_TCA_STATS2], [1], [True if the enum-member TCA_STATS2 exists])])
 
 	AC_COMPILE_IFELSE(
 [#include <stdio.h>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1326,6 +1326,8 @@ collectd_LDADD += "-dlopen" zfs_arc.la
 collectd_DEPENDENCIES += zfs_arc.la
 endif
 
+BUILT_SOURCES += $(dist_man_MANS)
+
 dist_man_MANS = collectd.1 \
 		collectd.conf.5 \
 		collectd-email.5 \


### PR DESCRIPTION
...RAM (or something similar) to get the setup right.

2) Fix for maintaier-clean so that you can run the autoreconf build script multiple times.
3) Clean up the generated man pages when running cleanup.

I've got a couple of other patches for you along the lines of this one, but I wanted to see if you wanted these sorts of patches first.

Cheers,
    -Brian
