### PR TITLE
Support specifying file owner/group when creating RRD files with rrdcached

### DIFF
--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -716,6 +716,18 @@ int cu_rrd_create_file (const char *filename, /* {{{ */
       DEBUG ("cu_rrd_create_file: Successfully created RRD file \"%s\".",
           filename);
     }
+
+    if (cfg->file_uid != -1 || cfg->file_gid != -1)
+    {
+      status = chown(filename, cfg->file_uid, cfg->file_gid);
+      if (status != 0)
+      {
+        char errbuf[1024];
+        WARNING ("cu_rrd_create_file: cannot chown (%s) to %i:%i: %s.",
+            filename, cfg->file_uid, cfg->file_gid,
+            sstrerror( errno, errbuf, sizeof (errbuf)));
+      }
+    }
   }
 
   free (argv);

--- a/src/utils_rrdcreate.h
+++ b/src/utils_rrdcreate.h
@@ -40,6 +40,8 @@ struct rrdcreate_config_s
   size_t consolidation_functions_num;
 
   _Bool async;
+  int file_uid;
+  int file_gid;
 };
 typedef struct rrdcreate_config_s rrdcreate_config_t;
 


### PR DESCRIPTION
This is needed to support the use case where rrdcached runs as a dedicated user while collectd runs as root.

Nope, this doesn't handle the created directories. There's no sane way to do this without modifying rrd, AFAIK.
