### PR TITLE
hddtemp: Support more than 32 drives

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,7 +72,7 @@ Aurélien Reynaud <collectd at wattapower.net>
  - LPAR plugin.
  - Various fixes for AIX, HP-UX and Solaris.
 
-Benjamin Gilbert <bgilbert at cs.cmu.edu>
+Benjamin Gilbert <bgilbert at backtick.net>
  - Improvements to the LVM plugin.
 
 Bert Vermeulen <bert at biot.com>

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -171,7 +171,7 @@ static char *hddtemp_query_daemon (void)
 	buffer_fill = 0;
 	while (1)
 	{
-		if (buffer_fill >= buffer_size - 1)
+		if ((buffer_size == 0) || (buffer_fill >= buffer_size - 1))
 		{
 			if (buffer_size == 0)
 				buffer_size = 1024;

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -23,7 +23,7 @@
  *   Vincent Stehlé <vincent.stehle at free.fr>
  *   Florian octo Forster <octo at collectd.org>
  *   Sebastian Harl <sh at tokkee.org>
- *   Benjamin Gilbert <bgilbert at cs.cmu.edu>
+ *   Benjamin Gilbert <bgilbert at backtick.net>
  *
  * TODO:
  *   Do a pass, some day, and spare some memory. We consume too much for now

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -18,7 +18,7 @@
  *
  * Authors:
  *   Chad Malfait <malfaitc at yahoo.com>
- *   Benjamin Gilbert <bgilbert at cs.cmu.edu>
+ *   Benjamin Gilbert <bgilbert at backtick.net>
  **/
 
 #include <lvm2app.h>


### PR DESCRIPTION
The hddtemp plugin imposes a 32-drive and 1024-byte limit on the response from the hddtemp daemon.  On my system, the 1024-byte limit truncates the response after 29 drives.

Drop the drive limit and increase the buffer limit to 1 MB.  (This is hopefully larger than anyone will need, and prevents collectd from being DoSed by the hddtemp daemon.)