### PR TITLE
Increase cache_size upper limit to match the memory upper limit.

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -12,7 +12,7 @@ cache_eviction		value:DERIVE:0:U
 cache_operation		value:DERIVE:0:U
 cache_ratio		value:GAUGE:0:100
 cache_result		value:DERIVE:0:U
-cache_size		value:GAUGE:0:4294967295
+cache_size		value:GAUGE:0:281474976710656
 charge			value:GAUGE:0:U
 compression_ratio	value:GAUGE:0:2
 compression		uncompressed:DERIVE:0:U, compressed:DERIVE:0:U


### PR DESCRIPTION
The current limit (4GB) is too small. The ZFS ARC size on my NAS is ~10GB and collectd is recording it as NaN.
