### PR TITLE
memory plugin: fix submit multivalue (fill vl.type)

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -487,6 +487,7 @@ static int memory_read (void) /* {{{ */
 	vl.values_len = STATIC_ARRAY_SIZE (v);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "memory", sizeof (vl.plugin));
+	sstrncpy (vl.type, "memory", sizeof (vl.type));
 	vl.time = cdtime ();
 
 	return (memory_read_internal (&vl));


### PR DESCRIPTION
When switching to the new multivalue submit, vl.type were not filled and no value is actually submitted. This one line patch fix this.
