### PR TITLE
graphite escape fixes for 5.4

### DIFF
--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -29,7 +29,7 @@
 #include "utils_cache.h"
 #include "utils_parse_option.h"
 
-#define GRAPHITE_FORBIDDEN " \t\"\\:!/\n\r"
+#define GRAPHITE_FORBIDDEN " \t\"\\:!/()\n\r"
 
 /* Utils functions to format data sets in graphite format.
  * Largely taken from write_graphite.c as it remains the same formatting */


### PR DESCRIPTION
This was reported by @tas50 in https://github.com/collectd/collectd/pull/611 a few months ago but the back/forward port to 5.4 might have slipped through the cracks.
