### PR TITLE
libstatgrab: correctly detect new signature for `sg_disk_io_stats()`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4175,6 +4175,7 @@ then
           )
   )
 
+  CFLAGS="$CFLAGS -Werror"
   AC_CACHE_CHECK([if sg_disk_io_stats() uses size_t],
           [c_cv_have_libstatgrab_get_disk_io_stats_sizet],
           AC_LINK_IFELSE([AC_LANG_PROGRAM(


### PR DESCRIPTION
Enable `-Werror` to turn the warning into an error. I would have loved
using `-Werror=incompatible-pointer-types` but it is only supported with
very recent versions of gcc. Otherwise, it would just throw an error.

Also see #806 for an alternate solution. I think that #806 is better because relying on `-Werror` to only trigger an error on signature mismatch seems fragile. We could get other kind of warnings, like "comparison always true" when compilers will get smarter.
