### PR TITLE
memcached plugin: actually connect when using a unix socket

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -84,6 +84,15 @@ static int memcached_connect_unix (memcached_t *st)
     return (-1);
   }
 
+  /* connect to the memcached daemon */
+  int status = connect (fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+  if (status != 0)
+  {
+      shutdown (fd, SHUT_RDWR);
+      close (fd);
+      fd = -1;
+  }
+
   return (fd);
 } /* int memcached_connect_unix */
 


### PR DESCRIPTION
It looks like someone created the sockadd_un, but just forgot to connect(2).
