### PR TITLE
version-gen.sh: Ensure only collectd repository versions are used

### DIFF
--- a/version-gen.sh
+++ b/version-gen.sh
@@ -2,7 +2,7 @@
 
 DEFAULT_VERSION="5.4.0.git"
 
-VERSION="`git describe 2> /dev/null | sed -e 's/^collectd-//'`"
+VERSION="`git describe 2> /dev/null | grep collectd | sed -e 's/^collectd-//'`"
 
 if test -z "$VERSION"; then
 	VERSION="$DEFAULT_VERSION"


### PR DESCRIPTION
When cross compiling in hosted environments using RPM,
the extracted tar-ball can be located in a parent .git repository.

The version-gen.sh script will then take the version number from
this repository as if it represents collectd.

This can be even more erroneous when the version returned is non
numerical and breaks the build

Signed-off-by: Kieran Bingham kieran.bingham@st.com
