### PR TITLE
Discuss the possibility of naming threads.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1349,6 +1349,48 @@ AC_CHECK_MEMBERS([kstat_io_t.nwritten, kstat_io_t.writes, kstat_io_t.nwrites, ks
 #endif
 	])
 
+# check for pthread_setname_np
+SAVE_LDFLAGS=$LDFLAGS
+LDFLAGS="$LDFLAGS -lpthread"
+
+AC_MSG_CHECKING([if have pthread_setname_np])
+	have_pthread_setname_np="no"
+	AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+#if HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+]],
+[[
+        pthread_setname_np(pthread_self(), "conftest");
+]]
+	)], [
+		have_pthread_setname_np="yes"
+		AC_DEFINE(HAVE_PTHREAD_SETNAME_NP, 1, [ pthread_setname_np() is available.])
+	])
+
+AC_MSG_RESULT([$have_pthread_set_name_np])
+
+# check for pthread_set_name_np
+AC_MSG_CHECKING([if have pthread_set_name_np])
+	have_pthread_set_name_np="no"
+	AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+#if HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+]],
+[[
+        pthread_set_name_np(pthread_self(), "conftest");
+]]
+	)], [
+		have_pthread_set_name_np="yes"
+		AC_DEFINE(HAVE_PTHREAD_SET_NAME_NP, 1, [ pthread_set_name_np() is available.])
+	])
+AC_MSG_RESULT([$have_pthread_set_name_np])
+
+LDFLAGS=$SAVE_LDFLAGS
+
 #
 # Checks for libraries begin here
 #

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -674,7 +674,7 @@ static int camqp_subscribe_init (camqp_config_t *conf) /* {{{ */
     memset (tmp, 0, sizeof (*tmp));
 
     status = plugin_thread_create (tmp, /* attr = */ NULL,
-            camqp_subscribe_thread, conf);
+            camqp_subscribe_thread, conf, "amqp subscribe");
     if (status != 0)
     {
         char errbuf[1024];

--- a/src/dns.c
+++ b/src/dns.c
@@ -338,7 +338,7 @@ static int dns_init (void)
 		return (-1);
 
 	status = plugin_thread_create (&listen_thread, NULL, dns_child_loop,
-			(void *) 0);
+			(void *) 0, "dns listen");
 	if (status != 0)
 	{
 		char errbuf[1024];

--- a/src/email.c
+++ b/src/email.c
@@ -483,7 +483,8 @@ static void *open_connection (void __attribute__((unused)) *arg)
 			collectors[i]->socket = NULL;
 
 			if (0 != (err = plugin_thread_create (&collectors[i]->thread,
-							&ptattr, collect, collectors[i]))) {
+							&ptattr, collect, collectors[i],
+							"email collector"))) {
 				char errbuf[1024];
 				log_err ("pthread_create() failed: %s",
 						sstrerror (errno, errbuf, sizeof (errbuf)));
@@ -559,7 +560,7 @@ static int email_init (void)
 	int err = 0;
 
 	if (0 != (err = plugin_thread_create (&connector, NULL,
-				open_connection, NULL))) {
+				open_connection, NULL, "email listener"))) {
 		char errbuf[1024];
 		disabled = 1;
 		log_err ("pthread_create() failed: %s",

--- a/src/exec.c
+++ b/src/exec.c
@@ -828,7 +828,7 @@ static int exec_read (void) /* {{{ */
 
     pthread_attr_init (&attr);
     pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
-    plugin_thread_create (&t, &attr, exec_read_one, (void *) pl);
+    plugin_thread_create (&t, &attr, exec_read_one, (void *) pl, "exec read");
     pthread_attr_destroy (&attr);
   } /* for (pl) */
 
@@ -872,7 +872,8 @@ static int exec_notification (const notification_t *n, /* {{{ */
 
     pthread_attr_init (&attr);
     pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
-    plugin_thread_create (&t, &attr, exec_notification_one, (void *) pln);
+    plugin_thread_create (&t, &attr, exec_notification_one, (void *) pln,
+      "exec notify");
     pthread_attr_destroy (&attr);
   } /* for (pl) */
 

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -880,7 +880,7 @@ static int mc_receive_thread_start (void) /* {{{ */
   mc_receive_thread_loop = 1;
 
   status = plugin_thread_create (&mc_receive_thread_id, /* attr = */ NULL,
-      mc_receive_thread, /* args = */ NULL);
+      mc_receive_thread, /* args = */ NULL, "gmond recv");
   if (status != 0)
   {
     ERROR ("gmond plugin: Starting receive thread failed.");

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -670,7 +670,7 @@ static int c_ipmi_init (void)
   c_ipmi_active = 1;
 
   status = plugin_thread_create (&thread_id, /* attr = */ NULL, thread_main,
-      /* user data = */ NULL);
+      /* user data = */ NULL, "ipmi");
   if (status != 0)
   {
     c_ipmi_active = 0;

--- a/src/network.c
+++ b/src/network.c
@@ -3425,7 +3425,7 @@ static int network_init (void)
 		status = plugin_thread_create (&dispatch_thread_id,
 				NULL /* no attributes */,
 				dispatch_thread,
-				NULL /* no argument */);
+				NULL /* no argument */, "network dispatch");
 		if (status != 0)
 		{
 			char errbuf[1024];
@@ -3445,7 +3445,7 @@ static int network_init (void)
 		status = plugin_thread_create (&receive_thread_id,
 				NULL /* no attributes */,
 				receive_thread,
-				NULL /* no argument */);
+				NULL /* no argument */, "network recv");
 		if (status != 0)
 		{
 			char errbuf[1024];

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -648,7 +648,7 @@ static int plugin_init (void) /* {{{ */
   status = plugin_thread_create (&collector_thread_id,
       /* attrs = */ NULL,
       collector_thread,
-      /* args = */ NULL);
+      /* args = */ NULL, "pinba collector");
   if (status != 0)
   {
     char errbuf[1024];

--- a/src/ping.c
+++ b/src/ping.c
@@ -380,7 +380,7 @@ static int start_thread (void) /* {{{ */
   ping_thread_loop = 1;
   ping_thread_error = 0;
   status = plugin_thread_create (&ping_thread_id, /* attr = */ NULL,
-      ping_thread, /* arg = */ (void *) 0);
+      ping_thread, /* arg = */ (void *) 0, "ping");
   if (status != 0)
   {
     ping_thread_loop = 0;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -20,7 +20,9 @@
  *   Sebastian Harl <sh at tokkee.org>
  **/
 
+/* _GNU_SOURCE is needed in Linux to use pthread_setname_np */
 #define _GNU_SOURCE 
+
 #include "collectd.h"
 #include "common.h"
 #include "plugin.h"

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -426,6 +426,6 @@ cdtime_t plugin_get_interval (void);
  */
 
 int plugin_thread_create (pthread_t *thread, const pthread_attr_t *attr,
-		void *(*start_routine) (void *), void *arg);
+		void *(*start_routine) (void *), void *arg, char *name);
 
 #endif /* PLUGIN_H */

