### PR TITLE
Add target_concat plugin

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5179,6 +5179,7 @@ AC_PLUGIN([target_notification], [yes],        [The notification target])
 AC_PLUGIN([target_replace], [yes],             [The replace target])
 AC_PLUGIN([target_scale],[yes],                [The scale target])
 AC_PLUGIN([target_set],  [yes],                [The set target])
+AC_PLUGIN([target_concat], [yes],              [The concat target])
 AC_PLUGIN([target_v5upgrade], [yes],           [The v5upgrade target])
 AC_PLUGIN([tcpconns],    [$plugin_tcpconns],   [TCP connection statistics])
 AC_PLUGIN([teamspeak2],  [yes],                [TeamSpeak2 server statistics])
@@ -5522,6 +5523,7 @@ Configuration:
     target_scale  . . . . $enable_target_scale
     target_set  . . . . . $enable_target_set
     target_v5upgrade  . . $enable_target_v5upgrade
+    target_concat . . . . $enable_target_concat
     tcpconns  . . . . . . $enable_tcpconns
     teamspeak2  . . . . . $enable_teamspeak2
     ted . . . . . . . . . $enable_ted

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1183,6 +1183,14 @@ collectd_LDADD += "-dlopen" target_replace.la
 collectd_DEPENDENCIES += target_replace.la
 endif
 
+if BUILD_PLUGIN_TARGET_CONCAT
+pkglib_LTLIBRARIES += target_concat.la
+target_concat_la_SOURCES = target_concat.c
+target_concat_la_LDFLAGS = -module -avoid-version
+collectd_LDADD += "-dlopen" target_concat.la
+collectd_DEPENDENCIES += target_concat.la
+endif
+
 if BUILD_PLUGIN_TARGET_SCALE
 pkglib_LTLIBRARIES += target_scale.la
 target_scale_la_SOURCES = target_scale.c

--- a/src/target_concat.c
+++ b/src/target_concat.c
@@ -1,0 +1,64 @@
+/**
+ * collectd - src/target_concat.c
+ * Copyright (C) 2013  Savoir-faire Linux Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; only version 2 of the License is applicable.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   Philippe Proulx <philippe.proulx@savoirfairelinux.com>
+ **/
+#include "collectd.h"
+#include "common.h"
+#include "filter_chain.h"
+
+static int tr_destroy (void **user_data) /* {{{ */
+{
+  return (0);
+} /* }}} int tr_destroy */
+
+static int tr_create (const oconfig_item_t *ci, void **user_data) /* {{{ */
+{
+  return 0;
+} /* }}} int tr_create */
+
+static int tr_invoke (const data_set_t *ds, value_list_t *vl, /* {{{ */
+    notification_meta_t __attribute__((unused)) **meta, void **user_data)
+{
+  if ((ds == NULL) || (vl == NULL))
+    return (-EINVAL);
+
+  if (strlen(vl->plugin_instance) > 0) {
+    /* concatenate plugin instance to type instance */
+    strcat(vl->type, "-");
+    strcat(vl->type, vl->plugin_instance);
+
+    /* normalize plugin instance */
+    strcpy(vl->plugin_instance, "");
+  }
+
+  return (FC_TARGET_CONTINUE);
+} /* }}} int tr_invoke */
+
+void module_register (void)
+{
+	target_proc_t tproc;
+
+	memset (&tproc, 0, sizeof (tproc));
+	tproc.create  = tr_create;
+	tproc.destroy = tr_destroy;
+	tproc.invoke  = tr_invoke;
+	fc_register_target ("concat", tproc);
+} /* module_register */
+
+/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */


### PR DESCRIPTION
Hello  !

We made a new target to merge/concat plugin instances.
With this : 

```
<Chain "PreCache">
  <Rule "merge_cpu" >
    <Match "regex">
      Plugin "^cpu$"
      TypeInstance "idle|system"
    </Match>
    <Target "concat">
    </Target>
    Target return
  </Rule>
  Target stop
</Chain>
```

You can transform this :
1383922533.751 tcohen-pc.mtl.sfl/cpu-0/cpu-idle value=6.999575e+01
1383922533.751 tcohen-pc.mtl.sfl/cpu-0/cpu-system value=4.999696e+00
1383922533.751 tcohen-pc.mtl.sfl/cpu-1/cpu-idle value=9.299431e+01
1383922533.751 tcohen-pc.mtl.sfl/cpu-1/cpu-system value=0.000000e+00

to this : 
1383922533.751 tcohen-pc.mtl.sfl/cpu/cpu-0-idle value=6.999575e+01
1383922533.751 tcohen-pc.mtl.sfl/cpu/cpu-0-system value=4.999696e+00
1383922533.751 tcohen-pc.mtl.sfl/cpu/cpu-1-idle value=9.299431e+01
1383922533.751 tcohen-pc.mtl.sfl/cpu/cpu-1-system value=0.000000e+00
