### PR TITLE
curl_json, curl_xml: Fix unitialized variable

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -858,17 +858,17 @@ static int cj_curl_perform(cj_t *db) /* {{{ */
   int status;
   long rc;
   char *url;
-  url = NULL;
-  curl_easy_getinfo(db->curl, CURLINFO_EFFECTIVE_URL, &url);
+  url = db->url;
 
   status = curl_easy_perform (db->curl);
   if (status != CURLE_OK)
   {
     ERROR ("curl_json plugin: curl_easy_perform failed with status %i: %s (%s)",
-           status, db->curl_errbuf, (url != NULL) ? url : "<null>");
+           status, db->curl_errbuf, url);
     return (-1);
   }
 
+  curl_easy_getinfo(db->curl, CURLINFO_EFFECTIVE_URL, &url);
   curl_easy_getinfo(db->curl, CURLINFO_RESPONSE_CODE, &rc);
 
   /* The response code is zero if a non-HTTP transport was used. */

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -608,6 +608,7 @@ static int cx_curl_perform (cx_t *db, CURL *curl) /* {{{ */
   long rc;
   char *ptr;
   char *url;
+  url = db->url;
 
   db->buffer_fill = 0; 
   status = curl_easy_perform (curl);


### PR DESCRIPTION
The variable url is used unintialized here. The code used to be the same
in both plugins, but diverged in 19808b44. The solution applied there
does not work correctly as the effective URL can only be queried after
performing the request. Instead, just use the original request URL.
