### PR TITLE
mysql wsrep stats

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2855,6 +2855,12 @@ Memory subsystem rail (uVolts).
 
 =back
 
+=item B<WsrepStats> I<true|false>
+
+Enable the collection of wsrep plugin statistics, used in Master-Master
+replication setups like in MySQL Galera/Percona XtraDB Cluster.
+User needs only privileges to execute 'SHOW GLOBAL STATUS'
+
 =back
 
 =head2 Plugin C<memory>

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -53,6 +53,7 @@ struct mysql_database_s /* {{{ */
 	_Bool master_stats;
 	_Bool slave_stats;
 	_Bool innodb_stats;
+	_Bool wsrep_stats;
 
 	_Bool slave_notif;
 	_Bool slave_io_running;
@@ -182,6 +183,8 @@ static int mysql_config_database (oconfig_item_t *ci) /* {{{ */
 			status = cf_util_get_boolean (child, &db->slave_notif);
 		else if (strcasecmp ("InnodbStats", child->key) == 0)
 			status = cf_util_get_boolean (child, &db->innodb_stats);
+		else if (strcasecmp ("WsrepStats", child->key) == 0)
+			status = cf_util_get_boolean (child, &db->wsrep_stats);
 		else
 		{
 			WARNING ("mysql plugin: Option `%s' not allowed here.", child->key);
@@ -691,6 +694,144 @@ static int mysql_read_innodb_stats (mysql_database_t *db, MYSQL *con)
     return (0);
 }
 
