### PR TITLE
Fix access to json lists

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -234,8 +234,12 @@ static int cj_cb_number (void *ctx,
     if (key != NULL)
       NOTICE ("curl_json plugin: Found \"%s\", but the configuration expects"
               " a map.", buffer);
-    cj_cb_inc_array_index (ctx, /* update_key = */ 0);
-    return (CJ_CB_CONTINUE);
+    cj_cb_inc_array_index (ctx, /* update_key = */ 1);
+    key = db->state[db->depth].key;
+    if (key == NULL) {
+      return (CJ_CB_CONTINUE);
+    }
+    
   } else {
     cj_cb_inc_array_index (ctx, /* update_key = */ 1);
   }
@@ -276,10 +280,21 @@ static int cj_cb_map_key (void *ctx,
     memcpy (name, in_name, name_len);
     name[name_len] = 0;
 
-    if (c_avl_get (tree, name, (void *) &value) == 0)
-      db->state[db->depth].key = value;
+    if (c_avl_get (tree, name, (void *) &value) == 0) {
+      if (CJ_IS_KEY((cj_key_t*)value)) {
+	db->state[db->depth].key = value;
+      }
+      else {
+	db->state[db->depth].tree = (c_avl_tree_t*) value;
+      }
+    }
     else if (c_avl_get (tree, CJ_ANY, (void *) &value) == 0)
-      db->state[db->depth].key = value;
+      if (CJ_IS_KEY((cj_key_t*)value)) {
+	db->state[db->depth].key = value;
+      }
+      else {
+	db->state[db->depth].tree = (c_avl_tree_t*) value;
+      }
     else
       db->state[db->depth].key = NULL;
   }
@@ -455,6 +470,7 @@ static int cj_config_add_key (cj_t *db, /* {{{ */
   cj_key_t *key;
   int status;
   int i;
+
 
   if ((ci->values_num != 1)
       || (ci->values[0].type != OCONFIG_TYPE_STRING))

--- a/tests/curl_json/test.json
+++ b/tests/curl_json/test.json
@@ -1,0 +1,6 @@
+{
+"testArray":[1,2],
+"testArrayInbetween":[{"blarg":3},{"blub":4}],
+"testDirectHit":5,
+"testSubLevelHit":{"oneMoreLevel":6}
+}

--- a/tests/curl_json/testjson.conf
+++ b/tests/curl_json/testjson.conf
@@ -1,0 +1,39 @@
+LoadPlugin curl_json
+<Plugin curl_json>
+
+  <URL "http://localhost:80/test.json">
+    Instance "test_http_json"
+    <Key "testArray/0">
+      Type "gauge"
+      # Expect: 1
+    </Key>
+    <Key "testArray/1">
+      Type "gauge"
+      # Expect: 2
+    </Key>
+    <Key "testArrayInbetween/0/blarg">
+      Type "gauge"
+      # Expect: 3
+    </Key>
+    <Key "testArrayInbetween/1/blub">
+      Type "gauge"
+      # Expect: 4
+    </Key>
+    <Key "testDirectHit">
+      Type "gauge"
+      # Expect: 5
+    </Key>
+    <Key "testSubLevelHit/oneMoreLevel">
+      Type "gauge"
+      # Expect: 6
+    </Key>
+
+  </URL>
+</Plugin>
+
+LoadPlugin csv
+
+<Plugin csv>
+	DataDir "/var/tmp/collectd_csv"
+	StoreRates false
+</Plugin>


### PR DESCRIPTION
Given this json
{
"testArray":[1,2],
"testArrayInbetween":[{"blarg":3},{"blub":4}],
"testDirectHit":5,
"testSubLevelHit":{"oneMoreLevel":6}
}

These keys shold give -> these values
testArray/0 -> 1
testArray/1 ->2
testArrayInbetween/0/blarg -> 3
testArrayInbetween/1/blub -> 4
testDirectHit -> 5
testSubLevelHit/oneMoreLevel -> 6

(testArray/n wouldn't work without this patch)
(this time with the PR created from a propper branch)
