### PR TITLE
configure: Fixed check for AM_PATH_LIBCCRYPT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1926,7 +1926,7 @@ then
 		[with_libgcrypt="no (symbol gcry_md_hash_buffer not found)"])
 
 	if test "$with_libgcrypt" != "no"; then
-		AM_PATH_LIBGCRYPT(1:1.2.0,,with_libgcrypt="no (version 1.2.0+ required)")
+		m4_ifdef([AM_PATH_LIBGCRYPT],[AM_PATH_LIBGCRYPT(1:1.2.0,,with_libgcrypt="no (version 1.2.0+ required)")])
 		GCRYPT_CPPFLAGS="$LIBGCRYPT_CPPFLAGS $LIBGCRYPT_CFLAGS"
 		GCRYPT_LIBS="$LIBGCRYPT_LIBS"
 	fi


### PR DESCRIPTION
Problem : Getting following build error when libgcrypt is not found:

configure.ac:1909: warning: macro 'AM_PATH_LIBGCRYPT' not found in library
configure.ac:1909: error: possibly undefined macro: AM_PATH_LIBGCRYPT
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.

Solution: Fixed check for AM_PATH_LIBCCRYPT
