### PR TITLE
Add upstart daemon config

### DIFF
--- a/contrib/upstart.collectd.conf
+++ b/contrib/upstart.collectd.conf
@@ -1,0 +1,47 @@
+description "start/stop/control collectd"
+# http://collectd.org/
+# Upstart is the replacement init system used in Debian, Ubuntu,
+# and in Fedora. Refer to http://upstart.ubuntu.com/cookbook/
+#
+# Normally this file will live as `/etc/init/collectd.conf`
+
+usage "initctl <start|stop> collectd"
+author "Dave Cottlehuber <dch@jsonified.com>"
+version "1.1"
+
+# There are a number of alternative start sequences however
+# most of those do not work on all Ubuntu flavours and releases.
+start on started networking and filesystem
+stop on runlevel [!2345]
+
+# collectd itself will run with reduced privileges, but not
+# all plugins will. Test and edit as required.
+# An alternative configuration is as a user script in ~/.init/ however
+# these cannot be started at boot time by the system without
+# arcane trickery. Also a root user will not see these tasks/jobs
+# by default. set*id is a reasonable and secure compromise.
+#setuid nobody
+#setgid nobody
+
+# Other parameters such as the path to the configuration file
+# will have been compiled into the binary. These are trivially
+# added as environment variables below, and then into both
+# `pre-start` command check before collectd runs, and subsequent
+# `exec` command parameters below. Remember that upstart runs all
+# shell commands via `sh -e`.
+env DAEMON=/usr/sbin/collectd
+
+# Tell upstart to watch for forking when tracking the pid for us.
+expect fork
+
+# prevent thrashing - 10 restarts in 5 seconds
+respawn
+respawn limit 10 5
+
+# Make a log available in /var/log/upstart/collectd.log
+console log
+
+# The daemon will not start if the configuration is invalid.
+pre-start exec $DAEMON -t
+# Let's Fork!
+exec $DAEMON


### PR DESCRIPTION
Template config for running `collectd` as a system managed daemon using [upstart](http://upstart.ubuntu.com/cookbook/), the replacement for init.d scripts within Ubuntu, Debian, Fedora, and optionally on Suse.
