### PR TITLE
Statsd flexible histogram

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -818,9 +818,7 @@ static int statsd_metric_submit_unsafe (char const *name, /* {{{ */
       plugin_dispatch_values (&vl);
     }
 
-    latency_counter_reset (metric->latency,
-			   conf_timer_percentile_bucket_width_ms,
-			   conf_timer_percentile_no_buckets);
+    latency_counter_reset (metric->latency);
     return (0);
   }
   else if (metric->type == STATSD_SET)

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -278,7 +278,8 @@ static int statsd_handle_timer (char const *name, /* {{{ */
 
   if (metric->latency == NULL)
     metric->latency = latency_counter_create (conf_timer_percentile_bucket_width_ms,
-					      conf_timer_percentile_no_buckets);
+					      conf_timer_percentile_no_buckets,
+					      name);
   if (metric->latency == NULL)
   {
     pthread_mutex_unlock (&metrics_lock);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -803,7 +803,7 @@ static int statsd_metric_submit_unsafe (char const *name, /* {{{ */
       plugin_dispatch_values (&vl);
     }
 
-    latency_counter_reset (metric->latency);
+    latency_counter_reset (metric->latency, conf_timer_percentile_resolution_ms);
     return (0);
   }
   else if (metric->type == STATSD_SET)

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -84,6 +84,8 @@ static _Bool conf_delete_sets     = 0;
 static double *conf_timer_percentile = NULL;
 static size_t  conf_timer_percentile_num = 0;
 
+static int conf_timer_percentile_resolution_ms = 20;
+
 static _Bool conf_timer_lower     = 0;
 static _Bool conf_timer_upper     = 0;
 static _Bool conf_timer_sum       = 0;
@@ -274,7 +276,7 @@ static int statsd_handle_timer (char const *name, /* {{{ */
   }
 
   if (metric->latency == NULL)
-    metric->latency = latency_counter_create ();
+    metric->latency = latency_counter_create (conf_timer_percentile_resolution_ms);
   if (metric->latency == NULL)
   {
     pthread_mutex_unlock (&metrics_lock);
@@ -615,6 +617,17 @@ static int statsd_config_timer_percentile (oconfig_item_t *ci) /* {{{ */
   return (0);
 } /* }}} int statsd_config_timer_percentile */
 
+static int statsd_config_timer_percentile_histogram_resolution (oconfig_item_t *ci) /* {{{ */
+{
+  int status;
+
+  status = cf_util_get_int (ci, &conf_timer_percentile_resolution_ms);
+  if (status != 0)
+    return (status);
+
+  return (0);
+} /* }}} int statsd_config_timer_percentile_histogram_resolution */
+
 static int statsd_config (oconfig_item_t *ci) /* {{{ */
 {
   int i;
@@ -645,6 +658,8 @@ static int statsd_config (oconfig_item_t *ci) /* {{{ */
       cf_util_get_boolean (child, &conf_timer_count);
     else if (strcasecmp ("TimerPercentile", child->key) == 0)
       statsd_config_timer_percentile (child);
+    else if (strcasecmp ("TimerPercentileHistogramResolutionMS", child->key) == 0)
+      statsd_config_timer_percentile_histogram_resolution (child);
     else
       ERROR ("statsd plugin: The \"%s\" config option is not valid.",
           child->key);

--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -98,9 +98,11 @@ void latency_counter_reset (latency_counter_t *lc,
   if (lc == NULL)
     return;
 
-  memset (lc, 0, sizeof (*lc));
+  memset (lc, 0, sizeof (*lc) + no_buckets * sizeof(uint64_t));
   lc->start_time = cdtime ();
   lc->bucket_width = bucket_width;
+  lc->no_buckets = no_buckets;
+  
 } /* }}} void latency_counter_reset */
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc) /* {{{ */

--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -52,7 +52,10 @@ latency_counter_t *latency_counter_create (int bucket_width,
   if (lc == NULL)
     return (NULL);
 
-  latency_counter_reset (lc, bucket_width, no_buckets);
+  lc->bucket_width = bucket_width;
+  lc->no_buckets = no_buckets;
+
+  latency_counter_reset (lc);
   return (lc);
 } /* }}} latency_counter_t *latency_counter_create */
 
@@ -91,12 +94,16 @@ void latency_counter_add (latency_counter_t *lc, cdtime_t latency) /* {{{ */
     lc->histogram[lc->no_buckets - 1]++;
 } /* }}} void latency_counter_add */
 
