### PR TITLE
Change "plugin_dispatch_multivalue" to accept any metric type.

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2162,7 +2162,7 @@ int plugin_dispatch_values (value_list_t const *vl)
 
 __attribute__((sentinel))
 int plugin_dispatch_multivalue (value_list_t const *template, /* {{{ */
-		_Bool store_percentage, ...)
+		_Bool store_percentage, int store_type, ...)
 {
 	value_list_t *vl;
 	int failed = 0;
@@ -2171,28 +2171,32 @@ int plugin_dispatch_multivalue (value_list_t const *template, /* {{{ */
 
 	assert (template->values_len == 1);
 
-	va_start (ap, store_percentage);
-	while (42)
-	{
-		char const *name;
-		gauge_t value;
+  /* Calculate sum for Gauge to calculate percent if needed */
+	if (DS_TYPE_GAUGE == store_type)	{
+		va_start (ap, store_type);
+		while (42)
+		{
+			char const *name;
+			gauge_t value;
 
-		name = va_arg (ap, char const *);
-		if (name == NULL)
-			break;
+			name = va_arg (ap, char const *);
+			if (name == NULL)
+				break;
 
-		value = va_arg (ap, gauge_t);
-		if (!isnan (value))
-			sum += value;
+			value = va_arg (ap, gauge_t);
+			if (!isnan (value))
+				sum += value;
+		}
+		va_end (ap);
 	}
-	va_end (ap);
+
 
 	vl = plugin_value_list_clone (template);
 	/* plugin_value_list_clone makes sure vl->time is set to non-zero. */
 	if (store_percentage)
 		sstrncpy (vl->type, "percent", sizeof (vl->type));
 
-	va_start (ap, store_percentage);
+	va_start (ap, store_type);
 	while (42)
 	{
 		char const *name;
@@ -2205,9 +2209,27 @@ int plugin_dispatch_multivalue (value_list_t const *template, /* {{{ */
 		sstrncpy (vl->type_instance, name, sizeof (vl->type_instance));
 
 		/* Set the value. */
-		vl->values[0].gauge = va_arg (ap, gauge_t);
-		if (store_percentage)
-			vl->values[0].gauge *= 100.0 / sum;
+		switch (store_type)
+		{
+		case DS_TYPE_GAUGE:
+			vl->values[0].gauge = va_arg (ap, gauge_t);
+			if (store_percentage)
+				vl->values[0].gauge *= 100.0 / sum;
+			break;
+		case DS_TYPE_ABSOLUTE:
+			vl->values[0].absolute = va_arg (ap, absolute_t);
+			break;
+		case DS_TYPE_COUNTER:
+			vl->values[0].counter  = va_arg (ap, counter_t);
+			break;
+		case DS_TYPE_DERIVE:
+			vl->values[0].derive   = va_arg (ap, derive_t);
+			break;
+		default:
+			ERROR ("plugin_dispatch_multivalue: given store_type is incorrect.");
+			failed++;
+		}
+
 
 		status = plugin_write_enqueue (vl);
 		if (status != 0)

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -344,7 +344,7 @@ int plugin_dispatch_values (value_list_t const *vl);
  *  plugin_dispatch_multivalue
  *
  * SYNOPSIS
- *  plugin_dispatch_multivalue (vl, 1,
+ *  plugin_dispatch_multivalue (vl, 1, DS_TYPE_GAUGE,
  *                              "free", 42.0,
  *                              "used", 58.0,
  *                              NULL);
@@ -356,8 +356,16 @@ int plugin_dispatch_values (value_list_t const *vl);
  *  calculated and dispatched, rather than the absolute values. Values that are
  *  NaN are dispatched as NaN and will not influence the total.
  *
- *  The variadic arguments is a list of type_instance / gauge pairs, that are
- *  interpreted as type "char const *" and "gauge_t". The last argument must be
+ *  The variadic arguments is a list of type_instance / type pairs, that are
+ *  interpreted as type "char const *" and type, encoded by their corresponding
+ *  "store_type":
+ *
+ *     - "gauge_t"    when "DS_TYPE_GAUGE"
+ *     - "absolute_t" when "DS_TYPE_ABSOLUTE"
+ *     - "derive_t"   when "DS_TYPE_DERIVE"
+ *     - "counter_t"  when "DS_TYPE_COUNTER"
+ *
+ *  The last argument must be
  *  a NULL pointer to signal end-of-list.
  *
  * RETURNS
@@ -365,7 +373,7 @@ int plugin_dispatch_values (value_list_t const *vl);
  */
 __attribute__((sentinel))
 int plugin_dispatch_multivalue (value_list_t const *vl,
-		_Bool store_percentage, ...);
+		_Bool store_percentage, int store_type, ...);
 
 int plugin_dispatch_missing (const value_list_t *vl);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -160,9 +160,9 @@ static int memory_init (void)
 
 #define MEMORY_SUBMIT(...) do { \
 	if (values_absolute) \
-		plugin_dispatch_multivalue (vl, 0, __VA_ARGS__, NULL); \
+		plugin_dispatch_multivalue (vl, 0, DS_TYPE_GAUGE, __VA_ARGS__, NULL); \
 	if (values_percentage) \
-		plugin_dispatch_multivalue (vl, 1, __VA_ARGS__, NULL); \
+		plugin_dispatch_multivalue (vl, 1, DS_TYPE_GAUGE, __VA_ARGS__, NULL); \
 } while (0)
 
 static int memory_read_internal (value_list_t *vl)

--- a/src/swap.c
+++ b/src/swap.c
@@ -205,11 +205,11 @@ static void swap_submit_usage (char const *plugin_instance, /* {{{ */
 	sstrncpy (vl.type, "swap", sizeof (vl.type));
 
 	if (values_absolute)
-		plugin_dispatch_multivalue (&vl, 0,
+		plugin_dispatch_multivalue (&vl, 0, DS_TYPE_GAUGE,
 				"used", used, "free", free,
 				other_name, other_value, NULL);
 	if (values_percentage)
-		plugin_dispatch_multivalue (&vl, 1,
+		plugin_dispatch_multivalue (&vl, 1, DS_TYPE_GAUGE,
 				"used", used, "free", free,
 				other_name, other_value, NULL);
 } /* }}} void swap_submit_usage */


### PR DESCRIPTION
Currently, `plugin_dispatch_multivalue` works only with 
`gauge_t` metric type. 

Although this function is extremely useful for other other data types.

This commit changes it to accept a "store_type" (one of `DS_TYPE_{GAUGE|COUTNTER|ABSOLUTE|DERIVE}`).