### PR TITLE
Fix the conversion of time option in PUTNOTIF from timestamp to cdtime_t

### DIFF
--- a/src/utils_cmd_putnotif.c
+++ b/src/utils_cmd_putnotif.c
@@ -49,13 +49,18 @@ static int set_option_severity (notification_t *n, const char *value)
 
 static int set_option_time (notification_t *n, const char *value)
 {
-  time_t tmp;
-  
-  tmp = (time_t) atoi (value);
-  if (tmp <= 0)
+  char *endptr = NULL;
+  double tmp;
+
+  errno = 0;
+  tmp = strtod (value, &endptr);
+  if ((errno != 0)         /* Overflow */
+      || (endptr == value) /* Invalid string */
+      || (endptr == NULL)  /* This should not happen */
+      || (*endptr != 0))   /* Trailing chars */
     return (-1);
 
-  n->time = TIME_T_TO_CDTIME_T(tmp);
+  n->time = DOUBLE_TO_CDTIME_T (tmp);
 
   return (0);
 } /* int set_option_time */


### PR DESCRIPTION
The time parsed in PUTNOTIF, a timestamp, is not converted to cdtime_t.

Reported in the mailing list by George B:

```
Hello,

I have configured a simple test notification using the Exec plugin. This works, however, the Time value in the notification message is changed into something strange (1.307) - can anyone suggest why this is happening?

----
root@croaker:~# cat /etc/collectd/collectd.conf
LoadPlugin exec

<Plugin exec>
        NotificationExec "www-data" "/srv/www/notify.sh"
        Exec "www-data" "/srv/www/test.sh"
</Plugin>
----

----
root@croaker:~# cat /srv/www/test.sh
#!/bin/bash

MESSAGE="Some random text"
SEVERITY="warning"
TIME=`date +%s`

LINE="PUTNOTIF message=\"$MESSAGE\" severity=$SEVERITY time=$TIME"

echo "$LINE" >> /tmp/out.txt

echo "$LINE"
----

----
root@croaker:~# cat /srv/www/notify.sh
#!/bin/bash

echo "$(cat)" >> /tmp/out.txt
----

----
root@croaker:~# tail -n 5 /tmp/out.txt
PUTNOTIF message="Some random text" severity=warning time=1403113649
Severity: WARNING
Time: 1.307

Some random text
----

I am running collectd 5.1.0 (Debian Wheezy).


Thanks,

George
```
