### PR TITLE
Fix htonll check for OSX Yosemite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ src/tags
 
 # backup stuff
 *~
+
+# netbeans project stuff
+nbproject

--- a/configure.in
+++ b/configure.in
@@ -1218,16 +1218,16 @@ AC_MSG_CHECKING([if have htonll defined])
 
     have_htonll="no"
     AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
+[[
 #include <sys/types.h>
 #include <netinet/in.h>
 #if HAVE_INTTYPES_H
 # include <inttypes.h>
 #endif
-]]],
-[[[
+]],
+[[
           return htonll(0);
-]]]
+]]
     )],
     [
       have_htonll="yes"


### PR DESCRIPTION
fixes #884 (and would presumably further fix #862 once 9f5ea03c55ef747c63a258e7abdbbf07a3b1bbf7 was merged into `master`).

I'm filing this against `origin/collectd-5.3` since that seems like the most recently active branch; let me know if I should file it against a different branch instead, e.g. `origin/collectd-5.4`.

A few notes on this fix:
* I have no idea why `autoconf` seems to require double-square-brackets in the `htonll` check `AC_LANG_PROGRAM`.
* I inferred that this fix would work because:
  * I noticed that my `./configure` runs on OSX Yosemite were [erroneously failing to find `htonll` installed on my system](https://gist.github.com/ryan-williams/a4ac719c6461b29557ce#file-gistfile1-txt-L609).
  * Inspecting [my `config.log`](https://gist.github.com/ryan-williams/11172badc03a9e827b28#file-config-log), I noticed that the `htonll` test program was failing on what seemed to be stray [open-](https://gist.github.com/ryan-williams/11172badc03a9e827b28#file-config-log-L16357-L16361) and [close-](https://gist.github.com/ryan-williams/11172badc03a9e827b28#file-config-log-L16357-L16361) square-brackets.
  * Indeed, the `AC_LANG_PROGRAM`-generated test-program [seemed to have an extra set of square-brackets quoting its "prologue" and "body" sections](https://gist.github.com/ryan-williams/11172badc03a9e827b28#file-config-log-L16546-L16563):
  ```
  | [
  | #include <sys/types.h>
  | #include <netinet/in.h>
  | #if HAVE_INTTYPES_H
  | # include <inttypes.h>
  | #endif
  | ]
  | int
  | main ()
  | {
  | [
  |           return htonll(0);
  | ]
  | 
  |   ;
  |   return 0;
  | }
  configure:18820: result: no
  ```

So I am reasonably confident that this is a sane fix to the problem, though I have very little idea why it was necessary. I verified that compilation of `origin/collectd-5.3` (ba55ad9ae41052b665d008f20f4b7076983446e2) works on OSX Yosemite as well as on a CentOS 6.6 box I have laying around.