### PR TITLE
notify_email: Add charset in Content-Type header

### DIFF
--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -258,7 +258,7 @@ static int notify_email_notification (const notification_t *n,
   /* Let's make RFC822 message text with \r\n EOLs */
   ssnprintf (buf, buf_len,
       "MIME-Version: 1.0\r\n"
-      "Content-Type: text/plain;\r\n"
+      "Content-Type: text/plain; charset=UTF-8\r\n"
       "Content-Transfer-Encoding: 8bit\r\n"
       "Subject: %s\r\n"
       "\r\n"


### PR DESCRIPTION
notify_email: Add charset in Content-Type header. Without this, some emails generated by collectd were seen as spam in my case.

This is because Content-Type was not RFC compliant (RFC2045 : it should contains only "text/plain" or "text/plain; charset=xxx" but cannot end with a semi-colon)
