### PR TITLE
per-url intervals for curl_json

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1339,6 +1339,11 @@ The following options are valid within B<URL> blocks:
 
 Sets the plugin instance to I<Instance>.
 
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which the values will be collected from this
+URL. By default the global B<Interval> setting will be used.
+
 =item B<User> I<Name>
 
 =item B<Password> I<Password>


### PR DESCRIPTION
This change allows to configure per-url interval in curl_json plugin. (Particular use case was capturing data from rate limited 3rd party service).

(this is rebased #433)
