### PR TITLE
flush log messages right away when logging to stderr or stdout

### DIFF
--- a/src/logfile.c
+++ b/src/logfile.c
@@ -151,8 +151,11 @@ static void logfile_print (const char *msg, int severity,
 		else
 			fprintf (fh, "%s%s\n", level_str, msg);
 
-		if (do_close != 0)
+		if (do_close != 0) {
 			fclose (fh);
+		} else {
+			fflush(fh);
+		}
 	}
 
 	pthread_mutex_unlock (&file_lock);


### PR DESCRIPTION
If the logfile handle is not closed after writing a log message the message can sit in the IO buffers causing delayed logs.  This change calls fflush if we aren't closing the file to flush them out right away.
