### PR TITLE
increased buffer size

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -741,7 +741,7 @@ static int camqp_write (const data_set_t *ds, const value_list_t *vl, /* {{{ */
 {
     camqp_config_t *conf = user_data->data;
     char routing_key[6 * DATA_MAX_NAME_LEN];
-    char buffer[4096];
+    char buffer[8192];
     int status;
 
     if ((ds == NULL) || (vl == NULL) || (conf == NULL))


### PR DESCRIPTION
Hi,

we are using collectd with some custom types.db files, and some of them have quite some metrics in it. I experienced that the amqp plugin, output format set to JSON, sometimes generates an empty message in the queue. This is because of the limited buffer size inside this plugin. If you are using the JSON format, the buffer can get quite big. And in this case, RabbitMQ is unable to parse the message (since it's truncated and not a valid json anymore) and creates an empty one.

Since RabbitMQ can handle messages of (theoretically) unlimited length, I think the buffer size should be increased (I've doubled it to 8kb).

Regards,
Christian
