### PR TITLE
write_kafka: avoid unused function build error

### DIFF
--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -61,6 +61,7 @@ static int kafka_write(const data_set_t *, const value_list_t *, user_data_t *);
 static int32_t kafka_partition(const rd_kafka_topic_t *, const void *, size_t,
                                int32_t, void *, void *);
 
+#ifdef HAVE_LIBRDKAFKA_LOGGER
 static void kafka_log(const rd_kafka_t *, int, const char *, const char *);
 
 static void kafka_log(const rd_kafka_t *rkt, int level,
@@ -68,6 +69,7 @@ static void kafka_log(const rd_kafka_t *rkt, int level,
 {
     plugin_log(level, "%s", msg);
 }
+#endif
 
 static int32_t kafka_partition(const rd_kafka_topic_t *rkt,
                                const void *keydata, size_t keylen,


### PR DESCRIPTION
Noticed this problem when building with `-Werror`.
