### PR TITLE
don't assume pkg-config is in PATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1368,8 +1368,8 @@ AC_CHECK_LIB(hal,libhal_device_property_exists,
 	     [with_libhal="no"])
 if test "x$with_libhal" = "xyes"; then
 	if test "x$PKG_CONFIG" != "x"; then
-		BUILD_WITH_LIBHAL_CFLAGS="`pkg-config --cflags hal`"
-		BUILD_WITH_LIBHAL_LIBS="`pkg-config --libs hal`"
+		BUILD_WITH_LIBHAL_CFLAGS="`$PKG_CONFIG --cflags hal`"
+		BUILD_WITH_LIBHAL_LIBS="`$PKG_CONFIG --libs hal`"
 		AC_SUBST(BUILD_WITH_LIBHAL_CFLAGS)
 		AC_SUBST(BUILD_WITH_LIBHAL_LIBS)
 	fi
@@ -4005,8 +4005,8 @@ then
   if $PKG_CONFIG --exists tokyotyrant
   then
     with_libtokyotyrant_cppflags="$with_libtokyotyrant_cppflags `$PKG_CONFIG --cflags tokyotyrant`"
-    with_libtokyotyrant_ldflags="$with_libtokyotyrant_ldflags `pkg-config --libs-only-L tokyotyrant`"
-    with_libtokyotyrant_libs="$with_libtokyotyrant_libs `pkg-config --libs-only-l tokyotyrant`"
+    with_libtokyotyrant_ldflags="$with_libtokyotyrant_ldflags `$PKG_CONFIG --libs-only-L tokyotyrant`"
+    with_libtokyotyrant_libs="$with_libtokyotyrant_libs `$PKG_CONFIG --libs-only-l tokyotyrant`"
   fi
 fi
 
@@ -4462,7 +4462,7 @@ with_libvirt_cflags=""
 with_libvirt_ldflags=""
 if test "x$PKG_CONFIG" != "x"
 then
-	pkg-config --exists 'libxml-2.0' 2>/dev/null
+	$PKG_CONFIG --exists 'libxml-2.0' 2>/dev/null
 	if test "$?" = "0"
 	then
 		with_libxml2="yes"
@@ -4470,7 +4470,7 @@ then
 		with_libxml2="no (pkg-config doesn't know libxml-2.0)"
 	fi
 
-	pkg-config --exists libvirt 2>/dev/null
+	$PKG_CONFIG --exists libvirt 2>/dev/null
 	if test "$?" = "0"
 	then
 		with_libvirt="yes"
@@ -4480,12 +4480,12 @@ then
 fi
 if test "x$with_libxml2" = "xyes"
 then
-	with_libxml2_cflags="`pkg-config --cflags libxml-2.0`"
+	with_libxml2_cflags="`$PKG_CONFIG --cflags libxml-2.0`"
 	if test $? -ne 0
 	then
 		with_libxml2="no"
 	fi
-	with_libxml2_ldflags="`pkg-config --libs libxml-2.0`"
+	with_libxml2_ldflags="$PKG_CONFIG --libs libxml-2.0`"
 	if test $? -ne 0
 	then
 		with_libxml2="no"
@@ -4525,12 +4525,12 @@ if test "x$with_libxml2" = "xyes"; then
 fi
 if test "x$with_libvirt" = "xyes"
 then
-	with_libvirt_cflags="`pkg-config --cflags libvirt`"
+	with_libvirt_cflags="$PKG_CONFIG --cflags libvirt`"
 	if test $? -ne 0
 	then
 		with_libvirt="no"
 	fi
-	with_libvirt_ldflags="`pkg-config --libs libvirt`"
+	with_libvirt_ldflags="$PKG_CONFIG --libs libvirt`"
 	if test $? -ne 0
 	then
 		with_libvirt="no"


### PR DESCRIPTION
pkg-config might not be in path, so $PKG_CONFIG should be used instead. This is already done in other places in configure.ac, this patch just fixes the rest of the invocations to use it as well.

This, as well as AC_USE_SYSTEM_EXTENSIONS (as documented at https://github.com/collectd/collectd/issues/351#issuecomment-19444142) and the already-merged 1a822486f40287f552890a553181fd620c662ada are enough patches to build 5.4.1 on OmniOS (which doesn't ship pkg-config, but I have my own copy outside PATH)
