### PR TITLE
libstatgrab: only use one configure test for 0.90 API change

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4143,8 +4143,8 @@ then
   CFLAGS="$CFLAGS $with_libstatgrab_cflags"
   LDFLAGS="$LDFLAGS $with_libstatgrab_ldflags"
 
-  AC_CACHE_CHECK([if sg_init() requires an argument],
-          [c_cv_have_libstatgrab_init_arg],
+  AC_CACHE_CHECK([if libstatgrab >= 0.90],
+          [c_cv_have_libstatgrab_0_90],
           AC_LINK_IFELSE([AC_LANG_PROGRAM(
 [[[
 #include <stdio.h>
@@ -4154,42 +4154,8 @@ then
       if (sg_init()) return 0;
 ]]]
     )],
-    [c_cv_have_libstatgrab_init_arg="no"],
-    [c_cv_have_libstatgrab_init_arg="yes"]
-          )
-  )
-
-  AC_CACHE_CHECK([if sg_get_user_stats() requires an argument],
-          [c_cv_have_libstatgrab_get_user_stats_arg],
-          AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdio.h>
-#include <statgrab.h>
-]]],
-[[[
-      if (sg_get_user_stats()) return 0;
-]]]
-    )],
-    [c_cv_have_libstatgrab_get_user_stats_arg="no"],
-    [c_cv_have_libstatgrab_get_user_stats_arg="yes"]
-          )
-  )
-
-  AC_CACHE_CHECK([if sg_disk_io_stats() uses size_t],
-          [c_cv_have_libstatgrab_get_disk_io_stats_sizet],
-          AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdio.h>
-#include <statgrab.h>
-]]],
-[[[
-      sg_disk_io_stats *(*ptr) (size_t *);
-      ptr = sg_get_disk_io_stats;
-      if (ptr != NULL) return 0;
-]]]
-    )],
-    [c_cv_have_libstatgrab_get_disk_io_stats_sizet="yes"],
-    [c_cv_have_libstatgrab_get_disk_io_stats_sizet="no"]
+    [c_cv_have_libstatgrab_0_90="no"],
+    [c_cv_have_libstatgrab_0_90="yes"]
           )
   )
 
@@ -4205,17 +4171,9 @@ then
   BUILD_WITH_LIBSTATGRAB_LDFLAGS="$with_libstatgrab_ldflags"
   AC_SUBST(BUILD_WITH_LIBSTATGRAB_CFLAGS)
   AC_SUBST(BUILD_WITH_LIBSTATGRAB_LDFLAGS)
-  if test "x$c_cv_have_libstatgrab_init_arg" = "xyes"
+  if test "x$c_cv_have_libstatgrab_0_90" = "xyes"
   then
-        AC_DEFINE(HAVE_LIBSTATGRAB_INIT_ARG, 1, [Define to 1 if sg_init does require an argument])
-  fi
-  if test "x$c_cv_have_libstatgrab_get_user_stats_arg" = "xyes"
-  then
-        AC_DEFINE(HAVE_LIBSTATGRAB_GET_USER_STATS_ARG, 1, [Define to 1 if sg_get_user_stats does require an argument])
-  fi
-  if test "x$c_cv_have_libstatgrab_get_disk_io_stats_sizet" = "xyes"
-  then
-        AC_DEFINE(HAVE_LIBSTATGRAB_GET_DISK_IO_STATS_SIZET, 1, [Define to 1 if sg_get_disk_io_stats does require pointer to size_t as an argument])
+        AC_DEFINE(HAVE_LIBSTATGRAB_0_90, 1, [Define to 1 if libstatgrab version >= 0.90])
   fi
 fi
 # }}}

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -309,7 +309,7 @@ static int do_init (void)
 
 #if HAVE_LIBSTATGRAB
 	if (sg_init (
-# if HAVE_LIBSTATGRAB_INIT_ARG
+# if HAVE_LIBSTATGRAB_0_90
 		    0
 # endif
 		    ))

--- a/src/disk.c
+++ b/src/disk.c
@@ -831,7 +831,7 @@ static int disk_read (void)
 
 #elif defined(HAVE_LIBSTATGRAB)
 	sg_disk_io_stats *ds;
-# if HAVE_LIBSTATGRAB_GET_DISK_IO_STATS_SIZET
+# if HAVE_LIBSTATGRAB_0_90
 	size_t disks;
 # else
 	int disks;

--- a/src/users.c
+++ b/src/users.c
@@ -102,7 +102,7 @@ static int users_read (void)
 #elif HAVE_LIBSTATGRAB
 	sg_user_stats *us;
 
-# if HAVE_LIBSTATGRAB_GET_USER_STATS_ARG
+# if HAVE_LIBSTATGRAB_0_90
 	size_t num_entries;
 	us = sg_get_user_stats (&num_entries);
 # else
@@ -112,7 +112,7 @@ static int users_read (void)
 		return (-1);   
 
 	users_submit ((gauge_t)
-# if HAVE_LIBSTATGRAB_GET_USER_STATS_ARG
+# if HAVE_LIBSTATGRAB_0_90
 		      num_entries);
 # else
 		      us->num_entries);


### PR DESCRIPTION
Previously, each API change was tested in configure.ac. Some of the
tests are relying on signature checks and would need to have -Werror
flag enabled to make them work. This is quite fragile.

Instead, we assume that if `sg_init()` requires an argument, we must use
the 0.90 API.

Fixes: #795 

This is one possible fix for the problem introduced in c963d35fb88b7db81fcf6e3db51313d9002e17b4
