### PR TITLE
Limit the number of rrd_create threads

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -894,12 +894,14 @@
 #	DataDir "@localstatedir@/lib/@PACKAGE_NAME@/rrd"
 #	CreateFiles true
 #	CreateFilesAsync false
+#	CreateFilesAsyncLimit 0
 #	CollectStatistics true
 #</Plugin>
 
 #<Plugin rrdtool>
 #	DataDir "@localstatedir@/lib/@PACKAGE_NAME@/rrd"
 #	CreateFilesAsync false
+#	CreateFilesAsyncLimit 0
 #	CacheTimeout 120
 #	CacheFlush   900
 #	WritesPerSecond 50

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5066,6 +5066,15 @@ the file is available, values before the file is available will be discarded.
 When disabled (the default) files are created synchronously, blocking for a
 short while, while the file is being written.
 
+=item B<CreateFilesAsyncLimit> B<Limit>
+
+When CreateFilesAsync is enabled, new RRD files are enabled asynchronously,
+using a separate thread that runs in the background. This limit, when set to a
+positive non nul value, will limit the number of threads, e.g. the number of
+RRD files being created at the same time. This prevents too many thread (and
+file creation) at the same time, which happens for example when you start
+Collectd for the first time.
+
 =item B<StepSize> I<Seconds>
 
 B<Force> the stepsize of newly created RRD-files. Ideally (and per default)

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -48,7 +48,8 @@ static rrdcreate_config_t rrdcreate_config =
 	/* consolidation_functions = */ NULL,
 	/* consolidation_functions_num = */ 0,
 
-	/* async = */ 0
+	/* async = */ 0,
+	/* async_limit = */ 0
 };
 
 /*
@@ -243,6 +244,8 @@ static int rc_config (oconfig_item_t *ci)
       status = cf_util_get_boolean (child, &config_create_files);
     else if (strcasecmp ("CreateFilesAsync", key) == 0)
       status = cf_util_get_boolean (child, &rrdcreate_config.async);
+    else if (strcasecmp ("CreateFilesAsyncLimit", key) == 0)
+      status = cf_util_get_int (child, &rrdcreate_config.async_limit);
     else if (strcasecmp ("CollectStatistics", key) == 0)
       status = cf_util_get_boolean (child, &config_collect_stats);
     else if (strcasecmp ("StepSize", key) == 0)

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -106,7 +106,8 @@ static rrdcreate_config_t rrdcreate_config =
 	/* consolidation_functions = */ NULL,
 	/* consolidation_functions_num = */ 0,
 
-	/* async = */ 0
+	/* async = */ 0,
+	/* async_limit = */ 0
 };
 
 /* XXX: If you need to lock both, cache_lock and queue_lock, at the same time,
@@ -1040,6 +1041,19 @@ static int rrd_config (const char *key, const char *value)
 			rrdcreate_config.async = 1;
 		else
 			rrdcreate_config.async = 0;
+	}
+	else if (strcasecmp ("CreateFilesAsyncLimit", key) == 0)
+	{
+		int tmp = atoi (value);
+		if (tmp <= 0)
+		{
+			fprintf (stderr, "rrdtool: `CreateFilesAsyncLimit' must "
+					"be greater or equal than 0.\n");
+			ERROR ("rrdtool: `RRARows' must "
+					"be greater or equal than 0.\n");
+			return (1);
+		}
+		rrdcreate_config.async = tmp;
 	}
 	else if (strcasecmp ("RRARows", key) == 0)
 	{

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -127,7 +127,7 @@ static srrd_create_args_t *srrd_create_args_create (const char *filename,
   if (args->filename == NULL)
   {
     ERROR ("srrd_create_args_create: strdup failed.");
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (NULL);
   }
 
@@ -135,7 +135,7 @@ static srrd_create_args_t *srrd_create_args_create (const char *filename,
   if (args->argv == NULL)
   {
     ERROR ("srrd_create_args_create: calloc failed.");
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (NULL);
   }
 
@@ -145,7 +145,7 @@ static srrd_create_args_t *srrd_create_args_create (const char *filename,
     if (args->argv[args->argc] == NULL)
     {
       ERROR ("srrd_create_args_create: strdup failed.");
-      srrd_create_args_destroy (args);
+      srrd_create_args_destroy (args); free(args); args = NULL;
       return (NULL);
     }
   }
@@ -582,7 +582,7 @@ static void *srrd_create_thread (void *targs) /* {{{ */
     else
       ERROR ("srrd_create_thread: Unable to lock file \"%s\".",
           args->filename);
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (0);
   }
 
