### PR TITLE
Fixed failing compilation on OS X after temp code removal (f7100301f)

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -232,7 +232,6 @@ static int init (void)
 	DEBUG ("host_processors returned %i %s", (int) cpu_list_len, cpu_list_len == 1 ? "processor" : "processors");
 	INFO ("cpu plugin: Found %i processor%s.", (int) cpu_list_len, cpu_list_len == 1 ? "" : "s");
 
-	cpu_temp_retry_max = 86400 / CDTIME_T_TO_TIME_T (plugin_get_interval ());
 /* #endif PROCESSOR_CPU_LOAD_INFO */
 
 #elif defined(HAVE_LIBKSTAT)


### PR DESCRIPTION
After removing the temperature code from cpu.c compilation was failing on OS X 10.6 with the below message. Removing this line enabled compilation to complete.

```
   CC       cpu_la-cpu.lo
 cpu.c: In function ‘init’:
 cpu.c:235: error: ‘cpu_temp_retry_max’ undeclared (first use in this function)
 cpu.c:235: error: (Each undeclared identifier is reported only once
 cpu.c:235: error: for each function it appears in.)
 make[3]: *** [cpu_la-cpu.lo] Error 1
 make[2]: *** [all-recursive] Error 1
 make[1]: *** [all] Error 2
 make: *** [all-recursive] Error 1
```
