### PR TITLE
snmp: free snmp_pdu struct allocated by snmp_pdu_create()

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1503,6 +1503,10 @@ static int csnmp_read_table (host_definition_t *host, data_definition_t *data)
     snmp_free_pdu (res);
   res = NULL;
 
+  if (req != NULL)
+    snmp_free_pdu (req);
+  req = NULL;
+
   if (status == 0)
     csnmp_dispatch_table (host, data, instance_list_head, value_list_head);
 


### PR DESCRIPTION
This should fix the leak reported in issue #610.
