### PR TITLE
kafka: fix compilation for older versions of librdkafka

### DIFF
--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -61,7 +61,7 @@ static int kafka_write(const data_set_t *, const value_list_t *, user_data_t *);
 static int32_t kafka_partition(const rd_kafka_topic_t *, const void *, size_t,
                                int32_t, void *, void *);
 
-#ifdef HAVE_LIBRDKAFKA_LOGGER
+#if defined HAVE_LIBRDKAFKA_LOGGER || defined HAVE_LIBRDKAFKA_LOG_CB
 static void kafka_log(const rd_kafka_t *, int, const char *, const char *);
 
 static void kafka_log(const rd_kafka_t *rkt, int level,


### PR DESCRIPTION
Since commit f505691270f2317291c372fd5f004a4ffbce9f9a, kafka module was
broken. Enable definition of `kafka_log()` when using kafka logger
callback as well.
