### PR TITLE
lvm: add VG totals + instance name reorganisation

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -50,7 +50,8 @@ static int vg_read(vg_t vg, char const *vg_name)
     struct dm_list *lvs;
     struct lvm_lv_list *lvl;
 
-    lvm_submit (vg_name, "free", lvm_vg_get_free_size(vg));
+    lvm_submit ("free_size", vg_name, lvm_vg_get_free_size(vg));
+    lvm_submit ("total_size", vg_name, lvm_vg_get_size(vg));
 
     lvs = lvm_vg_list_lvs(vg);
     dm_list_iterate_items(lvl, lvs) {


### PR DESCRIPTION
- avoid risking a name conflict if one of the LVs is named "free"
- add total VG size(s)
