### PR TITLE
network: initialize ai_flags of client socket

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -2107,6 +2107,7 @@ static int sockent_client_connect (sockent_t *se) /* {{{ */
 		return (0);
 
 	memset (&ai_hints, 0, sizeof (ai_hints));
+	ai_hints.ai_flags  = 0;
 #ifdef AI_ADDRCONFIG
 	ai_hints.ai_flags |= AI_ADDRCONFIG;
 #endif


### PR DESCRIPTION
Bitwise OR-ing options on `ai_flags` without properly resetting it
silently enabled the `AI_PASSIVE` flag under certain conditions. So this
left collectd *clients* with an UDP socket open on 0.0.0.0.