### PR TITLE
BUG: fixes "port" DriverOption silently ignored for "mysql" driver

### DIFF
--- a/src/dbi.c
+++ b/src/dbi.c
@@ -694,8 +694,14 @@ static int cdbi_connect_database (cdbi_database_t *db) /* {{{ */
         db->driver_options[i].key,
         db->driver_options[i].value);
 
-    status = dbi_conn_set_option (connection,
-        db->driver_options[i].key, db->driver_options[i].value);
+    if (strcmp(db->driver_options[i].key,"port") == 0 && strcmp(db->driver,"mysql") == 0) {
+      status = dbi_conn_set_option_numeric (connection,
+          db->driver_options[i].key, strtol(db->driver_options[i].value,NULL,10));
+      INFO ("dbi plugin: dbi_conn_set_option_numeric (%s)", db->driver_options[i].key);
+    } else {
+      status = dbi_conn_set_option (connection,
+          db->driver_options[i].key, db->driver_options[i].value);
+    }
     if (status != 0)
     {
       char errbuf[1024];


### PR DESCRIPTION
All DriveroOptions explicitly defined as "numeric" in libdbi (see http://libdbi-drivers.sourceforge.net/docs.html are ignored by the dbi plugin, because the wrong function is being called(dbi_conn_set_option() instead of dbi_conn_set_option_numeric()).
As a consequence, specifying a non-standard port when using the mysql driver doesn't work as expected, as it's being silently ignored.
This patch only fixes the "port" DriverOption for "mysql" in an inelegant way. A proper fix is needed, and the struct cdbi_driver_option_s defines the value as a "char". I guess it should have an additional key which is 1 if numeric, then call the proper function according to this flag.
