### PR TITLE
logfile: (as in Syslog) if we can't find the loglevel specified by the c...

### DIFF
--- a/src/logfile.c
+++ b/src/logfile.c
@@ -53,8 +53,13 @@ static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 static int logfile_config (const char *key, const char *value)
 {
 	if (0 == strcasecmp (key, "LogLevel")) {
-		log_level = parse_log_severity(value);
-		if (log_level == -1) return 1; /* to keep previous behaviour */
+                log_level = parse_log_severity (value);
+                if (log_level < 0)
+                {
+                        log_level = LOG_INFO;
+                        ERROR ("syslog: invalid loglevel [%s] defauling to 'info'", value);
+                        return (1);
+                }
 	}
 	else if (0 == strcasecmp (key, "File")) {
 		sfree (log_file);


### PR DESCRIPTION
...onfiguration string default to 'info' and warn about the unknown configuration option. no way to make syslog totaly silent anymore.
