### PR TITLE
Fix the processes plugin on OpenBSD (#776)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,7 +1311,7 @@ AC_CHECK_MEMBERS([struct kinfo_proc.ki_pid, struct kinfo_proc.ki_rssize, struct 
 #include <sys/user.h>
 	])
 
-AC_CHECK_MEMBERS([struct kinfo_proc.kp_proc, struct kinfo_proc.kp_eproc],
+AC_CHECK_MEMBERS([struct kinfo_proc.p_pid, struct kinfo_proc.p_vm_rssize],
 	[
 		AC_DEFINE(HAVE_STRUCT_KINFO_PROC_OPENBSD, 1,
 			[Define if struct kinfo_proc exists in the OpenBSD variant.])
@@ -5250,6 +5250,11 @@ then
 fi
 
 if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_freebsd" = "xyes"
+then
+	plugin_processes="yes"
+fi
+
+if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_openbsd" = "xyes"
 then
 	plugin_processes="yes"
 fi


### PR DESCRIPTION
Properly check for struct kinfo_proc members in configure.ac
Use kvm_getprocs() like it was done on FreeBSD
