### PR TITLE
memcached: report global Hostname by default

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2257,7 +2257,9 @@ following options are allowed:
 
 =item B<Host> I<Hostname>
 
-Hostname to connect to. Defaults to B<127.0.0.1>.
+Hostname to connect to. Defaults to B<127.0.0.1>. Also sets the B<host> field
+of I<value lists> when dispatching values. Defaults to the global hostname
+setting.
 
 =item B<Port> I<Port>
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -256,7 +256,7 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
       sstrncpy (vl->host, hostname_g, sizeof (vl->host));
     else
       sstrncpy (vl->host,
-          (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
+          (st->host != NULL) ? st->host : hostname_g,
           sizeof (vl->host));
     sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
   }


### PR DESCRIPTION
When the Host parameter is left unspecified, the "host" part of the
value list should be set to the global hostname instead of the default
value hardcoded in the plugin.

Thanks to @Poil and @CyBeRoni for reporting and tracking down this
problem !

Fixes #801