### PR TITLE
Add a battery plugin that uses the modern Linux locations for battery in...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,9 @@ Amit Gupta <amit.gupta221 at gmail.com>
 Andreas Henriksson <andreas at fatal.se>
  - libmnl support in the netlink plugin.
 
+Andy Parkins <andyp at fussylogic.co.uk>
+ - sysfsbattery plugin.
+
 Anthony Dewhurst <dewhurst at gmail.com>
  - zfs_arc plugin.
 

--- a/configure.ac
+++ b/configure.ac
@@ -4954,6 +4954,7 @@ dependency_error="no"
 plugin_ascent="no"
 plugin_barometer="no"
 plugin_battery="no"
+plugin_sysfsbattery="no"
 plugin_bind="no"
 plugin_cgroups="no"
 plugin_conntrack="no"
@@ -4998,7 +4999,7 @@ plugin_zfs_arc="no"
 # Linux
 if test "x$ac_system" = "xLinux"
 then
-	plugin_battery="yes"
+	plugin_sysfsbattery="yes"
 	plugin_conntrack="yes"
 	plugin_contextswitch="yes"
 	plugin_cgroups="yes"
@@ -5312,6 +5313,7 @@ AC_PLUGIN([aquaero],     [$with_libaquaero5],  [Aquaero's hardware sensors])
 AC_PLUGIN([ascent],      [$plugin_ascent],     [AscentEmu player statistics])
 AC_PLUGIN([barometer],   [$plugin_barometer],  [Barometer sensor on I2C])
 AC_PLUGIN([battery],     [$plugin_battery],    [Battery statistics])
+AC_PLUGIN([sysfsbattery],[$plugin_sysfsbattery], [Battery statistics for newer Linux])
 AC_PLUGIN([bind],        [$plugin_bind],       [ISC Bind nameserver statistics])
 AC_PLUGIN([conntrack],   [$plugin_conntrack],  [nf_conntrack statistics])
 AC_PLUGIN([contextswitch], [$plugin_contextswitch], [context switch statistics])
@@ -5677,6 +5679,7 @@ Configuration:
     ascent  . . . . . . . $enable_ascent
     barometer . . . . . . $enable_barometer
     battery . . . . . . . $enable_battery
+    sysfsbattery  . . . . $enable_sysfsbattery
     bind  . . . . . . . . $enable_bind
     conntrack . . . . . . $enable_conntrack
     contextswitch . . . . $enable_contextswitch

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -242,6 +242,15 @@ collectd_LDADD += "-dlopen" battery.la
 collectd_DEPENDENCIES += battery.la
 endif
 
+if BUILD_PLUGIN_SYSFSBATTERY
+pkglib_LTLIBRARIES += sysfsbattery.la
+sysfsbattery_la_SOURCES = sysfsbattery.c
+sysfsbattery_la_LDFLAGS = -module -avoid-version
+sysfsbattery_la_LIBADD =
+collectd_LDADD += "-dlopen" sysfsbattery.la
+collectd_DEPENDENCIES += sysfsbattery.la
+endif
+
 if BUILD_PLUGIN_BIND
 pkglib_LTLIBRARIES += bind.la
 bind_la_SOURCES = bind.c

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -89,6 +89,7 @@
 #@BUILD_PLUGIN_ASCENT_TRUE@LoadPlugin ascent
 #@BUILD_PLUGIN_BAROMETER_TRUE@LoadPlugin barometer
 #@BUILD_PLUGIN_BATTERY_TRUE@LoadPlugin battery
+#@BUILD_PLUGIN_SYSFSBATTERY_TRUE@LoadPlugin sysfsbattery
 #@BUILD_PLUGIN_BIND_TRUE@LoadPlugin bind
 #@BUILD_PLUGIN_CONNTRACK_TRUE@LoadPlugin conntrack
 #@BUILD_PLUGIN_CONTEXTSWITCH_TRUE@LoadPlugin contextswitch

--- a/src/sysfsbattery.c
+++ b/src/sysfsbattery.c
@@ -1,0 +1,159 @@
+/**
+ * collectd - src/sysfsbattery.c
+ * Copyright (C) 2014  Andy Parkins
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   Andy Parkins <andyp@fussylogic.co.uk>
+ **/
+
+#include <stdbool.h>
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+#define MODULE_NAME "sysfsbattery"
+#define BASE_PATH "/sys/class/power_supply/BAT%d/%s"
+
+typedef struct {
+	unsigned long energy_full_design;
+	unsigned long energy_full;
+	unsigned long energy_now;
+	unsigned long power_now;
+	unsigned long voltage_min_design;
+	unsigned long voltage_now;
+} sBatterySample;
+
+static int target_battery = -1;
+
+static int battery_init (void)
+{
+	int status;
+	int i;
+	char filename[256];
+
+	for (i = 0; i < 10; i++) {
+		status = ssnprintf (filename, sizeof (filename),
+				BASE_PATH, i, "present");
+		if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+			continue;
+
+		if (access (filename, R_OK))
+			continue;
+
+		target_battery = i;
+		break;
+	}
+
+	return (0);
+} /* int battery_init */
+
+static void battery_submit (const char *plugin_instance, const char *type, double value)
+{
+	value_t values[1];
+	value_list_t vl = VALUE_LIST_INIT;
+
+	values[0].gauge = value;
+
+	vl.values = values;
+	vl.values_len = 1;
+	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+	sstrncpy (vl.plugin, "battery", sizeof (vl.plugin));
+	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
+	sstrncpy (vl.type, type, sizeof (vl.type));
+
+	plugin_dispatch_values (&vl);
+}
+
+static bool sysfs_file_to_ul(int i, const char *basename, unsigned long *target)
+{
+	int status;
+	FILE *fp;
+	char filename[256];
+	char buffer[16];
+
+	status = ssnprintf (filename, sizeof (filename),
+			BASE_PATH, i, basename);
+	if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+		return 0;
+
+	/* No file isn't the end of the world -- not every system will be
+	 * reporting the same set of statistics */
+	if (access (filename, R_OK))
+		return 0;
+
+	if ((fp = fopen (filename, "r")) == NULL)
+	{
+		char errbuf[1024];
+		WARNING ("battery: fopen (%s): %s", filename,
+				sstrerror (errno, errbuf,
+					sizeof (errbuf)));
+		return 0;
+	}
+
+	if (fgets (buffer, sizeof(buffer), fp) == NULL)
+	{
+		char errbuf[1024];
+		WARNING ("battery: fgets: %s",
+				sstrerror (errno, errbuf,
+					sizeof (errbuf)));
+		fclose (fp);
+		return 0;
+	}
+
+	*target = strtoul(buffer, NULL, 10);
+
+	if (fclose (fp))
+	{
+		char errbuf[1024];
+		WARNING ("battery: fclose: %s",
+				sstrerror (errno, errbuf,
+					sizeof (errbuf)));
+	}
+
+	DEBUG (MODULE_NAME " plugin: %s = %lu", filename, *target);
+
+	return 1;
+}
+
+static int battery_read (void)
+{
+	sBatterySample val;
+
+	/* Fill in sample */
+	memset(&val, 0, sizeof(val));
+//	if (sysfs_file_to_ul(target_battery, "energy_full_design", &(val.energy_full_design)))
+//		battery_submit("0", "charge", val.energy_full_design / 1000000.0);
+//	if (sysfs_file_to_ul(target_battery, "energy_full", &(val.energy_full)))
+//		battery_submit("0", "charge", val.energy_full / 1000000.0);
+	if (sysfs_file_to_ul(target_battery, "energy_now", &(val.energy_now)))
+		battery_submit("0", "charge", val.energy_now / 1000000.0);
+	if (sysfs_file_to_ul(target_battery, "power_now", &(val.power_now)))
+		battery_submit("0", "power", val.power_now / 1000000.0);
+//	if (sysfs_file_to_ul(target_battery, "voltage_min_design", &(val.voltage_min_design)))
+//		battery_submit("0", "voltage", val.voltage_min_design / 1000000.0);
+	if (sysfs_file_to_ul(target_battery, "voltage_now", &(val.voltage_now)))
+		battery_submit("0", "voltage", val.voltage_now / 1000000.0);
+
+	return (0);
+} /* int battery_read */
+
+void module_register (void)
+{
+	plugin_register_init (MODULE_NAME, battery_init);
+	plugin_register_read (MODULE_NAME, battery_read);
+}


### PR DESCRIPTION
...formation

https://github.com/collectd/collectd/issues/424

The existing plugin uses `/proc/acpi/battery`.  Linux no longer keeps
battery information here.

This patch adds an alternative battery plugin which uses the modern
location

```
/sys/class/power_supply/BATx/
```

It finds the first directory that exists for BATx.
