### PR TITLE
per-url intervals for curl_json

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1156,12 +1156,23 @@ The following options are valid within B<URL> blocks:
 
 Sets the plugin instance to I<Instance>.
 
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which the values will be collected from this
+URL. By default the global B<Interval> setting will be used.
+
 =item B<User> I<Name>
+
 =item B<Password> I<Password>
+
 =item B<VerifyPeer> B<true>|B<false>
+
 =item B<VerifyHost> B<true>|B<false>
+
 =item B<CACert> I<file>
+
 =item B<Header> I<Header>
+
 =item B<Post> I<Body>
 
 These options behave exactly equivalent to the appropriate options of the

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -76,6 +76,7 @@ struct cj_s /* {{{ */
   char *cacert;
   struct curl_slist *headers;
   char *post_body;
+  cdtime_t interval;
 
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];
@@ -687,6 +688,8 @@ static int cj_config_add_url (oconfig_item_t *ci) /* {{{ */
       status = cf_util_get_string (child, &db->post_body);
     else if (strcasecmp ("Key", child->key) == 0)
       status = cj_config_add_key (db, child);
+    else if (strcasecmp ("Interval", child->key) == 0)
+      status = cf_util_get_cdtime(child, &db->interval);
     else
     {
       WARNING ("curl_json plugin: Option `%s' not allowed here.", child->key);
@@ -714,6 +717,9 @@ static int cj_config_add_url (oconfig_item_t *ci) /* {{{ */
   {
     user_data_t ud;
     char cb_name[DATA_MAX_NAME_LEN];
+    struct timespec interval = { 0, 0 };
+
+    CDTIME_T_TO_TIMESPEC (db->interval, &interval);
 
     if (db->instance == NULL)
       db->instance = strdup("default");
@@ -729,7 +735,8 @@ static int cj_config_add_url (oconfig_item_t *ci) /* {{{ */
                db->instance, db->url ? db->url : db->sock);
 
     plugin_register_complex_read (/* group = */ NULL, cb_name, cj_read,
-                                  /* interval = */ NULL, &ud);
+                                  /* interval = */ (db->interval > 0) ? &interval : NULL,
+                                  &ud);
   }
   else
   {
@@ -812,6 +819,9 @@ static void cj_submit (cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
   sstrncpy (vl.plugin, "curl_json", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, db->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, key->type, sizeof (vl.type));
+
+  if (db->interval > 0)
+    vl.interval = db->interval;
 
   plugin_dispatch_values (&vl);
 } /* }}} int cj_submit */


### PR DESCRIPTION
This change allows to configure per-url interval in curl_json plugin. (Particular use case was capturing data from rate limited 3rd party service).
