### PR TITLE
Link aggregation.so to libm.so

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,7 +85,7 @@ pkglib_LTLIBRARIES += aggregation.la
 aggregation_la_SOURCES = aggregation.c \
                          utils_vl_lookup.c utils_vl_lookup.h
 aggregation_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-aggregation_la_LIBADD =
+aggregation_la_LIBADD = -lm
 endif
 
 if BUILD_PLUGIN_AMQP


### PR DESCRIPTION
Since `aggregation.c` [uses sqrt](https://github.com/bnordbo/collectd/blob/master/src/aggregation.c#L422), it should probably link against `libm.so`. The way it is, it will not work when aggregating using `CalculateStddev`.
