### PR TITLE
Adding Low Speed Limit 

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6849,6 +6849,17 @@ are available on the server side. I<Bytes> must be at least 1024 and cannot
 exceed the size of an C<int>, i.e. 2E<nbsp>GByte.
 Defaults to C<4096>.
 
+=item B<LowSpeedLimit> B<true|false>
+
+If set to B<true>, average transfer speed in bytes per second will be checked. 
+In case it is below B<LowLimitBytesPerSec> connection will be considered slow 
+and aborted.
+
+=item B<LowLimitBytesPerSec> I<Bytes>
+
+Sets bytes per second value for B<LowSpeedLimit> to make a decission if 
+connection is too slow. Default value is C<100>.
+
 =back
 
 =head2 Plugin C<write_kafka>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6860,6 +6860,11 @@ and aborted.
 Sets bytes per second value for B<LowSpeedLimit> to make a decission if 
 connection is too slow. Default value is C<100>.
 
+=item B<PostTimeoutSec> I<Seconds>
+
+If defined, provided positive integer value will be used to set maximum time
+in seconds that you allow for transfer(http post) operation to take.
+
 =back
 
 =head2 Plugin C<write_kafka>

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -58,9 +58,9 @@ struct wh_callback_s
         char *clientcert;
         char *clientkeypass;
         long sslversion;
-        _Bool store_rates;
-	_Bool abort_on_slow;
-	int   low_limit_bytes;
+        _Bool store_rates; 
+        _Bool abort_on_slow;
+        int   low_limit_bytes;
         time_t interval;
 
 #define WH_FORMAT_COMMAND 0
@@ -361,7 +361,7 @@ static int wh_write_command (const data_set_t *ds, const value_list_t *vl, /* {{
 
         if (cb->curl == NULL)
         {
-        	cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
+                cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
                 status = wh_callback_init (cb);
                 if (status != 0)
                 {
@@ -410,7 +410,7 @@ static int wh_write_json (const data_set_t *ds, const value_list_t *vl, /* {{{ *
 
         if (cb->curl == NULL)
         {
-       		cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
+                cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
 
                 status = wh_callback_init (cb);
                 if (status != 0)
@@ -522,7 +522,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         cb->verify_host = 1;
         cb->format = WH_FORMAT_COMMAND;
         cb->sslversion = CURL_SSLVERSION_DEFAULT;
-	cb->low_limit_bytes = WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC;
+        cb->low_limit_bytes = WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC;
 
         pthread_mutex_init (&cb->send_lock, /* attr = */ NULL);
 
@@ -586,7 +586,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
                         cf_util_get_boolean (child, &cb->store_rates);
                 else if (strcasecmp ("BufferSize", child->key) == 0)
                         cf_util_get_int (child, &buffer_size);
