### PR TITLE
cgroup plugin: issue parsing cpuacct.stat on some kernels

### DIFF
--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -93,7 +93,7 @@ static int read_cpuacct_procs (const char *dirname, char const *cgroup_name,
 	if (fh == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("cgroups pluign: fopen (\"%s\") failed: %s",
+		ERROR ("cgroups plugin: fopen (\"%s\") failed: %s",
 				abs_path,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);


### PR DESCRIPTION
Out of curiosity @octo, do you remember what kernel version you were using when you wrote 281456ffd ?

From what I understand of f19f64d58, the initial code didn't check for a colon character.
