### PR TITLE
processes plugin: add per-process open files count

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5610,7 +5610,7 @@ C<I<prefix>/var/run/collectd-powerdns>.
 Select more detailed statistics of processes matching this name. The statistics
 collected for these selected processes are size of the resident segment size
 (RSS), user- and system-time used, number of processes and number of threads,
-io data (where available) and minor and major pagefaults.
+number of open files, io data (where available) and minor and major pagefaults.
 
 =item B<ProcessMatch> I<name> I<regex>
 

--- a/src/processes.c
+++ b/src/processes.c
@@ -742,7 +742,7 @@ static void ps_submit_proc_list (procstat_t *ps)
 	vl.values_len = 2;
 	plugin_dispatch_values (&vl);
 
-	if (ps->num_fd != -1)
+	if (ps->num_fd > 0)
 	{
 		sstrncpy (vl.type, "files", sizeof (vl.type));
 		vl.values[0].gauge = ps->num_fd;
@@ -1135,8 +1135,8 @@ int ps_read_process (int pid, procstat_t *ps, char *state)
 		if ((ps_read_status(pid, ps)) == NULL)
 		{
 			/* No VMem data */
-			ps->vmem_data = -1;
-			ps->vmem_code = -1;
+			ps->vmem_data = 0;
+			ps->vmem_code = 0;
 			DEBUG("ps_read_process: did not get vmem data for pid %i",pid);
 		}
 		if (ps->num_lwp <= 0)
@@ -1440,14 +1440,14 @@ static int ps_read_process(long pid, procstat_t *ps, char *state)
 	 * TODO: Data and code segment calculations for Solaris
 	 */
 
-	ps->vmem_data = -1;
-	ps->vmem_code = -1;
+	ps->vmem_data = 0;
+	ps->vmem_code = 0;
 	ps->stack_size = myStatus->pr_stksize;
 
 	/*
 	 * TODO: File descriptor count for Solaris
 	 */
-	ps->num_fd = -1;
+	ps->num_fd = 0;
 
 	/*
 	 * Calculating input/ouput chars
@@ -1703,7 +1703,7 @@ static int ps_read (void)
 				pse.vmem_code = 0;
 
 				/* File descriptor count not implemented */
-				pse.num_fd    = -1;
+				pse.num_fd    = 0;
 
 				pse.vmem_minflt_counter = task_events_info.cow_faults;
 				pse.vmem_majflt_counter = task_events_info.faults;
@@ -2071,7 +2071,7 @@ static int ps_read (void)
 			/* context switch counters not implemented */
 			pse.cswitch_vol   = -1;
 			pse.cswitch_invol = -1;
-			pse.num_fd = -1;
+			pse.num_fd = 0;
 
 			ps_list_add (procs[i].ki_comm, have_cmdline ? cmdline : NULL, &pse);
 
@@ -2211,7 +2211,7 @@ static int ps_read (void)
 			pse.cswitch_invol = -1;
 
 			/* file descriptor count not implemented */
-			pse.num_fd = -1;
+			pse.num_fd = 0;
 
 			ps_list_add (procs[i].p_comm, have_cmdline ? cmdline : NULL, &pse);
 
@@ -2361,7 +2361,7 @@ static int ps_read (void)
 
 			pse.cswitch_vol   = -1;
 			pse.cswitch_invol = -1;
-			pse.num_fd = -1;
+			pse.num_fd = 0;
 
 			ps_list_add (cmdline, cargs, &pse);
 		} /* for (i = 0 .. nprocs) */


### PR DESCRIPTION
Only implemented on Linux for now. On other platforms no value will get
submitted.

Counts the number of files in the `/proc/<pid>/fd/` directory.
The function used to count the number of threads has been slightly
modified to work for this case too.
