### PR TITLE
linux container usage: collect from host's /proc volume mounted in /host_proc

### DIFF
--- a/bindings/perl/lib/Collectd/Plugins/OpenVZ.pm
+++ b/bindings/perl/lib/Collectd/Plugins/OpenVZ.pm
@@ -48,7 +48,7 @@ sub interface_read {
     my @tx_fields = qw(if_octets if_packets if_errors drop fifo frame compressed);
     my %v = _build_report_hash($name);
 
-    my @lines = `$vzctl exec $veid cat /proc/net/dev`;
+    my @lines = `$vzctl exec $veid cat /host_proc/net/dev`;
 
     for my $line (@lines) {
         # skip explanatory text
@@ -58,7 +58,7 @@ sub interface_read {
 
         my ($iface, %rx, %tx);
 
-        # read /proc/net/dev fields
+        # read /host_proc/net/dev fields
         ($iface, @rx{@rx_fields}, @tx{@tx_fields}) = split /[: ]+/, $line;
 
         # Skip this interface if it is in the ignored list
@@ -88,7 +88,7 @@ sub cpu_read {
     $v{'type'} = 'cpu';
 
     $i = 0;
-    @lines = split(/\n/, `$vzctl exec $veid cat /proc/stat`);
+    @lines = split(/\n/, `$vzctl exec $veid cat /host_proc/stat`);
     foreach (@lines) {
         next if (!/^cpu[0-9]/);
 
@@ -124,7 +124,7 @@ sub df_read {
     delete $v{'plugin_instance'};
     $v{'type'} = 'df';
 
-    $val = join(' ', map { (split)[1] } split(/\n/, `$vzctl exec $veid cat /proc/mounts`));
+    $val = join(' ', map { (split)[1] } split(/\n/, `$vzctl exec $veid cat /host_proc/mounts`));
     @lines = split(/\n/, `$vzctl exec $veid stat -tf $val`);
     foreach (@lines) {
         @parts = split(/ /);
@@ -151,7 +151,7 @@ sub load_read {
     $v{'type'} = 'load';
     delete $v{'type_instance'};
 
-    @parts = split(/ +/, `$vzctl exec $veid cat /proc/loadavg`);
+    @parts = split(/ +/, `$vzctl exec $veid cat /host_proc/loadavg`);
     $v{'values'} = [ $parts[0], $parts[1], $parts[2] ];
     plugin_dispatch_values(\%v);
 }
@@ -171,7 +171,7 @@ sub processes_read {
     delete $v{'plugin_instance'};
     $v{'type'} = 'ps_state';
 
-    @lines = map { (split)[2] } split(/\n/, `$vzctl exec $veid cat '/proc/[0-9]*/stat'`);
+    @lines = map { (split)[2] } split(/\n/, `$vzctl exec $veid cat '/host_proc/[0-9]*/stat'`);
     foreach $key (@lines) {
         ++$ps_states->{$state_map->{$key}};
     }

--- a/contrib/migrate-3-4.px
+++ b/contrib/migrate-3-4.px
@@ -321,7 +321,7 @@ sub _special_disk_instance
 	if (!defined ($cache))
 	{
 		my $fh;
-		open ($fh, "< /proc/diskstats") or die ("open (/proc/diststats): $!");
+		open ($fh, "< /host_proc/diskstats") or die ("open (/host_proc/diststats): $!");
 
 		$cache = {};
 		while (my $line = <$fh>)

--- a/src/battery.c
+++ b/src/battery.c
@@ -63,8 +63,8 @@
 /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
 #elif KERNEL_LINUX
-# define PROC_PMU_PATH_FORMAT "/proc/pmu/battery_%i"
-# define PROC_ACPI_PATH "/proc/acpi/battery"
+# define PROC_PMU_PATH_FORMAT "/host_proc/pmu/battery_%i"
+# define PROC_ACPI_PATH "/host_proc/acpi/battery"
 # define PROC_ACPI_FACTOR 0.001
 # define SYSFS_PATH "/sys/class/power_supply"
 # define SYSFS_FACTOR 0.000001
@@ -619,7 +619,7 @@ static int read_acpi_callback (char const *dir, /* {{{ */
 	}
 
 	/*
-	 * [11:00] <@tokkee> $ cat /proc/acpi/battery/BAT1/state
+	 * [11:00] <@tokkee> $ cat /host_proc/acpi/battery/BAT1/state
 	 * [11:00] <@tokkee> present:                 yes
 	 * [11:00] <@tokkee> capacity state:          ok
 	 * [11:00] <@tokkee> charging state:          charging

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1049,7 +1049,7 @@
 #</Plugin>
 
 #<Plugin table>
-#	<Table "/proc/slabinfo">
+#	<Table "/host_proc/slabinfo">
 #		Instance "slabinfo"
 #		Separator " "
 #		<Result>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -993,7 +993,7 @@ laptop batteries.
 When enabled, remaining capacity is reported as a percentage, e.g. "42%
 capacity remaining". Otherwise the capacity is stored as reported by the
 battery, most likely in "Wh". This option does not work with all input methods,
-in particular when only C</proc/pmu> is available on an old Linux system.
+in particular when only C</host_proc/pmu> is available on an old Linux system.
 Defaults to B<false>.
 
 =item B<ReportDegraded> B<false>|B<true>
@@ -1201,7 +1201,7 @@ This plugin collects IP conntrack statistics.
 =item B<OldFiles>
 
 Assume the B<conntrack_count> and B<conntrack_max> files to be found in
-F</proc/sys/net/ipv4/netfilter> instead of F</proc/sys/net/netfilter/>.
+F</host_proc/sys/net/ipv4/netfilter> instead of F</host_proc/sys/net/netfilter/>.
 
 =back
 
@@ -5806,7 +5806,7 @@ default), the summary over all swap devices is reported only, i.e. the globally
 used and available space over all devices. If B<true> is configured, the used
 and available space of each device will be reported separately.
 
-This option is only available if the I<Swap plugin> can read C</proc/swaps>
+This option is only available if the I<Swap plugin> can read C</host_proc/swaps>
 (under Linux) or use the L<swapctl(2)> mechanism (under I<Solaris>).
 
 =item B<ReportBytes> B<false>|B<true>
@@ -5861,7 +5861,7 @@ example, this plugin may be used to get values from the Linux L<proc(5)>
 filesystem or CSV (comma separated values) files.
 
   <Plugin table>
-    <Table "/proc/slabinfo">
+    <Table "/host_proc/slabinfo">
       Instance "slabinfo"
       Separator " "
       <Result>
@@ -6655,7 +6655,7 @@ This plugin doesn't have any options. B<VServer> support is only available for
 Linux. It cannot yet be found in a vanilla kernel, though. To make use of this
 plugin you need a kernel that has B<VServer> support built in, i.E<nbsp>e. you
 need to apply the patches and compile your own kernel, which will then provide
-the F</proc/virtual> filesystem that is required by this plugin.
+the F</host_proc/virtual> filesystem that is required by this plugin.
 
 The B<VServer> homepage can be found at L<http://linux-vserver.org/>.
 

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -29,10 +29,10 @@
 # error "No applicable input method."
 #endif
 
-#define CONNTRACK_FILE "/proc/sys/net/netfilter/nf_conntrack_count"
-#define CONNTRACK_MAX_FILE "/proc/sys/net/netfilter/nf_conntrack_max"
-#define CONNTRACK_FILE_OLD "/proc/sys/net/ipv4/netfilter/ip_conntrack_count"
-#define CONNTRACK_MAX_FILE_OLD "/proc/sys/net/ipv4/netfilter/ip_conntrack_max"
+#define CONNTRACK_FILE "/host_proc/sys/net/netfilter/nf_conntrack_count"
+#define CONNTRACK_MAX_FILE "/host_proc/sys/net/netfilter/nf_conntrack_max"
+#define CONNTRACK_FILE_OLD "/host_proc/sys/net/ipv4/netfilter/ip_conntrack_count"
+#define CONNTRACK_MAX_FILE_OLD "/host_proc/sys/net/ipv4/netfilter/ip_conntrack_max"
 
 static const char *config_keys[] =
 {

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -90,9 +90,9 @@ static int cs_read (void)
 	derive_t result = 0;
 	int status = -2;
 
-	fh = fopen ("/proc/stat", "r");
+	fh = fopen ("/host_proc/stat", "r");
 	if (fh == NULL) {
-		ERROR ("contextswitch plugin: unable to open /proc/stat: %s",
+		ERROR ("contextswitch plugin: unable to open /host_proc/stat: %s",
 				sstrerror (errno, buffer, sizeof (buffer)));
 		return (-1);
 	}

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -672,10 +672,10 @@ static int cpu_read (void)
 	char *fields[9];
 	int numfields;
 
-	if ((fh = fopen ("/proc/stat", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/stat", "r")) == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("cpu plugin: fopen (/proc/stat) failed: %s",
+		ERROR ("cpu plugin: fopen (/host_proc/stat) failed: %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}

--- a/src/disk.c
+++ b/src/disk.c
@@ -564,12 +564,12 @@ static int disk_read (void)
 
 	diskstats_t *ds, *pre_ds;
 
-	if ((fh = fopen ("/proc/diskstats", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/diskstats", "r")) == NULL)
 	{
-		fh = fopen ("/proc/partitions", "r");
+		fh = fopen ("/host_proc/partitions", "r");
 		if (fh == NULL)
 		{
-			ERROR ("disk plugin: fopen (/proc/{diskstats,partitions}) failed.");
+			ERROR ("disk plugin: fopen (/host_proc/{diskstats,partitions}) failed.");
 			return (-1);
 		}
 

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -38,7 +38,7 @@
 #include "common.h"
 #include "plugin.h"
 
-static const char *drbd_stats = "/proc/drbd";
+static const char *drbd_stats = "/host_proc/drbd";
 static const char *drbd_names[] =
 {
 	"network_send",	 /* ns (network send) */

--- a/src/entropy.c
+++ b/src/entropy.c
@@ -32,7 +32,7 @@
 # error "No applicable input method."
 #endif
 
-#define ENTROPY_FILE "/proc/sys/kernel/random/entropy_avail"
+#define ENTROPY_FILE "/host_proc/sys/kernel/random/entropy_avail"
 
 static void entropy_submit (double entropy)
 {

--- a/src/fscache.c
+++ b/src/fscache.c
@@ -34,7 +34,7 @@
 #define BUFSIZE 1024
 
 /*
-see /proc/fs/fscache/stats
+see /host_proc/fs/fscache/stats
 see Documentation/filesystems/caching/fscache.txt in linux kernel >= 2.6.30
 
 This shows counts of a number of events that can happen in FS-Cache:
@@ -131,7 +131,7 @@ static void fscache_read_stats_file (FILE *fh)
     char linebuffer[BUFSIZE];
 
 /*
- *  cat /proc/fs/fscache/stats
+ *  cat /host_proc/fs/fscache/stats
  *      FS-Cache statistics
  *      Cookies: idx=2 dat=0 spc=0
  *      Objects: alc=0 nal=0 avl=0 ded=0
@@ -210,7 +210,7 @@ static void fscache_read_stats_file (FILE *fh)
 
 static int fscache_read (void){
     FILE *fh;
-    fh = fopen("/proc/fs/fscache/stats", "r");
+    fh = fopen("/host_proc/fs/fscache/stats", "r");
     if (fh != NULL){
         fscache_read_stats_file(fh);
         fclose(fh);

--- a/src/interface.c
+++ b/src/interface.c
@@ -241,7 +241,7 @@ static int interface_read (void)
 	char *fields[16];
 	int numfields;
 
-	if ((fh = fopen ("/proc/net/dev", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/net/dev", "r")) == NULL)
 	{
 		char errbuf[1024];
 		WARNING ("interface plugin: fopen: %s",

--- a/src/irq.c
+++ b/src/irq.c
@@ -104,11 +104,11 @@ static int irq_read (void)
 	 * 1:     102553     158669     218062      70587   IO-APIC-edge      i8042
 	 * 8:          0          0          0          1   IO-APIC-edge      rtc0
 	 */
-	fh = fopen ("/proc/interrupts", "r");
+	fh = fopen ("/host_proc/interrupts", "r");
 	if (fh == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("irq plugin: fopen (/proc/interrupts): %s",
+		ERROR ("irq plugin: fopen (/host_proc/interrupts): %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
@@ -119,7 +119,7 @@ static int irq_read (void)
 				STATIC_ARRAY_SIZE (fields));
 	} else {
 		ERROR ("irq plugin: unable to get CPU count from first line "
-				"of /proc/interrupts");
+				"of /host_proc/interrupts");
 		return (-1);
 	}
 

--- a/src/load.c
+++ b/src/load.c
@@ -138,7 +138,7 @@ static int load_read (void)
 	char *fields[8];
 	int numfields;
 
-	if ((loadavg = fopen ("/proc/loadavg", "r")) == NULL)
+	if ((loadavg = fopen ("/host_proc/loadavg", "r")) == NULL)
 	{
 		char errbuf[1024];
 		WARNING ("load: fopen: %s",

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -891,9 +891,9 @@ procfs_iterate(int sk)
 	int num_success;
 	int num_fail;
 	
-	if ((fh = fopen ("/proc/net/dev", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/net/dev", "r")) == NULL)
 	{
-		WARNING ("madwifi plugin: opening /proc/net/dev failed");
+		WARNING ("madwifi plugin: opening /host_proc/net/dev failed");
 		return (-1);
 	}
 

--- a/src/md.c
+++ b/src/md.c
@@ -29,7 +29,7 @@
 #include <linux/major.h>
 #include <linux/raid/md_u.h>
 
-#define PROC_DISKSTATS "/proc/diskstats"
+#define PROC_DISKSTATS "/host_proc/diskstats"
 #define DEV_DIR "/dev"
 
 static const char *config_keys[] =

--- a/src/memory.c
+++ b/src/memory.c
@@ -292,7 +292,7 @@ static int memory_read_internal (value_list_t *vl)
 	gauge_t mem_slab_reclaimable = 0;
 	gauge_t mem_slab_unreclaimable = 0;
 
-	if ((fh = fopen ("/proc/meminfo", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/meminfo", "r")) == NULL)
 	{
 		char errbuf[1024];
 		WARNING ("memory: fopen: %s",

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -31,7 +31,7 @@
 #endif
 
 /*
-see /proc/net/rpc/nfs
+see /host_proc/net/rpc/nfs
 see http://www.missioncriticallinux.com/orph/NFS-Statistics
 
 net x x x x
@@ -353,13 +353,13 @@ static int nfs_read (void)
 {
 	FILE *fh;
 
-	if ((fh = fopen ("/proc/net/rpc/nfs", "r")) != NULL)
+	if ((fh = fopen ("/host_proc/net/rpc/nfs", "r")) != NULL)
 	{
 		nfs_read_linux (fh, "client");
 		fclose (fh);
 	}
 
-	if ((fh = fopen ("/proc/net/rpc/nfsd", "r")) != NULL)
+	if ((fh = fopen ("/host_proc/net/rpc/nfsd", "r")) != NULL)
 	{
 		nfs_read_linux (fh, "server");
 		fclose (fh);

--- a/src/processes.c
+++ b/src/processes.c
@@ -770,7 +770,7 @@ static int ps_read_tasks (int pid)
 	struct dirent *ent;
 	int count = 0;
 
-	ssnprintf (dirname, sizeof (dirname), "/proc/%i/task", pid);
+	ssnprintf (dirname, sizeof (dirname), "/host_proc/%i/task", pid);
 
 	if ((dh = opendir (dirname)) == NULL)
 	{
@@ -790,7 +790,7 @@ static int ps_read_tasks (int pid)
 	return ((count >= 1) ? count : 1);
 } /* int *ps_read_tasks */
 
-/* Read advanced virtual memory data from /proc/pid/status */
+/* Read advanced virtual memory data from /host_proc/pid/status */
 static procstat_t *ps_read_vmem (int pid, procstat_t *ps)
 {
 	FILE *fh;
@@ -802,7 +802,7 @@ static procstat_t *ps_read_vmem (int pid, procstat_t *ps)
 	char *fields[8];
 	int numfields;
 
-	ssnprintf (filename, sizeof (filename), "/proc/%i/status", pid);
+	ssnprintf (filename, sizeof (filename), "/host_proc/%i/status", pid);
 	if ((fh = fopen (filename, "r")) == NULL)
 		return (NULL);
 
@@ -862,7 +862,7 @@ static procstat_t *ps_read_io (int pid, procstat_t *ps)
 	char *fields[8];
 	int numfields;
 
-	ssnprintf (filename, sizeof (filename), "/proc/%i/io", pid);
+	ssnprintf (filename, sizeof (filename), "/host_proc/%i/io", pid);
 	if ((fh = fopen (filename, "r")) == NULL)
 		return (NULL);
 
@@ -931,7 +931,7 @@ int ps_read_process (int pid, procstat_t *ps, char *state)
 
 	memset (ps, 0, sizeof (procstat_t));
 
-	ssnprintf (filename, sizeof (filename), "/proc/%i/stat", pid);
+	ssnprintf (filename, sizeof (filename), "/host_proc/%i/stat", pid);
 
 	buffer_len = read_file_contents (filename,
 			buffer, sizeof(buffer) - 1);
@@ -1070,7 +1070,7 @@ static char *ps_get_cmdline (pid_t pid, char *name, char *buf, size_t buf_len)
 	if ((pid < 1) || (NULL == buf) || (buf_len < 2))
 		return NULL;
 
-	ssnprintf (file, sizeof (file), "/proc/%u/cmdline",
+	ssnprintf (file, sizeof (file), "/host_proc/%u/cmdline",
 		       	(unsigned int) pid);
 
 	errno = 0;
@@ -1143,7 +1143,7 @@ static char *ps_get_cmdline (pid_t pid, char *name, char *buf, size_t buf_len)
 		--n;
 	}
 
-	/* arguments are separated by '\0' in /proc/<pid>/cmdline */
+	/* arguments are separated by '\0' in /host_proc/<pid>/cmdline */
 	while (n > 0) {
 		if ('\0' == buf[n])
 			buf[n] = ' ';
@@ -1159,11 +1159,11 @@ static int read_fork_rate ()
 	value_t value;
 	_Bool value_valid = 0;
 
-	proc_stat = fopen ("/proc/stat", "r");
+	proc_stat = fopen ("/host_proc/stat", "r");
 	if (proc_stat == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("processes plugin: fopen (/proc/stat) failed: %s",
+		ERROR ("processes plugin: fopen (/host_proc/stat) failed: %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
@@ -1206,7 +1206,7 @@ static const char *ps_get_cmdline (pid_t pid, /* {{{ */
 	psinfo_t info;
 	int status;
 
-	snprintf(path, sizeof (path), "/proc/%i/psinfo", pid);
+	snprintf(path, sizeof (path), "/host_proc/%i/psinfo", pid);
 
 	status = read_file_contents (path, (void *) &info, sizeof (info));
 	if (status != ((int) buffer_size))
@@ -1226,7 +1226,7 @@ static const char *ps_get_cmdline (pid_t pid, /* {{{ */
 
 /*
  * Reads process information on the Solaris OS. The information comes mainly from
- * /proc/PID/status, /proc/PID/psinfo and /proc/PID/usage
+ * /host_proc/PID/status, /host_proc/PID/psinfo and /host_proc/PID/usage
  * The values for input and ouput chars are calculated "by hand"
  * Added a few "solaris" specific process states as well
  */
@@ -1240,9 +1240,9 @@ static int ps_read_process(int pid, procstat_t *ps, char *state)
 	psinfo_t *myInfo;
 	prusage_t *myUsage;
 
-	snprintf(filename, sizeof (filename), "/proc/%i/status", pid);
-	snprintf(f_psinfo, sizeof (f_psinfo), "/proc/%i/psinfo", pid);
-	snprintf(f_usage, sizeof (f_usage), "/proc/%i/usage", pid);
+	snprintf(filename, sizeof (filename), "/host_proc/%i/status", pid);
+	snprintf(f_psinfo, sizeof (f_psinfo), "/host_proc/%i/psinfo", pid);
+	snprintf(f_usage, sizeof (f_usage), "/host_proc/%i/usage", pid);
 
 
 	buffer = malloc(sizeof (pstatus_t));

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -33,8 +33,8 @@
 # error "No applicable input method."
 #endif
 
-#define SNMP_FILE "/proc/net/snmp"
-#define NETSTAT_FILE "/proc/net/netstat"
+#define SNMP_FILE "/host_proc/net/snmp"
+#define NETSTAT_FILE "/host_proc/net/netstat"
 
 /*
  * Global variables

--- a/src/serial.c
+++ b/src/serial.c
@@ -62,8 +62,8 @@ static int serial_read (void)
 	int len;
 
 	/* there are a variety of names for the serial device */
-	if ((fh = fopen ("/proc/tty/driver/serial", "r")) == NULL &&
-		(fh = fopen ("/proc/tty/driver/ttyS", "r")) == NULL)
+	if ((fh = fopen ("/host_proc/tty/driver/serial", "r")) == NULL &&
+		(fh = fopen ("/host_proc/tty/driver/ttyS", "r")) == NULL)
 	{
 		char errbuf[1024];
 		WARNING ("serial: fopen: %s",

--- a/src/swap.c
+++ b/src/swap.c
@@ -241,11 +241,11 @@ static int swap_read_separate (void) /* {{{ */
 	FILE *fh;
 	char buffer[1024];
 
-	fh = fopen ("/proc/swaps", "r");
+	fh = fopen ("/host_proc/swaps", "r");
 	if (fh == NULL)
 	{
 		char errbuf[1024];
-		WARNING ("swap plugin: fopen (/proc/swaps) failed: %s",
+		WARNING ("swap plugin: fopen (/host_proc/swaps) failed: %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
@@ -300,11 +300,11 @@ static int swap_read_combined (void) /* {{{ */
 	gauge_t swap_free   = NAN;
 	gauge_t swap_total  = NAN;
 
-	fh = fopen ("/proc/meminfo", "r");
+	fh = fopen ("/host_proc/meminfo", "r");
 	if (fh == NULL)
 	{
 		char errbuf[1024];
-		WARNING ("swap plugin: fopen (/proc/meminfo) failed: %s",
+		WARNING ("swap plugin: fopen (/host_proc/meminfo) failed: %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
@@ -357,11 +357,11 @@ static int swap_read_io (void) /* {{{ */
 	derive_t swap_in  = 0;
 	derive_t swap_out = 0;
 
-	fh = fopen ("/proc/vmstat", "r");
+	fh = fopen ("/host_proc/vmstat", "r");
 	if (fh == NULL)
 	{
-		/* /proc/vmstat does not exist in kernels <2.6 */
-		fh = fopen ("/proc/stat", "r");
+		/* /host_proc/vmstat does not exist in kernels <2.6 */
+		fh = fopen ("/host_proc/stat", "r");
 		if (fh == NULL)
 		{
 			char errbuf[1024];

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -777,9 +777,9 @@ static int conn_read (void)
   {
     int errors_num = 0;
 
-    if (conn_read_file ("/proc/net/tcp") != 0)
+    if (conn_read_file ("/host_proc/net/tcp") != 0)
       errors_num++;
-    if (conn_read_file ("/proc/net/tcp6") != 0)
+    if (conn_read_file ("/host_proc/net/tcp6") != 0)
       errors_num++;
 
     if (errors_num < 2)

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -36,7 +36,7 @@ static const char *config_keys[] = {
 };
 
 const char *const dirname_sysfs = "/sys/class/thermal";
-const char *const dirname_procfs = "/proc/acpi/thermal_zone";
+const char *const dirname_procfs = "/host_proc/acpi/thermal_zone";
 
 static _Bool force_procfs = 0;
 static ignorelist_t *device_list;
@@ -135,7 +135,7 @@ static int thermal_procfs_device_read (const char __attribute__((unused)) *dir,
 		return -1;
 
 	/**
-	 * rechot ~ # cat /proc/acpi/thermal_zone/THRM/temperature
+	 * rechot ~ # cat /host_proc/acpi/thermal_zone/THRM/temperature
 	 * temperature:             55 C
 	 */
 	

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -24,7 +24,7 @@
 #include "plugin.h"
 
 #if KERNEL_LINUX
-# define STAT_FILE "/proc/stat"
+# define STAT_FILE "/host_proc/stat"
 /* Using /proc filesystem to retrieve the boot time, Linux only. */
 /* #endif KERNEL_LINUX */
 

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -91,7 +91,7 @@
 
 /* stolen from quota-3.13 (quota-tools) */
 
-#define PROC_PARTITIONS "/proc/partitions"
+#define PROC_PARTITIONS "/host_proc/partitions"
 #define DEVLABELDIR     "/dev"
 #define UUID   1
 #define VOL    2

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -113,11 +113,11 @@ static int vmem_read (void)
   FILE *fh;
   char buffer[1024];
 
-  fh = fopen ("/proc/vmstat", "r");
+  fh = fopen ("/host_proc/vmstat", "r");
   if (fh == NULL)
   {
     char errbuf[1024];
-    ERROR ("vmem plugin: fopen (/proc/vmstat) failed: %s",
+    ERROR ("vmem plugin: fopen (/host_proc/vmstat) failed: %s",
 	sstrerror (errno, errbuf, sizeof (errbuf)));
     return (-1);
   }

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -35,7 +35,7 @@
 
 #define BUFSIZE 512
 
-#define PROCDIR "/proc/virtual"
+#define PROCDIR "/host_proc/virtual"
 
 #if !KERNEL_LINUX
 # error "No applicable input method."

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -32,7 +32,7 @@
 # error "No applicable input method."
 #endif
 
-#define WIRELESS_PROC_FILE "/proc/net/wireless"
+#define WIRELESS_PROC_FILE "/host_proc/net/wireless"
 
 #if 0
 static double wireless_dbm_to_watt (double dbm)

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -37,7 +37,7 @@
 
 #if defined(KERNEL_LINUX)
 #include "utils_llist.h"
-#define ZOL_ARCSTATS_FILE "/proc/spl/kstat/zfs/arcstats"
+#define ZOL_ARCSTATS_FILE "/host_proc/spl/kstat/zfs/arcstats"
 
 typedef	llist_t kstat_t;
 


### PR DESCRIPTION
This feature allows collection of metrics of the host machine from a linux container running `collectd`.
Hardcoded path of `proc` in the source code is replaced with `host_proc`.

To use this feature, mount the host directory `/proc` as a data volume `/host_proc` in the linux container.
For example, this can be done in docker using the command `docker run -v /proc:/host_proc <docker-image-name>`.
