### PR TITLE
src/network.c: Allow automatic flushing of "old" data.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -660,6 +660,7 @@
 #		AuthFile "/etc/collectd/passwd"
 #		Interface "eth0"
 #	</Listen>
+#	MaxAge 0
 #	MaxPacketSize 1024
 #
 #	# proxy setup (client and server as above):

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3585,6 +3585,12 @@ multicast, and IPv4 and IPv6 packets. The default is to not change this value.
 That means that multicast packets will be sent with a TTL of C<1> (one) on most
 operating systems.
 
+=item B<MaxAge> I<Milliseconds>
+
+Automatically flush the data accumulation buffer when new data is appended and
+the oldest data in the buffer is older then the maximum age. Set to zero to
+disable time based flushing (this is the default).
+
 =item B<MaxPacketSize> I<1024-65535>
 
 Set the maximum size for datagrams received over the network. Packets larger


### PR DESCRIPTION
Introduces a MaxAge configuration option to the network plugin. This
results in the accumulated data being evicted if it is older than
the maximum age.

This is useful for "slow" data sources.

Change-Id: I0af319d7d9e7350bed3e218c7e0a69bd099815c0
Signed-off-by: Daniel THOMPSON daniel.thompson@st.com
