### PR TITLE
Fix compiler warnings with Python3.

### DIFF
--- a/src/collectd-python.pod
+++ b/src/collectd-python.pod
@@ -57,9 +57,11 @@ modules, e.g. "time".
 =item B<Encoding> I<Name>
 
 The default encoding for Unicode objects you pass to collectd. If you omit this
-option it will default to B<ascii> on I<Python 2> and B<utf-8> on I<Python 3>.
-This is hardcoded in Python and will ignore everything else, including your
-locale.
+option it will default to B<ascii> on I<Python 2>. On I<Python 3> it will
+always be B<utf-8>, as this function was removed, so this will be silently
+ignored.
+These defaults are hardcoded in Python and will ignore everything else,
+including your locale.
 
 =item B<ModulePath> I<Name>
 

--- a/src/python.c
+++ b/src/python.c
@@ -1038,7 +1038,7 @@ static int cpy_init_python() {
 	PyObject *module;
 
 #ifdef IS_PY3K
-	wchar_t *argv = {0};
+	wchar_t *argv = L"";
 	/* Add a builtin module, before Py_Initialize */
 	PyImport_AppendInittab("collectd", PyInit_collectd);
 #else

--- a/src/python.c
+++ b/src/python.c
@@ -1034,13 +1034,15 @@ PyMODINIT_FUNC PyInit_collectd(void) {
 #endif
 
 static int cpy_init_python() {
-	char *argv = "";
 	PyObject *sys;
 	PyObject *module;
 
 #ifdef IS_PY3K
+	wchar_t *argv = {0};
 	/* Add a builtin module, before Py_Initialize */
 	PyImport_AppendInittab("collectd", PyInit_collectd);
+#else
+	char *argv = "";
 #endif
 	
 	Py_Initialize();
@@ -1117,9 +1119,13 @@ static int cpy_config(oconfig_item_t *ci) {
 		} else if (strcasecmp(item->key, "Encoding") == 0) {
 			if (item->values_num != 1 || item->values[0].type != OCONFIG_TYPE_STRING)
 				continue;
+#ifdef IS_PY3K
+			NOTICE("python: \"Encoding\" was used in the config file but Python3 was used, which does not support changing encodings. Ignoring this.");
+#else
 			/* Why is this even necessary? And undocumented? */
 			if (PyUnicode_SetDefaultEncoding(item->values[0].value.string))
 				cpy_log_exception("setting default encoding");
+#endif
 		} else if (strcasecmp(item->key, "LogTraces") == 0) {
 			if (item->values_num != 1 || item->values[0].type != OCONFIG_TYPE_BOOLEAN)
 				continue;


### PR DESCRIPTION
PyUnicode_SetDefaultEncoding was removed from the Python source between 3.1 and 3.2. It was never a documented API so I guess I have only myself to blame for this breakage.
https://github.com/collectd/collectd/issues/505