### PR TITLE
curl_json plugin: don't complain about not finding expected maps in arrays

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -229,7 +229,7 @@ static int cj_cb_number (void *ctx,
   buffer[sizeof (buffer) - 1] = 0;
 
   if ((key == NULL) || !CJ_IS_KEY (key)) {
-    if (key != NULL)
+    if (key != NULL && !db->state[db->depth].in_array/*can be inhomogeneous*/)
       NOTICE ("curl_json plugin: Found \"%s\", but the configuration expects"
               " a map.", buffer);
     cj_cb_inc_array_index (ctx, /* update_key = */ 0);


### PR DESCRIPTION
JSON arrays may have mixed maps and scalars.  I'm looking at you Solr which has crap like this,

   [ "CORE", {}, "QUERYHANDLER", {}]

which obviously should be a map though is not technically invalid, so we should support it without complaint.
