### PR TITLE
Aid the user in setting up filterchains by better logmessages

### DIFF
--- a/src/filter_chain.c
+++ b/src/filter_chain.c
@@ -718,6 +718,8 @@ static int fc_bit_write_invoke (const data_set_t *ds, /* {{{ */
           "all write plugins failed with status %i (ENOENT). "
           "Most likely this means you didn't load any write plugins.",
           status);
+      plugin_log_available_writers ();
+
     }
     else if (status != 0)
     {
@@ -743,6 +745,7 @@ static int fc_bit_write_invoke (const data_set_t *ds, /* {{{ */
       {
         INFO ("Filter subsystem: Built-in target `write': Dispatching value to "
             "the `%s' plugin failed with status %i.", plugin_list[i], status);
+	plugin_log_available_writers ();
       }
     } /* for (i = 0; plugin_list[i] != NULL; i++) */
   }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -299,6 +299,7 @@ static void log_list_callbacks (llist_t **list, /* {{{ */
 	}
 	INFO(str);
 	free(str);
+	free(keys);
 	
 }
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -261,9 +261,17 @@ static void log_list_callbacks (llist_t **list, /* {{{ */
 	int len;
 	llentry_t *le;
 	int i;
-	int n = llist_size(*list);
-	char **keys = malloc(sizeof(char* *) * n);
-		
+	int n;
+	char **keys;
+
+	n = llist_size(*list);
+	keys = calloc(n, sizeof(char*));
+
+	if (keys == NULL)
+	{
+		ERROR("failed to allocate memory for list of callbacks");
+		return;
+	}
 
 	for (le = llist_head (*list), i = 0, len = 0;
 	     le != NULL;
@@ -300,8 +308,7 @@ static void log_list_callbacks (llist_t **list, /* {{{ */
 	INFO(str);
 	free(str);
 	free(keys);
-	
-}
+} /* }}} int log_list_callbacks */
 
 static int create_register_callback (llist_t **list, /* {{{ */
 		const char *name, void *callback, user_data_t *ud)

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -253,6 +253,55 @@ static int register_callback (llist_t **list, /* {{{ */
 	return (0);
 } /* }}} int register_callback */
 
+static void log_list_callbacks (llist_t **list, /* {{{ */
+				const char *comment, size_t clen)
+{
+	char *str;
+	char *pos;
+	int len;
+	llentry_t *le;
+	int i;
+	int n = llist_size(*list);
+	char **keys = malloc(sizeof(char* *) * n);
+		
+
+	for (le = llist_head (*list), i = 0, len = 0;
+	     le != NULL;
+	     le = le->next, i++)
+	{
+		keys[i] = le->key;
+		len += strlen(le->key) + 6;
+	}
+
+	if (len == 0)
+	{
+		len += strlen(comment) + 10;
+		str = malloc(len + 10);
+		*str = '\0';
+
+		pos = memcpy(str, comment, len);
+		pos = strncpy(pos, " [none]", len - (pos - str));
+	}
+	else
+	{
+		len += strlen(comment);
+		pos = str=malloc(len + 10);
+		*str = '\0';
+
+		strncpy(str, comment, clen);
+		pos += clen;
+		strncpy(pos, " ['", len - (pos - str));
+		pos += 3;
+
+		n = strjoin(pos, len - (pos - str), keys, n, "', '");
+		pos += n;
+		strncpy(pos, "']", len - (pos - str));
+	}
+	INFO(str);
+	free(str);
+	
+}
+
 static int create_register_callback (llist_t **list, /* {{{ */
 		const char *name, void *callback, user_data_t *ud)
 {
@@ -1345,6 +1394,13 @@ int plugin_unregister_read (const char *name) /* {{{ */
 
 	return (0);
 } /* }}} int plugin_unregister_read */
+
+#define _STR_W_LEN(a) a, sizeof(a) - 1
+void plugin_log_available_writers ()
+{
+	
+	log_list_callbacks (&list_write, _STR_W_LEN("Available writers:"));
+}
 
 static int compare_read_func_group (llentry_t *e, void *ud) /* {{{ */
 {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -312,6 +312,7 @@ int plugin_unregister_data_set (const char *name);
 int plugin_unregister_log (const char *name);
 int plugin_unregister_notification (const char *name);
 
+void plugin_log_available_writers ();
 
 /*
  * NAME

--- a/src/utils_llist.h
+++ b/src/utils_llist.h
@@ -60,4 +60,6 @@ llentry_t *llist_search_custom (llist_t *l,
 llentry_t *llist_head (llist_t *l);
 llentry_t *llist_tail (llist_t *l);
 
+
+
 #endif /* UTILS_LLIST_H */


### PR DESCRIPTION
The builtin filterchain writer module requires to know the name of the writer module to send the data to. I didn't find any documentation about how the writers names were created; some of them are dynamicaly generated depending on the configuration. 
This patch outputs the name of all configured writers right next to the errormessage of being unable to choose one so the user can succeed in generating his config without source reading and documentation nightmares.