### PR TITLE
Nginx accepted and handled

### DIFF
--- a/src/nginx.c
+++ b/src/nginx.c
@@ -181,9 +181,7 @@ static void submit (char *type, char *inst, long long value)
     values[0].gauge = value;
   else if (strcmp (type, "nginx_requests") == 0)
     values[0].derive = value;
-  else if (strcmp (type, "nginx_accepts") == 0)
-    values[0].derive = value;
-  else if (strcmp (type, "nginx_handled") == 0)
+  else if (strcmp (type, "connections") == 0)
     values[0].derive = value;
   else
     return;
@@ -258,8 +256,8 @@ static int nginx_read (void)
 	  && (atoll (fields[1]) != 0)
 	  && (atoll (fields[2]) != 0))
       {
-	submit ("nginx_accepts", NULL, atoll (fields[0]));
-	submit ("nginx_handled", NULL, atoll (fields[1]));
+	submit ("connections", "accepted", atoll (fields[0]));
+	submit ("connections", "handled", atoll (fields[1]));
 	submit ("nginx_requests", NULL, atoll (fields[2]));
       }
     }

--- a/src/types.db
+++ b/src/types.db
@@ -107,8 +107,6 @@ mysql_octets		rx:DERIVE:0:U, tx:DERIVE:0:U
 nfs_procedure		value:DERIVE:0:U
 nginx_connections	value:GAUGE:0:U
 nginx_requests		value:DERIVE:0:U
-nginx_accepts		value:DERIVE:0:U
-nginx_handled		value:DERIVE:0:U
 node_octets		rx:DERIVE:0:U, tx:DERIVE:0:U
 node_rssi		value:GAUGE:0:255
 node_stat		value:DERIVE:0:U


### PR DESCRIPTION
According to http://wiki.nginx.org/HttpStubStatusModule#stub_status these 2 `accepts` and `handled` values are _connections_ counters. So I changed the plugin to use the existing `connection` DS.

To sum up, we have:
- `nginx/nginx_connections-{active,reading,waiting,writing}`: connections gauges
- `nginx/nginx_requests`: requests counter
- `nginx/connections-{accepted,handled}`: connections counters

(I also rebased the patch from #227 on current master)

@octo & @patrickshan, what do you think ?
