### PR TITLE
Don't notify continuously when MySQL slave SQL thread is running

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -534,7 +534,7 @@ static int mysql_read_slave_stats (mysql_database_t *db, MYSQL *con)
 			ssnprintf (n.message, sizeof (n.message),
 					"slave SQL thread started");
 			plugin_dispatch_notification (&n);
-			db->slave_sql_running = 0;
+			db->slave_sql_running = 1;
 		}
 	}
 


### PR DESCRIPTION
I'm getting notified continuously when MySQL is correctly running as a slave:

```
[2013-05-29 14:22:19] Notification: severity = OKAY, host = eu1.thumbr.it, plugin = mysql, plugin_instance = thumbrit, type = time_offset, message = slave SQL thread started
[2013-05-29 14:22:29] Notification: severity = OKAY, host = eu1.thumbr.it, plugin = mysql, plugin_instance = thumbrit, type = time_offset, message = slave SQL thread started
[2013-05-29 14:22:39] Notification: severity = OKAY, host = eu1.thumbr.it, plugin = mysql, plugin_instance = thumbrit, type = time_offset, message = slave SQL thread started
[2013-05-29 14:22:49] Notification: severity = OKAY, host = eu1.thumbr.it, plugin = mysql, plugin_instance = thumbrit, type = time_offset, message = slave SQL thread started
```

I think this small patch fixes the problem. I didn't tested it yet.
