### PR TITLE
curl_xml: Creating unique callback name fails for long URLs.

### DIFF
--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -98,6 +98,20 @@ typedef struct cx_s cx_t; /* }}} */
 /*
  * Private functions
  */
+void cx_gen_random(char *s, const int len) {/*{{{*/
+  int i;
+  static const char alphanum[] =
+    "0123456789"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz";
+
+  for (i = 0; i < len; ++i) {
+    s[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+  }
+
+  s[len] = 0;
+}/*}}}*/
+
 static size_t cx_curl_callback (void *buf, /* {{{ */
     size_t size, size_t nmemb, void *user_data)
 {
@@ -967,6 +981,7 @@ static int cx_config_add_url (oconfig_item_t *ci) /* {{{ */
   {
     user_data_t ud;
     char cb_name[DATA_MAX_NAME_LEN];
+    char cb_name_random[DATA_MAX_NAME_LEN];
 
     if (db->instance == NULL)
       db->instance = strdup("default");
@@ -978,8 +993,9 @@ static int cx_config_add_url (oconfig_item_t *ci) /* {{{ */
     ud.data = (void *) db;
     ud.free_func = cx_free;
 
+    cx_gen_random (cb_name_random, DATA_MAX_NAME_LEN);
     ssnprintf (cb_name, sizeof (cb_name), "curl_xml-%s-%s",
-               db->instance, db->url);
+               db->instance, cb_name_random);
 
     plugin_register_complex_read (/* group = */ NULL, cb_name, cx_read,
                                   /* interval = */ NULL, &ud);


### PR DESCRIPTION
Hello,

I noticed that the curl_xml plugin truncates its URLs after the 47th character. Given a set of URLs to collect the data from, for example:

```
http://www.hide.me/script/streaming/data/mobile/mobile-bigbang
http://www.hide.me/script/streaming/data/mobile/mobile-cufotv
http://www.hide.me/script/streaming/data/mobile/mobile-digiplus
```

… this appears in the collectd logfile:

```
[2013-03-08 11:26:43] [warning] The read function "curl_xml-stream-http://www.tvim.tv/script/streaming/data/mobile" is already registered. Check for duplicate "LoadPlugin" lines in your configuration!
[2013-03-08 11:26:43] [debug] curl_xml plugin: Registering new read callback: stream
[2013-03-08 11:26:43] [warning] The read function "curl_xml-stream-http://www.tvim.tv/script/streaming/data/mobile" is already registered. Check for duplicate "LoadPlugin" lines in your configuration!
[2013-03-08 11:26:43] [debug] curl_xml plugin: Registering new read callback: stream
[2013-03-08 11:26:43] [warning] The read function "curl_xml-stream-http://www.tvim.tv/script/streaming/data/mobile" is already registered. Check for duplicate "LoadPlugin" lines in your configuration!
```

I dug into the source and figured out that the name of the callback function gets constructed from the URL itself and then gets truncated to **DATA_MAX_NAME_LEN**. Since this is a show-stopper for my use case, I added some code to generate random strings and then constructed the callback name from these strings instead of the URL.

The patch is clumsy, but it works for me. PS: not sure about this but it might enable multiple fetches from the same URL too.
