### PR TITLE
Unbreak type_inst value in collectd psql view.

### DIFF
--- a/contrib/postgresql/collectd_insert.sql
+++ b/contrib/postgresql/collectd_insert.sql
@@ -104,7 +104,7 @@ CREATE OR REPLACE VIEW collectd
                     WHEN type_inst IS NOT NULL THEN '-'
                     ELSE ''
                 END
-                || coalesce(plugin_inst, '') AS identifier,
+                || coalesce(type_inst, '') AS identifier,
             tstamp, name, value
         FROM identifiers
             JOIN values


### PR DESCRIPTION
There was an error in the `collectd` view where `plugin_inst` was used instead of the correct `type_inst`.
#### Before

```
collectd=# SELECT * FROM collectd LIMIT 2;
  host   | plugin | plugin_inst |   type    |       type_inst       |      identifier         |            tstamp             | name | value
---------+--------+-------------+-----------+-----------------------+-------------------------+-------------------------------+------+-------
 switch0 | snmp   |             | if_octets | GigabitEthernet1_0_22 | switch0/snmp/if_octets- | 2013-06-08 16:06:31.625519+02 | 'rx' |     0
 switch0 | snmp   |             | if_octets | GigabitEthernet1_0_22 | switch0/snmp/if_octets- | 2013-06-08 16:06:31.625519+02 | 'tx' |     0
```
#### After

```
collectd=# SELECT * FROM collectd LIMIT 2;
  host   | plugin | plugin_inst |   type    |       type_inst       |      identifier                              |            tstamp             | name | value
---------+--------+-------------+-----------+-----------------------+----------------------------------------------+-------------------------------+------+-------
 switch0 | snmp   |             | if_octets | GigabitEthernet1_0_22 | switch0/snmp/if_octets-GigabitEthernet1_0_22 | 2013-06-08 16:06:31.625519+02 | 'rx' |     0
 switch0 | snmp   |             | if_octets | GigabitEthernet1_0_22 | switch0/snmp/if_octets-GigabitEthernet1_0_22 | 2013-06-08 16:06:31.625519+02 | 'tx' |     0
```

(look at the `identifier` column)
