### PR TITLE
TSDB metadata

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7789,7 +7789,7 @@ Example:
 
 =item B<TSDBPrefix> I<String>
 
-=item B<TSDBTags> I<Strings>
+=item B<TSDBTags> I<String>
 
 These are used by the B<write_tsdb> plugin. The prefix is prepended to the
 metric name and should include the separator, i.e. "sys.". Tags are passed as

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7785,6 +7785,26 @@ Example:
    TypeInstance "core3"
  </Target>
 
+=over 4
+
+=item B<TSDBPrefix> I<String>
+
+=item B<TSDBTags> I<Strings>
+
+These are used by the B<write_tsdb> plugin. The prefix is prepended to the
+metric name and should include the separator, i.e. "sys.". Tags are passed as
+name=value pairs along with the metrics and aid in filtering and aggregating
+metrics in OpenTSDB.
+
+=back
+
+Example:
+
+ <Target "set">
+   TSDBPrefix "sys."
+   TSDBTags "devicerole=webserver"
+ </Target>
+
 =back
 
 =head2 Backwards compatibility


### PR DESCRIPTION
This allows collectd to closely align with OpenTSDB concepts without drastic changes to either system by using the metadata and filter chains in collectd:
* http://opentsdb.net/docs/build/html/user_guide/writing.html
* https://collectd.org/wiki/index.php/Meta_Data_Interface
* https://collectd.org/wiki/index.php/Chains

We use prefixes for organizing metrics into trees, and it is particularly useful for i.e. separating systems metrics vs applications metrics:  "app.", "sys." and then making those easily browsable in UIs like http://grafana.org/ or Graphite (with the TSDB backend https://github.com/graphite-project/graphite-web/issues/693).

The tag is a central component of TSDB.  Using filter chains, complex tagging is easily available for all plugins and can be driven by config management.  Since we use the collectd metadata API, it is also a first class attribute usable by the collectd perl and python plugins.

A quite simple example to prefix all collectd metric names with "sys." and add an arbitrary "status" tag:
```
<Chain "PreCache">
  <Rule "add_sys_prefix">
    <Match "regex">
      Host "^"
    </Match>
    <Target "set">
      TSDBPrefix "sys."
      TSDBTags "status=production"
    </Target>
  </Rule>
</Chain>
```
![target-set1](https://cloud.githubusercontent.com/assets/90042/3928596/b6ea7672-240c-11e4-9da6-a4fe9fd14d97.png)

