### PR TITLE
Add a write_log output plugin which logs values.

### DIFF
--- a/README
+++ b/README
@@ -433,6 +433,9 @@ Features
     - write_kafka
       Sends data to Apache Kafka, a distributed queue.
 
+    - write_log
+      Writes data to the log
+
     - write_mongodb
       Sends data to MongoDB, a NoSQL database.
 

--- a/configure.ac
+++ b/configure.ac
@@ -5578,6 +5578,7 @@ AC_PLUGIN([wireless],    [$plugin_wireless],   [Wireless statistics])
 AC_PLUGIN([write_graphite], [yes],             [Graphite / Carbon output plugin])
 AC_PLUGIN([write_http],  [$with_libcurl],      [HTTP output plugin])
 AC_PLUGIN([write_kafka],  [$with_librdkafka],  [Kafka output plugin])
+AC_PLUGIN([write_log], [yes],                  [Log output plugin])
 AC_PLUGIN([write_mongodb], [$with_libmongoc],  [MongoDB output plugin])
 AC_PLUGIN([write_redis], [$with_libhiredis],    [Redis output plugin])
 AC_PLUGIN([write_riemann], [$have_protoc_c],   [Riemann output plugin])
@@ -5947,6 +5948,7 @@ Configuration:
     write_graphite  . . . $enable_write_graphite
     write_http  . . . . . $enable_write_http
     write_kafka . . . . . $enable_write_kafka
+    write_log . . . . . . $enable_write_log
     write_mongodb . . . . $enable_write_mongodb
     write_redis . . . . . $enable_write_redis
     write_riemann . . . . $enable_write_riemann

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1175,6 +1175,13 @@ write_kafka_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBRDKAFKA_LDFLAGS)
 write_kafka_la_LIBADD = $(BUILD_WITH_LIBRDKAFKA_LIBS)
 endif
 
+if BUILD_PLUGIN_WRITE_LOG
+pkglib_LTLIBRARIES += write_log.la
+write_log_la_SOURCES = write_log.c \
+                        utils_format_graphite.c utils_format_graphite.h
+write_log_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+endif
+
 if BUILD_PLUGIN_WRITE_MONGODB
 pkglib_LTLIBRARIES += write_mongodb.la
 write_mongodb_la_SOURCES = write_mongodb.c

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -198,6 +198,7 @@
 #@BUILD_PLUGIN_WRITE_GRAPHITE_TRUE@LoadPlugin write_graphite
 #@BUILD_PLUGIN_WRITE_HTTP_TRUE@LoadPlugin write_http
 #@BUILD_PLUGIN_WRITE_KAFKA_TRUE@LoadPlugin write_kafka
+#@BUILD_PLUGIN_WRITE_LOG_TRUE@LoadPlugin write_log
 #@BUILD_PLUGIN_WRITE_MONGODB_TRUE@LoadPlugin write_mongodb
 #@BUILD_PLUGIN_WRITE_REDIS_TRUE@LoadPlugin write_redis
 #@BUILD_PLUGIN_WRITE_RIEMANN_TRUE@LoadPlugin write_riemann

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7129,6 +7129,12 @@ want to set B<metadata.broker.list> to your Kafka broker list.
 
 =back
 
+=head2 Plugin C<write_log>
+
+The I<write_log plugin> will send values to the configured log destination.
+It is meant to be used for testing purposes, to ensure that values
+are correctly reported. Values will be formatted in the I<graphite> format.
+
 =head2 Plugin C<write_redis>
 
 The I<write_redis plugin> submits values to I<Redis>, a data structure server.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7129,12 +7129,6 @@ want to set B<metadata.broker.list> to your Kafka broker list.
 
 =back
 
-=head2 Plugin C<write_log>
-
-The I<write_log plugin> will send values to the configured log destination.
-It is meant to be used for testing purposes, to ensure that values
-are correctly reported. Values will be formatted in the I<graphite> format.
-
 =head2 Plugin C<write_redis>
 
 The I<write_redis plugin> submits values to I<Redis>, a data structure server.

--- a/src/write_log.c
+++ b/src/write_log.c
@@ -1,0 +1,76 @@
+/**
+ * collectd - src/write_log.c
+ * Copyright (C) 2015       Pierre-Yves Ritschard
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; only version 2 of the License is applicable.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   Pierre-Yves Ritschard <pyr at spootnik.org>
+ *
+ **/
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+#include "configfile.h"
+
+#include "utils_format_graphite.h"
+
+/* Folks without pthread will need to disable this plugin. */
+#include <pthread.h>
+
+#include <sys/socket.h>
+#include <netdb.h>
+
+#define WL_BUF_SIZE 8192
+
+static int wl_write_messages (const data_set_t *ds, const value_list_t *vl)
+{
+    char buffer[WL_BUF_SIZE];
+    int status;
+
+    if (0 != strcmp (ds->type, vl->type))
+    {
+        ERROR ("write_log plugin: DS type does not match "
+                "value list type");
+        return -1;
+    }
+
+    memset (buffer, 0, sizeof (buffer));
+    status = format_graphite (buffer, sizeof (buffer), ds, vl,
+                              NULL, NULL, '_', 0);
+    if (status != 0) /* error message has been printed already. */
+        return (status);
+
+    INFO ("write_log values:\n%s", buffer);
+
+    return (0);
+} /* int wl_write_messages */
+
+static int wl_write (const data_set_t *ds, const value_list_t *vl,
+        user_data_t *user_data)
+{
+    int status;
+
+    status = wl_write_messages (ds, vl);
+
+    return (status);
+}
+
+void module_register (void)
+{
+    plugin_register_write ("write_log", wl_write, NULL);
+}
+
+/* vim: set sw=4 ts=4 sts=4 tw=78 et : */

--- a/src/write_log.c
+++ b/src/write_log.c
@@ -2,18 +2,23 @@
  * collectd - src/write_log.c
  * Copyright (C) 2015       Pierre-Yves Ritschard
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; only version 2 of the License is applicable.
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
  *
  * Authors:
  *   Pierre-Yves Ritschard <pyr at spootnik.org>


### PR DESCRIPTION
I find this to be useful when developping new input plugins,
it allows creating a very simple configuration and combined
with `-f` can be used for a very simple workflow.

I'm proposing this, since I think it could be useful for
people wanting to debug their config on local agents as well.