### PR TITLE
per-cpu statistings on Linux and cpu in % on Solaris

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -447,7 +447,7 @@ static int cpu_read (void)
 
 #elif defined(HAVE_LIBKSTAT)
 	int cpu;
-	derive_t user, syst, idle, wait, total;
+	derive_t user, syst, idle, wait;
 	derive_t tuser = 0, tsyst = 0, tidle = 0, twait = 0;
 	static cpu_stat_t cs;
 	unsigned long local_copy_of_numcpu = numcpu;


### PR DESCRIPTION
Hello,

This patch adds per cpu statistics on Linux (initial patch from Cyril Feraudet)

On Solaris, cpu statistics are converted to % because aggregation plugins do not like jiffies (initial patch from Cosmin Ioiart)

Note : Linux collects jiffies on values that seems to be %. So aggregation plugins should not complain. But one day, one should add an option to have % instead of jiffies on Linux too.

Regards,
Yves
