### PR TITLE
Renamed all CPU_STATE_* defines for consistency and to avoid conflicts

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -88,17 +88,17 @@
 # define CAN_USE_SYSCTL 0
 #endif
 
-#define CPU_STATE_USER 0
-#define CPU_STATE_SYSTEM 1
-#define CPU_STATE_WAIT 2
-#define CPU_STATE_NICE 3
-#define CPU_STATE_SWAP 4
-#define CPU_STATE_INTERRUPT 5
-#define CPU_STATE_SOFTIRQ 6
-#define CPU_STATE_STEAL 7
-#define CPU_STATE_IDLE 8
-#define CPU_STATE_COLLECTD_ACTIVE 9 /* sum of (!idle) */
-#define CPU_STATE_COLLECTD_MAX 10 /* #states */
+#define COLLECTD_CPU_STATE_USER 0
+#define COLLECTD_CPU_STATE_SYSTEM 1
+#define COLLECTD_CPU_STATE_WAIT 2
+#define COLLECTD_CPU_STATE_NICE 3
+#define COLLECTD_CPU_STATE_SWAP 4
+#define COLLECTD_CPU_STATE_INTERRUPT 5
+#define COLLECTD_CPU_STATE_SOFTIRQ 6
+#define COLLECTD_CPU_STATE_STEAL 7
+#define COLLECTD_CPU_STATE_IDLE 8
+#define COLLECTD_CPU_STATE_ACTIVE 9 /* sum of (!idle) */
+#define COLLECTD_CPU_STATE_MAX 10 /* #states */
 
 #if HAVE_STATGRAB_H
 # include <statgrab.h>
@@ -362,7 +362,7 @@ static int cpu_states_alloc (size_t cpu_num) /* {{{ */
 	cpu_state_t *tmp;
 	size_t sz;
 
-	sz = (((size_t) cpu_num) + 1) * CPU_STATE_COLLECTD_MAX;
+	sz = (((size_t) cpu_num) + 1) * COLLECTD_CPU_STATE_MAX;
 	assert (sz > 0);
 
 	/* We already have enough space. */
@@ -385,7 +385,7 @@ static int cpu_states_alloc (size_t cpu_num) /* {{{ */
 
 static cpu_state_t *get_cpu_state (size_t cpu_num, size_t state) /* {{{ */
 {
-	size_t index = ((cpu_num * CPU_STATE_COLLECTD_MAX) + state);
+	size_t index = ((cpu_num * COLLECTD_CPU_STATE_MAX) + state);
 
 	if (index >= cpu_states_num)
 		return (NULL);
@@ -393,58 +393,58 @@ static cpu_state_t *get_cpu_state (size_t cpu_num, size_t state) /* {{{ */
 	return (&cpu_states[index]);
 } /* }}} cpu_state_t *get_cpu_state */
 
