### PR TITLE
Fix tcp state names in AIX to be like others.

### DIFF
--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -215,13 +215,13 @@ static const char *tcp_state[] =
   "CLOSED",
   "LISTEN",
   "SYN_SENT",
-  "SYN_RCVD",
+  "SYN_RECV",
   "ESTABLISHED",
   "CLOSE_WAIT",
-  "FIN_WAIT_1",
+  "FIN_WAIT1",
   "CLOSING",
   "LAST_ACK",
-  "FIN_WAIT_2",
+  "FIN_WAIT2",
   "TIME_WAIT"
 };
 


### PR DESCRIPTION
The names of the tcp states in AIX were copied from the defined in includes, it doesn't match
the names of tcp states in the other systems.

It is a headache to generate graphs
