### PR TITLE
declare cpu_temp_retry_max in src/cpu.c to fix comp under clang (#862)

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -218,7 +218,7 @@ static int init (void)
 {
 #if PROCESSOR_CPU_LOAD_INFO
 	kern_return_t status;
-	static int cpu_temp_retry_max;
+	static time_t cpu_temp_retry_max;
 
 	port_host = mach_host_self ();
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -218,6 +218,7 @@ static int init (void)
 {
 #if PROCESSOR_CPU_LOAD_INFO
 	kern_return_t status;
+	static int cpu_temp_retry_max;
 
 	port_host = mach_host_self ();
 


### PR DESCRIPTION
This may be vaguely related to #862, but this makes master compile on 10.10 for me.