### PR TITLE
Add a limit to the receive queue length before dropping packets.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3055,6 +3055,17 @@ buffer of 1024E<nbsp>bytes. Versions I<4.8>, I<4.9> and I<4.10> used a default
 value of 1024E<nbsp>bytes to avoid problems when sending data to an older
 server.
 
+=item B<QueueLengthLimitLow> I<Number>
+=item B<QueueLengthLimitHigh> I<Number>
+
+When set, if the receive queue length is higher than B<QueueLengthLimitHigh>, the
+network plugin will stop dispatching the packets it receives. This mode will
+end when the receive queue length returns lower than B<QueueLengthLimitLow>.
+
+If B<QueueLengthLimitHigh> is I<0> or not defined, no packet will be dropped.
+If B<QueueLengthLimitHigh> is not nul, and B<QueueLengthLimitLow> is nul or 
+not defined, B<QueueLengthLimitLow> will be forced to some positive value.
+
 =item B<Forward> I<true|false>
 
 If set to I<true>, write packets that were received via the network plugin to


### PR DESCRIPTION
Hello,

This patch adds 2 more configuration parameters to the network plugin.
If you have too big queue and want to drop packets, you can configure them.

Extract from new collectd.conf :

```
    QueueLengthLimitLow Number
    QueueLengthLimitHigh Number

When set, if the receive queue length is higher than QueueLengthLimitHigh, the
network plugin will stop dispatching the packets it receives. This mode will
end when the receive queue length returns lower than QueueLengthLimitLow.

If QueueLengthLimitHigh is 0 or not defined, no packet will be dropped.
If QueueLengthLimitHigh is not nul, and QueueLengthLimitLow is nul or
not defined, QueueLengthLimitLow will be forced to some positive value.
```

This is interesting when used with plugin rrdtool_createonly (#243) or other plugins that have a big queue (I/O hell ? issue #75 ?) and may crash. Dropping may be better than losing them because of a crash because you can configure when to drop them.

Regards,
Yves
