### PR TITLE
Syslog: if we can't find the loglevel specified by the configuration str...

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -2188,6 +2188,8 @@ int parse_log_severity (const char *severity)
 	else if (0 == strcasecmp (severity, "debug"))
 		log_level = LOG_DEBUG;
 #endif /* COLLECT_DEBUG */
+	else
+		log_level = -2;
 
 	return (log_level);
 } /* int parse_log_severity */

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -47,6 +47,11 @@ static int sl_config (const char *key, const char *value)
 	if (strcasecmp (key, "LogLevel") == 0)
 	{
 		log_level = parse_log_severity (value);
+		if (log_level < -1)
+		{
+			log_level = LOG_INFO;
+			ERROR ("syslog: invalid loglevel [%s] defauling to 'info'", value);
+		}
 		if (log_level < 0)
 			return (1);
 	}


### PR DESCRIPTION
...ing default to 'info' and warn about the unknown configuration option.

else logging is turned off without any notice to the administrator.
