### PR TITLE
Update bind plugin to support the new XML v3 API.

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -670,29 +670,29 @@ static int bind_parse_generic_name_attr_value_list (const char *xpath_expression
       if (child->type != XML_ELEMENT_NODE)
         continue;
 
-      if (strncmp ("counter", (char *) child->name, strlen ("counter")) == 0)
+      if (strncmp ("counter", (char *) child->name, strlen ("counter")) != 0)
+        continue;
+
+      char *attr_name;
+      value_t value;
+      int status;
+
+      attr_name = (char *) xmlGetProp (child, BAD_CAST "name");
+      if (attr_name == NULL)
       {
-        char *attr_name;
-        value_t value;
-        int status;
-
-        attr_name = (char *) xmlGetProp (child, BAD_CAST "name");
-        if (attr_name == NULL)
-        {
-          DEBUG ("bind plugin: found <counter> without name.");
-          continue;
-        }
-        if (ds_type == DS_TYPE_GAUGE)
-          status = bind_xml_read_gauge (doc, child, &value.gauge);
-        else
-          status = bind_xml_read_derive (doc, child, &value.derive);
-        if (status != 0)
-          continue;
-
-        status = (*list_callback) (attr_name, value, current_time, user_data);
-        if (status == 0)
-          num_entries++;
+        DEBUG ("bind plugin: found <counter> without name.");
+        continue;
       }
+      if (ds_type == DS_TYPE_GAUGE)
+        status = bind_xml_read_gauge (doc, child, &value.gauge);
+      else
+        status = bind_xml_read_derive (doc, child, &value.derive);
+      if (status != 0)
+        continue;
+
+      status = (*list_callback) (attr_name, value, current_time, user_data);
+      if (status == 0)
+        num_entries++;
     }
   }
 
@@ -1016,33 +1016,11 @@ static int bind_xml_stats_search_views (int version, xmlDoc *doc, /* {{{ */
   return (0);
 } /* }}} int bind_xml_stats_search_views */
 
-static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
-    xmlXPathContext *xpathCtx, xmlNode *statsnode)
+static void bind_xml_stats_v3 (xmlDoc *doc, /* {{{ */
+    xmlXPathContext *xpathCtx, xmlNode *statsnode, time_t current_time)
 {
-  time_t current_time = 0;
-  int status;
-
-  xpathCtx->node = statsnode;
-
-  /* TODO: Check `server/boot-time' to recognize server restarts. */
-
-  status = bind_xml_read_timestamp ("server/current-time",
-      doc, xpathCtx, &current_time);
-  if (status != 0)
-  {
-    ERROR ("bind plugin: Reading `server/current-time' failed.");
-    return (-1);
-  }
-  DEBUG ("bind plugin: Current server time is %i.", (int) current_time);
-  /* XPath:     server/requests/opcode, server/counters[@type='opcode']
+  /* XPath:     server/counters[@type='opcode']
    * Variables: QUERY, IQUERY, NOTIFY, UPDATE, ...
-   * Layout V1 and V2:
-   *   <opcode>
-   *     <name>A</name>
-   *     <counter>1</counter>
-   *   </opcode>
-   *   :
-   *
    * Layout v3:
    *   <counters type="opcode">
    *     <counter name="A">1</counter>
@@ -1056,33 +1034,16 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
       /* plugin instance = */ "global-opcodes",
       /* type = */ "dns_opcode"
     };
