### PR TITLE
graphite-write: by default UDP is chosen as protocoll - when outputting ...

### DIFF
--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -131,12 +131,7 @@ static int wg_send_buffer (struct wg_callback *cb)
     if (cb->log_send_errors && status < 0)
     {
         char errbuf[1024];
-	const char *protocol;
-	
-	if (cb->protocol != NULL)
-		protocol = cb->protocol;
-	else
-		protocol = "UDP";
+	const char *protocol = cb->protocol ? cb->protocol : WG_DEFAULT_PROTOCOL;
 
         ERROR ("write_graphite plugin: send to %s:%s (%s) failed with status %zi (%s)",
                 cb->node, cb->service, protocol,


### PR DESCRIPTION
...error message do this instead of putting NULL as %s argument
