### PR TITLE
Add ReconnectInterval option to Network plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -706,6 +706,7 @@
 #		Username "user"
 #		Password "secret"
 #		Interface "eth0"
+#		ResolveInterval 14400
 @LOAD_PLUGIN_NETWORK@	</Server>
 #	TimeToLive "128"
 #

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3890,6 +3890,12 @@ behavior is to let the kernel choose the appropriate interface. Be warned
 that the manual selection of an interface for unicast traffic is only
 necessary in rare cases.
 
+=item B<ResolveInterval> I<Seconds>
+
+Sets the interval at which to re-resolve the DNS for the I<Host>. This is
+useful to force a regular DNS lookup to support a high availability setup. If
+not specified, re-resolves are never attempted.
+
 =back
 
 =item B<E<lt>Listen> I<Host> [I<Port>]B<E<gt>>


### PR DESCRIPTION
The Network plugin only performs DNS resolution at initialization. This
can be problematic when trying to performs migrations of collectd
infrastructure or when trying to create HA solutions which are dependant
on DNS.

The ReconnectInterval options forces a reconnect of all the sockets at
the defined number of seconds. By default no re-connections are attempted
if this option is not set.
