### PR TITLE
Fix memory leaks when plugin gets no results

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -403,6 +403,7 @@ static int mysql_read_master_stats (mysql_database_t *db, MYSQL *con)
 	{
 		ERROR ("mysql plugin: Failed to get master statistics: "
 				"`%s' did not return any rows.", query);
+		mysql_free_result (res);
 		return (-1);
 	}
 
@@ -411,6 +412,7 @@ static int mysql_read_master_stats (mysql_database_t *db, MYSQL *con)
 	{
 		ERROR ("mysql plugin: Failed to get master statistics: "
 				"`%s' returned less than two columns.", query);
+		mysql_free_result (res);
 		return (-1);
 	}
 
@@ -454,6 +456,7 @@ static int mysql_read_slave_stats (mysql_database_t *db, MYSQL *con)
 	{
 		ERROR ("mysql plugin: Failed to get slave statistics: "
 				"`%s' did not return any rows.", query);
+		mysql_free_result (res);
 		return (-1);
 	}
 
@@ -462,6 +465,7 @@ static int mysql_read_slave_stats (mysql_database_t *db, MYSQL *con)
 	{
 		ERROR ("mysql plugin: Failed to get slave statistics: "
 				"`%s' returned less than 33 columns.", query);
+		mysql_free_result (res);
 		return (-1);
 	}
 


### PR DESCRIPTION
The mysql plugin currently leaks memory when it's not correctly setup, which isn't desirable. Whenever you log either of these type of messages:

Feb 26 12:29:03 jslave19 collectd[24575]: mysql plugin: Failed to get master statistics: `SHOW MASTER STATUS' did not return any rows.
Feb 26 12:29:03 jslave19 collectd[24575]: mysql plugin: Failed to get slave statistics:`SHOW SLAVE STATUS' did not return any rows.

then a chunk of RAM for the MySQL result gets leaked, as per valgrind trace below
==24575== 92,840 (2,024 direct, 90,816 indirect) bytes in 11 blocks are definitely lost in loss record 747 of 752
==24575==    at 0x4C274A8: malloc (vg_replace_malloc.c:236)
==24575==    by 0x8CE15B1: my_malloc (in /usr/lib/libmysqlclient_r.so.16.0.0)
==24575==    by 0x8D0C1BC: mysql_store_result (in /usr/lib/libmysqlclient_r.so.16.0.0)
==24575==    by 0x8A8B2BA: exec_query (mysql.c:374)
==24575==    by 0x8A8C2C1: mysql_read (mysql.c:397)
==24575==    by 0x40F3F1: plugin_read_thread (plugin.c:450)
==24575==    by 0x52BE9C9: start_thread (pthread_create.c:300)
==24575==    by 0xB4E06FF: ???

This patch should fix that, freeing that memory up.
