### PR TITLE
Add support for monitoring lm_sensors' "power" sensors

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -62,7 +62,9 @@ static char *sensor_type_name_map[] =
 	"fanspeed",
 # define SENSOR_TYPE_TEMPERATURE 2
 	"temperature",
-# define SENSOR_TYPE_UNKNOWN     3
+# define SENSOR_TYPE_POWER       3
+	"power",
+# define SENSOR_TYPE_UNKNOWN     4
 	NULL
 };
 
@@ -127,7 +129,8 @@ static sensors_labeltypes_t known_features[] =
 	{ "3.3V", SENSOR_TYPE_VOLTAGE },
 	{ "2.5V", SENSOR_TYPE_VOLTAGE },
 	{ "2.0V", SENSOR_TYPE_VOLTAGE },
-	{ "12V", SENSOR_TYPE_VOLTAGE }
+	{ "12V", SENSOR_TYPE_VOLTAGE },
+	{ "power1", SENSOR_TYPE_POWER }
 };
 static int known_features_num = STATIC_ARRAY_SIZE (known_features);
 /* end new naming */
@@ -411,7 +414,8 @@ static int sensors_load_conf (void)
 			/* Only handle voltage, fanspeeds and temperatures */
 			if ((feature->type != SENSORS_FEATURE_IN)
 					&& (feature->type != SENSORS_FEATURE_FAN)
-					&& (feature->type != SENSORS_FEATURE_TEMP))
+					&& (feature->type != SENSORS_FEATURE_TEMP)
+					&& (feature->type != SENSORS_FEATURE_POWER))
 			{
 				DEBUG ("sensors plugin: sensors_load_conf: "
 						"Ignoring feature `%s', "
@@ -427,7 +431,8 @@ static int sensors_load_conf (void)
 
 				if ((subfeature->type != SENSORS_SUBFEATURE_IN_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_FAN_INPUT)
-						&& (subfeature->type != SENSORS_SUBFEATURE_TEMP_INPUT))
+						&& (subfeature->type != SENSORS_SUBFEATURE_TEMP_INPUT)
+						&& (subfeature->type != SENSORS_SUBFEATURE_POWER_INPUT))
 					continue;
 
 				fl = (featurelist_t *) malloc (sizeof (featurelist_t));
@@ -573,6 +578,9 @@ static int sensors_read (void)
 		else if (fl->feature->type
 				== SENSORS_FEATURE_TEMP)
 			type = "temperature";
+		else if (fl->feature->type
+				== SENSORS_FEATURE_POWER)
+			type = "power";
 		else
 			continue;
 


### PR DESCRIPTION
The patch shall probably be extended to include additional sensor names in
future. My servers, however, use "power1" for all of the readings, so I'm not
making that change now.
