### PR TITLE
Use the canonical hostname instead of the usual short hostname.

### DIFF
--- a/bindings/java/org/collectd/java/GenericJMXConfConnection.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfConnection.java
@@ -89,7 +89,7 @@ class GenericJMXConfConnection
     try
     {
       InetAddress localHost = InetAddress.getLocalHost();
-      return (localHost.getHostName ());
+      return (localHost.getCanonicalHostName ());
     }
     catch (UnknownHostException e)
     {


### PR DESCRIPTION
Since the default value for FQDNLookup setting is true, the GenericJMX
plugin should use the canonical hostname by default as well. Although, the C code does make
a check for whether the FQDNLookup is turned on or not and accordingly sets
the hostname. I am not sure how the global configuration properties can
be accessed in Java plugins. Any pointers would be appreciated, so that
I can provide a proper fix.
