### PR TITLE
Load plugin: Reporting load relative to number of CPU cores

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -469,6 +469,11 @@
 #	InterfaceFormat name
 #</Plugin>
 
+#<Plugin load>
+#	ReportAbsoluteLoad	true
+#	ReportRelativeLoad	false
+#</Plugin>
+
 #<Plugin lpar>
 #	CpuPoolStats   false
 #	ReportBySerial false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2104,6 +2104,30 @@ interface path might change between reboots of a guest or across migrations.
 
 =back
 
+=head2 Plugin C<load>
+
+The I<Load plugin> collects the system load. These numbers give a rough overview 
+over the utilization of a machine. The system load is defined as the number of 
+runnable tasks in the run-queue and is provided by many operating systems as a 
+one, five or fifteen minute average.
+
+The following configuration options are available:
+
+=over 4
+
+=item B<ReportAbsoluteLoad> B<false>|B<true>
+
+When enabled, system load is reported for intervals 1 min, 5 min
+and 15 min.
+Defaults to true.
+
+=item B<ReportRelativeLoad> B<false>|B<true>
+
+When enabled, system load divided by number of available CPU cores is reported 
+for intervals 1 min, 5 min and 15 min. Defaults to false.
+
+=back
+
 =head2 Plugin C<logfile>
 
 =over 4

--- a/src/types.db
+++ b/src/types.db
@@ -90,6 +90,7 @@ irq			value:DERIVE:0:U
 latency			value:GAUGE:0:65535
 links			value:GAUGE:0:U
 load			shortterm:GAUGE:0:100, midterm:GAUGE:0:100, longterm:GAUGE:0:100
+load_relative		shortterm:GAUGE:0:100, midterm:GAUGE:0:100, longterm:GAUGE:0:100
 md_disks		value:GAUGE:0:U
 memcached_command	value:DERIVE:0:U
 memcached_connections	value:GAUGE:0:U


### PR DESCRIPTION
Hi,
The changes in this pull request allow options for reporting load:
- ReportAbsoluteLoad - like it was beofre (uptime style)
- ReportRelativeLoad - load divided by number of cores

Relative load is usefull in environments where collects server, or e.g. another party using rrd data from collectd server, would not know how many cores are on the collectd clients.

The patch also introduces a tiny refactoring which should help the maintenance effort.

There is also one bug fix:

``` c
@@ -95,6 +155,7 @@ static int load_read (void)
     char errbuf[1024];
     WARNING ("load: fopen: %s",
         sstrerror (errno, errbuf, sizeof (errbuf)));
+    fclose (loadavg);
     return (-1);
   }
```

Worth commenting is this:

```
+  int cores =  sysconf(_SC_NPROCESSORS_ONLN);
```

sysconf() is from glibc. More portable would be to explicitly read /proc/cpuinfo, but I was a bit in hurry.
