### PR TITLE
Fix Py list length check in cpy_build_meta()

### DIFF
--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -428,8 +428,10 @@ static meta_data_t *cpy_build_meta(PyObject *meta) {
 		return NULL;
 	}
 	s = PyList_Size(l);
-    if (s <= 0)
-        return NULL;
+	if (s <= 0) {
+		Py_XDECREF(l);
+		return NULL;
+	}
 
 	m = meta_data_create();
 	for (i = 0; i < s; ++i) {


### PR DESCRIPTION
This is a followup of https://github.com/collectd/collectd/issues/716 to fix Py list length check in cpy_build_meta() function. 
