### PR TITLE
Added return (0) to the Mac/IOKit variant of battery_read()

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -376,6 +376,8 @@ static int battery_read (void) /* {{{ */
 		battery_submit ("0", "current", current);
 	if (!isnan (voltage))
 		battery_submit ("0", "voltage", voltage);
+
+	return (0);
 } /* }}} int battery_read */
 /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 


### PR DESCRIPTION
Added return (0) to the Mac/IOKit variant of battery_read() to prevent compiler warning/error.
