### PR TITLE
statsd plugin: measure latency min, max, sum and count

### DIFF
--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -117,6 +117,13 @@ cdtime_t latency_counter_get_sum (latency_counter_t *lc) /* {{{ */
   return (lc->sum);
 } /* }}} cdtime_t latency_counter_get_sum */
 
+size_t latency_counter_get_num (latency_counter_t *lc) /* {{{ */
+{
+  if (lc == NULL)
+    return (0);
+  return (lc->num);
+} /* }}} size_t latency_counter_get_num */
+
 cdtime_t latency_counter_get_average (latency_counter_t *lc) /* {{{ */
 {
   double average;

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -39,6 +39,7 @@ void latency_counter_reset (latency_counter_t *lc);
 cdtime_t latency_counter_get_min (latency_counter_t *lc);
 cdtime_t latency_counter_get_max (latency_counter_t *lc);
 cdtime_t latency_counter_get_sum (latency_counter_t *lc);
+size_t   latency_counter_get_num (latency_counter_t *lc);
 cdtime_t latency_counter_get_average (latency_counter_t *lc);
 cdtime_t latency_counter_get_percentile (latency_counter_t *lc,
     double percent);


### PR DESCRIPTION
This implements part of the feature request I opened earlier (#402).
