### PR TITLE
Statsd: avoid doing a division by zero when calculating the average

### DIFF
--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -146,7 +146,7 @@ cdtime_t latency_counter_get_percentile (latency_counter_t *lc,
   int sum;
   size_t i;
 
-  if ((lc == NULL) || !((percent > 0.0) && (percent < 100.0)))
+  if ((lc == NULL) || (lc->num == 0) || !((percent > 0.0) && (percent < 100.0)))
     return (0);
 
   /* Find index i so that at least "percent" events are within i+1 ms. */


### PR DESCRIPTION
if there was no value in the interval, lc->num == 0, and by that we would return the result of a division by zero
->
gdb> print average
$18 = -nan(0x8000000000000)
