### PR TITLE
src/network.c: Fix the build on FreeBSD.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -59,18 +59,8 @@
 
 #if HAVE_LIBGCRYPT
 # include <pthread.h>
-# if defined __APPLE__
-/* default xcode compiler throws warnings even when deprecated functionality
- * is not used. -Werror breaks the build because of erroneous warnings.
- * http://stackoverflow.com/questions/10556299/compiler-warnings-with-libgcrypt-v1-5-0/12830209#12830209
- */
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-# endif
+# define GCRYPT_NO_DEPRECATED
 # include <gcrypt.h>
-# if defined __APPLE__
-/* Re enable deprecation warnings */
-#  pragma GCC diagnostic warning "-Wdeprecated-declarations"
-# endif
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #endif
 


### PR DESCRIPTION
Instead of overriding the -Wdeprecated-declarations warning, simply use
the GCRYPT_NO_DEPRECATED definition that disables the deprecated
functionality completely.
