### PR TITLE
Adding support for IPMI sensor aliases and IgnoreSensorFail option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -130,6 +130,10 @@ Marco Chiappero <marco at absence.it>
  - ip6tables support in the iptables plugin.
  - openvpn plugin (support for more status file formats)
 
+Marina Zapater <marina at die.upm.es>
+ - Custom sensor naming
+ - Avoid removing sensors on failure
+
 Michael Hanselmann <public at hansmi.ch>
  - md plugin.
 

--- a/src/collectd-java.pod
+++ b/src/collectd-java.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 NAME
 
 collectd-java - Documentation of collectd's "java plugin"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -429,9 +429,10 @@
 #</Plugin>
 
 #<Plugin ipmi>
-#	Sensor "some_sensor"
-#	Sensor "another_one"
+#	Sensor "default_sensor_name"
+#	Sensor "another_default_sensor_name;custom_sensor_name"
 #	IgnoreSelected false
+#	IgnoreSensorFail false
 #	NotifySensorAdd false
 #	NotifySensorRemove true
 #	NotifySensorNotPresent false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -430,7 +430,7 @@
 
 #<Plugin ipmi>
 #	Sensor "default_sensor_name"
-#	Sensor "another_default_sensor_name;custom_sensor_name"
+#	SensorAlias "default sensor name" "sensor.name.alias"
 #	IgnoreSelected false
 #	IgnoreSensorFail false
 #	NotifySensorAdd false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 NAME
 
 collectd.conf - Configuration for the system statistics collection daemon B<collectd>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1897,8 +1897,14 @@ other interfaces are collected.
 
 Selects sensors to collect or to ignore, depending on B<IgnoreSelected>.
 
-Also, the default sensor name can be overriden with an alias given after the
-default sensor name followed by a semicolon.
+=item B<SensorAlias> I<SensorName> I<SensorNameAlias>
+
+Assigns an alias to be used instead of the default sensor name.
+
+This is very useful when adapting the default B<ipmi> sensor names (quite long
+and with spaces) to something else required by an external monitoring tool. For
+example, in B<graphite>, metric keys are recommended to have a namespacing with
+the dot as separator (I<namespace.server.servername.id>).
 
 =item B<IgnoreSelected> I<true>|I<false>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1893,9 +1893,12 @@ other interfaces are collected.
 
 =over 4
 
-=item B<Sensor> I<Sensor>
+=item B<Sensor> I<SensorName>|I<SensorName;CustomSensorName>
 
 Selects sensors to collect or to ignore, depending on B<IgnoreSelected>.
+
+Also, the default sensor name can be overriden with an alias given after the
+default sensor name followed by a semicolon.
 
 =item B<IgnoreSelected> I<true>|I<false>
 
@@ -1904,6 +1907,16 @@ sensors found of type "temperature", "voltage", "current" and "fanspeed".
 This option enables you to do that: By setting B<IgnoreSelected> to I<true>
 the effect of B<Sensor> is inverted: All selected sensors are ignored and
 all other sensors are collected.
+
+=item B<IgnoreSensorFail> I<true>|I<false>
+
+Before, the B<ipmi> plugin would remove a sensor when a single read failure
+occurred. With this option set to I<true>, the sensor won't be removed after
+failing (i.e. the B<ipmi> plugin will retry reading from the sensor the next
+time it gathers data).
+    
+By default, it's set to I<false> (i.e. removing sensors even if they fail one
+reading).
 
 =item B<NotifySensorAdd> I<true>|I<false>
 

--- a/src/collectdctl.pod
+++ b/src/collectdctl.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 NAME
 
 collectdctl - Control interface for collectd

--- a/src/common.c
+++ b/src/common.c
@@ -288,6 +288,11 @@ ssize_t swrite (int fd, const void *buf, size_t count)
 
 int strsplit (char *string, char **fields, size_t size)
 {
+    return strsplitsep (string, fields, " \t\r\n", size);
+}
+
+int strsplitsep (char *string, char **fields, const char *sep, size_t size)
+{
 	size_t i;
 	char *ptr;
 	char *saveptr;
@@ -295,7 +300,7 @@ int strsplit (char *string, char **fields, size_t size)
 	i = 0;
 	ptr = string;
 	saveptr = NULL;
-	while ((fields[i] = strtok_r (ptr, " \t\r\n", &saveptr)) != NULL)
+	while ((fields[i] = strtok_r (ptr, sep, &saveptr)) != NULL)
 	{
 		ptr = NULL;
 		i++;

--- a/src/common.h
+++ b/src/common.h
@@ -129,6 +129,29 @@ int strsplit (char *string, char **fields, size_t size);
 
 /*
  * NAME
+ *   strsplitsep
+ *
+ * DESCRIPTION
+ *   Splits a string into parts and stores pointers to the parts in `fields'.
+ *   The string with characters that act as field separators is given as an
+ *   argument (`sep').
+ *
+ * PARAMETERS
+ *   `string'      String to split. This string will be modified. `fields' will
+ *                 contain pointers to parts of this string, so free'ing it
+ *                 will destroy `fields' as well.
+ *   `fields'      Array of strings where pointers to the parts will be stored.
+ *   `sep'         String with characters that act as field separators.
+ *   `size'        Number of elements in the array. No more than `size'
+ *                 pointers will be stored in `fields'.
+ *
+ * RETURN VALUE
+ *    Returns the number of parts stored in `fields'.
+ */
+int strsplitsep (char *string, char **fields, const char *sep, size_t size);
+
+/*
+ * NAME
  *   strjoin
  *
  * DESCRIPTION

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -1069,25 +1069,46 @@ int cf_read (char *filename)
  * success. */
 int cf_util_get_string (const oconfig_item_t *ci, char **ret_string) /* {{{ */
 {
-	char *string;
-
-	if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING))
-	{
-		ERROR ("cf_util_get_string: The %s option requires "
-				"exactly one string argument.", ci->key);
-		return (-1);
-	}
-
-	string = strdup (ci->values[0].value.string);
-	if (string == NULL)
-		return (-1);
-
-	if (*ret_string != NULL)
-		sfree (*ret_string);
-	*ret_string = string;
-
-	return (0);
+    return cf_util_get_strings (ci, 1, ret_string);
 } /* }}} int cf_util_get_string */
