### PR TITLE
Fix for #477: Notification time gone wrong

### DIFF
--- a/src/utils_cmd_putnotif.c
+++ b/src/utils_cmd_putnotif.c
@@ -55,7 +55,7 @@ static int set_option_time (notification_t *n, const char *value)
   if (tmp <= 0)
     return (-1);
 
-  n->time = tmp;
+  n->time = TIME_T_TO_CDTIME_T (tmp);
 
   return (0);
 } /* int set_option_time */


### PR DESCRIPTION
The time parsed from PUTNOTIF needs to be converted to cdtime.
