### PR TITLE
bind-plugin: fix zones iteratation upper limit

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -745,7 +745,7 @@ static int bind_xml_stats_handle_zone (int version, xmlDoc *doc, /* {{{ */
   xmlFree (zone_name);
   zone_name = NULL;
 
-  if (j >= views_num)
+  if (j >= views->zones_num)
   {
     xmlXPathFreeObject (path_obj);
     return (0);


### PR DESCRIPTION
Seems like it was created due to the copy-paste. Similar loop and check is in the `bind_xml_stats_handle_view`