### PR TITLE
Improve OpenVZ.pm

### DIFF
--- a/bindings/perl/lib/Collectd/Plugins/OpenVZ.pm
+++ b/bindings/perl/lib/Collectd/Plugins/OpenVZ.pm
@@ -43,7 +43,7 @@ my $enable_users     = 1;
 my @ignored_interfaces = ( "lo" );
 
 sub interface_read {
-    my ($veid, $name) = @_
+    my ($veid, $name) = @_;
     my @rx_fields = qw(if_octets if_packets if_errors drop fifo frame compressed multicast);
     my @tx_fields = qw(if_octets if_packets if_errors drop fifo frame compressed);
     my %v = _build_report_hash($name);


### PR DESCRIPTION
- Output now matches the regular interface plugin
  - before it was if_octets -> lo -> tx, now it is lo -> if_octets -> tx
- Disables CPU plugin by default, as all guests would report the same info give or take a few  milliseconds
  - with 32 core machines with 8 guests, that was a lot of duplicate data

Sample Graphite output can be seen here,
http://snag.gy/CXyUJ.jpg

Target was:
`render?from=-1h&target=test-vps_chef_blueboxgrid_com.interface.venet0.*.*&width=1200&height=800`
