### PR TITLE
collectd ignores command line argument "-P"

### DIFF
--- a/src/collectd.c
+++ b/src/collectd.c
@@ -41,6 +41,7 @@
  */
 char hostname_g[DATA_MAX_NAME_LEN];
 cdtime_t interval_g;
+int  pidfile_from_cli = 0;
 int  timeout_g;
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;
@@ -439,6 +440,7 @@ int main (int argc, char **argv)
 #if COLLECT_DAEMON
 			case 'P':
 				global_option_set ("PIDFile", optarg);
+				pidfile_from_cli = 1;
 				break;
 			case 'f':
 				daemonize = 0;

--- a/src/collectd.h
+++ b/src/collectd.h
@@ -296,6 +296,7 @@ typedef uint64_t cdtime_t;
 
 extern char     hostname_g[];
 extern cdtime_t interval_g;
+extern int      pidfile_from_cli;
 extern int      timeout_g;
 
 #endif /* COLLECTD_H */

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -891,6 +891,13 @@ int global_option_set (const char *option, const char *value)
 	if (i >= cf_global_options_num)
 		return (-1);
 
+	if (strcasecmp (option, "PIDFile") == 0 && pidfile_from_cli == 1)
+	{
+		DEBUG ("Configfile: Ignoring `PIDFILE' option because "
+			"command-line option `-P' take precedence.");
+		return (0);
+	}
+
 	sfree (cf_global_options[i].value);
 
 	if (value != NULL)


### PR DESCRIPTION
Hi,
`man collectd` says

```
Options
       [...]
       -P <pid-file>
           Specify an alternative pid file. This overwrites any settings in the config file. This is thought for
           init-scripts that require the PID-file in a certain directory to work correctly. For everyday-usage use
           the PIDFile config-option.
```

That doesn't work:
1. Make sure your collectd configuration file `/etc/collectd.conf` contains `PIDFile` setting, e.g. `PIPFile /run/collectd/collectd-from-conf.pid`
2. Now start collectd like `/usr/sbin/collectd -C /etc/collectd.conf -P /tmp/collectd-from-cli.pid`

You will see that `/tmp/collectd-from-cli.pid` won't be created but `/run/collectd/collectd-from-conf.pid`.

Tested with collectd-5.4.0.
