### PR TITLE
Fix a bug with duplicate "mac" or "phys" interfaces on Solaris10

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -333,9 +333,9 @@ static int interface_read (void)
 		if(solaris_version_10_and_upper && 
 						( !strcmp("mac", ksp[i]->ks_name) || !strcmp("phys", ksp[i]->ks_name) )
 		  ) {
-				snprintf(device_name, sizeof(device_name), "%s%ld", ksp[i]->ks_module, ksp[i]->ks_instance);
+				snprintf(device_name, sizeof(device_name), "%s%d", ksp[i]->ks_module, ksp[i]->ks_instance);
 		} else {
-				snprintf(device_name, sizeof(device_name), "%s_%ld", ksp[i]->ks_name, ksp[i]->ks_instance);
+				snprintf(device_name, sizeof(device_name), "%s_%d", ksp[i]->ks_name, ksp[i]->ks_instance);
 		}
 
 		/* try to get 64bit counters */


### PR DESCRIPTION
Hello,
# Solaris 10 and 11

On Solaris 10 and 11, there is a new device driver framework called GLDv3 (project name "nemo"). More information here : http://hub.opensolaris.org/bin/view/Project+nemo/
## bugfix

As a consequence, with kstat, you will no more check (for example) `"e1000g:0:e1000g0:obytes64"` but `"e1000g:0:mac:obytes64"`. The latest still exist but is duplicate. Moreover, you will find a `"e1000g:0:mac:link_up"` metric but no `"e1000g:0:e1000g0:link_up"`. 

Because the collectd interface plugin is using the 3rd field as the plugin instance, we now have duplicates ("mac" or "phys"). Example :
`e1000g:0:mac:obytes64` (this is obytes64 for the interface e1000g0)
`e1000g:1:mac:obytes64` (this is obytes64 for the interface e1000g1)

The plugin instance should become the concatenation of fields 1 and 2.

The duplicate result in such lines in your log files :

```
[2013-01-07 03:19:18] [error] rrdcached plugin: rrdc_update (/var/lib/collectd/hostname/interface-mac/if_packets.rrd, [1357525158:0:0], 1) failed with status -1.
```

This patch fixes this bug.

Notice that your interface-mac metrics are currupted : they contain the data from the first interface that sent the data at any interval. Your interface-e1000g0 (or any other interface) may contain correct value, but it seems to not be exactly the same as what you should have got with the mac data. Check this with :

```
kstat -c net -p :::obytes64
```
## new feature

It also add the following feature : if link_up is not 1, the metric is ignored. In other words, it will not take interfaces that are down.
# Other OS using libkstat

Because we can also have duplicates with other OS or older Solaris, the interface plugin is the concatenation of field 3 and field 2. In the previous example, it would be e1000g0_0.
Well, Solaris 9 and older are now unsupported, so who cares ?

Regards,
Yves
