### PR TITLE
curl_json plugin: avoid accessing off the end of the avl_tree_s

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -48,10 +48,10 @@ struct cj_key_s;
 typedef struct cj_key_s cj_key_t;
 struct cj_key_s /* {{{ */
 {
+  unsigned long magic;
   char *path;
   char *type;
   char *instance;
-  unsigned long magic;
 };
 /* }}} */
 


### PR DESCRIPTION
It's not written this way, but really we have a union { *key; *tree; }
which is differentiated by checking for the presence a magic field
which only exists in key.  This leads to accesses off the end of the
tree.  Putting the magic at start of the key avoids this.
