### PR TITLE
Including vl->type, even when vl->type_instance is available to avoid ov...

### DIFF
--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -387,8 +387,8 @@ static int wt_format_name(char *ret, int ret_len,
         ssnprintf(ret, ret_len, "%s%s.%s.%s",
                   prefix, vl->plugin, vl->plugin_instance, vl->type);
     } else {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s",
-                  prefix, vl->plugin, vl->plugin_instance, vl->type_instance);
+        ssnprintf(ret, ret_len, "%s%s.%s.%s.%s",
+                  prefix, vl->plugin, vl->plugin_instance, vl->type, vl->type_instance);
     }
 
     sfree(temp);


### PR DESCRIPTION
Including vl->type, even when vl->type_instance is available to avoid over-writing values (i.e. with the 'df' plugin).

We're hitting [this code path](https://github.com/collectd/collectd/blob/master/src/write_tsdb.c#L391) for submitting stats to opentsdb.

The problem is that [`df_complex` values](https://github.com/collectd/collectd/blob/master/src/df.c#L300) are being overwritten by [`df_inodes` values](https://github.com/collectd/collectd/blob/master/src/df.c#L354) when we also capture inodes.

This is probably happening elsewhere, as well.
