### PR TITLE
Add a JMXProvider Class Loader to be able to load Provider using

### DIFF
--- a/bindings/java/org/collectd/java/GenericJMXConfConnection.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfConnection.java
@@ -118,6 +118,7 @@ private void connect () /* {{{ */
 
     environment = new HashMap ();
     environment.put (JMXConnector.CREDENTIALS, credentials);
+    environment.put(JMXConnectorFactory.PROTOCOL_PROVIDER_CLASS_LOADER, this.getClass().getClassLoader());
   }
 
   try


### PR DESCRIPTION
In JMXConnectorFactory, there are two methods to get a JMXConnectorProvider to have non-standard protocol working with JMX:
- Having a ClientProvider Class that's implementing JMXConnectorProvider. In this case, setting the jmx.remote.protocol.provider.pkgs should work.
- Having a Class that's implementing JMXConnectorProvider. In this case, a provider class loader needs to be set to have the getConnectorAsService from JMXConnectorFactory to be called.

In JMXConnectorFactory, there is a block of code in resolveClassLoader method that's searching the ClassLoader from the CurrentThread if none is set : Thread.currentThread().getContextClassLoader().

In collectd, this method returns null. I stop my investigation after reading this thread : http://stackoverflow.com/questions/225594/thread-getcontextclassloader-null . The alternative is to set a ClassLoader in the environment.

In this patch, I set jmx.remote.protocol.provider.class.loader to the current class loader in the environment that's sending to JMXConnectorFactory.connect to have one ClassLoader.
