### PR TITLE
collection3: Fix data source names

### DIFF
--- a/contrib/collection3/etc/collection.conf
+++ b/contrib/collection3/etc/collection.conf
@@ -3,7 +3,7 @@ GraphWidth 400
 #UnixSockAddr "/var/run/collectd-unixsock"
 <Type apache_bytes>
   DataSources value
-  DSName "count Bytes/s"
+  DSName "value Bytes/s"
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Bytes/s"
   RRDFormat "%5.1lf%s"
@@ -11,7 +11,7 @@ GraphWidth 400
 </Type>
 <Type apache_requests>
   DataSources value
-  DSName "count Requests/s"
+  DSName "value Requests/s"
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Requests/s"
   RRDFormat "%5.2lf"
@@ -246,14 +246,14 @@ GraphWidth 400
 </Type>
 <Type conntrack>
   DataSources value
-  DSName conntrack Conntrack count
+  DSName value Conntrack count
   RRDTitle "nf_conntrack connections on {hostname}"
   RRDVerticalLabel "Count"
   RRDFormat "%4.0lf"
 </Type>
 <Type entropy>
   DataSources value
-  DSName entropy Entropy bits
+  DSName value Entropy bits
   RRDTitle "Available entropy on {hostname}"
   RRDVerticalLabel "Bits"
   RRDFormat "%4.0lf"
@@ -268,7 +268,7 @@ GraphWidth 400
 </Type>
 <Type frequency>
   DataSources value
-  DSName frequency Frequency
+  DSName value Frequency
   RRDTitle "Frequency ({type_instance})"
   RRDVerticalLabel "Hertz"
   RRDFormat "%4.1lfHz"
@@ -543,7 +543,7 @@ GraphWidth 400
 </Type>
 <Type percent>
   DataSources value
-  DSName percent Percent
+  DSName value Percent
   RRDTitle "Percent ({type_instance})"
   RRDVerticalLabel "Percent"
   RRDFormat "%4.1lf%%"
@@ -551,7 +551,7 @@ GraphWidth 400
 </Type>
 <Type ping>
   DataSources value
-  DSName "ping Latency"
+  DSName "value Latency"
   RRDTitle "Network latency ({type_instance})"
   RRDVerticalLabel "Milliseconds"
   RRDFormat "%5.2lfms"
@@ -701,7 +701,7 @@ GraphWidth 400
 </Type>
 <Type users>
   DataSources value
-  DSName users Users
+  DSName value Users
   RRDTitle "Users ({type_instance}) on {hostname}"
   RRDVerticalLabel "Users"
   RRDFormat "%.1lf"


### PR DESCRIPTION
Data sources were renamed in 6c1415d, but the data source names for some
of these entries still referenced the old data sources.
