### PR TITLE
write_http: deprecate <URL> blocks in favor of <Node>

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1277,7 +1277,8 @@
 #</Plugin>
 
 #<Plugin write_http>
-#	<URL "http://example.com/collectd-post">
+#	<Node "example">
+#		URL "http://example.com/collectd-post"
 #		User "collectd"
 #		Password "weCh3ik0"
 #		VerifyPeer true
@@ -1291,7 +1292,7 @@
 #		Format "Command"
 #		StoreRates false
 #		BufferSize 4096
-#	</URL>
+#	</Node>
 #</Plugin>
 
 #<Plugin write_kafka>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6954,24 +6954,28 @@ want to use authentication all three fields must be set.
 
 This output plugin submits values to an HTTP server using POST requests and
 encoding metrics with JSON or using the C<PUTVAL> command described in
-L<collectd-unixsock(5)>. Each destination you want to post data to needs to
-have one B<URL> block, within which the destination can be configured further,
-for example by specifying authentication data.
+L<collectd-unixsock(5)>.
 
 Synopsis:
 
  <Plugin "write_http">
-   <URL "http://example.com/post-collectd">
+   <Node "example">
+     URL "http://example.com/post-collectd"
      User "collectd"
      Password "weCh3ik0"
      Format JSON
-   </URL>
+   </Node>
  </Plugin>
 
-B<URL> blocks need one string argument which is used as the URL to which data
-is posted. The following options are understood within B<URL> blocks.
+The plugin can send values to multiple HTTP servers by specifying one
+E<lt>B<Node>E<nbsp>I<Name>E<gt> block for each server. Within each B<Node>
+block, the following options are available:
 
 =over 4
+
+=item B<URL> I<URL>
+
+URL to which the values are submitted to. Mandatory.
 
 =item B<User> I<Username>
 

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -498,6 +498,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         wh_callback_t *cb;
         int buffer_size = 0;
         user_data_t user_data;
+        char callback_name[DATA_MAX_NAME_LEN];
         int i;
 
         cb = malloc (sizeof (*cb));
@@ -600,16 +601,18 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         /* Nulls the buffer and sets ..._free and ..._fill. */
         wh_reset_buffer (cb);
 
-        DEBUG ("write_http: Registering write callback with URL %s",
+        ssnprintf (callback_name, sizeof (callback_name), "write_http/%s",
                         cb->location);
+        DEBUG ("write_http: Registering write callback '%s' with URL '%s'",
+                        callback_name, cb->location);
 
         memset (&user_data, 0, sizeof (user_data));
         user_data.data = cb;
         user_data.free_func = NULL;
-        plugin_register_flush ("write_http", wh_flush, &user_data);
+        plugin_register_flush (callback_name, wh_flush, &user_data);
 
         user_data.free_func = wh_callback_free;
-        plugin_register_write ("write_http", wh_write, &user_data);
+        plugin_register_write (callback_name, wh_write, &user_data);
 
         return (0);
 } /* }}} int wh_config_url */


### PR DESCRIPTION
This makes the plugin use `<Node>` blocks like most other write plugins,
while maintaining backwards compatibility with `<URL>` blocks.

It's a follow up to #899, which was merely a fix for the release
branches.

It should also make using write_http with filter chains more convenient.