-    if (version == 3)
-    {
-      bind_parse_generic_name_attr_value_list (/* xpath = */ "server/counters[@type='opcode']",
-        /* callback = */ bind_xml_list_callback,
-        /* user_data = */ &list_info,
-        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
-    else
-    {
-      bind_parse_generic_name_value (/* xpath = */ "server/requests/opcode",
-          /* callback = */ bind_xml_list_callback,
-          /* user_data = */ &list_info,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
+    bind_parse_generic_name_attr_value_list (/* xpath = */ "server/counters[@type='opcode']",
+      /* callback = */ bind_xml_list_callback,
+      /* user_data = */ &list_info,
+      doc, xpathCtx, current_time, DS_TYPE_COUNTER);
   }
 
-  /* XPath:     server/queries-in/rdtype, server/counters[@type='qtype']
+  /* XPath:     server/counters[@type='qtype']
    * Variables: RESERVED0, A, NS, CNAME, SOA, MR, PTR, HINFO, MX, TXT, RP,
    *            X25, PX, AAAA, LOC, SRV, NAPTR, A6, DS, RRSIG, NSEC, DNSKEY,
    *            SPF, TKEY, IXFR, AXFR, ANY, ..., Others
-   * Layout v1 or v2:
-   *   <rdtype>
-   *     <name>A</name>
-   *     <counter>1</counter>
-   *   </rdtype>
-   *   :
-   *
    * Layout v3:
    *   <counters type="opcode">
    *     <counter name="A">1</counter>
@@ -1096,20 +1057,147 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
       /* plugin instance = */ "global-qtypes",
       /* type = */ "dns_qtype"
     };
-    if (version == 3)
+
+    bind_parse_generic_name_attr_value_list (/* xpath = */ "server/counters[@type='qtype']",
+        /* callback = */ bind_xml_list_callback,
+        /* user_data = */ &list_info,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
+  }
+
+  /* XPath:     server/counters[@type='nsstat']
+   * Variables: Requestv4, Requestv6, ReqEdns0, ReqBadEDNSVer, ReqTSIG,
+   *            ReqSIG0, ReqBadSIG, ReqTCP, AuthQryRej, RecQryRej, XfrRej,
+   *            UpdateRej, Response, TruncatedResp, RespEDNS0, RespTSIG,
+   *            RespSIG0, QrySuccess, QryAuthAns, QryNoauthAns, QryReferral,
+   *            QryNxrrset, QrySERVFAIL, QryFORMERR, QryNXDOMAIN, QryRecursion,
+   *            QryDuplicate, QryDropped, QryFailure, XfrReqDone, UpdateReqFwd,
+   *            UpdateRespFwd, UpdateFwdFail, UpdateDone, UpdateFail,
+   *            UpdateBadPrereq
+   * Layout v3:
+   *   <counters type="nsstat"
+   *     <counter name="Requestv4">1</counter>
+   *     <counter name="Requestv6">0</counter>
+   *     :
+   *   </counter>
+   */
+  if (global_server_stats)
+  {
+    translation_table_ptr_t table_ptr =
     {
-      bind_parse_generic_name_attr_value_list (/* xpath = */ "server/counters[@type='qtype']",
-          /* callback = */ bind_xml_list_callback,
-          /* user_data = */ &list_info,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
-    else
+      nsstats_translation_table,
+      nsstats_translation_table_length,
+      /* plugin_instance = */ "global-server_stats"
+    };
+
+    bind_parse_generic_name_attr_value_list ("server/counters[@type='nsstat']",
+        /* callback = */ bind_xml_table_callback,
+        /* user_data = */ &table_ptr,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
+  }
+
+  /* XPath:     server/zonestats, server/zonestat, server/counters[@type='zonestat']
+   * Variables: NotifyOutv4, NotifyOutv6, NotifyInv4, NotifyInv6, NotifyRej,
+   *            SOAOutv4, SOAOutv6, AXFRReqv4, AXFRReqv6, IXFRReqv4, IXFRReqv6,
+   *            XfrSuccess, XfrFail
+   * Layout v3:
+   *   <counters type="zonestat"
+   *     <counter name="NotifyOutv4">0</counter>
+   *     <counter name="NotifyOutv6">0</counter>
+   *     :
+   *   </counter>
+   */
+  if (global_zone_maint_stats)
+  {
+    translation_table_ptr_t table_ptr =
     {
-      bind_parse_generic_name_value (/* xpath = */ "server/queries-in/rdtype",
-          /* callback = */ bind_xml_list_callback,
-          /* user_data = */ &list_info,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
+      zonestats_translation_table,
+      zonestats_translation_table_length,
+      /* plugin_instance = */ "global-zone_maint_stats"
+    };
+
+    bind_parse_generic_name_attr_value_list ("server/counters[@type='zonestat']",
+        /* callback = */ bind_xml_table_callback,
+        /* user_data = */ &table_ptr,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
+  }
+
+  /* XPath:     server/resstats, server/counters[@type='resstat']
+   * Variables: Queryv4, Queryv6, Responsev4, Responsev6, NXDOMAIN, SERVFAIL,
+   *            FORMERR, OtherError, EDNS0Fail, Mismatch, Truncated, Lame,
+   *            Retry, GlueFetchv4, GlueFetchv6, GlueFetchv4Fail,
+   *            GlueFetchv6Fail, ValAttempt, ValOk, ValNegOk, ValFail
+   * Layout v3:
+   *   <counters type="resstat"
+   *     <counter name="Queryv4">0</counter>
+   *     <counter name="Queryv6">0</counter>
+   *     :
+   *   </counter>
+   */
+  if (global_resolver_stats != 0)
+  {
+    translation_table_ptr_t table_ptr =
+    {
+      resstats_translation_table,
+      resstats_translation_table_length,
+      /* plugin_instance = */ "global-resolver_stats"
+    };
+
+    bind_parse_generic_name_attr_value_list ("server/counters[@type='resstat']",
+        /* callback = */ bind_xml_table_callback,
+        /* user_data = */ &table_ptr,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
+  }
+} /* }}} bind_xml_stats_v3 */
+
+static void bind_xml_stats_v1_v2 (int version, xmlDoc *doc, /* {{{ */
+    xmlXPathContext *xpathCtx, xmlNode *statsnode, time_t current_time)
+{
+  /* XPath:     server/requests/opcode, server/counters[@type='opcode']
+   * Variables: QUERY, IQUERY, NOTIFY, UPDATE, ...
+   * Layout V1 and V2:
+   *   <opcode>
+   *     <name>A</name>
+   *     <counter>1</counter>
+   *   </opcode>
+   *   :
+   */
+  if (global_opcodes != 0)
+  {
+    list_info_ptr_t list_info =
+    {
+      /* plugin instance = */ "global-opcodes",
+      /* type = */ "dns_opcode"
+    };
+
+    bind_parse_generic_name_value (/* xpath = */ "server/requests/opcode",
+        /* callback = */ bind_xml_list_callback,
+        /* user_data = */ &list_info,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
+  }
+
+  /* XPath:     server/queries-in/rdtype, server/counters[@type='qtype']
+   * Variables: RESERVED0, A, NS, CNAME, SOA, MR, PTR, HINFO, MX, TXT, RP,
+   *            X25, PX, AAAA, LOC, SRV, NAPTR, A6, DS, RRSIG, NSEC, DNSKEY,
+   *            SPF, TKEY, IXFR, AXFR, ANY, ..., Others
+   * Layout v1 or v2:
+   *   <rdtype>
+   *     <name>A</name>
+   *     <counter>1</counter>
+   *   </rdtype>
+   *   :
+   */
+  if (global_qtypes != 0)
+  {
+    list_info_ptr_t list_info =
+    {
+      /* plugin instance = */ "global-qtypes",
+      /* type = */ "dns_qtype"
+    };
+
+    bind_parse_generic_name_value (/* xpath = */ "server/queries-in/rdtype",
+        /* callback = */ bind_xml_list_callback,
+        /* user_data = */ &list_info,
+        doc, xpathCtx, current_time, DS_TYPE_COUNTER);
   }
 
   /* XPath:     server/nsstats, server/nsstat, server/counters[@type='nsstat']
@@ -1137,17 +1225,11 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
    *     <counter>0</counter>
    *   </nsstat>
    *   :
-   * Layout v3:
-   *   <counters type="nsstat"
-   *     <counter name="Requestv4">1</counter>
-   *     <counter name="Requestv6">0</counter>
-   *     :
-   *   </counter>
    */
   if (global_server_stats)
   {
     translation_table_ptr_t table_ptr =
-    { 
+    {
       nsstats_translation_table,
       nsstats_translation_table_length,
       /* plugin_instance = */ "global-server_stats"
@@ -1160,16 +1242,9 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
     }
-    else if (version == 2)
+    else
     {
       bind_parse_generic_name_value ("server/nsstat",
-          /* callback = */ bind_xml_table_callback,
-          /* user_data = */ &table_ptr,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
-    else // version == 3
-    {
-      bind_parse_generic_name_attr_value_list ("server/counters[@type='nsstat']",
           /* callback = */ bind_xml_table_callback,
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
@@ -1196,17 +1271,11 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
    *     <counter>0</counter>
    *   </zonestat>
    *   :
-   * Layout v3:
-   *   <counters type="zonestat"
-   *     <counter name="NotifyOutv4">0</counter>
-   *     <counter name="NotifyOutv6">0</counter>
-   *     :
-   *   </counter>
    */
   if (global_zone_maint_stats)
   {
     translation_table_ptr_t table_ptr =
-    { 
+    {
       zonestats_translation_table,
       zonestats_translation_table_length,
       /* plugin_instance = */ "global-zone_maint_stats"
@@ -1219,16 +1288,9 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
     }
-    else if (version == 2)
+    else
     {
       bind_parse_generic_name_value ("server/zonestat",
-          /* callback = */ bind_xml_table_callback,
-          /* user_data = */ &table_ptr,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
-    else // version == 3
-    {
-      bind_parse_generic_name_attr_value_list ("server/counters[@type='zonestat']",
           /* callback = */ bind_xml_table_callback,
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
@@ -1256,17 +1318,11 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
    *     <counter>0</counter>
    *   </resstat>
    *   :
-   * Layout v3:
-   *   <counters type="resstat"
-   *     <counter name="Queryv4">0</counter>
-   *     <counter name="Queryv6">0</counter>
-   *     :
-   *   </counter>
    */
   if (global_resolver_stats != 0)
   {
     translation_table_ptr_t table_ptr =
-    { 
+    {
       resstats_translation_table,
       resstats_translation_table_length,
       /* plugin_instance = */ "global-resolver_stats"
@@ -1279,20 +1335,42 @@ static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
     }
-    else if (version == 2)
+    else
     {
       bind_parse_generic_name_value ("server/resstat",
           /* callback = */ bind_xml_table_callback,
           /* user_data = */ &table_ptr,
           doc, xpathCtx, current_time, DS_TYPE_COUNTER);
     }
-    else
-    {
-      bind_parse_generic_name_attr_value_list ("server/counters[@type='resstat']",
-          /* callback = */ bind_xml_table_callback,
-          /* user_data = */ &table_ptr,
-          doc, xpathCtx, current_time, DS_TYPE_COUNTER);
-    }
+  }
+} /* }}} bind_xml_stats_v1_v2 */
+
+static int bind_xml_stats (int version, xmlDoc *doc, /* {{{ */
+    xmlXPathContext *xpathCtx, xmlNode *statsnode)
+{
+  time_t current_time = 0;
+  int status;
+
+  xpathCtx->node = statsnode;
+
+  /* TODO: Check `server/boot-time' to recognize server restarts. */
+
+  status = bind_xml_read_timestamp ("server/current-time",
+      doc, xpathCtx, &current_time);
+  if (status != 0)
+  {
+    ERROR ("bind plugin: Reading `server/current-time' failed.");
+    return (-1);
+  }
+  DEBUG ("bind plugin: Current server time is %i.", (int) current_time);
+
+  if (version == 3)
+  {
+    bind_xml_stats_v3(doc, xpathCtx, statsnode, current_time);
+  }
+  else
+  {
+    bind_xml_stats_v1_v2(version, doc, xpathCtx, statsnode, current_time);
   }
 
   /* XPath:  memory/summary


### PR DESCRIPTION
This commit adds support for the new XML schema of Bind9 statistics-channels (version 3). This new schema is the default one in Bind9.9 (can be reverted to v2 with a `./configure` switch) and support for older versions has been dropped in Bind9.10.

Support for versions 1 and 2 remain in the collectd plugin.

Unfortunately, this new schema does not provide per-zone data any more, thus 'Zone' options like 

```
Zone "example.com/IN"
```

are ignored if schema version is 3.

Before this, a v3 schema was silently failed with only `read-function of plugin `bind' failed.`.
