### PR TITLE
Record load averages over 100

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -88,7 +88,7 @@ ipt_packets		value:DERIVE:0:U
 irq			value:DERIVE:0:U
 latency			value:GAUGE:0:65535
 links			value:GAUGE:0:U
-load			shortterm:GAUGE:0:100, midterm:GAUGE:0:100, longterm:GAUGE:0:100
+load			shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
 md_disks		value:GAUGE:0:U
 memcached_command	value:DERIVE:0:U
 memcached_connections	value:GAUGE:0:U


### PR DESCRIPTION
Currently load values are dropped when they go above 100:

![image](https://f.cloud.github.com/assets/2567/379858/17f70062-a5af-11e2-898c-ef2b11b6f4bf.png)
