### PR TITLE
Improve support for FreeBSD

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -78,6 +78,10 @@ case $host_os in
 	AC_DEFINE([KERNEL_AIX], 1, [True if program is to be compiled for a AIX kernel])
 	ac_system="AIX"
 	;;
+	*freebsd*)
+	AC_DEFINE([KERNEL_FREEBSD], 1, [True if program is to be compiled for a FreeBSD kernel])
+	ac_system="FreeBSD"
+	;;
 	*)
 	ac_system="unknown"
 esac
@@ -1361,6 +1365,8 @@ fi
 
 m4_divert_once([HELP_WITH], [
 collectd additional packages:])
+
+AM_CONDITIONAL([BUILD_FREEBSD],[test "x$x$ac_system" = "xFreeBSD"])
 
 AM_CONDITIONAL([BUILD_AIX],[test "x$x$ac_system" = "xAIX"]) 
 
@@ -4779,6 +4785,14 @@ if test "x$ac_system" = "xAIX"
 then
         plugin_tcpconns="yes"
 fi
+
+# FreeBSD
+
+if test "x$ac_system" = "xFreeBSD"
+then
+        plugin_zfs_arc="yes"
+fi
+
 
 if test "x$with_perfstat" = "xyes"
 then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1402,7 +1402,11 @@ pkglib_LTLIBRARIES += zfs_arc.la
 zfs_arc_la_SOURCES = zfs_arc.c
 zfs_arc_la_CFLAGS = $(AM_CFLAGS)
 zfs_arc_la_LDFLAGS = -module -avoid-version
+if BUILD_FREEBSD
+zfs_arc_la_LIBADD = -lm
+else
 zfs_arc_la_LIBADD = -lkstat
+endif
 collectd_LDADD += "-dlopen" zfs_arc.la
 collectd_DEPENDENCIES += zfs_arc.la
 endif


### PR DESCRIPTION
This proposed changeset adds the following:
- Support for FreeBSD ZFS ARC statistics.  On FreeBSD, there is no kstat library but the numbers are exposed via sysctl interface.  Provide code to support the FreeBSD facilities.
- Support for disk I/O data collection.  This is done by using devstat(3) library.
