### PR TITLE
Link collectd-tg with pthreads

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,6 +129,9 @@ endif
 if BUILD_AIX
 collectd_tg_LDADD += -lm
 endif
+if BUILD_WITH_LIBPTHREAD
+collectd_tg_LDADD += -lpthread
+endif
 collectd_tg_LDADD += libcollectdclient/libcollectdclient.la
 collectd_tg_DEPENDENCIES = libcollectdclient/libcollectdclient.la
 


### PR DESCRIPTION
collectd-tg link with utils_heap.c that uses pthread_mutex, in Linux seems to be macros
but in AIX they aren't.

    CCLD   collectd-tg
    ld: 0711-317 ERROR: Undefined symbol: .pthread_mutex_init
    ld: 0711-317 ERROR: Undefined symbol: .pthread_mutex_destroy
    ld: 0711-317 ERROR: Undefined symbol: .pthread_mutex_lock
    ld: 0711-317 ERROR: Undefined symbol: .pthread_mutex_unlock
    ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
    collect2: error: ld returned 8 exit status
    make: 1254-004 The error code from the last command is 1.
