### PR TITLE
Configparser: when we alocate an empty list, we also need to reset

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -477,6 +477,12 @@ static int cf_ci_replace_child (oconfig_item_t *dst, oconfig_item_t *src,
 
 	/* Resize the memory containing the children to be big enough to hold
 	 * all children. */
+	if (dst->children_num + src->children_num - 1 == 0)
+	{
+		dst->children_num = 0;
+		return (0);
+	}
+
 	temp = (oconfig_item_t *) realloc (dst->children,
 			sizeof (oconfig_item_t)
 			* (dst->children_num + src->children_num - 1));
@@ -591,7 +597,8 @@ static int cf_include_all (oconfig_item_t *root, int depth)
 			return (-1);
 
 		/* Now replace the i'th child in `root' with `new'. */
-		cf_ci_replace_child (root, new, i);
+		if (cf_ci_replace_child (root, new, i) < 0)
+			return (-1);
 
 		/* ... and go back to the new i'th child. */
 		--i;


### PR DESCRIPTION
the counter; else we will trip over this later.

This fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750440
