### PR TITLE
Fix overquoting in htonll tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1242,16 +1242,16 @@ fi
 AC_CACHE_CHECK([if have htonll defined],
                   [c_cv_have_htonll],
                   AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
+[[
 #include <sys/types.h>
 #include <netinet/in.h>
 #if HAVE_INTTYPES_H
 # include <inttypes.h>
 #endif
-]]],
-[[[
+]],
+[[
           return htonll(0);
-]]]
+]]
     )],
     [c_cv_have_htonll="yes"],
     [c_cv_have_htonll="no"]


### PR DESCRIPTION
Similar to 4def66d6820b46e9044c4e2a0e30b043b330e8d2, the overquoting
here is not completely undone, leaving spurious `[` and `]` characters
in the C source, which leads to a compiler failure and the determination
that HAVE_HTONLL=no even if, as on OS X Yosemite, it is defined.

There are other instances of [[[ ]]] in configure.ac, but as always
touching things that aren't known to be broken seems dangerous!
