### PR TITLE
Collectd can't handle ( or ) in metric names either

### DIFF
--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -29,7 +29,7 @@
 #include "utils_cache.h"
 #include "utils_parse_option.h"
 
-#define GRAPHITE_FORBIDDEN " \t\"\\:!/\n\r"
+#define GRAPHITE_FORBIDDEN " \t\"\\:!/\n\r()"
 
 /* Utils functions to format data sets in graphite format.
  * Largely taken from write_graphite.c as it remains the same formatting */


### PR DESCRIPTION
These metrics can't be handled by Graphite Web and result in data that can be written to disk, but never read
