### PR TITLE
In decode_network_values dstype should be the ordinal value of string literal

### DIFF
--- a/contrib/collectd_network.py
+++ b/contrib/collectd_network.py
@@ -76,7 +76,7 @@ def decode_network_values(ptype, plen, buf):
     assert double.size == number.size
 
     result = []
-    for dstype in buf[header.size+short.size:off]:
+    for dstype in [ord(x) for x in buf[header.size+short.size:off]]:
         if dstype == DS_TYPE_COUNTER:
             result.append((dstype, number.unpack_from(buf, off)[0]))
             off += valskip


### PR DESCRIPTION
I tried using the python network code in contrib to receive data from collectd 5.3.0 and got an exception
arising from decode_network_values.

The problem is that the dstype comparison is actually comparing a string literal with integers to determine the data type. None matches so the code attempts to throw ValueError. There's actually a problem with that too because the exception string uses %i to include the dstype (which, as mentioned, is a string literal).

This patch sets dstype to the ordinal value of the string literal. This fixes the behaviour of the comparisons and in the exception case.