-void latency_counter_reset (latency_counter_t *lc,
-			    int bucket_width,
-			    int no_buckets) /* {{{ */
+void latency_counter_reset (latency_counter_t *lc) /* {{{ */
 {
+  int bucket_width;
+  int no_buckets;
+
   if (lc == NULL)
     return;
+
+  bucket_width = lc->bucket_width;
+  no_buckets = lc->no_buckets;
 
   memset (lc, 0, sizeof (*lc) + no_buckets * sizeof(uint64_t));
   lc->start_time = cdtime ();

--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -38,13 +38,16 @@ struct latency_counter_s
   cdtime_t min;
   cdtime_t max;
 
+  const char *name;
+
   int bucket_width;
   int no_buckets;
   uint64_t *histogram;
 };
 
 latency_counter_t *latency_counter_create (int bucket_width,
-					   int no_buckets) /* {{{ */
+					   int no_buckets,
+					   const char *name) /* {{{ */
 {
   latency_counter_t *lc;
 
@@ -54,6 +57,8 @@ latency_counter_t *latency_counter_create (int bucket_width,
 
   lc->bucket_width = bucket_width;
   lc->no_buckets = no_buckets;
+  lc->name = name;
+  lc->num = 0;
 
   latency_counter_reset (lc);
   return (lc);
@@ -98,18 +103,23 @@ void latency_counter_reset (latency_counter_t *lc) /* {{{ */
 {
   int bucket_width;
   int no_buckets;
+  const char *name;
 
   if (lc == NULL)
     return;
 
   bucket_width = lc->bucket_width;
   no_buckets = lc->no_buckets;
+  name = lc->name;
 
   memset (lc, 0, sizeof (*lc) + no_buckets * sizeof(uint64_t));
   lc->start_time = cdtime ();
   lc->bucket_width = bucket_width;
   lc->no_buckets = no_buckets;
-  
+  lc->name = name;
+
+  /* the memory area of the histogram is right after the struct */
+  lc->histogram = (uint64_t *)(&lc->histogram) + 1;
 } /* }}} void latency_counter_reset */
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc) /* {{{ */

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -34,7 +34,7 @@ latency_counter_t *latency_counter_create (int Resolution);
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);
-void latency_counter_reset (latency_counter_t *lc);
+void latency_counter_reset (latency_counter_t *lc, int Resolution);
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc);
 cdtime_t latency_counter_get_max (latency_counter_t *lc);

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -30,11 +30,14 @@
 struct latency_counter_s;
 typedef struct latency_counter_s latency_counter_t;
 
-latency_counter_t *latency_counter_create (int bucket_width);
+latency_counter_t *latency_counter_create (int bucket_width,
+					   int no_buckets);
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);
-void latency_counter_reset (latency_counter_t *lc, int bucket_width);
+void latency_counter_reset (latency_counter_t *lc,
+			    int bucket_width,
+			    int no_buckets);
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc);
 cdtime_t latency_counter_get_max (latency_counter_t *lc);

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -31,7 +31,8 @@ struct latency_counter_s;
 typedef struct latency_counter_s latency_counter_t;
 
 latency_counter_t *latency_counter_create (int bucket_width,
-					   int no_buckets);
+					   int no_buckets,
+					   const char *name);
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -35,9 +35,7 @@ latency_counter_t *latency_counter_create (int bucket_width,
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);
-void latency_counter_reset (latency_counter_t *lc,
-			    int bucket_width,
-			    int no_buckets);
+void latency_counter_reset (latency_counter_t *lc);
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc);
 cdtime_t latency_counter_get_max (latency_counter_t *lc);

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -30,7 +30,7 @@
 struct latency_counter_s;
 typedef struct latency_counter_s latency_counter_t;
 
-latency_counter_t *latency_counter_create ();
+latency_counter_t *latency_counter_create (int Resolution);
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -30,11 +30,11 @@
 struct latency_counter_s;
 typedef struct latency_counter_s latency_counter_t;
 
-latency_counter_t *latency_counter_create (int Resolution);
+latency_counter_t *latency_counter_create (int bucket_width);
 void latency_counter_destroy (latency_counter_t *lc);
 
 void latency_counter_add (latency_counter_t *lc, cdtime_t latency);
-void latency_counter_reset (latency_counter_t *lc, int Resolution);
+void latency_counter_reset (latency_counter_t *lc, int bucket_width);
 
 cdtime_t latency_counter_get_min (latency_counter_t *lc);
 cdtime_t latency_counter_get_max (latency_counter_t *lc);


### PR DESCRIPTION
The collectd Statsd implementation currently will only accept values in the range from 0 - 1000 in the histogram it uses to calculate the percentile. In case of of values > 1000 these will be ignored; the Histogram is to be compared to an over exposure photo. 
To be able to adopt to other usecases the range of the histogramm has to become flexible so the user can configure the range of values his data series generate.

(fixes #401)
