### PR TITLE
Remove spammy debug message from putval.

### DIFF
--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -223,11 +223,7 @@ int handle_putval (FILE *fh, char *buffer)
 	} /* while (*buffer != 0) */
 	/* Done parsing the options. */
 
-	print_to_socket (fh, "0 Success: %i %s been dispatched.\n",
-			values_submitted,
-			(values_submitted == 1) ? "value has" : "values have");
-
-	sfree (vl.values); 
+	sfree (vl.values);
 
 	return (0);
 } /* int handle_putval */


### PR DESCRIPTION
Other messages are printed to the socket in this section of the code,
but they are all error messages and therefore helpful.  This message
appears to be more of a debug message indicating that things are working
normally.  As people have reported in #664, in production scenarios it
floods logs and is spammy and unhelpful.
