### PR TITLE
Don't clobber TMPDIR during Java detection

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1994,31 +1994,31 @@ then
 	if test -d "$with_java_home"
 	then
 		AC_MSG_CHECKING([for jni.h])
-		TMPDIR=`find "$with_java_home" -name jni.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
-		if test "x$TMPDIR" != "x"
+		TMPVAR=`find "$with_java_home" -name jni.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
+		if test "x$TMPVAR" != "x"
 		then
-			AC_MSG_RESULT([found in $TMPDIR])
-			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPDIR"
+			AC_MSG_RESULT([found in $TMPVAR])
+			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
 		else
 			AC_MSG_RESULT([not found])
 		fi
 
 		AC_MSG_CHECKING([for jni_md.h])
-		TMPDIR=`find "$with_java_home" -name jni_md.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
-		if test "x$TMPDIR" != "x"
+		TMPVAR=`find "$with_java_home" -name jni_md.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
+		if test "x$TMPVAR" != "x"
 		then
-			AC_MSG_RESULT([found in $TMPDIR])
-			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPDIR"
+			AC_MSG_RESULT([found in $TMPVAR])
+			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
 		else
 			AC_MSG_RESULT([not found])
 		fi
 
 		AC_MSG_CHECKING([for libjvm.so])
-		TMPDIR=`find "$with_java_home" -name libjvm.so -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
-		if test "x$TMPDIR" != "x"
+		TMPVAR=`find "$with_java_home" -name libjvm.so -type f -exec 'dirname' '{}' ';' 2>/dev/null | head -n 1`
+		if test "x$TMPVAR" != "x"
 		then
-			AC_MSG_RESULT([found in $TMPDIR])
-			JAVA_LDFLAGS="$JAVA_LDFLAGS -L$TMPDIR -Wl,-rpath -Wl,$TMPDIR"
+			AC_MSG_RESULT([found in $TMPVAR])
+			JAVA_LDFLAGS="$JAVA_LDFLAGS -L$TMPVAR -Wl,-rpath -Wl,$TMPVAR"
 		else
 			AC_MSG_RESULT([not found])
 		fi
@@ -2026,10 +2026,10 @@ then
 		if test "x$JAVAC" = "x"
 		then
 			AC_MSG_CHECKING([for javac])
-			TMPDIR=`find "$with_java_home" -name javac -type f 2>/dev/null | head -n 1`
-			if test "x$TMPDIR" != "x"
+			TMPVAR=`find "$with_java_home" -name javac -type f 2>/dev/null | head -n 1`
+			if test "x$TMPVAR" != "x"
 			then
-				JAVAC="$TMPDIR"
+				JAVAC="$TMPVAR"
 				AC_MSG_RESULT([$JAVAC])
 			else
 				AC_MSG_RESULT([not found])
@@ -2038,10 +2038,10 @@ then
 		if test "x$JAR" = "x"
 		then
 			AC_MSG_CHECKING([for jar])
-			TMPDIR=`find "$with_java_home" -name jar -type f 2>/dev/null | head -n 1`
-			if test "x$TMPDIR" != "x"
+			TMPVAR=`find "$with_java_home" -name jar -type f 2>/dev/null | head -n 1`
+			if test "x$TMPVAR" != "x"
 			then
-				JAR="$TMPDIR"
+				JAR="$TMPVAR"
 				AC_MSG_RESULT([$JAR])
 			else
 				AC_MSG_RESULT([not found])


### PR DESCRIPTION
- Java detection used TMPDIR as var to parse command output
- TMPDIR is used in libltdl later on in ./configure
- alternative fix is local var or subshell
- fixes issue introduced via #33163ee

This should allow building on OS X again via homebrew for example.