@@ -596,7 +596,7 @@ static void *srrd_create_thread (void *targs) /* {{{ */
         args->filename, status);
     unlink (tmpfile);
     unlock_file (args->filename);
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (0);
   }
 
@@ -609,7 +609,7 @@ static void *srrd_create_thread (void *targs) /* {{{ */
         sstrerror (errno, errbuf, sizeof (errbuf)));
     unlink (tmpfile);
     unlock_file (args->filename);
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (0);
   }
 
@@ -617,7 +617,7 @@ static void *srrd_create_thread (void *targs) /* {{{ */
       args->filename);
 
   unlock_file (args->filename);
-  srrd_create_args_destroy (args);
+  srrd_create_args_destroy (args); free(args); args = NULL;
 
   return (0);
 } /* }}} void *srrd_create_thread */
@@ -658,7 +658,7 @@ static int srrd_create_async (const char *filename, /* {{{ */
   status = pthread_attr_init (&attr);
   if (status != 0)
   {
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (-1);
   }
 
@@ -666,7 +666,7 @@ static int srrd_create_async (const char *filename, /* {{{ */
   if (status != 0)
   {
     pthread_attr_destroy (&attr);
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (-1);
   }
 
@@ -677,7 +677,7 @@ static int srrd_create_async (const char *filename, /* {{{ */
     ERROR ("srrd_create_async: pthread_create failed: %s",
         sstrerror (status, errbuf, sizeof (errbuf)));
     pthread_attr_destroy (&attr);
-    srrd_create_args_destroy (args);
+    srrd_create_args_destroy (args); free(args); args = NULL;
     return (status);
   }
 

--- a/src/utils_rrdcreate.h
+++ b/src/utils_rrdcreate.h
@@ -40,6 +40,7 @@ struct rrdcreate_config_s
   size_t consolidation_functions_num;
 
   _Bool async;
+  int   async_limit;
 };
 typedef struct rrdcreate_config_s rrdcreate_config_t;
 


### PR DESCRIPTION
Hello,

PR #262 is a nice feature (create asynchronous threads for rrd files creation).

However, when too many new metrics come, there is still an issue : too many rrdcreate threads (I can have more than 1000 at the same time). And more there are, slower they become.

PR #244 has already proven to me that it was useful, but it does not help when the problem comes from too many RRD files to create.

So we should limit the number or create threads.

Check the attached patch and the new option `CreateFilesAsyncLimit`, that defaults to 0 (no limit, current behaviour) but that can be set to limit the number of threads.

```
CreateFilesAsync true
CreateFilesAsyncLimit 10
```

__Description__
There is a list (`async_creation_list`) of rrd files being created. I added a var (`async_creation_list_size`) with the size of this list.
Before the thread is created, `async_creation_list_size` is checked quickly (no lock) to see if the rrd file can be created or if there are already too many threads.
If there are too many threads, the metric is dropped and we hope that it will be sent again in 60 seconds (or whatever the interval is) and file can be created then.
This check is done fast, outside a pthread_locked section, so it is reliable only if there are too many threads.

If `async_creation_list_size` is small enough, the thread is created. A new check is done on `async_creation_list_size` because many threads can start and launch file creation at the same time (1st check was out of the pthread_locked section). The second check is reliable because it is done inside the locked section.

Note : 1st check is reliable when there are already too many threads running. This is why I implemented it : no need to start a new thread to see that it was useless.

