### PR TITLE
fix grammar in plugin loading error message

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -393,7 +393,7 @@ static int plugin_load_file (char *file, uint32_t flags)
 
 		ssnprintf (errbuf, sizeof (errbuf),
 				"lt_dlopen (\"%s\") failed: %s. "
-				"The most common cause for this problem are "
+				"The most common cause for this problem is "
 				"missing dependencies. Use ldd(1) to check "
 				"the dependencies of the plugin "
 				"/ shared object.",


### PR DESCRIPTION
"cause for this problem are" => "cause for this problem is"
