### PR TITLE
perl plugin: #undef macros before poisoning them.

### DIFF
--- a/src/perl.c
+++ b/src/perl.c
@@ -41,6 +41,7 @@
 #include <perl.h>
 
 #if defined(COLLECT_DEBUG) && COLLECT_DEBUG && defined(__GNUC__) && __GNUC__
+# undef sprintf
 # pragma GCC poison sprintf
 #endif
 


### PR DESCRIPTION
This fixes --enable-debug builds.
