### PR TITLE
write_graphite plugin: Implement the ReconnectInterval option

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6759,6 +6759,10 @@ Service name or port number to connect to. Defaults to C<2003>.
 
 Protocol to use when connecting to I<Graphite>. Defaults to C<tcp>.
 
+=item B<ForceReconnectTimeout> I<Timeout Seconds>
+
+This parameter enables a forced close and reopen established connection with graphite backend after the specified Timeout seconds. This behaviour is desired in environments where the connection to the backend of graphite is done through load balancers. Default to 0 seconds ( 0 seconds = disabled ).
+
 =item B<LogSendErrors> B<false>|B<true>
 
 If set to B<true> (the default), logs errors when sending data to I<Graphite>.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6761,7 +6761,7 @@ Protocol to use when connecting to I<Graphite>. Defaults to C<tcp>.
 
 =item B<ForceReconnectTimeout> I<Timeout Seconds>
 
-This parameter enables a forced close and reopen established connection with graphite backend after the specified Timeout seconds. This behaviour is desired in environments where the connection to the backend of graphite is done through load balancers. Default to 0 seconds ( 0 seconds = disabled ).
+This parameter enables a forced close and re-open of the established connection with the Graphite backend after the specified timeout in seconds. This behavior is desirable in environments where the connection to the Graphite backend is done through load balancers. Default to 0 seconds (0 seconds = disabled).
 
 =item B<LogSendErrors> B<false>|B<true>
 

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -113,7 +113,33 @@ struct wg_callback
     pthread_mutex_t send_lock;
     c_complain_t init_complaint;
     cdtime_t last_connect_time;
+
+    /*Force reconnect useful for load balanced environments*/
+    cdtime_t last_force_reconnect_time;
+    int force_reconnect_timeout;
 };
+
+/*
+* Force Reconnect functions
+*/
+
+static void wg_force_reconnect_check(struct wg_callback *cb)
+{
+    cdtime_t now;
+    if(!cb->force_reconnect_timeout) return;
+    //check if address changes if addr_timeout
+    now = cdtime ();
+    DEBUG("wg_force_reconnect_check: now %ld last: %ld ",CDTIME_T_TO_TIME_T(now),CDTIME_T_TO_TIME_T(cb->last_force_reconnect_time));
+    if ((now - cb->last_force_reconnect_time) < TIME_T_TO_CDTIME_T(cb->force_reconnect_timeout)){
+       return;
+    }
+    //here we should close connection on next
+    close (cb->sock_fd);
+    cb->sock_fd = -1;
+    INFO("Connection Forced closed after %ld seconds ",CDTIME_T_TO_TIME_T(now - cb->last_force_reconnect_time));
+    cb->last_force_reconnect_time = now;
+}
+
 
 
 /*
@@ -351,6 +377,8 @@ static int wg_send_message (char const *message, struct wg_callback *cb)
 
     pthread_mutex_lock (&cb->send_lock);
 
+    wg_force_reconnect_check(cb);
+
     if (cb->sock_fd < 0)
     {
         status = wg_callback_init (cb);
@@ -489,6 +517,8 @@ static int wg_config_node (oconfig_item_t *ci)
     cb->node = NULL;
     cb->service = NULL;
     cb->protocol = NULL;
+    cb->last_force_reconnect_time=cdtime();
+    cb->force_reconnect_timeout=0;
     cb->log_send_errors = WG_DEFAULT_LOG_SEND_ERRORS;
     cb->prefix = NULL;
     cb->postfix = NULL;
@@ -529,6 +559,8 @@ static int wg_config_node (oconfig_item_t *ci)
                 status = -1;
             }
         }
+        else if (strcasecmp ("ForceReconnectTimeout", child->key) == 0)
+            cf_util_get_int (child,&cb->force_reconnect_timeout);
         else if (strcasecmp ("LogSendErrors", child->key) == 0)
             cf_util_get_boolean (child, &cb->log_send_errors);
         else if (strcasecmp ("Prefix", child->key) == 0)

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -117,6 +117,7 @@ struct wg_callback
     /*Force reconnect useful for load balanced environments*/
     cdtime_t last_force_reconnect_time;
     int force_reconnect_timeout;
+    int conn_forced_closed;
 };
 
 /*
@@ -138,6 +139,7 @@ static void wg_force_reconnect_check(struct wg_callback *cb)
     cb->sock_fd = -1;
     INFO("Connection Forced closed after %ld seconds ",CDTIME_T_TO_TIME_T(now - cb->last_force_reconnect_time));
     cb->last_force_reconnect_time = now;
+    cb->conn_forced_closed=1;
 }
 
 
@@ -300,9 +302,16 @@ static int wg_callback_init (struct wg_callback *cb)
                 "write_graphite plugin: Successfully connected to %s:%s via %s.",
                 node, service, protocol);
     }
-
-    wg_reset_buffer (cb);
-
+    if(!cb->conn_forced_closed || cb->send_buf_free== 0)
+    {
+        /*when not forced connection*/
+        /*or buffer not initialized -- happens if forceReconnect happens before first connection*/
+        wg_reset_buffer (cb);
+    }
+    else {
+         /*if forced connection don't reset buffer with valid metrics when reconnect*/
+         cb->conn_forced_closed=0;
+    }
     return (0);
 }
 
@@ -519,6 +528,7 @@ static int wg_config_node (oconfig_item_t *ci)
     cb->protocol = NULL;
     cb->last_force_reconnect_time=cdtime();
     cb->force_reconnect_timeout=0;
+    cb->conn_forced_closed=0;
     cb->log_send_errors = WG_DEFAULT_LOG_SEND_ERRORS;
     cb->prefix = NULL;
     cb->postfix = NULL;


### PR DESCRIPTION
This parameter enables a forced close and reopen established connection with graphite backend after the specified Timeout seconds. This behaviour is desired in environments where the connection to the backend of graphite is done through load balancers. Default to 0 seconds ( 0 seconds = disabled ).

This new parameter fixes https://github.com/collectd/collectd/issues/832

with this parameter configured at 21600 seconds ( = 6 hours) all established connections will be rebalanced after any load balancer changes its state.