### PR TITLE
Fix issue #430 where write_graphite fails to reconnect

### DIFF
--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -128,13 +128,15 @@ static int wg_send_buffer (struct wg_callback *cb)
     ssize_t status = 0;
 
     status = swrite (cb->sock_fd, cb->send_buf, strlen (cb->send_buf));
-    if (cb->log_send_errors && status < 0)
+    if (status < 0)
     {
-        char errbuf[1024];
-        ERROR ("write_graphite plugin: send to %s:%s (%s) failed with status %zi (%s)",
-                cb->node, cb->service, cb->protocol,
-                status, sstrerror (errno, errbuf, sizeof (errbuf)));
-
+        if (cb->log_send_errors)
+        {
+            char errbuf[1024];
+            ERROR ("write_graphite plugin: send to %s:%s (%s) failed with status %zi (%s)",
+                    cb->node, cb->service, cb->protocol,
+                    status, sstrerror (errno, errbuf, sizeof (errbuf)));
+        }
 
         close (cb->sock_fd);
         cb->sock_fd = -1;


### PR DESCRIPTION
If LogSendErrors is set to false and protocol is tcp, the socket file descriptor was not getting reset to -1, and thus the tcp connection is never re-established if the remote end goes away. This pull requests fixes that problem, as described in issue #430 
