### PR TITLE
Fix handling of 127.0.0.1 instead of localhost for *sql plugins

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -287,6 +287,7 @@ static void set_host (mysql_database_t *db, char *buf, size_t buflen)
 {
 	if ((db->host == NULL)
 			|| (strcmp ("", db->host) == 0)
+			|| (strcmp ("127.0.0.1", db->host) == 0)
 			|| (strcmp ("localhost", db->host) == 0))
 		sstrncpy (buf, hostname_g, buflen);
 	else

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -571,6 +571,7 @@ static int c_psql_exec_query (c_psql_database_t *db, udb_query_t *q,
 	}
 
 	if (C_PSQL_IS_UNIX_DOMAIN_SOCKET (db->host)
+			|| (0 == strcmp (db->host, "127.0.0.1"))
 			|| (0 == strcmp (db->host, "localhost")))
 		host = hostname_g;
 	else


### PR DESCRIPTION
The mysql and postgresql plugins have special handling if you use localhost as your hostname.  Sometimes you need to use 127.0.0.1 instead and want to not have that make changes to the hostname for the metrics.
