### PR TITLE
Plugin java: fix notification time conversion to cdtime_t.

### DIFF
--- a/src/java.c
+++ b/src/java.c
@@ -906,7 +906,7 @@ static jobject ctoj_notification (JNIEnv *jvm_env, /* {{{ */
 #undef SET_STRING
 
   /* Set the `time' member. Java stores time in milliseconds. */
-  status = ctoj_long (jvm_env, ((jlong) n->time) * ((jlong) 1000),
+  status = ctoj_long (jvm_env, (jlong) CDTIME_T_TO_MS (n->time),
       c_notification, o_notification, "setTime");
   if (status != 0)
   {
@@ -1306,7 +1306,7 @@ static int jtoc_notification (JNIEnv *jvm_env, notification_t *n, /* {{{ */
     return (-1);
   }
   /* Java measures time in milliseconds. */
-  n->time = (time_t) (tmp_long / ((jlong) 1000));
+  n->time = MS_TO_CDTIME_T(tmp_long);
 
   status = jtoc_int (jvm_env, &tmp_int,
       class_ptr, object_ptr, "getSeverity");


### PR DESCRIPTION
Fix conversion of time in notifications to `cdtime_t`.

To reproduce the problem:

Read notitications:

```
import org.collectd.api.Collectd;
import org.collectd.api.Notification;
import org.collectd.api.CollectdNotificationInterface;

public class TestNotify implements CollectdNotificationInterface
{
public TestNotify ()
{
    Collectd.registerNotification("TestNotify", this);
}

public  int notification (Notification n)
{
    System.out.println(n.toString());
    return 0;
    }
}
```

Generate notifications:

```
import org.collectd.api.Collectd;
import org.collectd.api.Notification;
import java.util.Date;
import org.collectd.api.CollectdReadInterface;

public class TestDispatchNotification implements CollectdReadInterface
{
    public TestDispatchNotification ()
    {
    Collectd.registerRead("TestNotify", this);
}

public int read()
{
    Notification n = new Notification();

    n.setTime(new Date().getTime());
    n.setSeverity(Notification.WARNING);
    n.setHost("localhost");
    n.setPlugin("java");
    n.setPluginInstance("TestDispatchNotification");
    n.setType("counter");
    n.setMessage("TestDispatchNotification");

    Collectd.dispatchNotification(n);

    return 0;
}
}
```

The cmd `PUTNOTIF` has the same problem, fixed in https://github.com/collectd/collectd/pull/644
