### PR TITLE
Fix problem with write limits

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -2027,7 +2027,7 @@ static long get_drop_probability (void) /* {{{ */
 	if (wql < write_limit_low)
 		return (0);
 	if (wql >= write_limit_high)
-		return (1);
+		return (DROP_PROBABILITY_MAX);
 
 	pos = 1 + wql - write_limit_low;
 	size = 1 + write_limit_high - write_limit_low;


### PR DESCRIPTION
I'm currently having an overloaded server running Collectd.
PR #280 (merged in collectd-5.4.0) is working well except in some strange cases. This PR fixes the problems with comparisons on `long` instead of `double` and removing all equality checks on `double`.
