### PR TITLE
Fix ttl order

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -3163,6 +3163,14 @@ static int network_config (oconfig_item_t *ci) /* {{{ */
 {
   int i;
 
+  /* The options need to be applied first */
+  for (i = 0; i < ci->children_num; i++)
+  {
+    oconfig_item_t *child = ci->children + i;
+    if (strcasecmp ("TimeToLive", child->key) == 0)
+      network_config_set_ttl (child);
+  }
+
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *child = ci->children + i;
@@ -3171,8 +3179,9 @@ static int network_config (oconfig_item_t *ci) /* {{{ */
       network_config_add_listen (child);
     else if (strcasecmp ("Server", child->key) == 0)
       network_config_add_server (child);
-    else if (strcasecmp ("TimeToLive", child->key) == 0)
-      network_config_set_ttl (child);
+    else if (strcasecmp ("TimeToLive", child->key) == 0) {
+      /* Handled earlier */
+    }
     else if (strcasecmp ("MaxPacketSize", child->key) == 0)
       network_config_set_buffer_size (child);
     else if (strcasecmp ("Forward", child->key) == 0)


### PR DESCRIPTION
In the network plugin, TimeToLive must be set prior to any Server definitions.  This patch scans for TimeToLive before setting up the send sockets.  Also warns if TimeToLive is out of bounds.
