### PR TITLE
adding support for using irq assignments not numbers

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -489,10 +489,14 @@
 #</Plugin>
 
 #<Plugin irq>
-#	Irq 7
-#	Irq 8
-#	Irq 9
-#	IgnoreSelected true
+#	Irq "/eth/"
+#	Irq LOC
+#	Irq RES
+#	Irq CAL
+#	Irq TLB
+#	Irq TRM
+#	IgnoreSelected false
+#	NamedIrq true
 #</Plugin>
 
 #<Plugin java>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2291,6 +2291,21 @@ few ones. This option enables you to do that: By setting B<IgnoreSelected> to
 I<true> the effect of B<Irq> is inverted: All selected interrupts are ignored
 and all other interrupts are collected.
 
+Setting B<NamedIrq> to I<true> will use the allocated name of the irq instead of the number.
+
+Synopsis:
+
+  <Plugin irq>
+    Irq "/eth/"
+    Irq LOC
+    Irq RES
+    Irq CAL
+    Irq TLB
+    Irq TRM
+    IgnoreSelected false
+    NamedIrq true
+  </Plugin>
+
 =back
 
 =head2 Plugin C<java>

--- a/src/irq.c
+++ b/src/irq.c
@@ -37,11 +37,13 @@
 static const char *config_keys[] =
 {
 	"Irq",
-	"IgnoreSelected"
+	"IgnoreSelected",
+	"NamedIrq"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
 static ignorelist_t *ignorelist = NULL;
+static int named_irq;
 
 /*
  * Private functions
@@ -62,6 +64,17 @@ static int irq_config (const char *key, const char *value)
 			invert = 0;
 		ignorelist_set_invert (ignorelist, invert);
 	}
+	else if ( strcasecmp (key, "NamedIrq") == 0)
+        {
+	        if (IS_TRUE (value))
+                {
+                        named_irq = 1;
+                }
+                else
+                {
+                        named_irq = 0;
+                }
+        }
 	else
 	{
 		return (-1);
@@ -157,6 +170,13 @@ static int irq_read (void)
 
 		irq_name[irq_name_len - 1] = 0;
 		irq_name_len--;
+                /* Use the last column instead of the irq number */
+                if (named_irq == 1)
+                {
+                        /* Some first column names are already non digits */
+                        if ( isdigit(irq_name[0]) )
+                                irq_name = fields[4];
+                }
 
 		irq_value = 0;
 		for (i = 1; i <= irq_values_to_parse; i++)


### PR DESCRIPTION
This is to give the option of a more readable key for the irq, like munin.