### PR TITLE
curl_json plugin: avoid cache aliasing by using all fields instead of just two

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -749,11 +749,10 @@ static void cj_submit (cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
 
   if (key->instance == NULL)
   {
-    if ((db->depth == 0) || (strcmp ("", db->state[db->depth-1].name) == 0))
-      sstrncpy (vl.type_instance, db->state[db->depth].name, sizeof (vl.type_instance));
-    else
-      ssnprintf (vl.type_instance, sizeof (vl.type_instance), "%s-%s",
-          db->state[db->depth-1].name, db->state[db->depth].name);
+    int i, len = 0;
+    for (i = 0; i < db->depth; i++)
+      len += ssnprintf(vl.type_instance+len, sizeof(vl.type_instance)-len,
+                       i ? "-%s" : "%s", db->state[i+1].name);
   }
   else
     sstrncpy (vl.type_instance, key->instance, sizeof (vl.type_instance));


### PR DESCRIPTION
The following two keys

  Key workers/_/requests
  Key workers/_/apps/*/requests

can both lead to type_instance's of say

  0-requests

which would alias in the cache.  If, instead of just the final two key
name components, we use all of them it would lead to these

  Key workers-0-requests
  Key workers-0-apps-0-requests

which would not overlap.
