### PR TITLE
Add --with-mnttab to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -856,6 +856,26 @@ if test "x$have_swapctl" = "xyes"; then
         fi
 fi
 
+# use an alternative path for mount table (eg. /proc/mounts)
+AC_ARG_WITH([mnttab], AS_HELP_STRING([--with-mnttab], [path to table of mounts.]))
+
+AS_IF([test -f "$with_mnttab" ],
+      [AC_DEFINE_UNQUOTED([CUSTOM_MNTTAB], ["$with_mnttab"], [Define if overwrite mnttab path])],
+      [AS_IF([test -n "$with_mnttab" ],
+             [AC_MSG_ERROR([specified mntab does not exist!])
+      ])
+])
+
+# use an alternative path for mount table (eg. /proc/mounts)
+AC_ARG_WITH([mnttab], AS_HELP_STRING([--with-mnttab], [path to table of mounts.]))
+
+AS_IF([test -f "$with_mnttab" ],
+      [AC_DEFINE_UNQUOTED([CUSTOM_MNTTAB], ["$with_mnttab"], [Define if overwrite mnttab path])],
+      [AS_IF([test -n "$with_mnttab" ],
+             [AC_MSG_ERROR([specified mntab does not exist!])
+      ])
+])
+
 # Check for NAN
 AC_ARG_WITH(nan-emulation, [AS_HELP_STRING([--with-nan-emulation], [use emulated NAN. For crosscompiling only.])],
 [

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -71,7 +71,9 @@
 #  undef COLLECTD_MNTTAB
 #endif
 
-#if defined(_PATH_MOUNTED) /* glibc */
+#if defined(CUSTOM_MNTTAB)
+#  define COLLECTD_MNTTAB CUSTOM_MNTTAB
+#elif defined(_PATH_MOUNTED) /* glibc */
 #  define COLLECTD_MNTTAB _PATH_MOUNTED
 #elif defined(MNTTAB) /* Solaris */
 #  define COLLECTD_MNTTAB MNTTAB


### PR DESCRIPTION
Allow to specify an alternate mnttab path.
This may be usefull for systems on which /proc/mounts is
more relaiable than /etc/mtab.
