### PR TITLE
Updated Color to match DataSources and DSName for single-series graphs.

### DIFF
--- a/contrib/collection3/etc/collection.conf
+++ b/contrib/collection3/etc/collection.conf
@@ -7,7 +7,7 @@ GraphWidth 400
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Bytes/s"
   RRDFormat "%5.1lf%s"
-  Color count 0000ff
+  Color value 0000ff
 </Type>
 <Type apache_requests>
   DataSources value
@@ -15,7 +15,7 @@ GraphWidth 400
   RRDTitle "Apache Traffic"
   RRDVerticalLabel "Requests/s"
   RRDFormat "%5.2lf"
-  Color count 00d000
+  Color value 00d000
 </Type>
 <Type apache_scoreboard>
   Module GenericStacked
@@ -272,7 +272,7 @@ GraphWidth 400
   RRDTitle "Frequency ({type_instance})"
   RRDVerticalLabel "Hertz"
   RRDFormat "%4.1lfHz"
-  Color frequency a000a0
+  Color value a000a0
 </Type>
 <Type humidity>
   DataSources value
@@ -547,7 +547,7 @@ GraphWidth 400
   RRDTitle "Percent ({type_instance})"
   RRDVerticalLabel "Percent"
   RRDFormat "%4.1lf%%"
-  Color percent 0000ff
+  Color value 0000ff
 </Type>
 <Type ping>
   DataSources value
@@ -705,7 +705,7 @@ GraphWidth 400
   RRDTitle "Users ({type_instance}) on {hostname}"
   RRDVerticalLabel "Users"
   RRDFormat "%.1lf"
-  Color users 0000f0
+  Color value 0000f0
 </Type>
 <Type voltage>
   DataSources value


### PR DESCRIPTION
In handling [Bug 1065338](https://bugzilla.redhat.com/show_bug.cgi?id=1065338) in Fedora, we noticed that 6c1415d and 147690b didn't quite migrate everything from v4 to v5. This patch makes the Color entries in collection.conf match the DataSources and DSName when there is only one data series named "value". Without this, the graphs for these types are drawn in gray instead of the intended colors.

I guess this should be merged into collectd-5.4 and trunk as well, since the bug exists from 5.3 onwards.
