### PR TITLE
OKAY notification in missing values broken.

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -299,7 +299,7 @@ static int agg_instance_update (agg_instance_t *inst, /* {{{ */
     return (EINVAL);
   }
 
-  rate = uc_get_rate (ds, vl);
+  rate = uc_get_rate (ds, vl, /* include missing = */ 0);
   if (rate == NULL)
   {
     char ident[6 * DATA_MAX_NAME_LEN];

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -430,7 +430,7 @@ static int get_reference_temperature(double * result)
         {
             if(uc_get_rate_by_name(list->sensor_name,
                                    &values,
-                                   &values_num))
+                                   &values_num, /* include missing = */ 0))
             {
                 DEBUG ("barometer: get_reference_temperature - rate \"%s\" not found yet",
                        list->sensor_name);
@@ -489,7 +489,7 @@ static int get_reference_temperature(double * result)
         {
             if(uc_get_rate_by_name(list->sensor_name,
                                    &values,
-                                   &values_num))
+                                   &values_num, /* include missing = */ 0))
             {
                 ERROR ("barometer: get_reference_temperature - rate \"%s\" lost",
                        list->sensor_name);

--- a/src/csv.c
+++ b/src/csv.c
@@ -77,7 +77,8 @@ static int value_list_to_string (char *buffer, int buffer_len,
 		else if (store_rates != 0)
 		{
 			if (rates == NULL)
-				rates = uc_get_rate (ds, vl);
+				rates = uc_get_rate (ds, vl,
+						/* include missing = */ 0);
 			if (rates == NULL)
 			{
 				WARNING ("csv plugin: "

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -970,7 +970,8 @@ int format_values (char *ret, size_t ret_len, /* {{{ */
                 else if (store_rates)
                 {
                         if (rates == NULL)
-                                rates = uc_get_rate (ds, vl, 0);
+                                rates = uc_get_rate (ds, vl,
+                                            /* include missing = */ 0);
                         if (rates == NULL)
                         {
                                 WARNING ("format_values: uc_get_rate failed.");

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -970,7 +970,7 @@ int format_values (char *ret, size_t ret_len, /* {{{ */
                 else if (store_rates)
                 {
                         if (rates == NULL)
-                                rates = uc_get_rate (ds, vl);
+                                rates = uc_get_rate (ds, vl, 0);
                         if (rates == NULL)
                         {
                                 WARNING ("format_values: uc_get_rate failed.");

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -321,9 +321,7 @@ int uc_check_timeout (void)
     return (0);
   }
 
-  /* Call the "missing" callback for each value. Do this before removing the
-   * value from the cache, so that callbacks can still access the data stored,
-   * including plugin specific meta data, rates, history, …. This must be done
+  /* Call the "missing" callback for each value. This must be done
    * without holding the lock, otherwise we will run into a deadlock if a
    * plugin calls the cache interface. */
   for (int i = 0; i < keys_len; i++)

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -39,11 +39,11 @@
 int uc_init (void);
 int uc_check_timeout (void);
 int uc_update (const data_set_t *ds, const value_list_t *vl);
-int uc_get_rate_by_name (const char *name, gauge_t **ret_values, size_t *ret_values_num);
-gauge_t *uc_get_rate (const data_set_t *ds, const value_list_t *vl);
+int uc_get_rate_by_name (const char *name, gauge_t **ret_values, size_t *ret_values_num, _Bool include_missing);
+gauge_t *uc_get_rate (const data_set_t *ds, const value_list_t *vl, _Bool include_missing);
 
 size_t uc_get_size (void);
-int uc_get_names (char ***ret_names, cdtime_t **ret_times, size_t *ret_number);
+int uc_get_names (char ***ret_names, cdtime_t **ret_times, size_t *ret_number, _Bool include_missing);
 
 int uc_get_state (const data_set_t *ds, const value_list_t *vl);
 int uc_set_state (const data_set_t *ds, const value_list_t *vl, int state);

--- a/src/daemon/utils_cache_mock.c
+++ b/src/daemon/utils_cache_mock.c
@@ -27,7 +27,8 @@
 #include "utils_cache.h"
 
 gauge_t *uc_get_rate (__attribute__((unused)) data_set_t const *ds,
-                      __attribute__((unused)) value_list_t const *vl)
+                      __attribute__((unused)) value_list_t const *vl,
+                      __attribute__((unused)) _Bool include_missing)
 {
   return (NULL);
 }

--- a/src/match_value.c
+++ b/src/match_value.c
@@ -277,7 +277,7 @@ static int mv_match (const data_set_t *ds, const value_list_t *vl, /* {{{ */
 
   m = *user_data;
 
-  values = uc_get_rate (ds, vl);
+  values = uc_get_rate (ds, vl, /* include missing = */ 0);
   if (values == NULL)
   {
     ERROR ("`value' match: Retrieving the current rate from the cache "

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -761,7 +761,7 @@ static char *values_to_sqlarray (const data_set_t *ds, const value_list_t *vl,
 					","GAUGE_FORMAT, vl->values[i].gauge);
 		else if (store_rates) {
 			if (rates == NULL)
-				rates = uc_get_rate (ds, vl);
+				rates = uc_get_rate (ds, vl, /* include missing = */ 0);
 
 			if (rates == NULL) {
 				log_err ("c_psql_write: Failed to determine rate");

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -244,7 +244,7 @@ static int tn_invoke (const data_set_t *ds, value_list_t *vl, /* {{{ */
     {
       if ((rates == NULL) && (rates_failed == 0))
       {
-        rates = uc_get_rate (ds, vl);
+        rates = uc_get_rate (ds, vl, /* include missing = */ 0);
         if (rates == NULL)
           rates_failed = 1;
       }

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -783,7 +783,7 @@ static int ut_check_threshold (const data_set_t *ds, const value_list_t *vl,
 
   DEBUG ("ut_check_threshold: Found matching threshold(s)");
 
-  values = uc_get_rate (ds, vl);
+  values = uc_get_rate (ds, vl, /* include missing = */ 1);
   if (values == NULL)
     return (0);
 

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -124,7 +124,8 @@ int handle_getval (FILE *fh, char *buffer)
 
   values = NULL;
   values_num = 0;
-  status = uc_get_rate_by_name (identifier, &values, &values_num);
+  status = uc_get_rate_by_name (identifier, &values, &values_num,
+                                /* include missing = */ 0);
   if (status != 0)
   {
     print_to_socket (fh, "-1 No such value\n");

--- a/src/utils_cmd_listval.c
+++ b/src/utils_cmd_listval.c
@@ -86,7 +86,7 @@ int handle_listval (FILE *fh, char *buffer)
     free_everything_and_return (-1);
   }
 
-  status = uc_get_names (&names, &times, &number);
+  status = uc_get_names (&names, &times, &number, /* include missing = */ 0);
   if (status != 0)
   {
     DEBUG ("command listval: uc_get_names failed with status %i", status);

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -189,7 +189,7 @@ int format_graphite (char *buffer, size_t buffer_size,
 
     gauge_t *rates = NULL;
     if (flags & GRAPHITE_STORE_RATES)
-      rates = uc_get_rate (ds, vl);
+      rates = uc_get_rate (ds, vl, /* include missing = */ 0);
 
     for (size_t i = 0; i < ds->ds_num; i++)
     {

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -130,7 +130,7 @@ static int values_to_json (char *buffer, size_t buffer_size, /* {{{ */
     else if (store_rates)
     {
       if (rates == NULL)
-        rates = uc_get_rate (ds, vl);
+        rates = uc_get_rate (ds, vl, /* include missing = */ 0);
       if (rates == NULL)
       {
         WARNING ("utils_format_json: uc_get_rate failed.");

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -147,7 +147,7 @@ static int values_to_kairosdb (char *buffer, size_t buffer_size, /* {{{ */
   else if (store_rates)
   {
     if (rates == NULL)
-      rates = uc_get_rate (ds, vl);
+      rates = uc_get_rate (ds, vl, /* include missing = */ 0);
     if (rates == NULL)
     {
       WARNING ("utils_format_kairosdb: uc_get_rate failed for %s|%s|%s|%s|%s",

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -85,7 +85,7 @@ static bson *wm_create_bson (const data_set_t *ds, /* {{{ */
 
   if (store_rates)
   {
-    rates = uc_get_rate (ds, vl);
+    rates = uc_get_rate (ds, vl, /* include missing = */ 0);
     if (rates == NULL)
     {
       ERROR ("write_mongodb plugin: uc_get_rate() failed.");

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -406,7 +406,7 @@ wrr_value_list_to_message(struct riemann_host const *host, /* {{{ */
   }
 
   if (host->store_rates) {
-    rates = uc_get_rate(ds, vl);
+    rates = uc_get_rate(ds, vl, /* include missing = */ 0);
     if (rates == NULL) {
       ERROR("write_riemann plugin: uc_get_rate failed.");
       riemann_message_free(msg);

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -215,7 +215,7 @@ int write_riemann_threshold_check (const data_set_t *ds, const value_list_t *vl,
 
   DEBUG ("ut_check_threshold: Found matching threshold(s)");
 
-  values = uc_get_rate (ds, vl);
+  values = uc_get_rate (ds, vl, /* include missing = */ 0);
   if (values == NULL)
 	  return (0);
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -889,7 +889,7 @@ static int sensu_write(const data_set_t *ds, /* {{{ */
 	memset(statuses, 0, vl->values_len * sizeof(*statuses));
 
 	if (host->store_rates) {
-		rates = uc_get_rate(ds, vl);
+		rates = uc_get_rate(ds, vl, /* include missing = */ 0);
 		if (rates == NULL) {
 			ERROR("write_sensu plugin: uc_get_rate failed.");
 			pthread_mutex_unlock(&host->lock);

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -306,7 +306,7 @@ static int wt_format_values(char *ret, size_t ret_len,
     else if (store_rates)
     {
         if (rates == NULL)
-            rates = uc_get_rate (ds, vl);
+            rates = uc_get_rate (ds, vl, /* include missing = */ 0);
         if (rates == NULL)
         {
             WARNING("format_values: "


### PR DESCRIPTION
Hello.

This is a slightly different version of https://github.com/collectd/collectd/pull/225

There are two changes form the original patch of @mce35:

Change the state to `STATE_MISSING` in `ut_missing`
to `uc_check_timeout` after call `plugin_dispatch_missing` because
threshold is a plugin (maybe you can use another plugin to track missings...)

Also in `uc_check_timeout` instead of not call `plugin_dispatch_missing` 
if value is missing, not put in the value in the list of entries to be flushed if
it's missing.

I was using this feature in collectd 4, would be nice to recover it in collectd 5.

I've been using this patch for a couple of months in production.
