### PR TITLE
Plugin multimeter: fix compilation error in AIX.

### DIFF
--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -170,7 +170,7 @@ static int multimeter_init (void)
 
 			tcflush(fd, TCIFLUSH);
 			tcsetattr(fd, TCSANOW, &tios);
-			ioctl(fd, TIOCMBIC, &rts);
+			ioctl(fd, (int)TIOCMBIC, &rts);
 			
     			if (multimeter_read_value (&value) < -1)
 			{


### PR DESCRIPTION
The plugin multimeter is build by default,  in AIX when you compile in 64 bit you get the error:

```
Target "all-am" is up to date.
  CC     multimeter.lo
multimeter.c: In function 'multimeter_init':
multimeter.c:173:4: error: overflow in implicit constant conversion [-Werror=overflow]
cc1: all warnings being treated as errors
make: 1254-004 The error code from the last command is 1.
```

The  TIOCMBIC is defined:

```
sys/ioctl.h:#define   TIOCMBIC        _IOW('t', 107, int)     /* bic modem bits */
```

and the other defines:

```
sys/stropts.h:#define _IOW(x,y,t)     (_IOC_IN|((sizeof(t)&_IOCPARM_MASK)<<16)|(x<<8)|y)
sys/stropts.h:#define _IOC_IN          0x80000000      /* copy in parameters */
sys/stropts.h:#define _IOCPARM_MASK    0x7f
```

in /usr/include/sys/ioctl.h more than a half have a cast to int, for example:

```
#define SIOCADDMTU      (int)_IOW('i',112, int) /* add mtu  */
#define SIOCDELMTU      (int)_IOW('i',113, int) /* delete mtu */
#define SIOCIF_ATM_UBR          (int)_IOW('i',120,struct ifreq)  /* set ubr rate */
#define SIOCIF_ATM_SNMPARP      (int)_IOW('i',121,struct ifreq)  /* atm snmp arp */
#define SIOCIF_ATM_IDLE         (int)_IOW('i',122,struct ifreq)  /* set idle time */
#define   TIOCMBIC        _IOW('t', 107, int)     /* bic modem bits */
```

If you compile in AIX collectd in 32 bits you will not get the error.

Other option is to disable the build of multimeter in AIX.
