### PR TITLE
Increase MAX_NUMDISKS

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -109,7 +109,7 @@ static diskstats_t *disklist;
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
-#define MAX_NUMDISK 256
+#define MAX_NUMDISK 1024
 extern kstat_ctl_t *kc;
 static kstat_t *ksp[MAX_NUMDISK];
 static int numdisk = 0;


### PR DESCRIPTION
On large systems (particularly ZFS systems using large JBODs), it's
quite possible to have more than 256 disks.
