### PR TITLE
fixes StringIO unicode handling in python 2.7

### DIFF
--- a/contrib/collectd_network.py
+++ b/contrib/collectd_network.py
@@ -17,10 +17,15 @@ Collectd network protocol implementation.
 """
 
 import socket,struct,sys
-try:
-  from io import StringIO
-except ImportError:
-  from cStringIO import StringIO
+import platform
+if platform.python_version() < '2.8.0':
+    # Python 2.7 and below io.StringIO does not like unicode
+    from StringIO import StringIO
+else:
+    try:
+      from io import StringIO
+    except ImportError:
+      from cStringIO import StringIO
 
 from datetime import datetime
 from copy import deepcopy


### PR DESCRIPTION
This patches fixes unicode handling in StringIO for python 2.7 and below. The patch causes python 2.7.x and earlier to use StringIO.StringIO instead of io.StringIO.

Test script dumping received packets using collectd_network.py generates exception under python 2.7. This is due to io.StringIO's handling of unicode.

``` python
Traceback (most recent call last):
  File "test.py", line 10, in <module>
    print x
  File "/home/else/code/collectd-5.3.0/contrib/collectd_network.py", line 219, in __str__
    return "%s %s" % (Data.__str__(self), list.__str__(self))
  File "/home/else/code/collectd-5.3.0/contrib/collectd_network.py", line 181, in __str__
    return "[%i] %s" % (self.time, self.source)
  File "/home/else/code/collectd-5.3.0/contrib/collectd_network.py", line 165, in source
    buf.write(str(self.host))
TypeError: unicode argument expected, got 'str'
```

Test script (run it and point collectd at it):

``` python
from collectd_network import *
reader = Reader()
while True:
    interpreted = reader.interpret()
    for x in interpreted:
        print x
    print '------------------------------------------'
```
