### PR TITLE
Fix compliation error in AIX7: conflicting types for 'getargs'

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -223,7 +223,7 @@ static int pagesize;
 int     getprocs64 (void *procsinfo, int sizproc, void *fdsinfo, int sizfd, pid_t *index, int count);
 int     getthrds64( pid_t, void *, int, tid64_t *, int );
 #endif
-int getargs (struct procentry64 *processBuffer, int bufferLen, char *argsBuffer, int argsLen);
+int getargs (void *processBuffer, int bufferLen, char *argsBuffer, int argsLen);
 #endif /* HAVE_PROCINFO_H */
 
 /* put name of process from config to list_head_g tree


### PR DESCRIPTION
The compilation error in AIX7:

```
  CC     processes.lo
processes.c:226:5: error: conflicting types for 'getargs'
 int getargs (struct procentry64 *processBuffer, int bufferLen, char *argsBuffer, int argsLen);
 ^
In file included from processes.c:106:0:
/usr/include/procinfo.h:1093:17: note: previous declaration of 'getargs' was here
 extern  int     getargs( void *, int, char *, int );
```

In AIX6 getargs was not declared but in AIX7 the declaration was added in procinfo.h.

Change the declaration of `getargs` to match the declaration in AIX7.
