### PR TITLE
network: don't enable gcrypt thread callbacks when gcrypt recent enough

### DIFF
--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -54,7 +54,9 @@
 /* Re enable deprecation warnings */
 #  pragma GCC diagnostic warning "-Wdeprecated-declarations"
 # endif
+# if GCRYPT_VERSION_NUMBER < 0x010600
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
+# endif
 #endif
 
 #include "collectd/network_buffer.h"
@@ -131,7 +133,9 @@ static _Bool have_gcrypt (void) /* {{{ */
   need_init = 0;
 
 #if HAVE_LIBGCRYPT
+# if GCRYPT_VERSION_NUMBER < 0x010600
   gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+# endif
 
   if (!gcry_check_version (GCRYPT_VERSION))
     return (0);

--- a/src/network.c
+++ b/src/network.c
@@ -76,7 +76,9 @@
 /* Re enable deprecation warnings */
 #  pragma GCC diagnostic warning "-Wdeprecated-declarations"
 # endif
+# if GCRYPT_VERSION_NUMBER < 0x010600
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
+# endif
 #endif
 
 #ifndef IPV6_ADD_MEMBERSHIP
@@ -510,7 +512,9 @@ static void network_init_gcrypt (void) /* {{{ */
   * above doesn't count, as it doesn't implicitly initalize Libgcrypt.
   *
   * tl;dr: keep all these gry_* statements in this exact order please. */
+# if GCRYPT_VERSION_NUMBER < 0x010600
   gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+# endif
   gcry_check_version (NULL);
   gcry_control (GCRYCTL_INIT_SECMEM, 32768);
   gcry_control (GCRYCTL_INITIALIZATION_FINISHED);


### PR DESCRIPTION
From `gcrypt.h`:

> NOTE: Since Libgcrypt 1.6 the thread callbacks are not anymore used.
> However we keep it to allow for some source code compatibility if used
> in the standard way.

Otherwise, we get a deprecation warning which is turned into an error:

```
  CC       libcollectdclient_la-network_buffer.lo
../../../src/libcollectdclient/network_buffer.c:58:15: error: 'gcry_thread_cbs' is deprecated (declared at /usr/include/gcrypt.h:213) [-Werror=deprecated-declarations]
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
```

Fixes: #632