-	        else if (strcasecmp ("LowSpeedLimit", child->key) == 0)
+                else if (strcasecmp ("LowSpeedLimit", child->key) == 0)
                         cf_util_get_boolean (child,&cb->abort_on_slow);
                 else if (strcasecmp ("LowLimitBytesPerSec", child->key) == 0)
                         cf_util_get_int (child, &cb->low_limit_bytes);

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -357,8 +357,6 @@ static int wh_write_command (const data_set_t *ds, const value_list_t *vl, /* {{
                 return (-1);
         }
 
-	cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
-		
         pthread_mutex_lock (&cb->send_lock);
 
         if (cb->curl == NULL)

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -607,7 +607,12 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
 
         if(cb->abort_on_slow)
         {
-        	cb->interval = CDTIME_T_TO_TIME_T(cf_get_default_interval ());
+        	cb->interval = CDTIME_T_TO_TIME_T(plugin_get_interval());
+        }
+        if(cb->post_timeout == 0)
+        {
+        	//setting default timeout to plugin interval.
+        	cb->post_timeout = CDTIME_T_TO_TIME_T(plugin_get_interval());
         }
 
         /* Determine send_buffer_size. */

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -59,8 +59,8 @@ struct wh_callback_s
         char *clientkeypass;
         long sslversion;
         _Bool store_rates;
-		_Bool abort_on_slow;
-		int   low_limit_bytes;
+	_Bool abort_on_slow;
+	int   low_limit_bytes;
         time_t interval;
 
 #define WH_FORMAT_COMMAND 0
@@ -357,12 +357,13 @@ static int wh_write_command (const data_set_t *ds, const value_list_t *vl, /* {{
                 return (-1);
         }
 
-		cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
+	cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
 		
         pthread_mutex_lock (&cb->send_lock);
 
         if (cb->curl == NULL)
         {
+        	cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
                 status = wh_callback_init (cb);
                 if (status != 0)
                 {
@@ -407,12 +408,12 @@ static int wh_write_json (const data_set_t *ds, const value_list_t *vl, /* {{{ *
 {
         int status;
 		
-		cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
-
         pthread_mutex_lock (&cb->send_lock);
 
         if (cb->curl == NULL)
         {
+       		cb->interval = CDTIME_T_TO_TIME_T(vl->interval);
+
                 status = wh_callback_init (cb);
                 if (status != 0)
                 {
@@ -523,7 +524,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         cb->verify_host = 1;
         cb->format = WH_FORMAT_COMMAND;
         cb->sslversion = CURL_SSLVERSION_DEFAULT;
-		cb->low_limit_bytes = WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC;
+	cb->low_limit_bytes = WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC;
 
         pthread_mutex_init (&cb->send_lock, /* attr = */ NULL);
 
@@ -587,7 +588,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
                         cf_util_get_boolean (child, &cb->store_rates);
                 else if (strcasecmp ("BufferSize", child->key) == 0)
                         cf_util_get_int (child, &buffer_size);
-	            else if (strcasecmp ("LowSpeedLimit", child->key) == 0)
+	        else if (strcasecmp ("LowSpeedLimit", child->key) == 0)
                         cf_util_get_boolean (child,&cb->abort_on_slow);
                 else if (strcasecmp ("LowLimitBytesPerSec", child->key) == 0)
                         cf_util_get_int (child, &cb->low_limit_bytes);

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -62,6 +62,7 @@ struct wh_callback_s
         _Bool abort_on_slow;
         int   low_limit_bytes;
         time_t interval;
+        int post_timeout;
 
 #define WH_FORMAT_COMMAND 0
 #define WH_FORMAT_JSON    1
@@ -128,6 +129,10 @@ static int wh_callback_init (wh_callback_t *cb) /* {{{ */
         {
             curl_easy_setopt(cb->curl, CURLOPT_LOW_SPEED_LIMIT, (cb->low_limit_bytes?cb->low_limit_bytes:WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC));
             curl_easy_setopt(cb->curl, CURLOPT_LOW_SPEED_TIME, cb->interval);
+        }
+        if(cb->post_timeout >0)
+        {
+           curl_easy_setopt(cb->curl, CURLOPT_TIMEOUT, cb->post_timeout);
         }
 
         curl_easy_setopt (cb->curl, CURLOPT_NOSIGNAL, 1L);
@@ -523,6 +528,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         cb->format = WH_FORMAT_COMMAND;
         cb->sslversion = CURL_SSLVERSION_DEFAULT;
         cb->low_limit_bytes = WH_DEFAULT_LOW_LIMIT_BYTES_PER_SEC;
+        cb->post_timeout = 0;
 
         pthread_mutex_init (&cb->send_lock, /* attr = */ NULL);
 
@@ -590,6 +596,8 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
                         cf_util_get_boolean (child,&cb->abort_on_slow);
                 else if (strcasecmp ("LowLimitBytesPerSec", child->key) == 0)
                         cf_util_get_int (child, &cb->low_limit_bytes);
+                else if (strcasecmp ("PostTimeoutSec", child->key) == 0)
+                        cf_util_get_int (child, &cb->post_timeout);
                 else
                 {
                         ERROR ("write_http plugin: Invalid configuration "


### PR DESCRIPTION
By default libcurl will not abort stuck/slow connections. If stuck (for whatever reason) connection was not terminated from outside, plugin will be stuck with it. This addition expected to abort slow connections and allow plugin  to reconnect. 