### PR TITLE
Fallback to /usr/lib/jvm if JAVA_HOME is not set

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1956,6 +1956,10 @@ fi
 
 # --with-java {{{
 with_java_home="$JAVA_HOME"
+if test "x$with_java_home" = "x"
+then
+	with_java_home="/usr/lib/jvm"
+fi
 with_java_vmtype="client"
 with_java_cflags=""
 with_java_libs=""


### PR DESCRIPTION
This makes the java plugin build out of the box
on systems with a JDK installed.
/usr/lib/jvm is the default location for the JDK
on at least Fedora, Red Hat and Debian.
