### PR TITLE
virt plugin: Fix memory stats to use the same units

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -588,7 +588,7 @@ lv_read (void)
         }
 
         for (j = 0; j < status; j++) {
-            memory_stats_submit ((gauge_t) minfo[j].val, domains[i], minfo[j].tag);
+            memory_stats_submit ((gauge_t) minfo[j].val * 1024, domains[i], minfo[j].tag);
         }
 
         sfree (minfo);


### PR DESCRIPTION
memory_submit and memory_stats_submit should use same units "Bytes"
- Fixes: #856
