### PR TITLE
On error, write error to client handle, and to thread local storage

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -131,6 +131,22 @@ then
 fi
 AM_CONDITIONAL(BUILD_FEATURE_STANDARDS, test "x$enable_standards" = "xyes")
 
+AC_MSG_CHECKING(for __thread support in compiler)
+AC_RUN_IFELSE(
+	[AC_LANG_SOURCE(
+	[[
+		static __thread int val;
+		int main(int argc, char **argv) {
+			val = 0;
+			return val;
+		}
+	]])
+	],[have_tls=yes],[have_tls=no],[have_tls=no])
+AC_MSG_RESULT($have_tls)
+if test "x$have_tls" = "xyes"; then
+	AC_DEFINE([HAVE_THREAD_TLS],[1],[Define if the compiler supports __thread])
+fi
+
 #
 # Checks for header files.
 #


### PR DESCRIPTION
As mentioned in #382 client handle errbuf is freed before the caller gets a chance to look at it.

There is no standard for thread local storage in C, though the major compilers GCC, clang and visual studio all have support.

It is possible to add TLS support by using the pthread functions, but to be honest, it's sort of a PITA and probably not worth it for something so trivial.
