### PR TITLE
Upstart configuration clean-up

### DIFF
--- a/contrib/upstart.collectd.conf
+++ b/contrib/upstart.collectd.conf
@@ -6,7 +6,7 @@ description "collectd daemon"
 start on started networking and filesystem
 stop on runlevel [!2345]
 
-expect fork
+expect stop
 respawn
 
 env DAEMON=/usr/sbin/collectd


### PR DESCRIPTION
Clean up Upstart configuration so that:

1) Fork is correctly accepted (and thus the PID can be properly tracked).
2) collectd is actually stopped on 'stop' (it doesn't with the old configuration).
3) File looks more like what's in /etc/init/ on a default Ubuntu install.
