### PR TITLE
lvm: remove duplicate call to lvm_submit()

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -125,10 +125,6 @@ static void vg_read(vg_t vg, char const *vg_name)
     }
 
     dm_list_iterate_items(lvl, lvs) {
-         lvm_submit(vg_name, lvm_lv_get_name(lvl->lv), lvm_lv_get_size(lvl->lv));
-    }
-
-    dm_list_iterate_items(lvl, lvs) {
         name = lvm_lv_get_name(lvl->lv);
         attrs = get_lv_property_string(lvl->lv, "lv_attr");
         size = lvm_lv_get_size(lvl->lv);


### PR DESCRIPTION
This got added by accident when solving the merge conflict in 103f05e0.

It led to the plugin triggering the classical `uc_update: Value too old`
error message.
