### PR TITLE
Plugin exec: change notification time to integer.

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -744,8 +744,8 @@ static void *exec_notification_one (void *arg) /* {{{ */
 
   fprintf (fh,
       "Severity: %s\n"
-      "Time: %.3f\n",
-      severity, CDTIME_T_TO_DOUBLE (n->time));
+      "Time: %u\n",
+      severity, (unsigned int)CDTIME_T_TO_TIME_T(n->time));
 
   /* Print the optional fields */
   if (strlen (n->host) > 0)


### PR DESCRIPTION
  Acording to `collectd-exec.5` NOTIFICATION DATA FORMAT: time is epoch, i. e. as seconds since 1970-01-01 00:00:00 UTC.
