### PR TITLE
collection3: Updating data source for collectd v5

### DIFF
--- a/contrib/collection3/etc/collection.conf
+++ b/contrib/collection3/etc/collection.conf
@@ -2,7 +2,7 @@
 GraphWidth 400
 #UnixSockAddr "/var/run/collectd-unixsock"
 <Type apache_bytes>
-  DataSources count
+  DataSources value
   DSName "count Bytes/s"
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Bytes/s"
@@ -10,7 +10,7 @@ GraphWidth 400
   Color count 0000ff
 </Type>
 <Type apache_requests>
-  DataSources count
+  DataSources value
   DSName "count Requests/s"
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Requests/s"
@@ -19,7 +19,7 @@ GraphWidth 400
 </Type>
 <Type apache_scoreboard>
   Module GenericStacked
-  DataSources count
+  DataSources value
   RRDTitle "Apache scoreboard on {hostname}"
   RRDVerticalLabel "Slots"
   RRDFormat "%6.2lf"
@@ -245,14 +245,14 @@ GraphWidth 400
   RRDFormat "%6.1lf"
 </Type>
 <Type conntrack>
-  DataSources conntrack
+  DataSources value
   DSName conntrack Conntrack count
   RRDTitle "nf_conntrack connections on {hostname}"
   RRDVerticalLabel "Count"
   RRDFormat "%4.0lf"
 </Type>
 <Type entropy>
-  DataSources entropy
+  DataSources value
   DSName entropy Entropy bits
   RRDTitle "Available entropy on {hostname}"
   RRDVerticalLabel "Bits"
@@ -267,7 +267,7 @@ GraphWidth 400
   Color value 00b000
 </Type>
 <Type frequency>
-  DataSources frequency
+  DataSources value
   DSName frequency Frequency
   RRDTitle "Frequency ({type_instance})"
   RRDVerticalLabel "Hertz"
@@ -542,7 +542,7 @@ GraphWidth 400
   Scale 8
 </Type>
 <Type percent>
-  DataSources percent
+  DataSources value
   DSName percent Percent
   RRDTitle "Percent ({type_instance})"
   RRDVerticalLabel "Percent"
@@ -550,7 +550,7 @@ GraphWidth 400
   Color percent 0000ff
 </Type>
 <Type ping>
-  DataSources ping
+  DataSources value
   DSName "ping Latency"
   RRDTitle "Network latency ({type_instance})"
   RRDVerticalLabel "Milliseconds"
@@ -700,7 +700,7 @@ GraphWidth 400
   Scale 0.001
 </Type>
 <Type users>
-  DataSources users
+  DataSources value
   DSName users Users
   RRDTitle "Users ({type_instance}) on {hostname}"
   RRDVerticalLabel "Users"


### PR DESCRIPTION
See https://collectd.org/wiki/index.php/V4_to_v5_migration_guide

After upgrading from v4 to v5 collection3 stopped working for some data types like entropy and users.  The fix is simple.
