### PR TITLE
Allow parsing plugin_instance in parse_option().

### DIFF
--- a/src/utils_parse_option.c
+++ b/src/utils_parse_option.c
@@ -127,7 +127,7 @@ int parse_option (char **ret_buffer, char **ret_key, char **ret_value)
 
   /* Look for the equal sign */
   buffer = key;
-  while (isalnum ((int) *buffer))
+  while (isalnum ((int) *buffer) || *buffer == '_')
     buffer++;
   if ((*buffer != '=') || (buffer == key))
     return (1);


### PR DESCRIPTION
This is used by PUTNOTIF in unixsock and exec.

isalnum() is not enough to catch the underscore.
