### PR TITLE
Add df_simple type

### DIFF
--- a/contrib/collection3/etc/collection.conf
+++ b/contrib/collection3/etc/collection.conf
@@ -143,6 +143,10 @@ GraphWidth 400
   Module Df
   DataSources free used
 </Type>
+<Type df_simple>
+  Module Df
+  DataSources free used
+</Type>
 <Type df_complex>
   Module GenericStacked
   DataSources value

--- a/src/types.db
+++ b/src/types.db
@@ -29,6 +29,7 @@ delay			value:GAUGE:-1000000:1000000
 derive			value:DERIVE:0:U
 df_complex		value:GAUGE:0:U
 df_inodes		value:GAUGE:0:U
+df_simple		used:GAUGE:0:1125899906842623, free:GAUGE:0:1125899906842623
 df			used:GAUGE:0:1125899906842623, free:GAUGE:0:1125899906842623
 disk_latency		read:GAUGE:0:U, write:GAUGE:0:U
 disk_merged		read:DERIVE:0:U, write:DERIVE:0:U


### PR DESCRIPTION
- Reintroduce the old df type as df_simple
  - Avoid triggering the v5_df() of target_v5upgrade
  - It has two values only: used and free
    - Free is reported as f_bavail like the command df does
  - It allows to easily configure notifications/thresholds using percents
  - The default behaviour of df is to report df_complex type
  - To make it report df_simple the boolean configuration option ReportSimple
    is introduced.