+
+/* Assures that the config options are strings, duplicates them and returns the
+ * copies in the given string pointers. If necessary, the pointers are freed
+ * first. Returns zero upon success.
+ */
+int cf_util_get_strings (const oconfig_item_t *ci, int expected_strings, ...)
+{
+    int i;
+    va_list strings;
+
+    char *string;
+    char **ret_string;
+
+    va_start (strings, expected_strings);
+    for (i = 0; i < expected_strings; i++)
+    {
+        ret_string = va_arg (strings, char **);
+
+        if ((ci->values_num != expected_strings) || (ci->values[i].type != OCONFIG_TYPE_STRING))
+        {
+            ERROR ("cf_util_get_string(s): The %s option requires "
+                    "exactly %i string(s) argument(s).",
+                    ci->key, expected_strings);
+            return (-1);
+        }
+
+        string = strdup (ci->values[i].value.string);
+        if (string == NULL)
+            return (-1);
+
+        if (*ret_string != NULL)
+            sfree (*ret_string);
+        *ret_string = string;
+    }
+    va_end (strings);
+
+    return (0);
+}
 
 /* Assures the config option is a string and copies it to the provided buffer.
  * Assures null-termination. */

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -94,6 +94,12 @@ cdtime_t cf_get_default_interval (void);
  * success. */
 int cf_util_get_string (const oconfig_item_t *ci, char **ret_string);
 
+/* Assures that the config options are strings, duplicates them and returns the
+ * copies in the given string pointers. If necessary, the pointers are freed
+ * first. Returns zero upon success.
+ */
+int cf_util_get_strings (const oconfig_item_t *ci, int expected_strings, ...);
+
 /* Assures the config option is a string and copies it to the provided buffer.
  * Assures null-termination. */
 int cf_util_get_string_buffer (const oconfig_item_t *ci, char *buffer,

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -70,7 +70,6 @@ static _Bool c_ipmi_nofiy_add = 0;
 static _Bool c_ipmi_nofiy_remove = 0;
 static _Bool c_ipmi_nofiy_notpresent = 0;
 static _Bool c_ipmi_ignore_failed = 0;
-static _Bool c_ipmi_ignore_selected = 1;
 
 /*
  * Misc private functions
@@ -659,13 +658,19 @@ static int c_ipmi_config (oconfig_item_t *ci)
 
     if (strcasecmp ("Sensor", child->key) == 0)
     {
+      char *default_name = NULL;
+
       status = cf_util_get_string (child, &default_name);
 
       if (status == 0)
         ignorelist_add (ignorelist, default_name);
+        sfree (default_name);
     }
     else if (strcasecmp ("SensorAlias", child->key) == 0)
     {
+      char *default_name = NULL;
+      char *aliased_name = NULL;
+
       llentry_t *aliased_name_entry;
 
       status = cf_util_get_strings (child, 2, &default_name, &aliased_name);
@@ -678,10 +683,6 @@ static int c_ipmi_config (oconfig_item_t *ci)
         if (aliased_name_list != NULL)
         {
           aliased_name_entry = llentry_create (default_name, aliased_name);
-          /* NOTE: pointing the names to NULL to avoid freeing them in
-           * cf_util_get_strings!!
-           */
-          default_name = aliased_name = NULL;
 
           if (aliased_name_entry != NULL)
           {
@@ -702,9 +703,11 @@ static int c_ipmi_config (oconfig_item_t *ci)
     }
     else if (strcasecmp ("IgnoreSelected", child->key) == 0)
     {
-      status = cf_util_get_boolean (child, &c_ipmi_ignore_selected);
+      _Bool ignore_selected = 1;
+
+      status = cf_util_get_boolean (child, &ignore_selected);
       if (status == 0)
-        ignorelist_set_invert (ignorelist, !c_ipmi_ignore_selected);
+        ignorelist_set_invert (ignorelist, !ignore_selected);
     }
     else if (strcasecmp ("NotifySensorAdd", child->key) == 0)
     {


### PR DESCRIPTION
Sensor Aliases
----------------------
The IPMI plugin sets a default naming policy for sensors. This feature allows the user to override the default naming on a per-sensor basis.

To override the default sensor name simply add the custom name after the default name in the config, as follows:

    Sensor "default_sensor_name;custom_sensor_name"

Note that the `default_sensor_name` is the default name given by the IPMI plugin. At the moment, there is no easy way to know it beforehand, other than by running the IPMI plugin and checking the names it assigns to the sensors.

In the future, a helper tool should exist to list all of the available sensors with their default IPMI `default_sensor_name`.

IgnoreSensorFail option
----------------------------------
Before, the IPMI plugin would remove a sensor when a single read failure occurred. With this option set to `true`, the sensor won't be removed after failing (i.e., the IPMI plugin will retry reading from the sensor the next time it gathers data).

By default, it's set to `false`, leaving the default behavior as it was before the change (i.e. removing sensors even if they fail one reading).