### PR TITLE
csv plugin: fix forgotten "datadir" in re-implement value_list_to_filena...

### DIFF
--- a/src/csv.c
+++ b/src/csv.c
@@ -215,7 +215,10 @@ static int csv_config (const char *key, const char *value)
 	if (strcasecmp ("DataDir", key) == 0)
 	{
 		if (datadir != NULL)
+		{
 			free (datadir);
+			datadir = NULL;
+		}
 		if (strcasecmp ("stdout", value) == 0)
 		{
 			use_stdio = 1;


### PR DESCRIPTION
In the commit 7f90e30 the re-implementation of value_list_to_filename forgot to prepend the datadir string.

Even if you put:

```
 DataDir "/var/lib/collectd/cvs"
```

in csv plugin config
you will get files like:

```
/var/lib/collectd/localhost/load/load-2013-08-06
```

instead

```
/var/lib/collectd/csv/localhost/load/load-2013-08-06
```

Notice that you are writing in basedir "/var/lib/collectd"
The version 5.3.1 is affected.