-/* Populates the per-CPU CPU_STATE_COLLECTD_ACTIVE rate and the global rate_by_state
+/* Populates the per-CPU COLLECTD_CPU_STATE_ACTIVE rate and the global rate_by_state
  * array. */
 static void aggregate (gauge_t *sum_by_state) /* {{{ */
 {
 	size_t cpu_num;
 	size_t state;
 
-	for (state = 0; state < CPU_STATE_COLLECTD_MAX; state++)
+	for (state = 0; state < COLLECTD_CPU_STATE_MAX; state++)
 		sum_by_state[state] = NAN;
 
 	for (cpu_num = 0; cpu_num < global_cpu_num; cpu_num++)
 	{
 		cpu_state_t *this_cpu_states = get_cpu_state (cpu_num, 0);
 
-		this_cpu_states[CPU_STATE_COLLECTD_ACTIVE].rate = NAN;
+		this_cpu_states[COLLECTD_CPU_STATE_ACTIVE].rate = NAN;
 
-		for (state = 0; state < CPU_STATE_COLLECTD_ACTIVE; state++)
+		for (state = 0; state < COLLECTD_CPU_STATE_ACTIVE; state++)
 		{
 			if (!this_cpu_states[state].has_value)
 				continue;
 
 			RATE_ADD (sum_by_state[state], this_cpu_states[state].rate);
-			if (state != CPU_STATE_IDLE)
-				RATE_ADD (this_cpu_states[CPU_STATE_COLLECTD_ACTIVE].rate, this_cpu_states[state].rate);
+			if (state != COLLECTD_CPU_STATE_IDLE)
+				RATE_ADD (this_cpu_states[COLLECTD_CPU_STATE_ACTIVE].rate, this_cpu_states[state].rate);
 		}
 
-		RATE_ADD (sum_by_state[CPU_STATE_COLLECTD_ACTIVE], this_cpu_states[CPU_STATE_COLLECTD_ACTIVE].rate);
+		RATE_ADD (sum_by_state[COLLECTD_CPU_STATE_ACTIVE], this_cpu_states[COLLECTD_CPU_STATE_ACTIVE].rate);
 	}
 } /* }}} void aggregate */
 
 /* Commits (dispatches) the values for one CPU or the global aggregation.
  * cpu_num is the index of the CPU to be committed or -1 in case of the global
- * aggregation. rates is a pointer to CPU_STATE_COLLECTD_MAX gauge_t values holding the
+ * aggregation. rates is a pointer to COLLECTD_CPU_STATE_MAX gauge_t values holding the
  * current rate; each rate may be NAN. Calculates the percentage of each state
  * and dispatches the metric. */
 static void cpu_commit_one (int cpu_num, /* {{{ */
-		gauge_t rates[static CPU_STATE_COLLECTD_MAX])
+		gauge_t rates[static COLLECTD_CPU_STATE_MAX])
 {
 	size_t state;
 	gauge_t sum;
 
-	sum = rates[CPU_STATE_COLLECTD_ACTIVE];
-	RATE_ADD (sum, rates[CPU_STATE_IDLE]);
+	sum = rates[COLLECTD_CPU_STATE_ACTIVE];
+	RATE_ADD (sum, rates[COLLECTD_CPU_STATE_IDLE]);
 
 	if (!report_by_state)
 	{
-		gauge_t percent = 100.0 * rates[CPU_STATE_COLLECTD_ACTIVE] / sum;
-		submit_percent (cpu_num, CPU_STATE_COLLECTD_ACTIVE, percent);
+		gauge_t percent = 100.0 * rates[COLLECTD_CPU_STATE_ACTIVE] / sum;
+		submit_percent (cpu_num, COLLECTD_CPU_STATE_ACTIVE, percent);
 		return;
 	}
 
-	for (state = 0; state < CPU_STATE_COLLECTD_ACTIVE; state++)
+	for (state = 0; state < COLLECTD_CPU_STATE_ACTIVE; state++)
 	{
 		gauge_t percent = 100.0 * rates[state] / sum;
 		submit_percent (cpu_num, state, percent);
@@ -468,7 +468,7 @@ static void cpu_commit_without_aggregation (void) /* {{{ */
 {
 	int state;
 
-	for (state = 0; state < CPU_STATE_COLLECTD_ACTIVE; state++)
+	for (state = 0; state < COLLECTD_CPU_STATE_ACTIVE; state++)
 	{
 		size_t cpu_num;
 		if (report_by_cpu) {
@@ -501,7 +501,7 @@ static void cpu_commit_without_aggregation (void) /* {{{ */
 /* Aggregates the internal state and dispatches the metrics. */
 static void cpu_commit (void) /* {{{ */
 {
-	gauge_t global_rates[CPU_STATE_COLLECTD_MAX] = {
+	gauge_t global_rates[COLLECTD_CPU_STATE_MAX] = {
 		NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN
 	};
 	size_t cpu_num;
@@ -523,12 +523,12 @@ static void cpu_commit (void) /* {{{ */
 	for (cpu_num = 0; cpu_num < global_cpu_num; cpu_num++)
 	{
 		cpu_state_t *this_cpu_states = get_cpu_state (cpu_num, 0);
-		gauge_t local_rates[CPU_STATE_COLLECTD_MAX] = {
+		gauge_t local_rates[COLLECTD_CPU_STATE_MAX] = {
 			NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN
 		};
 		size_t state;
 
-		for (state = 0; state < CPU_STATE_COLLECTD_ACTIVE; state++)
+		for (state = 0; state < COLLECTD_CPU_STATE_ACTIVE; state++)
 			if (this_cpu_states[state].has_value)
 				local_rates[state] = this_cpu_states[state].rate;
 
@@ -545,7 +545,7 @@ static int cpu_stage (size_t cpu_num, size_t state, derive_t value, cdtime_t now
 	cpu_state_t *s;
 	value_t v;
 
-	if (state >= CPU_STATE_COLLECTD_ACTIVE)
+	if (state >= COLLECTD_CPU_STATE_ACTIVE)
 		return (EINVAL);
 
 	status = cpu_states_alloc (cpu_num);
@@ -595,16 +595,16 @@ static int cpu_read (void)
 			continue;
 		}
 
-		if (cpu_info_len < CPU_STATE_COLLECTD_MAX)
+		if (cpu_info_len < COLLECTD_CPU_STATE_MAX)
 		{
 			ERROR ("cpu plugin: processor_info returned only %i elements..", cpu_info_len);
 			continue;
 		}
 
-		cpu_stage (cpu, CPU_STATE_USER,   (derive_t) cpu_info.cpu_ticks[CPU_STATE_USER],   now);
-		cpu_stage (cpu, CPU_STATE_NICE,   (derive_t) cpu_info.cpu_ticks[CPU_STATE_NICE],   now);
-		cpu_stage (cpu, CPU_STATE_SYSTEM, (derive_t) cpu_info.cpu_ticks[CPU_STATE_SYSTEM], now);
-		cpu_stage (cpu, CPU_STATE_IDLE,   (derive_t) cpu_info.cpu_ticks[CPU_STATE_IDLE],   now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_USER,   (derive_t) cpu_info.cpu_ticks[COLLECTD_CPU_STATE_USER],   now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_NICE,   (derive_t) cpu_info.cpu_ticks[COLLECTD_CPU_STATE_NICE],   now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_SYSTEM, (derive_t) cpu_info.cpu_ticks[COLLECTD_CPU_STATE_SYSTEM], now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_IDLE,   (derive_t) cpu_info.cpu_ticks[COLLECTD_CPU_STATE_IDLE],   now);
 	}
 /* }}} #endif PROCESSOR_CPU_LOAD_INFO */
 
@@ -637,19 +637,19 @@ static int cpu_read (void)
 
 		cpu = atoi (fields[0] + 3);
 
-		cpu_stage (cpu, CPU_STATE_USER,   (derive_t) atoll(fields[1]), now);
-		cpu_stage (cpu, CPU_STATE_NICE,   (derive_t) atoll(fields[2]), now);
-		cpu_stage (cpu, CPU_STATE_SYSTEM, (derive_t) atoll(fields[3]), now);
-		cpu_stage (cpu, CPU_STATE_IDLE,   (derive_t) atoll(fields[4]), now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_USER,   (derive_t) atoll(fields[1]), now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_NICE,   (derive_t) atoll(fields[2]), now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_SYSTEM, (derive_t) atoll(fields[3]), now);
+		cpu_stage (cpu, COLLECTD_CPU_STATE_IDLE,   (derive_t) atoll(fields[4]), now);
 
 		if (numfields >= 8)
 		{
-			cpu_stage (cpu, CPU_STATE_WAIT,      (derive_t) atoll(fields[5]), now);
-			cpu_stage (cpu, CPU_STATE_INTERRUPT, (derive_t) atoll(fields[6]), now);
-			cpu_stage (cpu, CPU_STATE_SOFTIRQ,   (derive_t) atoll(fields[7]), now);
+			cpu_stage (cpu, COLLECTD_CPU_STATE_WAIT,      (derive_t) atoll(fields[5]), now);
+			cpu_stage (cpu, COLLECTD_CPU_STATE_INTERRUPT, (derive_t) atoll(fields[6]), now);
+			cpu_stage (cpu, COLLECTD_CPU_STATE_SOFTIRQ,   (derive_t) atoll(fields[7]), now);
 
 			if (numfields >= 9)
-				cpu_stage (cpu, CPU_STATE_STEAL, (derive_t) atoll(fields[8]), now);
+				cpu_stage (cpu, COLLECTD_CPU_STATE_STEAL, (derive_t) atoll(fields[8]), now);
 		}
 	}
 	fclose (fh);
@@ -667,10 +667,10 @@ static int cpu_read (void)
 		if (kstat_read (kc, ksp[cpu], &cs) == -1)
 			continue; /* error message? */
 
-		cpu_stage (ksp[cpu]->ks_instance, CPU_STATE_IDLE,   (derive_t) cs.cpu_sysinfo.cpu[CPU_IDLE],   now);
-		cpu_stage (ksp[cpu]->ks_instance, CPU_STATE_USER,   (derive_t) cs.cpu_sysinfo.cpu[CPU_USER],   now);
-		cpu_stage (ksp[cpu]->ks_instance, CPU_STATE_SYSTEM, (derive_t) cs.cpu_sysinfo.cpu[CPU_KERNEL], now);
-		cpu_stage (ksp[cpu]->ks_instance, CPU_STATE_WAIT,   (derive_t) cs.cpu_sysinfo.cpu[CPU_WAIT],   now);
+		cpu_stage (ksp[cpu]->ks_instance, COLLECTD_CPU_STATE_IDLE,   (derive_t) cs.cpu_sysinfo.cpu[CPU_IDLE],   now);
+		cpu_stage (ksp[cpu]->ks_instance, COLLECTD_CPU_STATE_USER,   (derive_t) cs.cpu_sysinfo.cpu[CPU_USER],   now);
+		cpu_stage (ksp[cpu]->ks_instance, COLLECTD_CPU_STATE_SYSTEM, (derive_t) cs.cpu_sysinfo.cpu[CPU_KERNEL], now);
+		cpu_stage (ksp[cpu]->ks_instance, COLLECTD_CPU_STATE_WAIT,   (derive_t) cs.cpu_sysinfo.cpu[CPU_WAIT],   now);
 	}
 /* }}} #endif defined(HAVE_LIBKSTAT) */
 
@@ -730,11 +730,11 @@ static int cpu_read (void)
 	}
 
 	for (i = 0; i < numcpu; i++) {
-		cpu_stage (i, CPU_STATE_USER,      (derive_t) cpuinfo[i][CP_USER], now);
-		cpu_stage (i, CPU_STATE_NICE,      (derive_t) cpuinfo[i][CP_NICE], now);
-		cpu_stage (i, CPU_STATE_SYSTEM,    (derive_t) cpuinfo[i][CP_SYS], now);
-		cpu_stage (i, CPU_STATE_IDLE,      (derive_t) cpuinfo[i][CP_IDLE], now);
-		cpu_stage (i, CPU_STATE_INTERRUPT, (derive_t) cpuinfo[i][CP_INTR], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_USER,      (derive_t) cpuinfo[i][CP_USER], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_NICE,      (derive_t) cpuinfo[i][CP_NICE], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_SYSTEM,    (derive_t) cpuinfo[i][CP_SYS], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_IDLE,      (derive_t) cpuinfo[i][CP_IDLE], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_INTERRUPT, (derive_t) cpuinfo[i][CP_INTR], now);
 	}
 /* }}} #endif CAN_USE_SYSCTL */
 
@@ -755,11 +755,11 @@ static int cpu_read (void)
 	}
 
 	for (i = 0; i < numcpu; i++) {
-		cpu_stage (i, CPU_STATE_USER,      (derive_t) cpuinfo[i][CP_USER], now);
-		cpu_stage (i, CPU_STATE_NICE,      (derive_t) cpuinfo[i][CP_NICE], now);
-		cpu_stage (i, CPU_STATE_SYSTEM,    (derive_t) cpuinfo[i][CP_SYS], now);
-		cpu_stage (i, CPU_STATE_IDLE,      (derive_t) cpuinfo[i][CP_IDLE], now);
-		cpu_stage (i, CPU_STATE_INTERRUPT, (derive_t) cpuinfo[i][CP_INTR], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_USER,      (derive_t) cpuinfo[i][CP_USER], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_NICE,      (derive_t) cpuinfo[i][CP_NICE], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_SYSTEM,    (derive_t) cpuinfo[i][CP_SYS], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_IDLE,      (derive_t) cpuinfo[i][CP_IDLE], now);
+		cpu_stage (i, COLLECTD_CPU_STATE_INTERRUPT, (derive_t) cpuinfo[i][CP_INTR], now);
 	}
 /* }}} #endif HAVE_SYSCTL_KERN_CP_TIMES */
 
@@ -777,11 +777,11 @@ static int cpu_read (void)
 		return (-1);
 	}
 
-	cpu_stage (0, CPU_STATE_USER,      (derive_t) cpuinfo[CP_USER], now);
-	cpu_stage (0, CPU_STATE_NICE,      (derive_t) cpuinfo[CP_NICE], now);
-	cpu_stage (0, CPU_STATE_SYSTEM,    (derive_t) cpuinfo[CP_SYS], now);
-	cpu_stage (0, CPU_STATE_IDLE,      (derive_t) cpuinfo[CP_IDLE], now);
-	cpu_stage (0, CPU_STATE_INTERRUPT, (derive_t) cpuinfo[CP_INTR], now);
+	cpu_stage (0, COLLECTD_CPU_STATE_USER,      (derive_t) cpuinfo[CP_USER], now);
+	cpu_stage (0, COLLECTD_CPU_STATE_NICE,      (derive_t) cpuinfo[CP_NICE], now);
+	cpu_stage (0, COLLECTD_CPU_STATE_SYSTEM,    (derive_t) cpuinfo[CP_SYS], now);
+	cpu_stage (0, COLLECTD_CPU_STATE_IDLE,      (derive_t) cpuinfo[CP_IDLE], now);
+	cpu_stage (0, COLLECTD_CPU_STATE_INTERRUPT, (derive_t) cpuinfo[CP_INTR], now);
 /* }}} #endif HAVE_SYSCTLBYNAME */
 
 #elif defined(HAVE_LIBSTATGRAB) /* {{{ */
@@ -794,12 +794,12 @@ static int cpu_read (void)
 		return (-1);
 	}
 
-	cpu_state (0, CPU_STATE_IDLE,   (derive_t) cs->idle);
-	cpu_state (0, CPU_STATE_NICE,   (derive_t) cs->nice);
-	cpu_state (0, CPU_STATE_SWAP,   (derive_t) cs->swap);
-	cpu_state (0, CPU_STATE_SYSTEM, (derive_t) cs->kernel);
-	cpu_state (0, CPU_STATE_USER,   (derive_t) cs->user);
-	cpu_state (0, CPU_STATE_WAIT,   (derive_t) cs->iowait);
+	cpu_state (0, COLLECTD_CPU_STATE_IDLE,   (derive_t) cs->idle);
+	cpu_state (0, COLLECTD_CPU_STATE_NICE,   (derive_t) cs->nice);
+	cpu_state (0, COLLECTD_CPU_STATE_SWAP,   (derive_t) cs->swap);
+	cpu_state (0, COLLECTD_CPU_STATE_SYSTEM, (derive_t) cs->kernel);
+	cpu_state (0, COLLECTD_CPU_STATE_USER,   (derive_t) cs->user);
+	cpu_state (0, COLLECTD_CPU_STATE_WAIT,   (derive_t) cs->iowait);
 /* }}} #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT) /* {{{ */
@@ -834,10 +834,10 @@ static int cpu_read (void)
 
 	for (i = 0; i < cpus; i++)
 	{
-		cpu_stage (i, CPU_STATE_IDLE,   (derive_t) perfcpu[i].idle, now);
-		cpu_stage (i, CPU_STATE_SYSTEM, (derive_t) perfcpu[i].sys,  now);
-		cpu_stage (i, CPU_STATE_USER,   (derive_t) perfcpu[i].user, now);
-		cpu_stage (i, CPU_STATE_WAIT,   (derive_t) perfcpu[i].wait, now);
+		cpu_stage (i, COLLECTD_CPU_STATE_IDLE,   (derive_t) perfcpu[i].idle, now);
+		cpu_stage (i, COLLECTD_CPU_STATE_SYSTEM, (derive_t) perfcpu[i].sys,  now);
+		cpu_stage (i, COLLECTD_CPU_STATE_USER,   (derive_t) perfcpu[i].user, now);
+		cpu_stage (i, COLLECTD_CPU_STATE_WAIT,   (derive_t) perfcpu[i].wait, now);
 	}
 #endif /* }}} HAVE_PERFSTAT */
 


### PR DESCRIPTION
Hello,

I have done some further renaming of the CPU_STATE_\* defines to make the naming more consistent and to fix a further problem with CPU_STATE_IDLE. (f14ab93574956799debcc592d8f647cd0d5a632d wasn't enough).

This fixes #812 for me.

nick.