+static int mysql_read_wsrep_stats (mysql_database_t *db, MYSQL *con)
+{
+	MYSQL_RES *res;
+	MYSQL_ROW  row;
+
+	char *query;
+	int   field_num;
+
+	derive_t wsrep_apply_oooe         = 0;
+	derive_t wsrep_apply_oool         = 0;
+	derive_t wsrep_causal_reads       = 0;
+	derive_t wsrep_commit_oooe        = 0;
+	derive_t wsrep_commit_oool        = 0;
+	derive_t wsrep_flow_control_recv  = 0;
+	derive_t wsrep_flow_control_sent  = 0;
+	derive_t wsrep_local_bf_aborts    = 0;
+	derive_t wsrep_local_commits      = 0;
+	derive_t wsrep_local_replays      = 0;
+	derive_t wsrep_received           = 0;
+	derive_t wsrep_received_bytes     = 0;
+	derive_t wsrep_replicated         = 0;
+	derive_t wsrep_replicated_bytes   = 0;
+
+	gauge_t wsrep_apply_window        = NAN;
+	gauge_t wsrep_cert_deps_distance  = NAN;
+	gauge_t wsrep_commit_window       = NAN;
+	gauge_t wsrep_local_recv_queue          = NAN;
+	gauge_t wsrep_local_recv_queue_avg      = NAN;
+	gauge_t wsrep_local_send_queue          = NAN;
+	gauge_t wsrep_local_send_queue_avg      = NAN;
+
+	query = "SHOW GLOBAL STATUS LIKE 'wsrep_%'";
+
+	res = exec_query (con, query);
+	if (res == NULL)
+		return (-1);
+
+	row = mysql_fetch_row (res);
+	if (row == NULL)
+	{
+		ERROR ("mysql plugin: Failed to get wsrep statistics: "
+				"`%s' did not return any rows.", query);
+		mysql_free_result (res);
+		return (-1);
+	}
+
+	field_num = mysql_num_fields (res);
+	if (field_num < 2)
+	{
+		ERROR ("mysql plugin: Failed to get wsrep statistics: "
+				"`%s' returned less than two columns.", query);
+		mysql_free_result (res);
+		return (-1);
+	}
+
+	while ((row = mysql_fetch_row (res)))
+	{
+		char *key;
+		unsigned long long val;
+		size_t key_length;
+		key = row[0];
+		val = atoll (row[1]);
+		key_length = strlen(key);
+		if (strncmp (key, "wsrep_apply_oooe", key_length ) == 0 )
+			wsrep_apply_oooe = (derive_t) val;
+		else if (strncmp (key, "wsrep_apply_oool", key_length ) == 0 )
+			wsrep_apply_oool = (derive_t) val;
+		else if (strncmp (key, "wsrep_causal_reads", key_length ) == 0 )
+			wsrep_causal_reads = (derive_t) val;
+		else if (strncmp (key, "wsrep_commit_oooe", key_length ) == 0 )
+			wsrep_commit_oooe = (derive_t) val;
+		else if (strncmp (key, "wsrep_commit_oool", key_length ) == 0 )
+			wsrep_commit_oool = (derive_t) val;
+		else if (strncmp (key, "wsrep_flow_control_recv", key_length ) == 0 )
+			wsrep_flow_control_recv = (derive_t) val;
+		else if (strncmp (key, "wsrep_flow_control_sent", key_length ) == 0 )
+			wsrep_flow_control_sent = (derive_t) val;
+		else if (strncmp (key, "wsrep_local_bf_aborts", key_length ) == 0 )
+			wsrep_local_bf_aborts = (derive_t) val;
+		else if (strncmp (key, "wsrep_local_commits", key_length ) == 0 )
+			wsrep_local_commits = (derive_t) val;
+		else if (strncmp (key, "wsrep_local_replays", key_length ) == 0 )
+			wsrep_local_replays = (derive_t) val;
+		else if (strncmp (key, "wsrep_received", key_length ) == 0 )
+			wsrep_received = (derive_t) val;
+		else if (strncmp (key, "wsrep_received_bytes", key_length ) == 0 )
+			wsrep_received_bytes = (derive_t) val;
+		else if (strncmp (key, "wsrep_replicated", key_length ) == 0 )
+			wsrep_replicated = (derive_t) val;
+		else if (strncmp (key, "wsrep_replicated_bytes", key_length ) == 0 )
+			wsrep_replicated_bytes = (derive_t) val;
+
+		else if (strncmp (key, "wsrep_apply_window", key_length ) == 0 )
+			wsrep_apply_window = (gauge_t) val;
+		else if (strncmp (key, "wsrep_cert_deps_distance", key_length ) == 0 )
+			wsrep_cert_deps_distance = (gauge_t) val;
+		else if (strncmp (key, "wsrep_local_recv_queue", key_length ) == 0 )
+			wsrep_local_recv_queue = (gauge_t) val;
+		else if (strncmp (key, "wsrep_local_recv_queue_avg", key_length ) == 0 )
+			wsrep_local_recv_queue_avg = (gauge_t) val;
+		else if (strncmp (key, "wsrep_local_send_queue", key_length ) == 0 )
+			wsrep_local_send_queue = (gauge_t) val;
+		else if (strncmp (key, "wsrep_local_send_queue_avg", key_length ) == 0 )
+			wsrep_local_send_queue_avg = (gauge_t) val;
+		else if (strncmp (key, "wsrep_commit_window", key_length ) == 0 )
+			wsrep_commit_window = (gauge_t) val;
+	}
+
+	mysql_free_result (res);
+
+	counter_submit ("total_bytes",      "wsrep_received", wsrep_received_bytes, db);
+	counter_submit ("total_bytes",      "wsrep_replicated", wsrep_replicated_bytes, db);
+	counter_submit ("operations",       "wsrep_apply_oooe", wsrep_apply_oooe, db);
+	counter_submit ("operations",       "wsrep_apply_oool", wsrep_apply_oool, db);
+	counter_submit ("operations",       "wsrep_causal_reads", wsrep_causal_reads, db);
+	counter_submit ("operations",       "wsrep_commit_oooe", wsrep_commit_oooe, db);
+	counter_submit ("operations",       "wsrep_commit_oool", wsrep_commit_oool, db);
+	counter_submit ("operations",       "wsrep_flow_control_recv", wsrep_flow_control_recv, db);
+	counter_submit ("operations",       "wsrep_flow_control_sent", wsrep_flow_control_sent, db);
+	counter_submit ("operations",       "wsrep_local_bf_aborts", wsrep_local_bf_aborts, db);
+	counter_submit ("operations",       "wsrep_local_commits", wsrep_local_commits, db);
+	counter_submit ("operations",       "wsrep_local_replays", wsrep_local_replays, db);
+	counter_submit ("operations",       "wsrep_received", wsrep_received, db);
+	counter_submit ("operations",       "wsrep_replicated", wsrep_replicated, db);
+
+	gauge_submit   ("queue_length",     "wsrep_local_recv", wsrep_local_recv_queue, db);
+	gauge_submit   ("queue_length",     "wsrep_local_recv_avg", wsrep_local_recv_queue_avg, db);
+	gauge_submit   ("queue_length",     "wsrep_local_send", wsrep_local_send_queue, db);
+	gauge_submit   ("queue_length",     "wsrep_local_send_avg", wsrep_local_send_queue_avg, db);
+	gauge_submit   ("window_size",     "wsrep_apply", wsrep_apply_window, db);
+	gauge_submit   ("window_size",     "wsrep_cert_deps_distance", wsrep_cert_deps_distance, db);
+	gauge_submit   ("window_size",     "wsrep_commit" ,wsrep_commit_window, db);
+
+	return (0);
+} /* mysql_read_wsrep_stats */
+
+
+
 static int mysql_read (user_data_t *ud)
 {
 	mysql_database_t *db;
@@ -947,6 +1088,10 @@ static int mysql_read (user_data_t *ud)
 
 	if ((db->slave_stats) || (db->slave_notif))
 		mysql_read_slave_stats (db, con);
+	
+	if (db->wsrep_stats)
+		mysql_read_wsrep_stats (db, con);
+	
 
 	return (0);
 } /* int mysql_read */

--- a/src/types.db
+++ b/src/types.db
@@ -222,6 +222,7 @@ voltage			value:GAUGE:U:U
 vs_memory		value:GAUGE:0:9223372036854775807
 vs_processes		value:GAUGE:0:65535
 vs_threads		value:GAUGE:0:65535
+window_size		value:GAUGE:0:U
 
 #
 # Legacy types


### PR DESCRIPTION
I've added option to gather some stats specific to MySQL Galera replication setup ( more details here http://www.percona.com/doc/percona-xtradb-cluster/5.5/wsrep-status-index.html )

as per https://github.com/collectd/collectd/pull/641 I used generic datatypes and added one, window_size as there wasn't any existing one that would fit. Also rebased on current master instead of latest stable