### PR TITLE
rrdtool plugin: fix forgotten "datadir" in re-implement of value_list_to...

### DIFF
--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -251,6 +251,18 @@ static int value_list_to_filename (char *buffer, size_t buffer_size,
 	int status;
 	size_t len;
 
+	if (datadir != NULL)
+	{
+		size_t len = strlen (datadir) + 1;
+		if (len >= buffer_size)
+			return (ENOBUFS);
+
+		memcpy (buffer, datadir, len);
+		buffer[len-1] = '/';
+		buffer += len;
+		buffer_size -= len;
+	}
+
 	status = FORMAT_VL (buffer, buffer_size, vl);
 	if (status != 0)
 		return (status);


### PR DESCRIPTION
In the commit bfd3f06 the re-implementation of value_list_to_filename forgot to prepend the datadir string.

Is the same case of csv plugin.

The version 5.3.1 is affected
