### PR TITLE
Add BUILD file with build instructions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,12 @@
+To build collectd from the source repository, you will need to run
+`build.sh`, which will generate the `configure` script, which you can
+then run following the instructions in README.
+
+build.sh requires:
+
+autoconf
+automake
+flex
+bison
+libtool
+libtool-ltdl


### PR DESCRIPTION
Adds instructions for build.sh and its dependencies.

Note that this just adds the file.  Not sure if any configuration is
required to keep it out of the distribution.
