### PR TITLE
Fix exec-nagios.px return code handling

### DIFF
--- a/contrib/exec-nagios.px
+++ b/contrib/exec-nagios.px
@@ -442,7 +442,7 @@ sub execute_script
 
   close ($fh);
   # Save the exit status of the check in $state
-  $state = $?;
+  $state = $? >> 8;
 
   if ($state == 0)
   {


### PR DESCRIPTION
In exec-nagios.px the exit status contains the return code of the process, but does not correctly calculate the value. From http://perldoc.perl.org/functions/system.html the exit status should be shifted right by 8 to obtain the return code.

This was causing all scripts in my environment to return failure for any non-zero return code.
