### PR TITLE
Fix missed change from int to double for interval

### DIFF
--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -767,7 +767,7 @@ static void Values_dealloc(PyObject *self) {
 }
 
 static PyMemberDef Values_members[] = {
-	{"interval", T_INT, offsetof(Values, interval), 0, interval_doc},
+	{"interval", T_DOUBLE, offsetof(Values, interval), 0, interval_doc},
 	{"values", T_OBJECT_EX, offsetof(Values, values), 0, values_doc},
 	{"meta", T_OBJECT_EX, offsetof(Values, meta), 0, meta_doc},
 	{NULL}


### PR DESCRIPTION
In the commits from edd0e26..965246d the interval was converted from an int to a double. After upgrading our 4.10 collectd server, I noticed my write plugin written in python was no longer reporting the correct interval.

relevant simplified python writer:

``` python
import collectd
import syslog
import pprint
pp = pprint.PrettyPrinter()
def test_write(vl, data=None):
    syslog.syslog("pprint: %s" % (pp.pformat(vl)))
    syslog.syslog("type=%s, plugin=%s, host=%s, time=%d, interval=%d, values=%s" % (vl.type, vl.plugin, vl.host, vl.time, vl.interval, vl.values))
collectd.register_write(test_write)
```

output from this for old (working) and new (not-working) collectd respectively:

``` bash
Mar  5 22:43:04 collectd5 collectd[25770]: pprint: collectd.Values(type='memory',type_instance='free',plugin='memory',host='collectd5.host',time=1394088184.9372065,interval=15.0,values=[376823808.0])
Mar  5 22:43:04 collectd5 collectd[25770]: type=memory, plugin=memory, host=collectd5.host, time=1394088184, interval=15, values=[376823808.0]
```

``` bash
Mar  5 22:27:25 collectd5 collectd[25691]: pprint: collectd.Values(type='percent',type_instance='used',plugin='conntrack',host='collectd5.host',time=1394087245.8947451,interval=15.0,values=[0.0])
Mar  5 22:27:25 collectd5 collectd[25691]: type=percent, plugin=conntrack, host=collectd5.host, time=1394087245, interval=0, values=[0.0]
```

Notice in the non `pprint` line, the interval = 15 on the old version but is 0 in the new version

The change in this PR makes it so that `vl.interval` now properly returns the right value (it's 15 flat in this output because the pformat is showing the signed integer not the floating point number).

also just a sidenote, `git bisect` is awesome :smile: 
