### PR TITLE
src/libcollectdclient/network_buffer.c check for htonll exitence

### DIFF
--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -140,6 +140,7 @@ static _Bool have_gcrypt (void) /* {{{ */
   return (1);
 } /* }}} _Bool have_gcrypt */
 
+#ifndef HAVE_HTONLL
 static uint64_t htonll (uint64_t val) /* {{{ */
 {
   static int config = 0;
@@ -169,6 +170,7 @@ static uint64_t htonll (uint64_t val) /* {{{ */
 
   return ((((uint64_t) lo) << 32) | ((uint64_t) hi));
 } /* }}} uint64_t htonll */
+#endif
 
 static double htond (double val) /* {{{ */
 {


### PR DESCRIPTION
Check for htonll exitence before defining it. I have to to this to get it compiled on AIX6. 
