### PR TITLE
Syslog: don't go all silent on 'debug' with production binary

### DIFF
--- a/src/syslog.c
+++ b/src/syslog.c
@@ -48,7 +48,11 @@ static int sl_config (const char *key, const char *value)
 	{
 		log_level = parse_log_severity (value);
 		if (log_level < 0)
+		{
+			log_level = LOG_INFO;
+			ERROR ("syslog: invalid loglevel [%s] defauling to 'info'", value);
 			return (1);
+		}
 	}
 	else if (strcasecmp (key, "NotifyLevel") == 0)
 	{


### PR DESCRIPTION
so far if the collectd binary was compiled without debug, and the user configures loglevel 'debug' the logging will go all silent.
Imho this is orthogonal to what the user wants. 
This approach will switch loglevel to 'info' and warn about an unsupported config value.
