### PR TITLE
Wrong number of brakets in htonll test in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1222,16 +1222,16 @@ AC_MSG_CHECKING([if have htonll defined])
 
     have_htonll="no"
     AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
+[[
 #include <sys/types.h>
 #include <netinet/in.h>
 #if HAVE_INTTYPES_H
 # include <inttypes.h>
 #endif
-]]],
-[[[
+]],
+[[
           return htonll(0);
-]]]
+]]
     )],
     [
       have_htonll="yes"


### PR DESCRIPTION
When compile collectd in AIX htonll is defined, so the check in configure must work to detect this.

There is a problem with the brackets, in config.log:

```
configure:18335: checking if have htonll defined
configure:18359: /home/manuellsr/collectd-5.4.1/libltdl/config/compile gcc -o conftest -maix64 -D_THREAD_SAFE_ERRNO  -Wl,-brtl conftest.c  >&5
conftest.c:139:1: error: expected identifier or '(' before '[' token
conftest.c:145:1: error: expected identifier or '(' before ']' token
configure:18359: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "collectd"


| #define HAVE_ONE_GETMNTENT 1
| /* end confdefs.h.  */
| [
| #include <sys/types.h>
| #include <netinet/in.h>
| #if HAVE_INTTYPES_H
| # include <inttypes.h>
| #endif
| ]
| int
| main ()
| {
| [
|           return htonll(0);
| ]
|
|   ;
|   return 0;
| }
```

Autoconf generate a pair of [ and ] in c check in configure:

```
# Check for htonll
{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if have htonll defined" >&5
$as_echo_n "checking if have htonll defined... " >&6; }

    have_htonll="no"
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
/* end confdefs.h.  */
[ 
#include <sys/types.h>
#include <netinet/in.h>
#if HAVE_INTTYPES_H
# include <inttypes.h>
#endif
]
int
main ()
{
[
          return htonll(0);
]   

  ;
  return 0;
} 
```