--- a/src/python.c
+++ b/src/python.c
@@ -933,7 +933,7 @@ static int cpy_init(void) {
 	pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 	state = PyEval_SaveThread();
 	if (do_interactive) {
-		if (plugin_thread_create(&thread, NULL, cpy_interactive, NULL)) {
+		if (plugin_thread_create(&thread, NULL, cpy_interactive, NULL, "python interpreter")) {
 			ERROR("python: Error creating thread for interactive interpreter.");
 		}
 	}

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -1218,7 +1218,7 @@ static int rrd_init (void)
 	pthread_mutex_unlock (&cache_lock);
 
 	status = plugin_thread_create (&queue_thread, /* attr = */ NULL,
-			rrd_queue_thread, /* args = */ NULL);
+			rrd_queue_thread, /* args = */ NULL, "rrdtool queue");
 	if (status != 0)
 	{
 		ERROR ("rrdtool plugin: Cannot create queue-thread.");

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -358,7 +358,7 @@ static int sigrok_init(void)
 	}
 
 	if ((status = plugin_thread_create(&sr_thread, NULL, sigrok_read_thread,
-			NULL)) != 0) {
+			NULL, "sigrok read")) != 0) {
 		ERROR("sigrok plugin: Failed to create thread: %s.",
 				strerror(status));
 		return -1;

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -364,7 +364,7 @@ static void *us_server_thread (void __attribute__((unused)) *arg)
 		DEBUG ("Spawning child to handle connection on fd #%i", *remote_fd);
 
 		status = plugin_thread_create (&th, &th_attr,
-				us_handle_client, (void *) remote_fd);
+				us_handle_client, (void *) remote_fd, "unixsock client");
 		if (status != 0)
 		{
 			char errbuf[1024];
@@ -445,7 +445,7 @@ static int us_init (void)
 	loop = 1;
 
 	status = plugin_thread_create (&listen_thread, NULL,
-			us_server_thread, NULL);
+			us_server_thread, NULL, "unixsock listener");
 	if (status != 0)
 	{
 		char errbuf[1024];


### PR DESCRIPTION
This pull request is to debate the possibility of naming threads using  `pthread_setname_np` or   `pthread_set_name_np` in BSDs.

In Linux we need to use  `#define _GNU_SOURCE` to use  `pthread_setname_np`. I don't know If the best approach is to do in configure.ac for all the files or put in plugin.c.

The advantage of naming threads is that in a top you can see by the name of the thread if some plugin that create threads is consuming to much cpu, or see the behaviour of readers and writers.
