### PR TITLE
Surround htonll with #if !HAVE_HTONLL #endif

### DIFF
--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -140,6 +140,7 @@ static _Bool have_gcrypt (void) /* {{{ */
   return (1);
 } /* }}} _Bool have_gcrypt */
 
+#if !HAVE_HTONLL
 static uint64_t htonll (uint64_t val) /* {{{ */
 {
   static int config = 0;
@@ -169,6 +170,7 @@ static uint64_t htonll (uint64_t val) /* {{{ */
 
   return ((((uint64_t) lo) << 32) | ((uint64_t) hi));
 } /* }}} uint64_t htonll */
+#endif 
 
 static double htond (double val) /* {{{ */
 {


### PR DESCRIPTION
I have problems while trying to compile 5.2.0 at  AIX6. I got a kind of syntax error 
network_buffer.c:143: error: expected ')' before 'val'

Applying this patch and this https://github.com/collectd/collectd/pull/201 solves my problems. 

Thanks
