### PR TITLE
Fix memory leak

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5097,6 +5097,7 @@ AC_COLLECTD([getifaddrs],[enable],  [feature], [getifaddrs under Linux])
 dependency_warning="no"
 dependency_error="no"
 
+plugin_aoe_stats="no"
 plugin_ascent="no"
 plugin_barometer="no"
 plugin_battery="no"
@@ -5110,6 +5111,7 @@ plugin_curl_json="no"
 plugin_curl_xml="no"
 plugin_df="no"
 plugin_disk="no"
+plugin_disk_errors="no"
 plugin_drbd="no"
 plugin_entropy="no"
 plugin_ethstat="no"
@@ -5118,15 +5120,18 @@ plugin_interface="no"
 plugin_ipmi="no"
 plugin_ipvs="no"
 plugin_irq="no"
+plugin_link_stats="no"
 plugin_load="no"
 plugin_log_logstash="no"
 plugin_memory="no"
 plugin_multimeter="no"
 plugin_nfs="no"
+plugin_nfssvr_stats="no"
 plugin_numa="no"
 plugin_perl="no"
 plugin_processes="no"
 plugin_protocols="no"
+plugin_rpc_stats="no"
 plugin_serial="no"
 plugin_swap="no"
 plugin_tape="no"
@@ -5140,6 +5145,7 @@ plugin_vmem="no"
 plugin_vserver="no"
 plugin_wireless="no"
 plugin_zfs_arc="no"
+plugin_zfs_stats="no"
 plugin_zookeeper="no"
 
 # Linux
@@ -5227,9 +5233,16 @@ fi
 # Solaris
 if test "x$with_kstat" = "xyes"
 then
+    plugin_aoe_stats="yes"
+    plugin_cpu_stats="yes"
+    plugin_disk_errors="yes"
+    plugin_link_stats="yes"
 	plugin_nfs="yes"
-	plugin_uptime="yes"
+    plugin_nfssvr_stats="yes"
+    plugin_rpc_stats="yes"
+    plugin_uptime="yes"
 	plugin_zfs_arc="yes"
+	plugin_zfs_stats="yes"
 fi
 
 if test "x$with_devinfo$with_kstat" = "xyesyes"
@@ -5458,6 +5471,7 @@ m4_divert_once([HELP_ENABLE], [])
 
 AC_PLUGIN([aggregation], [yes],                [Aggregation plugin])
 AC_PLUGIN([amqp],        [$with_librabbitmq],  [AMQP output plugin])
+AC_PLUGIN([aoe_stats],   [$plugin_aoe_stats],  [AoE plugin])
 AC_PLUGIN([apache],      [$with_libcurl],      [Apache httpd statistics])
 AC_PLUGIN([apcups],      [yes],                [Statistics of UPSes by APC])
 AC_PLUGIN([apple_sensors], [$with_libiokit],   [Apple's hardware sensors])
@@ -5469,6 +5483,7 @@ AC_PLUGIN([bind],        [$plugin_bind],       [ISC Bind nameserver statistics])
 AC_PLUGIN([conntrack],   [$plugin_conntrack],  [nf_conntrack statistics])
 AC_PLUGIN([contextswitch], [$plugin_contextswitch], [context switch statistics])
 AC_PLUGIN([cpufreq],     [$plugin_cpufreq],    [CPU frequency statistics])
+AC_PLUGIN([cpu_stats],   [$plugin_cpu_stats],  [CPU detailed statistics])
 AC_PLUGIN([cpu],         [$plugin_cpu],        [CPU usage statistics])
 AC_PLUGIN([csv],         [yes],                [CSV output plugin])
 AC_PLUGIN([curl],        [$with_libcurl],      [CURL generic web statistics])
@@ -5478,6 +5493,7 @@ AC_PLUGIN([cgroups],     [$plugin_cgroups],    [CGroups CPU usage accounting])
 AC_PLUGIN([dbi],         [$with_libdbi],       [General database statistics])
 AC_PLUGIN([df],          [$plugin_df],         [Filesystem usage statistics])
 AC_PLUGIN([disk],        [$plugin_disk],       [Disk usage statistics])
+AC_PLUGIN([disk_errors], [$plugin_disk_errors],[Disk error counters])
 AC_PLUGIN([drbd],        [$plugin_drbd],       [DRBD statistics])
 AC_PLUGIN([dns],         [$with_libpcap],      [DNS traffic analysis])
 AC_PLUGIN([email],       [yes],                [EMail statistics])
@@ -5494,6 +5510,7 @@ AC_PLUGIN([iptables],    [$with_libiptc],      [IPTables rule counters])
 AC_PLUGIN([ipvs],        [$plugin_ipvs],       [IPVS connection statistics])
 AC_PLUGIN([irq],         [$plugin_irq],        [IRQ statistics])
 AC_PLUGIN([java],        [$with_java],         [Embed the Java Virtual Machine])
+AC_PLUGIN([link_stats],  [$plugin_link_stats], [Network link statistics])
 AC_PLUGIN([load],        [$plugin_load],       [System load])
 AC_PLUGIN([logfile],     [yes],                [File logging plugin])
 AC_PLUGIN([log_logstash], [$plugin_log_logstash], [Logstash json_event compatible logging])
@@ -5518,6 +5535,7 @@ AC_PLUGIN([netapp],      [$with_libnetapp],    [NetApp plugin])
 AC_PLUGIN([netlink],     [$with_libmnl],       [Enhanced Linux network statistics])
 AC_PLUGIN([network],     [yes],                [Network communication plugin])
 AC_PLUGIN([nfs],         [$plugin_nfs],        [NFS statistics])
+AC_PLUGIN([nfssvr_stats],   [$plugin_nfs],     [NFS extended statistics])
 AC_PLUGIN([nginx],       [$with_libcurl],      [nginx statistics])
 AC_PLUGIN([notify_desktop], [$with_libnotify], [Desktop notifications])
 AC_PLUGIN([notify_email], [$with_libesmtp],    [Email notifier])
@@ -5541,6 +5559,7 @@ AC_PLUGIN([protocols],   [$plugin_protocols],  [Protocol (IP, TCP, ...) statisti
 AC_PLUGIN([python],      [$with_python],       [Embed a Python interpreter])
 AC_PLUGIN([redis],       [$with_libhiredis],    [Redis plugin])
 AC_PLUGIN([routeros],    [$with_librouteros],  [RouterOS plugin])
+AC_PLUGIN([rpc_stats],   [$plugin_rpc_stats],  [RPC stats plugin])
 AC_PLUGIN([rrdcached],   [$librrd_rrdc_update], [RRDTool output plugin])
 AC_PLUGIN([rrdtool],     [$with_librrd],       [RRDTool output plugin])
 AC_PLUGIN([sensors],     [$with_libsensors],   [lm_sensors statistics])
@@ -5584,6 +5603,7 @@ AC_PLUGIN([write_riemann], [$have_protoc_c],   [Riemann output plugin])
 AC_PLUGIN([write_tsdb],  [yes],                [TSDB output plugin])
 AC_PLUGIN([xmms],        [$with_libxmms],      [XMMS statistics])
 AC_PLUGIN([zfs_arc],     [$plugin_zfs_arc],    [ZFS ARC statistics])
+AC_PLUGIN([zfs_stats],   [$plugin_zfs_stats],  [ZFS statistics])
 AC_PLUGIN([zookeeper],   [yes],  	       [Zookeeper statistics])
 
 dnl Default configuration file
@@ -5828,6 +5848,7 @@ Configuration:
   Modules:
     aggregation . . . . . $enable_aggregation
     amqp    . . . . . . . $enable_amqp
+    aoe . . . . . . . . . $enable_aoe_stats
     apache  . . . . . . . $enable_apache
     apcups  . . . . . . . $enable_apcups
     aquaero . . . . . . . $enable_aquaero
@@ -5841,6 +5862,7 @@ Configuration:
     cgroups . . . . . . . $enable_cgroups
     cpu . . . . . . . . . $enable_cpu
     cpufreq . . . . . . . $enable_cpufreq
+    cpu_stats . . . . . . $enable_cpu_stats
     csv . . . . . . . . . $enable_csv
     curl  . . . . . . . . $enable_curl
     curl_json . . . . . . $enable_curl_json
@@ -5848,6 +5870,7 @@ Configuration:
     dbi . . . . . . . . . $enable_dbi
     df  . . . . . . . . . $enable_df
     disk  . . . . . . . . $enable_disk
+    disk_errors . . . . . $enable_disk_errors
     dns . . . . . . . . . $enable_dns
     drbd  . . . . . . . . $enable_drbd
     email . . . . . . . . $enable_email
@@ -5864,6 +5887,7 @@ Configuration:
     ipvs  . . . . . . . . $enable_ipvs
     irq . . . . . . . . . $enable_irq
     java  . . . . . . . . $enable_java
+    link_stats  . . . . . $enable_link_stats
     load  . . . . . . . . $enable_load
     logfile . . . . . . . $enable_logfile
     lpar  . . . . . . . . $enable_lpar
@@ -5888,6 +5912,7 @@ Configuration:
     netlink . . . . . . . $enable_netlink
     network . . . . . . . $enable_network
     nfs . . . . . . . . . $enable_nfs
+    nfssvr_stats  . . . . $enable_nfssvr_stats
     nginx . . . . . . . . $enable_nginx
     notify_desktop  . . . $enable_notify_desktop
     notify_email  . . . . $enable_notify_email
@@ -5910,6 +5935,7 @@ Configuration:
     python  . . . . . . . $enable_python
     redis . . . . . . . . $enable_redis
     routeros  . . . . . . $enable_routeros
+    rpc_stats . . . . . . $enable_rpc_stats
     rrdcached . . . . . . $enable_rrdcached
     rrdtool . . . . . . . $enable_rrdtool
     sensors . . . . . . . $enable_sensors
@@ -5953,6 +5979,7 @@ Configuration:
     write_tsdb  . . . . . $enable_write_tsdb
     xmms  . . . . . . . . $enable_xmms
     zfs_arc . . . . . . . $enable_zfs_arc
+    zfs_stats . . . . . . $enable_zfs_stats
     zookeeper . . . . . . $enable_zookeeper
 
 EOF

--- a/contrib/Coraid/README
+++ b/contrib/Coraid/README
@@ -1,0 +1,2 @@
+Coraid uses and sells products based on Linux, Solaris, and derivatives.
+This directory contains useful tools that enhance Coraid's collectd environment.

--- a/contrib/Coraid/collectd.xml
+++ b/contrib/Coraid/collectd.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<!--
+  Copyright 2014 Coraid, Inc.
+-->
+<service_bundle type='manifest' name='export'>
+  <service name='system/collectd' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <single_instance/>
+    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/milestone/network:default'/>
+    </dependency>
+    <dependency name='filesystem' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/system/filesystem/local'/>
+    </dependency>
+    <exec_method name='start' type='method' exec='/opt/collectd/sbin/collectd' timeout_seconds='360'>
+      <method_context>
+        <method_credential user='root' group='staff'/>
+        <method_environment>
+          <envvar name='PATH' value='/usr/bin:/usr/sbin'/>
+        </method_environment>
+      </method_context>
+    </exec_method>
+    <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'>
+      <method_context>
+        <method_credential user='root' group='staff'/>
+      </method_context>
+    </exec_method>
+    <property_group name='startd' type='framework'>
+      <propval name='ignore_error' type='astring' value='core,signal'/>
+    </property_group>
+    <property_group name='application' type='application'/>
+    <stability value='Evolving'/>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Run collectd</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>
+

--- a/contrib/Coraid/zfs_pool_dataset_stats
+++ b/contrib/Coraid/zfs_pool_dataset_stats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Publish pool and dataset latency, bandwidth, and IOPS to collectd.
+# Suitable for illumos, OpenSolaris, and Solaris 11 derivatives.
+#
+# Data is collected per-pool and per-pool+dataset. The pool and datasets
+# are referenced by their guid (zpool get guid poolname) with the binary
+# 64-bit int guid value transformed to base64. This avoids ambiguity and
+# character-delimiter collisions in the metrics namespace. Cross-reference
+# between poolname and its base64 guid is left as an exercise for the consumer.
+#
+# General output format:
+#    $(uname -n)/ZFS-VOps-POOLGUID/gauge-([rw]lat|[rw]iops|[rw]bw)
+#    $(uname -n)/ZFS-VOps-POOLGUID-DATASETGUID/gauge-([rw]lat|[rw]iops|[rw]bw)
+#
+# All metrics are normalized to per-second, independent of the sample interval.
+#  [rw]lat = [read|write] average latency in microseconds
+#  [rw]iops = [read|write] IOPS
+#  [rw]bw = [read|write] bandwidth in KiB/sec
+#
+# Note: it is expected that the dtrace can fail, in which case this script will
+# automatically try to restart the dtrace collector.
+#
+# Copyright 2014 Coraid, Inc.
+#
+# MIT License
+# ===========
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+COLLECTD_CMD="nc -U /opt/collectd/var/run/collectd-unixsock"
+#COLLECTD_CMD=cat
+
+NODENAME=$(uname -n)
+INTERVAL=60  # sampling interval in seconds
+
+while true
+do
+/usr/sbin/dtrace -Cn '
+/*
+ * trace read/write requests on a per-pool and per-dataset basis
+ */
+#pragma D option quiet
+#pragma D option switchrate=10hz
+#pragma D option dynvarsize=12m
+
+BEGIN
+{
+    /* 
+     * Note: his is not conventional base64, yet. collectd's unixsock agent
+     * will need to be updated to allow '/' characters. The actual
+     * characters used aren't as important as both ends being in agreement.
+     */
+    b64[0]  = "A"; b64[1]  = "B"; b64[2]  = "C"; b64[3]  = "D";
+    b64[4]  = "E"; b64[5]  = "F"; b64[6]  = "G"; b64[7]  = "H";
+    b64[8]  = "I"; b64[9]  = "J"; b64[10] = "K"; b64[11] = "L";
+    b64[12] = "M"; b64[13] = "N"; b64[14] = "O"; b64[15] = "P";
+    b64[16] = "Q"; b64[17] = "R"; b64[18] = "S"; b64[19] = "T";
+    b64[20] = "U"; b64[21] = "V"; b64[22] = "W"; b64[23] = "X";
+    b64[24] = "Y"; b64[25] = "Z"; b64[26] = "a"; b64[27] = "b";
+    b64[28] = "c"; b64[29] = "d"; b64[30] = "e"; b64[31] = "f";
+    b64[32] = "g"; b64[33] = "h"; b64[34] = "i"; b64[35] = "j";
+    b64[36] = "k"; b64[37] = "l"; b64[38] = "m"; b64[39] = "n";
+    b64[40] = "o"; b64[41] = "p"; b64[42] = "q"; b64[43] = "r";
+    b64[44] = "s"; b64[45] = "t"; b64[46] = "u"; b64[47] = "v";
+    b64[48] = "w"; b64[49] = "x"; b64[50] = "y"; b64[51] = "z";
+    b64[52] = "0"; b64[53] = "1"; b64[54] = "2"; b64[55] = "3";
+    b64[56] = "4"; b64[57] = "5"; b64[58] = "6"; b64[59] = "7";
+    b64[60] = "8"; b64[61] = "9"; b64[62] = "+"; b64[63] = "#";
+    pool_id[0] = "====";
+    dataset_id[0] = "====";
+    self->interval_start = timestamp;
+    self->c = 0;
+}
+
+fbt::zfs_read:entry,
+fbt::zfs_write:entry
+{
+    self->path = args[0]->v_path;
+    self->pool_guid = ((znode_t *)args[0]->v_data)->z_zfsvfs->z_os->os_spa->spa_load_guid;
+    self->dataset_guid = ((znode_t *)args[0]->v_data)->z_zfsvfs->z_os->os_dsl_dataset->ds_phys->ds_guid;
+    self->bytes = args[1]->uio_resid;
+    self->ts = timestamp;
+}
+
+fbt::zfs_read:entry,
+fbt::zfs_write:entry
+/pool_id[self->pool_guid] == NULL/
+{
+    self->s = strjoin(b64[(self->pool_guid >> 58) & 0x3f], b64[(self->pool_guid >> 52) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 46) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 40) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 34) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 28) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 22) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 16) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 10) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid >> 4) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->pool_guid << 2) & 0x3f]);
+    self->s = strjoin(self->s, "=");
+    pool_id[self->pool_guid] = self->s;
+}
+
+fbt::zfs_read:entry,
+fbt::zfs_write:entry
+/dataset_id[self->dataset_guid] == NULL/
+{
+    self->s = strjoin(b64[(self->dataset_guid >> 58) & 0x3f], b64[(self->dataset_guid >> 52) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 46) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 40) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 34) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 28) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 22) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 16) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 10) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid >> 4) & 0x3f]);
+    self->s = strjoin(self->s, b64[(self->dataset_guid << 2) & 0x3f]);
+    self->s = strjoin(self->s, "=");
+    dataset_id[self->dataset_guid] = self->s;
+}
+
+fbt::zfs_read:return,
+fbt::zfs_write:return
+/self->ts/
+{
+    self->deltat = timestamp - self->ts;
+
+    @pool_avg_lat[pool_id[self->pool_guid], "lat"] = avg(self->deltat);
+    @dataset_avg_lat[pool_id[self->pool_guid], dataset_id[self->dataset_guid], "lat"] = 
+        avg(self->deltat);
+    self->op = probefunc == "zfs_read" ? "rlat" : "wlat";
+    @pool_avg_lat[pool_id[self->pool_guid], self->op] = avg(self->deltat);
+    @dataset_avg_lat[pool_id[self->pool_guid], dataset_id[self->dataset_guid], self->op] = 
+        avg(self->deltat);
+
+    @pool_bw[pool_id[self->pool_guid], "bw"] = sum(self->bytes);
+    @dataset_bw[pool_id[self->pool_guid], dataset_id[self->dataset_guid], "bw"] = 
+        sum(self->bytes);
+    self->op = probefunc == "zfs_read" ? "rbw" : "wbw";
+    @pool_bw[pool_id[self->pool_guid], self->op] = sum(self->bytes);
+    @dataset_bw[pool_id[self->pool_guid], dataset_id[self->dataset_guid], self->op] = 
+        sum(self->bytes);
+
+    @pool_iops[pool_id[self->pool_guid], "iops"] = count();
+    @dataset_iops[pool_id[self->pool_guid], dataset_id[self->dataset_guid], "iops"] = count();
+    self->op = probefunc == "zfs_read" ? "riops" : "wiops";
+    @pool_iops[pool_id[self->pool_guid], self->op] = count();
+    @dataset_iops[pool_id[self->pool_guid], dataset_id[self->dataset_guid], self->op] = count();
+    self->ts = 0;
+}
+
+tick-'$INTERVAL'sec
+{
+    /* convert average latency to microseconds */
+    normalize(@pool_avg_lat, 1000);
+    normalize(@dataset_avg_lat, 1000);
+
+    /* normalize bandwidth from bytes to KB/sec: 976562 ~ 1e9/1024 */
+    self->t = timestamp - self->interval_start;
+    normalize(@pool_bw, 976562/self->t);
+    normalize(@dataset_bw, 976562/self->t);
+
+    /* normalize counts to per-second (IOPS) */
+    normalize(@pool_iops, 1000000000/self->t);
+    normalize(@dataset_iops, 1000000000/self->t);
+
+    printa("ZFS-VOps-%s/gauge-%s %@d\n", @pool_avg_lat);
+    printa("ZFS-VOps-%s/gauge-%s %@d\n", @pool_bw);
+    printa("ZFS-VOps-%s/gauge-%s %@d\n", @pool_iops);
+
+    printa("ZFS-VOps-%s-%s/gauge-%s %@d\n", @dataset_avg_lat);
+    printa("ZFS-VOps-%s-%s/gauge-%s %@d\n", @dataset_bw);
+    printa("ZFS-VOps-%s-%s/gauge-%s %@d\n", @dataset_iops);
+    
+    trunc(@pool_avg_lat); trunc(@dataset_avg_lat);
+    trunc(@pool_bw); trunc(@dataset_bw); trunc(@pool_iops); trunc(@dataset_iops);
+    self->interval_start = timestamp;
+    self->c++;
+}
+
+tick-'$INTERVAL'sec
+/self->c > 59/
+{
+    exit(0);
+}
+
+END
+{
+    trunc(@pool_avg_lat); trunc(@dataset_avg_lat);
+    trunc(@pool_bw); trunc(@dataset_bw); trunc(@pool_iops); trunc(@dataset_iops);
+}' | while read metric value
+    do
+        printf "PUTVAL %s/%s interval=%s %s:%s\n" $NODENAME $metric $INTERVAL $(date +%s) $value
+    done | $COLLECTD_CMD >/dev/null
+done

--- a/contrib/Coraid/zfs_pool_dataset_stats.xml
+++ b/contrib/Coraid/zfs_pool_dataset_stats.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<!--
+  Copyright 2014 Coraid, Inc.
+-->
+<service_bundle type='manifest' name='export'>
+  <service name='system/collectd/dtrace/zfs_pool_dataset' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <single_instance/>
+    <dependency name='collectd' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/system/collectd:default'/>
+    </dependency>
+    <exec_method name='start' type='method' exec='/opt/collectd/bin/zfs_pool_dataset_stats &amp;' timeout_seconds='60'>
+      <method_context>
+        <method_credential user='root' group='root'/>
+        <method_environment>
+          <envvar name='PATH' value='/usr/sbin:/usr/bin'/>
+        </method_environment>
+      </method_context>
+    </exec_method>
+    <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'>
+      <method_context>
+        <method_credential user='root' group='root'/>
+      </method_context>
+    </exec_method>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Coraid collectd ZFS pool and dataset performance collector</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,13 @@ amqp_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBRABBITMQ_CPPFLAGS)
 amqp_la_LIBADD = $(BUILD_WITH_LIBRABBITMQ_LIBS)
 endif
 
+if BUILD_PLUGIN_AOE_STATS
+pkglib_LTLIBRARIES += aoe_stats.la
+aoe_stats_la_SOURCES = aoe_stats.c
+aoe_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+aoe_stats_la_LIBADD = -lkstat -lnvpair
+endif
+
 if BUILD_PLUGIN_APACHE
 pkglib_LTLIBRARIES += apache.la
 apache_la_SOURCES = apache.c
@@ -222,6 +229,13 @@ cpufreq_la_SOURCES = cpufreq.c
 cpufreq_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
+if BUILD_PLUGIN_CPU_STATS
+pkglib_LTLIBRARIES += cpu_stats.la
+cpu_stats_la_SOURCES = cpu_stats.c
+cpu_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+cpu_stats_la_LIBADD = -lkstat
+endif
+
 if BUILD_PLUGIN_CSV
 pkglib_LTLIBRARIES += csv.la
 csv_la_SOURCES = csv.c
@@ -305,6 +319,13 @@ endif
 if BUILD_WITH_PERFSTAT
 disk_la_LIBADD += -lperfstat
 endif
+endif
+
+if BUILD_PLUGIN_DISK_ERRORS
+pkglib_LTLIBRARIES += disk_errors.la
+disk_errors_la_SOURCES = disk_errors.c
+disk_errors_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+disk_errors_la_LIBADD = -lkstat
 endif
 
 if BUILD_PLUGIN_DNS
@@ -437,6 +458,13 @@ java_la_CPPFLAGS = $(AM_CPPFLAGS) $(JAVA_CPPFLAGS)
 java_la_CFLAGS = $(AM_CFLAGS) $(JAVA_CFLAGS)
 java_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(JAVA_LDFLAGS)
 java_la_LIBADD = $(JAVA_LIBS)
+endif
+
+if BUILD_PLUGIN_LINK_STATS
+pkglib_LTLIBRARIES += link_stats.la
+link_stats_la_SOURCES = link_stats.c
+link_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+link_stats_la_LIBADD = -lkstat
 endif
 
 if BUILD_PLUGIN_LOAD
@@ -651,6 +679,13 @@ nfs_la_SOURCES = nfs.c
 nfs_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
+if BUILD_PLUGIN_NFSSVR_STATS
+pkglib_LTLIBRARIES += nfssvr_stats.la
+nfssvr_stats_la_SOURCES = nfssvr_stats.c
+nfssvr_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+nfssvr_stats_la_LIBADD = -lkstat
+endif
+
 if BUILD_PLUGIN_FSCACHE
 pkglib_LTLIBRARIES += fscache.la
 fscache_la_SOURCES = fscache.c
@@ -852,6 +887,13 @@ routeros_la_SOURCES = routeros.c
 routeros_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBROUTEROS_CPPFLAGS)
 routeros_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBROUTEROS_LDFLAGS)
 routeros_la_LIBADD = -lrouteros
+endif
+
+if BUILD_PLUGIN_RPC_STATS
+pkglib_LTLIBRARIES += rpc_stats.la
+rpc_stats_la_SOURCES = rpc_stats.c
+rpc_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+rpc_stats_la_LIBADD = -lkstat
 endif
 
 if BUILD_PLUGIN_RRDCACHED
@@ -1228,6 +1270,13 @@ else
 zfs_arc_la_LIBADD = -lkstat
 endif
 endif
+endif
+
+if BUILD_PLUGIN_ZFS_STATS
+pkglib_LTLIBRARIES += zfs_stats.la
+zfs_stats_la_SOURCES = zfs_stats.c
+zfs_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+zfs_stats_la_LIBADD = -lkstat
 endif
 
 if BUILD_PLUGIN_ZOOKEEPER

--- a/src/aoe_stats.c
+++ b/src/aoe_stats.c
@@ -1,0 +1,689 @@
+/*
+ * Coraid AoE collectd data collector
+ *
+ * Suitable for CorOS, illumos, and Solaris 11 derivatives using
+ * Coraid's AoE software target.
+ *
+ * AoE targets use the aoet module kstats.
+ *   aoet:0:aoet_tgt_ADDR:target-alias 
+ *     Contains the human-readable name associated with ADDR.
+ *
+ * AoE ports use the aoe module kstats. 
+ *   aoe:0:aoet_port_ADDR:port-alias 
+ *     Contains the human-readable name associated with ADDR.
+ *
+ * Copyright 2014 Coraid, Inc.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+#include <kstat.h>
+#include <libnvpair.h>
+
+extern kstat_ctl_t *kc;
+/*
+ * Many of the kstat counters for ARC stats are not gauges.
+ * For those that are, we pass as gauges. The rest are passed as derive.
+ * We also need to translate the most obscure kstat names into something
+ * a human might recognize. To do this, accept an override to the kstat
+ * statistic.
+ */
+
+/* pass the counters as collectd derive (int64_t) */
+void
+aoe_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll = 0;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass the gauges (double) */
+void
+aoe_stats_gauge(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].gauge = (gauge_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* 
+ * collectd's get_kstat_value() only understands numbers :-(
+ * This implementation understands strings.
+ */
+char *
+get_kstat_string(kstat_t *ksp, char *name) {
+    kstat_named_t *kn;
+
+    if (ksp == NULL) {
+        ERROR("get_kstat_string: ksp not valid");
+        return (NULL);
+    }
+    if (ksp->ks_type != KSTAT_TYPE_NAMED) {
+        ERROR("get_kstat_string: ksp->ks_type not KSTAT_TYPE_NAMED");
+        return (NULL);        
+    }
+    if ((kn = (kstat_named_t *) kstat_data_lookup(ksp, name)) == NULL) {
+        return (NULL);
+    }
+    if (kn->data_type != KSTAT_DATA_STRING) {
+        return (NULL);
+    }
+    return (KSTAT_NAMED_STR_PTR(kn));
+}
+
+
+/*
+ * simple parser to collect the ADDR field from a name
+ * the name format is "aoet_tgt_ADDR", we want the ADDR
+ */
+char *
+aoe_get_addr(char *s) {
+    char *t, *last;
+    int maxlen = KSTAT_STRLEN;
+    t = s;
+    last = s;
+
+    while (maxlen > 0 && *t != '\0') {
+        if (*t == '_') last = t + 1;
+        t++;
+        maxlen--;
+    }
+    return (last);
+}
+
+static int
+aoe_aoet_stats_read(void)
+{    
+    nvlist_t *aliases;   /* list for mapping ids to names (aliases) */
+    nvlist_t *aliases_child;
+    nvpair_t *alias;
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    char *s;
+    int64_t l;
+    char t[KSTAT_STRLEN << 1];
+    char *a;
+
+    /* 
+     * In the AoE target, each target's instance can associated with it's
+     * targe-alias. Collect these into an nvlist for cross-referencing.
+     *   target-alias = instance
+     */
+    if(nvlist_alloc(&aliases, NV_UNIQUE_NAME, 0)) {
+        ERROR("nvlist allocation failed");
+        return(-1);
+    }
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "aoet", KSTAT_STRLEN) == 0) &&
+           (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            if ((s = get_kstat_string(ksp, "target-alias")) == NULL)
+                continue;
+            if (nvlist_alloc(&aliases_child, NV_UNIQUE_NAME, 0)) 
+                continue;
+            if (nvlist_add_string(aliases_child, "alias", s) ||
+                nvlist_add_int64(aliases_child, "instance", 
+                    (int64_t)ksp->ks_instance)) {
+                ERROR("couldn't add to nvpair");
+                return (-1);
+            }
+            if (nvlist_add_nvlist(aliases, aoe_get_addr(ksp->ks_name), 
+                aliases_child)) {
+                ERROR("couldn't add child nvlist to aliases");
+                continue;
+            }
+        }
+    }
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+
+    /* cycle through the targets and locate their various kstats */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) != DATA_TYPE_NVLIST) {
+            ERROR("expected DATA_TYPE_NVLIST, got %d for %s\n", 
+                nvpair_type(alias), nvpair_name(alias));
+            continue;
+        }
+        if (nvpair_value_nvlist(alias, &aliases_child) != 0) {
+            ERROR("unable to get child nvlist for %s\n", nvpair_name(alias));
+            continue;
+        }
+        if (nvlist_lookup_int64(aliases_child, "instance", &l)) {
+            ERROR("unable to get instance for %s\n", nvpair_name(alias));
+            continue;
+        } 
+        if (nvlist_lookup_string(aliases_child, "alias", &a)) {
+            ERROR("unable to get alias for %s\n", nvpair_name(alias));
+            continue;
+        }
+        snprintf(t, sizeof (t), "aoet_tgt_aoe_%s", nvpair_name(alias));
+        get_kstat(&ksp, "aoet", (int)l, t);
+        if (ksp != NULL) {
+            sstrncpy(vl.plugin, "AoE-Target-Ops-In", sizeof (vl.plugin));
+            sstrncpy(vl.plugin_instance, a, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+            aoe_stats_derive(&vl, ksp, "in_ata_flush", "ata_flush");
+            aoe_stats_derive(&vl, ksp, "in_ata_flushext", "ata_flushext");
+            aoe_stats_derive(&vl, ksp, "in_ata_identify", "ata_identify");
+            aoe_stats_derive(&vl, ksp, "in_ata_read", "ata_read");
+            aoe_stats_derive(&vl, ksp, "in_ata_readext", "ata_readext");
+            aoe_stats_derive(&vl, ksp, "in_ata_unknown", "ata_unknown");
+            aoe_stats_derive(&vl, ksp, "in_ata_wbytes", "ata_wbytes");
+            aoe_stats_derive(&vl, ksp, "in_ata_write", "ata_write");
+            aoe_stats_derive(&vl, ksp, "in_ata_writeext", "ata_writeext");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_register", "kresrel_register");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_replace", "kresrel_replace");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_reserve", "kresrel_reserve");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_reset", "kresrel_reset");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_status", "kresrel_status");
+            aoe_stats_derive(&vl, ksp, "in_kresrel_unknown", "kresrel_unknown");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_rw_g", "krrtype_rw_g");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_rw_o", "krrtype_rw_o");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_rw_s", "krrtype_rw_s");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_unknown", "krrtype_unknown");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_w_g", "krrtype_w_g");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_w_o", "krrtype_w_o");
+            aoe_stats_derive(&vl, ksp, "in_krrtype_w_s", "krrtype_w_s");
+            aoe_stats_derive(&vl, ksp, "in_mask_edit", "mask_edit");
+            aoe_stats_derive(&vl, ksp, "in_mask_read", "mask_read");
+            aoe_stats_derive(&vl, ksp, "in_mask_unknown", "mask_unknown");
+            aoe_stats_derive(&vl, ksp, "in_mdir_add", "mdir_add");
+            aoe_stats_derive(&vl, ksp, "in_mdir_del", "mdir_del");
+            aoe_stats_derive(&vl, ksp, "in_mdir_noop", "mdir_noop");
+            aoe_stats_derive(&vl, ksp, "in_mdir_unknown", "mdir_unknown");
+            aoe_stats_derive(&vl, ksp, "in_qc_forceset", "qc_forceset");
+            aoe_stats_derive(&vl, ksp, "in_qc_read", "qc_read");
+            aoe_stats_derive(&vl, ksp, "in_qc_set", "qc_set");
+            aoe_stats_derive(&vl, ksp, "in_qc_test", "qc_test");
+            aoe_stats_derive(&vl, ksp, "in_qc_testprefix", "qc_testprefix");
+            aoe_stats_derive(&vl, ksp, "in_qc_testreplace", "qc_testreplace");
+            aoe_stats_derive(&vl, ksp, "in_qc_unknown", "qc_unknown");
+            aoe_stats_derive(&vl, ksp, "in_resrel_forceset", "resrel_forceset");
+            aoe_stats_derive(&vl, ksp, "in_resrel_read", "resrel_read");
+            aoe_stats_derive(&vl, ksp, "in_resrel_set", "resrel_set");
+            aoe_stats_derive(&vl, ksp, "in_resrel_unknown", "resrel_unknown");
+
+            sstrncpy(vl.plugin, "AoE-Target-Ops-Out", sizeof (vl.plugin));
+            aoe_stats_derive(&vl, ksp, "out_ata_err_abrt", "ata_err_abrt");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_amnf", "ata_err_amnf");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_bbk_icrc", "ata_err_bbk_icrc");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_eom", "ata_err_eom");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_idnf", "ata_err_idnf");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_mc", "ata_err_mc");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_mcr", "ata_err_mcr");
+            aoe_stats_derive(&vl, ksp, "out_ata_err_unc", "ata_err_unc");
+            aoe_stats_derive(&vl, ksp, "out_ata_flush", "ata_flush");
+            aoe_stats_derive(&vl, ksp, "out_ata_flushext", "ata_flushext");
+            aoe_stats_derive(&vl, ksp, "out_ata_identify", "ata_identify");
+            aoe_stats_derive(&vl, ksp, "out_ata_rbytes", "ata_rbytes");
+            aoe_stats_derive(&vl, ksp, "out_ata_read", "ata_read");
+            aoe_stats_derive(&vl, ksp, "out_ata_readext", "ata_readext");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_ae", "ata_sta_ae");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_bsy", "ata_sta_bsy");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_df", "ata_sta_df");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_drdy", "ata_sta_drdy");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_drq", "ata_sta_drq");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_dwe", "ata_sta_dwe");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_err", "ata_sta_err");
+            aoe_stats_derive(&vl, ksp, "out_ata_sta_sda", "ata_sta_sda");
+            aoe_stats_derive(&vl, ksp, "out_ata_write", "ata_write");
+            aoe_stats_derive(&vl, ksp, "out_ata_writeext", "ata_writeext");
+            aoe_stats_derive(&vl, ksp, "out_kresrel_register", "kresrel_register");
+            aoe_stats_derive(&vl, ksp, "out_kresrel_replace", "kresrel_replace");
+            aoe_stats_derive(&vl, ksp, "out_kresrel_reserve", "kresrel_reserve");
+            aoe_stats_derive(&vl, ksp, "out_kresrel_reset", "kresrel_reset");
+            aoe_stats_derive(&vl, ksp, "out_kresrel_status", "kresrel_status");
+            aoe_stats_derive(&vl, ksp, "out_mask_edit", "mask_edit");
+            aoe_stats_derive(&vl, ksp, "out_mask_read", "mask_read");
+            aoe_stats_derive(&vl, ksp, "out_qc_announce", "qc_announce");
+            aoe_stats_derive(&vl, ksp, "out_qc_forceset", "qc_forceset");
+            aoe_stats_derive(&vl, ksp, "out_qc_read", "qc_read");
+            aoe_stats_derive(&vl, ksp, "out_qc_set", "qc_set");
+            aoe_stats_derive(&vl, ksp, "out_qc_test", "qc_test");
+            aoe_stats_derive(&vl, ksp, "out_qc_testprefix", "qc_testprefix");
+            aoe_stats_derive(&vl, ksp, "out_qc_testreplace", "qc_testreplace");
+            aoe_stats_derive(&vl, ksp, "out_resrel_forceset", "resrel_forceset");
+            aoe_stats_derive(&vl, ksp, "out_resrel_read", "resrel_read");
+            aoe_stats_derive(&vl, ksp, "out_resrel_set", "resrel_set");
+        }
+        snprintf(t, sizeof (t), "aoet_tgt_io_%s", nvpair_name(alias));
+        get_kstat(&ksp, "aoet", (int)l, t);
+        if (ksp != NULL) {
+            sstrncpy(vl.plugin, "AoE-Target-IO-In", sizeof (vl.plugin));
+            sstrncpy(vl.plugin_instance, a, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+            aoe_stats_derive(&vl, ksp, "in_bytes", "bytes");            
+            aoe_stats_derive(&vl, ksp, "in_delivered", "delivered");
+            aoe_stats_derive(&vl, ksp, "in_dropped_badarg", "dropped_badarg");
+            aoe_stats_derive(&vl, ksp, "in_dropped_badcmd", "dropped_badcmd");
+            aoe_stats_derive(&vl, ksp, "in_dropped_badflags", "dropped_badflags");
+            aoe_stats_derive(&vl, ksp, "in_dropped_badsender", "dropped_badsender");
+            aoe_stats_derive(&vl, ksp, "in_dropped_badver", "dropped_badver");
+            aoe_stats_derive(&vl, ksp, "in_dropped_notask", "dropped_notask");
+            aoe_stats_derive(&vl, ksp, "in_dropped_toolong", "dropped_toolong");
+            aoe_stats_derive(&vl, ksp, "in_dropped_tooshort", "dropped_tooshort");
+            aoe_stats_derive(&vl, ksp, "in_extcmd", "extcmd");
+            aoe_stats_derive(&vl, ksp, "in_packets", "packets");
+            aoe_stats_derive(&vl, ksp, "in_task_copied", "task_copied");
+
+            sstrncpy(vl.plugin, "AoE-Target-IO-Out", sizeof (vl.plugin));
+            sstrncpy(vl.plugin_instance, a, sizeof (vl.plugin_instance));
+            aoe_stats_derive(&vl, ksp, "out_bytes", "bytes");
+            aoe_stats_derive(&vl, ksp, "out_dropped_nomem", "dropped_nomem");
+            aoe_stats_derive(&vl, ksp, "out_err_arginval", "err_arginval");
+            aoe_stats_derive(&vl, ksp, "out_err_cfgset", "err_cfgset");
+            aoe_stats_derive(&vl, ksp, "out_err_cmdunknown", "err_cmdunknown");
+            aoe_stats_derive(&vl, ksp, "out_err_devunavail", "err_devunavail");
+            aoe_stats_derive(&vl, ksp, "out_err_tgtreserved", "err_tgtreserved");
+            aoe_stats_derive(&vl, ksp, "out_err_vernotsupp", "err_vernotsupp");
+            aoe_stats_derive(&vl, ksp, "out_frame_norecycled", "frame_norecycled");
+            aoe_stats_derive(&vl, ksp, "out_frame_recycled", "frame_recycled");
+            aoe_stats_derive(&vl, ksp, "out_packets", "packets");
+       }
+    }
+
+    /* clean up */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) == DATA_TYPE_NVLIST)
+            if (nvpair_value_nvlist(alias, &aliases_child) == 0)
+              nvlist_free(aliases_child);
+    }
+    nvlist_free(aliases);
+    return (0);
+}
+/*
+ * atmf kstats are IO type and require different handling than NAMED
+ */
+#define DISPATCH_IO(valuename, stringname) \
+    v[0].derive = (derive_t)ksio->valuename; \
+    sstrncpy(vl.type_instance, stringname, sizeof(vl.type_instance)); \
+    plugin_dispatch_values(&vl);
+
+#define ATMF_TYPE_TARGET 0
+#define ATMF_TYPE_LU 1
+
+static int
+aoe_atmf_stats_read(int atmf_type)
+{    
+    nvlist_t *aliases;   /* list for mapping ids to names (aliases) */
+    nvlist_t *aliases_child;
+    nvpair_t *alias;
+    kstat_t *ksp = NULL;
+    kstat_io_t *ksio;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    value_t v[1];
+    char *s;
+    int64_t l;
+    char t[DATA_MAX_NAME_LEN];
+    char *a;
+    char *atmf_type_s = "target-alias";
+    char *atmf_type_desc = "AoE-Target-IO";
+    char *atmf_type_ks = "tgt";
+
+    if (atmf_type == ATMF_TYPE_LU) {
+        atmf_type_s = "lun-alias";
+        atmf_type_desc = "AoE-LU-IO";
+        atmf_type_ks = "lu";        
+    }
+
+    /* 
+     * In the AoE target, each target's instance can associated with it's
+     * targe-alias. Collect these into an nvlist for cross-referencing.
+     *   target-alias = instance
+     */
+    if (nvlist_alloc(&aliases, NV_UNIQUE_NAME, 0)) {
+        ERROR("nvlist allocation failed");
+        return(-1);
+    }
+
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "atmf", KSTAT_STRLEN) == 0) &&
+           (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            if ((s = get_kstat_string(ksp, atmf_type_s)) == NULL)
+                continue;
+            if (nvlist_alloc(&aliases_child, NV_UNIQUE_NAME, 0)) 
+                continue;
+            if (nvlist_add_string(aliases_child, "alias", s) ||
+                nvlist_add_int64(aliases_child, "instance", 
+                    (int64_t)ksp->ks_instance)) {
+                ERROR("couldn't add to nvpair");
+                return (-1);
+            }
+            if (nvlist_add_nvlist(aliases, aoe_get_addr(ksp->ks_name), 
+                aliases_child)) {
+                ERROR("couldn't add child nvlist to aliases");
+                continue;
+            }
+        }
+    }
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, atmf_type_desc, sizeof (vl.plugin));
+
+    /* cycle through the targets and locate their various kstats */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) != DATA_TYPE_NVLIST) {
+            ERROR("expected DATA_TYPE_NVLIST, got %d for %s\n", 
+                nvpair_type(alias), nvpair_name(alias));
+            continue;
+        }
+        if (nvpair_value_nvlist(alias, &aliases_child) != 0) {
+            ERROR("unable to get child nvlist for %s\n", nvpair_name(alias));
+            continue;
+        }
+        if (nvlist_lookup_int64(aliases_child, "instance", &l)) {
+            ERROR("unable to get instance for %s\n", nvpair_name(alias));
+            continue;
+        } 
+        if (nvlist_lookup_string(aliases_child, "alias", &a)) {
+            ERROR("unable to get alias for %s\n", nvpair_name(alias));
+            continue;
+        }
+        snprintf(t, sizeof (t), "atmf_%s_io_%s", atmf_type_ks, 
+            nvpair_name(alias));
+        get_kstat(&ksp, "atmf", (int)l, t);
+        if (ksp != NULL) {
+            if (ksp->ks_type != KSTAT_TYPE_IO) {
+                ERROR("aoe_stats_io: ksp->ks_type not KSTAT_TYPE_IO");
+                return (0);
+            }
+
+            ksio = KSTAT_IO_PTR(ksp);
+
+            vl.values = v;
+            vl.values_len = 1;
+            sstrncpy(vl.plugin_instance, a, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+
+            DISPATCH_IO(nread, "nread");
+            DISPATCH_IO(reads, "reads");
+            DISPATCH_IO(nwritten, "nwritten");
+            DISPATCH_IO(writes, "writes");
+            DISPATCH_IO(wtime, "wtime");
+            DISPATCH_IO(wlentime, "wlentime");
+            DISPATCH_IO(wlastupdate, "wlastupdate");
+            DISPATCH_IO(wcnt, "wcnt");
+            DISPATCH_IO(rtime, "rtime");
+            DISPATCH_IO(rlentime, "rlentime");
+            DISPATCH_IO(rlastupdate, "rlastupdate");
+            DISPATCH_IO(rcnt, "rcnt");
+       }
+    }
+
+    /* clean up */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) == DATA_TYPE_NVLIST)
+            if (nvpair_value_nvlist(alias, &aliases_child) == 0)
+              nvlist_free(aliases_child);
+    }
+    nvlist_free(aliases);
+    return (0);
+}
+
+static int
+aoe_port_stats_read(void)
+{    
+    nvlist_t *aliases;   /* list for mapping ids to names (aliases) */
+    nvlist_t *aliases_child;
+    nvpair_t *alias;
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    char *s;
+    int64_t l;
+    char t[KSTAT_STRLEN];
+    char *a;
+
+    /* 
+     * In the AoE target, each target's instance can associated with it's
+     * targe-alias. Collect these into an nvlist for cross-referencing.
+     *   target-alias = instance
+     */
+    if(nvlist_alloc(&aliases, NV_UNIQUE_NAME, 0)) {
+        ERROR("nvlist allocation failed");
+        return(-1);
+    }
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "aoe", KSTAT_STRLEN) == 0) &&
+           (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            if ((s = get_kstat_string(ksp, "port-alias")) == NULL)
+                continue;
+            if (nvlist_alloc(&aliases_child, NV_UNIQUE_NAME, 0)) 
+                continue;
+            if (nvlist_add_string(aliases_child, "alias", s) ||
+                nvlist_add_int64(aliases_child, "instance", (int64_t)ksp->ks_instance)) {
+                ERROR("couldn't add to nvpair");
+                return (-1);
+            }
+            if (nvlist_add_nvlist(aliases, aoe_get_addr(ksp->ks_name), aliases_child)) {
+                ERROR("couldn't add child nvlist to aliases");
+                continue;
+            }
+        }
+    }
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "AoE-Port-MAC", sizeof (vl.plugin));
+
+    /* cycle through the targets and locate their various kstats */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) != DATA_TYPE_NVLIST) {
+            ERROR("expected DATA_TYPE_NVLIST, got %d for %s\n", nvpair_type(alias), nvpair_name(alias));
+            continue;
+        }
+        if (nvpair_value_nvlist(alias, &aliases_child) != 0) {
+            ERROR("unable to get child nvlist for %s\n", nvpair_name(alias));
+            continue;
+        }
+        if (nvlist_lookup_int64(aliases_child, "instance", &l)) {
+            ERROR("unable to get instance for %s\n", nvpair_name(alias));
+            continue;
+        } 
+        if (nvlist_lookup_string(aliases_child, "alias", &a)) {
+            ERROR("unable to get alias for %s\n", nvpair_name(alias));
+            continue;
+        }
+        snprintf(t, sizeof (t), "aoe_port_mac_%s", nvpair_name(alias));
+        get_kstat(&ksp, "aoe", (int)l, t);
+        if (ksp != NULL) {
+            sstrncpy(vl.plugin_instance, a, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+            aoe_stats_derive(&vl, ksp, "delivered", NULL);
+            aoe_stats_derive(&vl, ksp, "dropped_nomem", NULL);
+            aoe_stats_derive(&vl, ksp, "dropped_other", NULL);
+            aoe_stats_derive(&vl, ksp, "dropped_runt", NULL);
+            aoe_stats_derive(&vl, ksp, "dropped_tooshort", NULL);
+            aoe_stats_derive(&vl, ksp, "pullups", NULL);
+       }
+    }
+
+    /* clean up */
+    for (alias = nvlist_next_nvpair(aliases, NULL); alias != NULL;
+        alias = nvlist_next_nvpair(aliases, alias)) {
+        if (nvpair_type(alias) == DATA_TYPE_NVLIST)
+            if (nvpair_value_nvlist(alias, &aliases_child) == 0)
+              nvlist_free(aliases_child);
+    }
+    nvlist_free(aliases);
+    return (0);
+}
+
+/*
+ * EtherDrive initiator (ethdrv) stats are read from pseudo files:
+ *   /dev/ethdrv/ca
+ *   /dev/ethdrv/acbs
+ *
+ * If these files don't exist or don't contain anything, they are ignored.
+ */
+#define DISPATCH_ETHDRV_GAUGE(name) \
+    if ((t = strtok_r(NULL, " ", &st)) == NULL) continue; \
+    v[0].gauge = (gauge_t)strtoll(t, NULL, 0); \
+    sstrncpy(vl.type_instance, name, sizeof(vl.type_instance)); \
+    plugin_dispatch_values(&vl);
+#define DISPATCH_ETHDRV_DERIVE(name) \
+    if ((t = strtok_r(NULL, " ", &st)) == NULL) continue; \
+    v[0].derive = (derive_t)strtoll(t, NULL, 0); \
+    sstrncpy(vl.type_instance, name, sizeof(vl.type_instance)); \
+    plugin_dispatch_values(&vl);
+#define DISPATCH_ETHDRV_MS(name) \
+    if ((t = strtok_r(NULL, " ", &st)) == NULL) continue; \
+    v[0].gauge = (gauge_t)(long long)(strtod(t, (char **)NULL) * 1e6); \
+    sstrncpy(vl.type_instance, name, sizeof(vl.type_instance)); \
+    plugin_dispatch_values(&vl);
+
+static int
+aoe_ethdrv_stats_read(void)
+{    
+    value_list_t vl = VALUE_LIST_INIT;
+    value_t v[1];
+    FILE *fp;
+    char *s, *st, *t, *tt;
+    char *poolnum, *volnum;
+    char poolvol[DATA_MAX_NAME_LEN];
+    size_t cap = 0;
+
+    if ((fp = fopen("/dev/ethdrv/ca", "r")) == NULL)
+        return (0);
+
+    vl.values = v;
+    vl.values_len = 1;
+    sstrncpy(vl.type, "gauge", sizeof (vl.type));
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "AoE-Ethdrv", sizeof (vl.plugin));
+    s = NULL;
+    while (getline(&s, &cap, fp) > 0) {
+        // skip first
+        if ((t = strtok_r(s, " ", &st)) == NULL) continue; 
+        // old notation: shelf.slot, new notation: pool.vol
+        if ((t = strtok_r(NULL, " ", &st)) == NULL) continue;
+        if ((poolnum = strtok_r(t, ".", &tt)) == NULL) continue;
+        if ((volnum = strtok_r(NULL, ".", &tt)) == NULL) continue;
+        snprintf(poolvol, sizeof (poolvol), "pool-%s-vol-%s", poolnum,
+            volnum);
+        sstrncpy(vl.plugin_instance, poolvol, sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "gauge", sizeof (vl.type));
+        DISPATCH_ETHDRV_GAUGE("cwrk");
+        DISPATCH_ETHDRV_GAUGE("clamp");
+        DISPATCH_ETHDRV_GAUGE("mxwn");
+        DISPATCH_ETHDRV_GAUGE("ssthresh");
+        DISPATCH_ETHDRV_MS("rttavg");
+        DISPATCH_ETHDRV_MS("rttdelt");
+        free (s);
+        s = NULL;
+    }
+    fclose(fp);
+
+    if ((fp = fopen("/dev/ethdrv/acbs", "r")) == NULL)
+        return (0);
+    s = NULL;
+    while (getline(&s, &cap, fp) > 0) {
+        // skip first two entries
+        if ((t = strtok_r(s, " ", &st)) == NULL) continue;
+        if ((t = strtok_r(NULL, " ", &st)) == NULL) continue;
+
+        // old notation: shelf.slot, new notation: pool.vol
+        if ((t = strtok_r(NULL, " ", &st)) == NULL) continue;
+        if ((poolnum = strtok_r(t, ".", &tt)) == NULL) continue;
+        if ((volnum = strtok_r(NULL, ".", &tt)) == NULL) continue;
+        snprintf(poolvol, sizeof (poolvol), "pool-%s-vol-%s", poolnum,
+            volnum);
+        sstrncpy(vl.plugin_instance, poolvol, sizeof (vl.plugin_instance));
+        // skip next two entries, they are redundant with above ca file
+        if ((t = strtok_r(NULL, " ", &st)) == NULL) continue;
+        if ((t = strtok_r(NULL, " ", &st)) == NULL) continue;
+        sstrncpy(vl.type, "gauge", sizeof (vl.type));
+        DISPATCH_ETHDRV_GAUGE("cscsi");
+        DISPATCH_ETHDRV_GAUGE("caoe");
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        DISPATCH_ETHDRV_DERIVE("cmds");
+        DISPATCH_ETHDRV_DERIVE("rtx");
+        DISPATCH_ETHDRV_DERIVE("unre");
+        free (s);
+        s = NULL;
+    }
+    fclose(fp);
+
+    return (0);
+}
+
+static int
+aoe_stats_read(void)
+{
+    int ret = 0;
+    if ((ret = aoe_aoet_stats_read()) != 0)
+        return (ret);
+    if ((ret = aoe_atmf_stats_read(ATMF_TYPE_TARGET)) != 0)
+        return (ret);
+    if ((ret = aoe_atmf_stats_read(ATMF_TYPE_LU)) != 0)
+        return (ret);
+    if ((ret = aoe_port_stats_read()) != 0)
+        return (ret);
+    if ((ret = aoe_ethdrv_stats_read()) != 0)
+        return (ret);
+    return (ret);
+}
+
+static int
+aoe_stats_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("aoe_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("aoe_stats", aoe_stats_init);
+    plugin_register_read ("aoe_stats", aoe_stats_read);
+}

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -90,6 +90,7 @@
 
 #@BUILD_PLUGIN_AGGREGATION_TRUE@LoadPlugin aggregation
 #@BUILD_PLUGIN_AMQP_TRUE@LoadPlugin amqp
+#@BUILD_PLUGIN_AOE_STATS_TRUE@LoadPlugin aoe_stats
 #@BUILD_PLUGIN_APACHE_TRUE@LoadPlugin apache
 #@BUILD_PLUGIN_APCUPS_TRUE@LoadPlugin apcups
 #@BUILD_PLUGIN_APPLE_SENSORS_TRUE@LoadPlugin apple_sensors
@@ -103,6 +104,7 @@
 #@BUILD_PLUGIN_CGROUPS_TRUE@LoadPlugin cgroups
 @BUILD_PLUGIN_CPU_TRUE@@BUILD_PLUGIN_CPU_TRUE@LoadPlugin cpu
 #@BUILD_PLUGIN_CPUFREQ_TRUE@LoadPlugin cpufreq
+#@BUILD_PLUGIN_CPU_STATS_TRUE@LoadPlugin cpu_stats
 @LOAD_PLUGIN_CSV@LoadPlugin csv
 #@BUILD_PLUGIN_CURL_TRUE@LoadPlugin curl
 #@BUILD_PLUGIN_CURL_JSON_TRUE@LoadPlugin curl_json
@@ -110,6 +112,7 @@
 #@BUILD_PLUGIN_DBI_TRUE@LoadPlugin dbi
 #@BUILD_PLUGIN_DF_TRUE@LoadPlugin df
 #@BUILD_PLUGIN_DISK_TRUE@LoadPlugin disk
+#@BUILD_PLUGIN_DISK_ERRORS_TRUE@LoadPlugin disk_errors
 #@BUILD_PLUGIN_DNS_TRUE@LoadPlugin dns
 #@BUILD_PLUGIN_DRBD_TRUE@LoadPlugin drbd
 #@BUILD_PLUGIN_EMAIL_TRUE@LoadPlugin email
@@ -126,6 +129,7 @@
 #@BUILD_PLUGIN_IPVS_TRUE@LoadPlugin ipvs
 #@BUILD_PLUGIN_IRQ_TRUE@LoadPlugin irq
 #@BUILD_PLUGIN_JAVA_TRUE@LoadPlugin java
+#@BUILD_PLUGIN_LINK_STATS_TRUE@LoadPlugin link_stats
 @BUILD_PLUGIN_LOAD_TRUE@@BUILD_PLUGIN_LOAD_TRUE@LoadPlugin load
 #@BUILD_PLUGIN_LPAR_TRUE@LoadPlugin lpar
 #@BUILD_PLUGIN_LVM_TRUE@LoadPlugin lvm
@@ -142,6 +146,7 @@
 #@BUILD_PLUGIN_NETLINK_TRUE@LoadPlugin netlink
 @LOAD_PLUGIN_NETWORK@LoadPlugin network
 #@BUILD_PLUGIN_NFS_TRUE@LoadPlugin nfs
+#@BUILD_PLUGIN_NFSSVR_STATS_TRUE@LoadPlugin nfssvr_stats
 #@BUILD_PLUGIN_NGINX_TRUE@LoadPlugin nginx
 #@BUILD_PLUGIN_NOTIFY_DESKTOP_TRUE@LoadPlugin notify_desktop
 #@BUILD_PLUGIN_NOTIFY_EMAIL_TRUE@LoadPlugin notify_email
@@ -167,6 +172,7 @@
 #@BUILD_PLUGIN_PYTHON_TRUE@</LoadPlugin>
 #@BUILD_PLUGIN_REDIS_TRUE@LoadPlugin redis
 #@BUILD_PLUGIN_ROUTEROS_TRUE@LoadPlugin routeros
+#@BUILD_PLUGIN_RPC_STATS_TRUE@LoadPlugin rpc_stats
 #@BUILD_PLUGIN_RRDCACHED_TRUE@LoadPlugin rrdcached
 @LOAD_PLUGIN_RRDTOOL@LoadPlugin rrdtool
 #@BUILD_PLUGIN_SENSORS_TRUE@LoadPlugin sensors
@@ -204,6 +210,7 @@
 #@BUILD_PLUGIN_WRITE_TSDB_TRUE@LoadPlugin write_tsdb
 #@BUILD_PLUGIN_XMMS_TRUE@LoadPlugin xmms
 #@BUILD_PLUGIN_ZFS_ARC_TRUE@LoadPlugin zfs_arc
+#@BUILD_PLUGIN_ZFS_STATS_TRUE@LoadPlugin zfs_stats
 #@BUILD_PLUGIN_ZOOKEEPER_TRUE@LoadPlugin zookeeper
 
 ##############################################################################
@@ -475,6 +482,7 @@
 #	IgnoreSelected false
 #	UseBSDName false
 #	UdevNameAttr "DEVNAME"
+#	IgnorePartitions true
 #</Plugin>
 
 #<Plugin dns>
@@ -754,6 +762,15 @@
 #	# "garbage collection"
 #	CacheFlush 1800
 @LOAD_PLUGIN_NETWORK@</Plugin>
+
+#<Plugin nfssvr_stats>
+#   # Reduce clutter by disabling unused NFS versions or features
+#    IgnoreNFSv2 false
+#    IgnoreNFSv3 false
+#    IgnoreNFSv4 false
+#    IgnoreReferrals false
+#    IgnoreACLs false
+#</Plugin>
 
 #<Plugin nginx>
 #	URL "http://localhost/status?auto"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -693,6 +693,13 @@ more than one DS.
 
 =back
 
+=head2 Plugin C<aoe_stats>
+
+The ATA over Ethernet (AoE) statistics are collected for AoE initiators and
+targets.
+
+There are no additional configuration options for the aoe_stats plugin.
+
 =head2 Plugin C<apache>
 
 To configure the C<apache>-plugin you first need to configure the Apache
@@ -1253,6 +1260,12 @@ Jiffies. By setting this option to B<true>, you can request percentage values
 in the un-aggregated (per-CPU, per-state) mode as well.
 
 =back
+
+=head2 Plugin C<cpu_stats>
+
+The C<cpu_stats> plugin collects detailed CPU usage data for CorOS, illumos,
+and Solaris-derived OSes. In general, this is information that is available via
+the mpstat(1m) command.
 
 =head2 Plugin C<cpufreq>
 
@@ -1977,6 +1990,15 @@ collected. If at least one B<Disk> option is given and no B<IgnoreSelected> or
 set to B<false>, B<only> matching disks will be collected. If B<IgnoreSelected>
 is set to B<true>, all disks are collected B<except> the ones matched.
 
+=item B<IgnorePartitions> B<true>|B<false>
+
+By default, kstat-based disk collector does not ignore partition statistics.
+However, there is a compile-time limit to the total number of disks collected
+for systems that use kstats. If B<IgnoredPartitions> is B<false> then a modest
+number of disks and active partitions can approach this limit. In some cases,
+only one partition per disk is active. Setting B<IgnoredPartitions> to B<true>
+disables collection of per-partition statistics.
+
 =item B<UseBSDName> B<true>|B<false>
 
 Whether to use the device's "BSD Name", on MacE<nbsp>OSE<nbsp>X, instead of the
@@ -1992,6 +2014,14 @@ given device, the default name is used. Example:
   UdevNameAttr "DM_NAME"
 
 =back
+
+=head2 Plugin C<disk_errors>
+
+The disk_errors plugin collects error counters reported by the sd driver on 
+Solaris systems. The errors collected are equivalent to the B<iostat -E> command.
+
+There are no additional configuration options for the disk_errors plugin.
+
 
 =head2 Plugin C<dns>
 
@@ -2453,6 +2483,13 @@ depends on the (Java) plugin registering the callback and is completely
 independent from the I<JavaClass> argument passed to B<LoadPlugin>.
 
 =back
+
+=head2 Plugin C<link_stats>
+
+The link statistics are collected for network links on Solaris systems. The data
+collected is similar to the B<dlstat> command.
+
+There are no additional configuration options for the link_stats plugin.
 
 =head2 Plugin C<load>
 
@@ -3925,6 +3962,16 @@ statistics available. Defaults to B<false>.
 
 =back
 
+=head2 Plugin C<nfssvr_stats>
+
+The C<nfssvr_stats> plugin collects NFS procedure counters and Sun RPC
+information for NFS servers.
+
+As of August 2014, this plugin supports contemporary Solaris and CorOS releases.
+
+The plugin can be configured to only collect data for NFS servers versions of
+interest. By default, all NFS versions and referrals are collected.
+
 =head2 Plugin C<nginx>
 
 This plugin collects the number of connections and requests handled by the
@@ -5395,6 +5442,13 @@ the result of the query. When not supplied will default to the escaped
 command, up to 64 chars.
 
 =back
+
+=head2 Plugin C<rpc_stats>
+
+The C<rpc_stats> plugin collects Sun RPC queue and processing information. The
+most typical uses are for NFS and related Sun RPC services.
+
+As of August 2014, this plugin supports contemporary Solaris and CorOS releases.
 
 =head2 Plugin C<rrdcached>
 
@@ -7289,6 +7343,12 @@ Consider the two given strings to be the key and value of an additional
 attribute for each metric being sent out to I<Riemann>.
 
 =back
+
+=head2 Plugin C<zfs_stats>
+
+The C<zfs_stats> plugin collects ZFS file system and related statistics.
+
+As of August 2014, this plugin supports contemporary Solaris and CorOS releases.
 
 =head2 Plugin C<zookeeper>
 

--- a/src/cpu_stats.c
+++ b/src/cpu_stats.c
@@ -1,0 +1,187 @@
+/*
+ * Coraid CPU detailed stats collector
+ *
+ * Suitable for illumos, CorOS, and Solaris 11 derivatives.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+extern kstat_ctl_t *kc;
+
+/* pass the counters as collectd derive (int64_t) */
+void
+cpu_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass the gauges (double) */
+void
+cpu_stats_gauge(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].gauge = (gauge_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* 
+ * Most of the work is done in the cpu_stats_read() callback.
+ * For brevity, a simplistic approach is taken to match a reasonable
+ * collectd and whisper-compatible namespace. The general form is:
+ *   CPU_stats-[cpu instance].[gauge|derive]-statistic
+ * 
+ * As a convenience, we also collect summary derive types for all
+ */
+static int
+cpu_stats_read(void)
+{
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    char s[16];   /* cpu instance as string */
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "CPU_stats", sizeof (vl.plugin));
+
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "cpu", KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_name, "sys", KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            (void) snprintf(s, sizeof (s), "%d", ksp->ks_instance);
+            sstrncpy(vl.plugin_instance, s, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+
+            /** collectors that are commented out exist, but tend to be less interesting **/
+            /* cpu_stats_derive(&vl, ksp, "bawrite", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "bread", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "bwrite", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "canch", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "cpu_load_intr", NULL); */            
+            cpu_stats_derive(&vl, ksp, "cpu_nsec_idle", NULL);
+            cpu_stats_derive(&vl, ksp, "cpu_nsec_intr", NULL);
+            cpu_stats_derive(&vl, ksp, "cpu_nsec_kernel", NULL);
+            cpu_stats_derive(&vl, ksp, "cpu_nsec_user", NULL);
+            /* cpu_stats_derive(&vl, ksp, "cpu_ticks_idle", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "cpu_ticks_kernel", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "cpu_ticks_user", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "cpu_ticks_wait", NULL); */
+            cpu_stats_derive(&vl, ksp, "cpumigrate", NULL);
+            cpu_stats_derive(&vl, ksp, "dtrace_probes", NULL);
+            /* cpu_stats_derive(&vl, ksp, "idlethread", NULL); */
+            cpu_stats_derive(&vl, ksp, "intr", NULL);
+            cpu_stats_derive(&vl, ksp, "intrblk", NULL);
+            cpu_stats_derive(&vl, ksp, "intrthread", NULL);
+            cpu_stats_derive(&vl, ksp, "intrunpin", NULL);
+            cpu_stats_derive(&vl, ksp, "inv_swtch", NULL);
+            /* cpu_stats_derive(&vl, ksp, "iowait", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "lread", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "lwrite", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "mdmint", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "modload", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "modunload", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "msg", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "mutex_adenters", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "namei", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "nthreads", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "outch", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "phread", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "phwrite", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "procovf", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "pswitch", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "rawch", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "rcvint", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "readch", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "rw_rdfails", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "rw_wrfails", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "sema", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "syscall", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "sysexec", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "sysfork", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "sysread", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "sysvfork", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "syswrite", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "trap", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "ufsdirblk", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "ufsiget", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "ufsinopage", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "ufsipage", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "wait_ticks_io", NULL); */
+            /* cpu_stats_derive(&vl, ksp, "writech", NULL); */
+            cpu_stats_derive(&vl, ksp, "xcalls", NULL);
+            /* cpu_stats_derive(&vl, ksp, "xmtint", NULL); */
+        }
+    }
+    /* Some Intel processors have turbo mode, collect ACNT and MCNT MSRs */
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "turbo", KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_name, "turbo", KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            (void) snprintf(s, sizeof (s), "%d", ksp->ks_instance);
+            sstrncpy(vl.plugin_instance, s, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+            cpu_stats_derive(&vl, ksp, "turbo_acnt", NULL);
+            cpu_stats_derive(&vl, ksp, "turbo_mcnt", NULL);
+        }
+    }
+    return (0);
+}
+
+static int
+cpu_stats_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("cpu_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("cpu_stats", cpu_stats_init);
+    plugin_register_read ("cpu_stats", cpu_stats_read);
+}

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -253,7 +253,7 @@ static void update_kstat (void)
 		kid = kstat_chain_update (kc);
 		if (kid > 0)
 		{
-			INFO ("kstat chain has been updated");
+			DEBUG ("kstat chain has been updated");
 			plugin_init_all ();
 		}
 		else if (kid < 0)

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -727,27 +727,18 @@ int get_kstat (kstat_t **ksp_ptr, char *module, int instance, char *name)
 		return (-1);
 	}
 
-	if ((*ksp_ptr)->ks_type != KSTAT_TYPE_NAMED)
+	if (((*ksp_ptr)->ks_type != KSTAT_TYPE_NAMED) &&
+		((*ksp_ptr)->ks_type != KSTAT_TYPE_IO))
 	{
-		ERROR ("get_kstat: kstat %s has wrong type", ident);
+		ERROR ("get_kstat: kstat %s has wrong type (%#x)", ident, 
+			(*ksp_ptr)->ks_type);
 		*ksp_ptr = NULL;
 		return (-1);
 	}
 
-#ifdef assert
-	assert (*ksp_ptr != NULL);
-	assert ((*ksp_ptr)->ks_type == KSTAT_TYPE_NAMED);
-#endif
-
 	if (kstat_read (kc, *ksp_ptr, NULL) == -1)
 	{
 		ERROR ("get_kstat: kstat %s could not be read", ident);
-		return (-1);
-	}
-
-	if ((*ksp_ptr)->ks_type != KSTAT_TYPE_NAMED)
-	{
-		ERROR ("get_kstat: kstat %s has wrong type", ident);
 		return (-1);
 	}
 
@@ -764,13 +755,15 @@ long long get_kstat_value (kstat_t *ksp, char *name)
 		ERROR ("get_kstat_value (\"%s\"): ksp is NULL.", name);
 		return (-1LL);
 	}
-	else if (ksp->ks_type != KSTAT_TYPE_NAMED)
+	else if ((ksp->ks_type != KSTAT_TYPE_NAMED) && 
+		(ksp->ks_type != KSTAT_TYPE_IO))
 	{
 		ERROR ("get_kstat_value (\"%s\"): ksp->ks_type (%#x) "
-				"is not KSTAT_TYPE_NAMED (%#x).",
+				"is neither KSTAT_TYPE_NAMED (%#x) nor KSTAT_TYPE_IO (%#x).",
 				name,
 				(unsigned int) ksp->ks_type,
-				(unsigned int) KSTAT_TYPE_NAMED);
+				(unsigned int) KSTAT_TYPE_NAMED,
+				(unsigned int) KSTAT_TYPE_IO);
 		return (-1LL);
 	}
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -392,11 +392,12 @@ int uc_update (const data_set_t *ds, const value_list_t *vl)
   if (ce->last_time >= vl->time)
   {
     pthread_mutex_unlock (&cache_lock);
-    NOTICE ("uc_update: Value too old: name = %s; value time = %.3f; "
-	"last cache update = %.3f;",
+    NOTICE ("uc_update: Value too old: name = %s;"
+      "value time = %.3f (%lld); "
+	    "last cache update = %.3f (%lld);",
 	name,
-	CDTIME_T_TO_DOUBLE (vl->time),
-	CDTIME_T_TO_DOUBLE (ce->last_time));
+    	CDTIME_T_TO_DOUBLE (vl->time), vl->time,
+    	CDTIME_T_TO_DOUBLE (ce->last_time), ce->last_time);
     return (-1);
   }
 

--- a/src/disk_errors.c
+++ b/src/disk_errors.c
@@ -1,0 +1,115 @@
+/*
+ * Coraid disk errors stats collector
+ *
+ * Suitable for illumos, CorOS, and Solaris 11 derivatives.
+ *
+ * Copyright 2014 Coraid, Inc.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+extern kstat_ctl_t *kc;
+
+/* pass the counters as collectd derive (int64_t) */
+void
+disk_errors_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* 
+ * Most of the work is done in the disk_errors_read() callback.
+ * For brevity, a simplistic approach is taken to match a reasonable
+ * collectd and whisper-compatible namespace. The general form is:
+ *   disk_errors-[sd instance].derive-[statistic]
+ */
+static int
+disk_errors_read(void)
+{
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    char *s;   /* sd instance as string */
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "Disk_Errors", sizeof (vl.plugin));
+
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_module, "sderr", KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_class, "device_error", KSTAT_STRLEN) == 0)) {
+
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+            if ((s = strtok(ksp->ks_name, ",")) == NULL)
+                continue;
+            sstrncpy(vl.plugin_instance, s, sizeof (vl.plugin_instance));
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+
+            /* note: hard and soft errors are counts of other types of errors */
+            disk_errors_derive(&vl, ksp, "All Resets", "All_Resets");
+            disk_errors_derive(&vl, ksp, "Device Not Ready", "DNR");
+            disk_errors_derive(&vl, ksp, "Hard Errors", "Hard");
+            disk_errors_derive(&vl, ksp, "Illegal Request", "Illegal_Request");
+            disk_errors_derive(&vl, ksp, "LUN Resets", "LUN_Resets");
+            disk_errors_derive(&vl, ksp, "Media Error", "Media");
+            disk_errors_derive(&vl, ksp, "No Device", "No_Device");
+            disk_errors_derive(&vl, ksp, "Predictive Failure Analysis", "PFA");
+            disk_errors_derive(&vl, ksp, "Retries", NULL);
+            disk_errors_derive(&vl, ksp, "Recoverable", "Recoverable");
+            disk_errors_derive(&vl, ksp, "Soft Errors", "Soft");
+            disk_errors_derive(&vl, ksp, "Transport Errors", "Transport");
+            disk_errors_derive(&vl, ksp, "Target Resets", "Target_Resets");
+            /* size isn't really an error, but can be handy to have at hand */
+            disk_errors_derive(&vl, ksp, "Size", NULL);
+        }
+   }
+    return (0);
+}
+
+static int
+disk_errors_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("disk_errors plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("disk_errors", disk_errors_init);
+    plugin_register_read ("disk_errors", disk_errors_read);
+}

--- a/src/link_stats.c
+++ b/src/link_stats.c
@@ -1,0 +1,231 @@
+/*
+ * Coraid collectd data collector for network link statistics.
+ *
+ * Suitable for illumos, OpenSolaris, and Solaris 11 derivatives.
+ *
+ * Copyright 2014 Coraid, Inc.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+extern kstat_ctl_t *kc;
+char ks_name[KSTAT_STRLEN + 1];
+boolean_t include_mac_protect = B_TRUE;         /* spoof stats? */
+boolean_t include_broadcast_multicast = B_TRUE; /* broad|multicast stats? */
+
+/*
+ * Many of the kstat counters for network stats are not gauges. We do use
+ * gauges to report link status and negotiaged speeds.
+ *
+ * The rest are passed as counters that only increment, using derive type.
+ */
+
+/* pass the counters as collectd derive (int64_t) */
+void
+link_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass simple value as derive */
+void
+link_stats_simple_derive(value_list_t *vl, long long ll, char *k, char *s)
+{
+    value_t v[1];
+    
+    v[0].derive = (derive_t) ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass the gauges (double) */
+void
+link_stats_gauge(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].gauge = (gauge_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/*
+ * Simple parser to collect the LINK field from an aggregation name.
+ * The name format is "AGGR-LINK", we want the LINK
+ */
+char *
+link_stats_get_aggrs_link(char *s) 
+{
+    char *t, *last;
+    int maxlen = KSTAT_STRLEN;
+    t = s;
+    last = s;
+
+    while (maxlen > 0 && *t != '\0') {
+        if (*t == '-') last = t + 1;
+        t++;
+        maxlen--;
+    }
+    return (last);
+}
+
+/* 
+ * Most of the work is done in the link_stats_read() callback.
+ * For brevity, a simplistic approach is taken to match a reasonable
+ * collectd and whisper-compatible namespace. The general form is:
+ *   Links-<subset>.[gauge|derive]-statistic
+ */
+static int
+link_stats_read(void)
+{
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "Links", sizeof (vl.plugin));
+
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_name, ks_name, KSTAT_STRLEN) == 0) &&
+            (strncmp(ksp->ks_class, "net", KSTAT_STRLEN) == 0)) {
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+ 
+            /* module name is either link or aggr-link combo */
+            sstrncpy(vl.plugin_instance, ksp->ks_module,
+                sizeof (vl.plugin_instance));
+            /* record crtime & snaptime since these may change since boot */
+            sstrncpy(vl.type, "derive", sizeof (vl.type));
+            link_stats_simple_derive(&vl, ksp->ks_crtime, "crtime", NULL);
+            link_stats_simple_derive(&vl, ksp->ks_snaptime, "snaptime", NULL);
+
+            link_stats_derive(&vl, ksp, "blockcnt", NULL);
+            link_stats_derive(&vl, ksp, "chainunder10", NULL);
+            link_stats_derive(&vl, ksp, "chain10to50", NULL);
+            link_stats_derive(&vl, ksp, "chainover50", NULL);
+            link_stats_derive(&vl, ksp, "idropbytes", NULL);
+            link_stats_derive(&vl, ksp, "idrops", NULL);
+            link_stats_derive(&vl, ksp, "intrbytes", NULL);
+            link_stats_derive(&vl, ksp, "intrs", NULL);
+            link_stats_derive(&vl, ksp, "ipackets", NULL);
+            link_stats_derive(&vl, ksp, "local", NULL);
+            link_stats_derive(&vl, ksp, "localbytes", NULL);
+            link_stats_derive(&vl, ksp, "obytes", NULL);
+            link_stats_derive(&vl, ksp, "odropbytes", NULL);
+            link_stats_derive(&vl, ksp, "odrops", NULL);
+            link_stats_derive(&vl, ksp, "oerrors", NULL);
+            link_stats_derive(&vl, ksp, "opackets", NULL);
+            link_stats_derive(&vl, ksp, "pollbytes", NULL);
+            link_stats_derive(&vl, ksp, "polls", NULL);
+            link_stats_derive(&vl, ksp, "rbytes", NULL);
+            link_stats_derive(&vl, ksp, "rxdrops", NULL);
+            link_stats_derive(&vl, ksp, "rxlocal", NULL);
+            link_stats_derive(&vl, ksp, "rxlocalbytes", NULL);
+            link_stats_derive(&vl, ksp, "txdropts", NULL);
+            link_stats_derive(&vl, ksp, "txerrors", NULL);
+            link_stats_derive(&vl, ksp, "txlocal", NULL);
+            link_stats_derive(&vl, ksp, "txlocalbytes", NULL);
+            link_stats_derive(&vl, ksp, "unblockcnt", NULL);
+
+            /*
+             * mac protect stats are bumped when a potential conflict
+             * is detected:
+             *   dhcp spoof
+             *   ip address spoof
+             */
+            if (include_mac_protect == B_TRUE) {
+                link_stats_derive(&vl, ksp, "dhcpdropped", NULL);
+                link_stats_derive(&vl, ksp, "dhcpspoofed", NULL);
+                link_stats_derive(&vl, ksp, "ipspoofed", NULL);
+                link_stats_derive(&vl, ksp, "macspoofed", NULL);
+                link_stats_derive(&vl, ksp, "restricted", NULL);
+            }
+
+            /* broadcast/multicast stats */
+            if (include_broadcast_multicast == B_TRUE) {
+                link_stats_derive(&vl, ksp, "multircv", NULL);
+                link_stats_derive(&vl, ksp, "multircvbytes", NULL);
+                link_stats_derive(&vl, ksp, "multixmt", NULL);
+                link_stats_derive(&vl, ksp, "multixmtbytes", NULL);
+                link_stats_derive(&vl, ksp, "bcstrcvbytes", NULL);
+                link_stats_derive(&vl, ksp, "bcstxmtbytes", NULL);
+                link_stats_derive(&vl, ksp, "brdcstrcv", NULL);
+                link_stats_derive(&vl, ksp, "brdcstxmt", NULL);
+            }
+        }
+    }
+    return (0);
+}
+
+static int
+link_stats_init(void)
+{
+    kstat_t *ksp = NULL;
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("link_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+
+    /* 
+     * find name of link kstats we care about
+     * for Solaris 11, this is "link"
+     * for illumos or older Solaris, this is "mac_misc_stat"
+     */
+    strlcpy(ks_name, "none", sizeof(ks_name));
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((ksp->ks_instance == 0) &&
+           (strncmp(ksp->ks_class, "net", KSTAT_STRLEN) == 0)) {
+            if ((strncmp(ksp->ks_name, "mac_misc_stat", KSTAT_STRLEN) == 0) ||
+                (strncmp(ksp->ks_name, "link", KSTAT_STRLEN) == 0)) {
+                strlcpy(ks_name, ksp->ks_name, sizeof(ks_name));
+                return (0);
+            }
+        }
+    }
+    ERROR ("cannot find misc kstat info for links");
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("link_stats", link_stats_init);
+    plugin_register_read ("link_stats", link_stats_read);
+}

--- a/src/nfssvr_stats.c
+++ b/src/nfssvr_stats.c
@@ -1,0 +1,289 @@
+/*
+ * Coraid NFS server collectd data collector
+ *
+ * This can be compiled for illumos or Solaris derivative, but the kstats
+ * must be available for data to flow.
+ *
+ * The collectd source contains a generic NFS data collector. However,
+ * delivering a single NFS collector for a number of different OSes becomes
+ * tedious to manage enhancements. This collector is specifically targeted
+ * at illumos and Solaris NFS server data collection. As such it offers more
+ * information for NFS servers, but does not collect any client information.
+ * Thus it complements, but does not necessarily replace the data collected
+ * by the nfs.c collector.
+ *
+ * Copyright 2014 Coraid, Inc.
+ * 
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+/* kstat chain is defined elsewhere */
+extern kstat_ctl_t *kc;
+
+/*
+ * By default, we look for v2, v3, and v4 data. You can choose
+ * to disable any version using the "IgnoreNFSv[234] true" in the
+ * collectd.conf file.
+ */
+static _Bool do_nfsv[] = {B_FALSE, B_FALSE, B_TRUE, B_TRUE, B_TRUE};
+
+/* Referrals are rarely used, set "IgnoreReferrals" option to disable */
+static _Bool do_referrals = B_TRUE;
+
+/* ACL information */
+static _Bool do_acls = B_TRUE;
+
+static const char *config_keys[] =
+{
+    "IgnoreNFSv2",
+    "IgnoreNFSv3",
+    "IgnoreNFSv4",
+    "IgnoreReferrals",
+    "IgnoreACLs"
+};
+static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
+
+/*
+ * Some kstats are gauges. The rest are passed as derive.
+ * We also need to translate the most obscure kstat names into something
+ * a human might recognize. To do this, accept an override to the kstat
+ * statistic.
+ */
+
+/* pass the counters as collectd derive (int64_t) */
+void
+nfssvr_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s) {
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/*
+ * Simple parser to collect the second (last) token from a string with '_' 
+ * as separator.
+ * Any parse error returns the original string.
+ */
+char *
+nfssvr_stats_get_version(char *s) {
+    char *st, *t;
+    if ((t = strtok_r(s, "_", &st)) == NULL)
+        return (s);
+    if ((t = strtok_r(NULL, "_", &st)) == NULL)
+        return (s);
+    return (t);
+}
+
+/* 
+ * Most of the work is done in the nfssvr_stats_read() callback.
+ */
+static int
+nfssvr_stats_read(void) {
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    int i;
+    char s[DATA_MAX_NAME_LEN];
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "NFSsvr", sizeof (vl.plugin));
+    /* for this plugin, all data types are derive */
+    sstrncpy(vl.type, "derive", sizeof (vl.type));
+
+    /*
+     * there are three sets of kstats to consider
+     *    nfs:0:rfsproccnt_v[234]:*  class=misc  procedure counters
+     *    nfs:[234]:nfs_server:*     class=misc  RPC statistics
+     *    nfs_acl:0:aclproccnt_v[234]:*  class=misc  ACL statistics
+     */
+    for (i = 2; i <= 4; i++) {
+        if (do_nfsv[i] == B_FALSE)
+            continue;
+        for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+            /* RPC statistics */
+            if (ksp->ks_instance == i && 
+                (strncmp(ksp->ks_module, "nfs", KSTAT_STRLEN) == 0) &&
+                (strncmp(ksp->ks_class, "misc", KSTAT_STRLEN) == 0)) {
+                if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                    continue;
+
+                snprintf(s, DATA_MAX_NAME_LEN, "v%d_rpc", i);
+                sstrncpy(vl.plugin_instance, s, sizeof(vl.plugin_instance));
+
+                nfssvr_stats_derive(&vl, ksp, "badcalls", NULL);
+                nfssvr_stats_derive(&vl, ksp, "calls", NULL);
+                if (do_referrals == B_TRUE) {
+                    nfssvr_stats_derive(&vl, ksp, "referlinks", NULL);
+                    nfssvr_stats_derive(&vl, ksp, "referrals", NULL);
+                }
+            }
+
+            /* procedure counters */
+            snprintf(s, KSTAT_STRLEN, "rfsproccnt_v%d", i);
+            if ((strncmp(ksp->ks_name, s, KSTAT_STRLEN) == 0) && ksp->ks_instance == 0 &&
+                (strncmp(ksp->ks_module, "nfs", KSTAT_STRLEN) == 0)) {
+                if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                    continue;
+
+                snprintf(s, DATA_MAX_NAME_LEN, "v%d_ops", i);
+                sstrncpy(vl.plugin_instance, s, sizeof(vl.plugin_instance));
+
+                /* ops common to all versions */
+                nfssvr_stats_derive(&vl, ksp, "create", NULL);
+                nfssvr_stats_derive(&vl, ksp, "getattr", NULL);
+                nfssvr_stats_derive(&vl, ksp, "link", NULL);
+                nfssvr_stats_derive(&vl, ksp, "lookup", NULL);
+                nfssvr_stats_derive(&vl, ksp, "null", NULL);
+                nfssvr_stats_derive(&vl, ksp, "read", NULL);
+                nfssvr_stats_derive(&vl, ksp, "readdir", NULL);
+                nfssvr_stats_derive(&vl, ksp, "readlink", NULL);
+                nfssvr_stats_derive(&vl, ksp, "remove", NULL);
+                nfssvr_stats_derive(&vl, ksp, "rename", NULL);
+                nfssvr_stats_derive(&vl, ksp, "setattr", NULL);
+                nfssvr_stats_derive(&vl, ksp, "write", NULL);
+
+                switch (i) {
+                    case 2:
+                        nfssvr_stats_derive(&vl, ksp, "mkdir", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "rmdir", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "root", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "statfs", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "symlink", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "wrcache", NULL);
+                        break;
+                    case 3:
+                        nfssvr_stats_derive(&vl, ksp, "access", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "commit", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "fsinfo", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "fsstat", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "mkdir", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "mknod", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "pathconf", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "readdirplus", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "rmdir", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "symlink", NULL);
+                        break;
+                    case 4:
+                        nfssvr_stats_derive(&vl, ksp, "access", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "close", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "commit", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "compound", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "delegpurge", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "delegreturn", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "getfh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "illegal", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "lock", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "lockt", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "locku", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "lookupp", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "nverify", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "open_confirm", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "open_downgrade", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "open", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "openattr", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "putfh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "putpubfh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "putrootfh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "release_lockowner", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "renew", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "reserved", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "restorefh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "savefh", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "secinfo", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "setclientid_confirm", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "setclientid", NULL);
+                        nfssvr_stats_derive(&vl, ksp, "verify", NULL);
+                        break;
+                }
+            }
+
+            /* ACL counters */
+            if (do_acls == B_TRUE) {
+                snprintf(s, KSTAT_STRLEN, "aclproccnt_v%d", i);
+                if ((strncmp(ksp->ks_name, s, KSTAT_STRLEN) == 0) && ksp->ks_instance == 0 &&
+                    (strncmp(ksp->ks_module, "nfs_acl", KSTAT_STRLEN) == 0)) {
+                    if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                        continue;
+
+                    snprintf(s, DATA_MAX_NAME_LEN, "v%d_acls", i);
+                    sstrncpy(vl.plugin_instance, s, sizeof(vl.plugin_instance));
+
+                    /* ops common to all versions */
+                    nfssvr_stats_derive(&vl, ksp, "getacl", NULL);
+                    nfssvr_stats_derive(&vl, ksp, "setacl", NULL);
+                    nfssvr_stats_derive(&vl, ksp, "null", NULL);
+                    if ((i == 2) || (i == 3))
+                        nfssvr_stats_derive(&vl, ksp, "getxattrdir", NULL);
+                }
+            }
+        }
+    }
+    return (0);
+}
+
+static int 
+nfssvr_stats_config (const char *key, const char *value)
+{
+    if (strncasecmp ("IgnoreNFSv2", key, 11) == 0) {
+        do_nfsv[2] = IS_TRUE (value) ? B_FALSE : B_TRUE;
+    } else if (strncasecmp ("IgnoreNFSv3", key, 11) == 0) {
+        do_nfsv[3] = IS_TRUE (value) ? B_FALSE : B_TRUE;
+    } else if (strncasecmp ("IgnoreNFSv4", key, 11) == 0) {
+        do_nfsv[4] = IS_TRUE (value) ? B_FALSE : B_TRUE;
+    } else if (strncasecmp ("IgnoreReferrals", key, 15) == 0) {
+        do_referrals = IS_TRUE (value) ? B_FALSE : B_TRUE;
+    } else if (strncasecmp ("IgnoreACLs", key, 10) == 0) {
+        do_acls = IS_TRUE (value) ? B_FALSE : B_TRUE;
+    } else {
+        return (-1);
+    }
+    return (0);
+}
+
+
+static int
+nfssvr_stats_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("nfssvr_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_config ("nfssvr_stats", nfssvr_stats_config,
+      config_keys, config_keys_num);
+    plugin_register_init ("nfssvr_stats", nfssvr_stats_init);
+    plugin_register_read ("nfssvr_stats", nfssvr_stats_read);
+}

--- a/src/rpc_stats.c
+++ b/src/rpc_stats.c
@@ -1,0 +1,227 @@
+/*
+ * Coraid RPC collectd data collector
+ *
+ * Suitable for CorOS 8. 
+ * This can be compiled for illumos or Solaris derivative, but the kstats
+ * must be available for data to flow.
+ *
+ * The kstats of interest have the (kstat -p) form:
+ *   rpcmod:0:svc_[program]_[instance]_[pid]
+ * These are translated to 
+ *   RPC-[program].[gauge|derive]-statistic
+ *
+ * Copyright 2014 Coraid, Inc.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+/* 
+ * Solaris complains about compiling in large file environments for 32-bit 
+ * processes. This is annoying and not really pertinent to how we use procfs.
+ * As a workaround, fake out the size of the file offset for this include.
+ */
+#undef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 32
+#include <procfs.h>
+
+extern kstat_ctl_t *kc;
+/*
+ * Some kstats are gauges. The rest are passed as derive.
+ * We also need to translate the most obscure kstat names into something
+ * a human might recognize. To do this, accept an override to the kstat
+ * statistic.
+ */
+
+/* pass the counters as collectd derive (int64_t) */
+void
+rpc_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s) {
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass the gauges (double) */
+void
+rpc_stats_gauge(value_list_t *vl, kstat_t *ksp, char *k, char *s) {
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].gauge = (gauge_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* since RPC services can be restarted, record crtime and snaptime */
+/* send crtime and snaptime as derive */
+void
+rpc_stats_send_kstimes(value_list_t *vl, kstat_t *ksp) {
+    value_t v[1];
+
+    vl->values = v;
+    vl->values_len = 1;
+
+    v[0].derive = (derive_t)ksp->ks_crtime;
+    sstrncpy(vl->type_instance, "crtime", sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+
+    v[0].derive = (derive_t)ksp->ks_snaptime;
+    sstrncpy(vl->type_instance, "snaptime", sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/*
+ * simple parser to collect the [program] from a string
+ * any parse error returns the original string
+ */
+char *
+rpc_stats_get_instance(char *s) {
+    char *st, *t;
+    if ((t = strtok_r(s, "_", &st)) == NULL)
+        return (s);
+    if ((t = strtok_r(NULL, "_", &st)) == NULL)
+        return (s);
+    return (t);
+}
+/*
+ * simple parser to collect the pid field from a name
+ */
+char *
+rpc_stats_get_pid(char *s) {
+    char *t, *last;
+    int maxlen = KSTAT_STRLEN;
+    t = s;
+    last = s;
+
+    while (maxlen > 0 && *t != '\0') {
+        if (*t == '_') last = t + 1;
+        t++;
+        maxlen--;
+    }
+    return (last);
+}
+
+/* 
+ * Most of the work is done in the rpc_stats_read() callback.
+ */
+static int
+rpc_stats_read(void) {
+    kstat_t *ksp = NULL;
+    kid_t kid;
+    value_list_t vl = VALUE_LIST_INIT;
+    psinfo_t info;
+    int fd;
+    char pname[MAXNAMELEN];
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "RPC", sizeof (vl.plugin));
+
+    for (ksp = kc->kc_chain; ksp != NULL; ksp = ksp->ks_next) {
+        if ((strncmp(ksp->ks_class, "rpcmod", KSTAT_STRLEN) == 0)) {
+            if ((kid = kstat_read(kc, ksp, NULL)) == -1)
+                continue;
+
+            /* Solaris uses name format: stp_[instance?]_[zone?]_[pid] */
+            if (strncmp(ksp->ks_name, "stp_", 4) == 0) {
+                /* lookup the program name from pid */
+                (void) snprintf(pname, sizeof (pname), "/proc/%s/psinfo", 
+                    rpc_stats_get_pid(ksp->ks_name));
+                if (((fd = open(pname, O_RDONLY)) != -1) &&
+                    (read(fd, (char *)&info, sizeof(info)) != -1)) {
+                    sstrncpy(vl.plugin_instance, info.pr_fname, sizeof (vl.plugin_instance));
+                    (void) close(fd);
+                } else {
+                    sstrncpy(vl.plugin_instance, rpc_stats_get_instance(ksp->ks_name), 
+                        sizeof (vl.plugin_instance));                    
+                }
+
+                sstrncpy(vl.type, "gauge", sizeof (vl.type));
+                rpc_stats_gauge(&vl, ksp, "active_threads", NULL);
+                rpc_stats_gauge(&vl, ksp, "avg_throttle", NULL);
+                rpc_stats_gauge(&vl, ksp, "csw_control", NULL);
+                rpc_stats_gauge(&vl, ksp, "flow_control", NULL);
+                rpc_stats_gauge(&vl, ksp, "requests_inq", NULL);
+
+                sstrncpy(vl.type, "derive", sizeof (vl.type));
+                rpc_stats_send_kstimes(&vl, ksp);
+                rpc_stats_derive(&vl, ksp, "dispatch_failed", NULL);
+            }
+
+            /* CorOS uses name format: svc_[program]_[instance]_[pid] */
+            if (strncmp(ksp->ks_name, "svc_", 4) == 0) {
+                sstrncpy(vl.plugin_instance, rpc_stats_get_instance(ksp->ks_name), 
+                    sizeof (vl.plugin_instance));
+
+                sstrncpy(vl.type, "gauge", sizeof (vl.type));
+                rpc_stats_gauge(&vl, ksp, "pool_mem_hiwat", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_mem_inuse", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_mem_lowat", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_mem_max", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_reqs_backlog", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_reqs_backlog_max", NULL);
+                rpc_stats_gauge(&vl, ksp, "pool_xprt_eager", NULL);
+                rpc_stats_gauge(&vl, ksp, "xprt_ready_qcnt", NULL);
+                rpc_stats_gauge(&vl, ksp, "xprt_ready_qsize", NULL);
+                rpc_stats_gauge(&vl, ksp, "xprt_registered", NULL);
+
+                sstrncpy(vl.type, "derive", sizeof (vl.type));
+                rpc_stats_send_kstimes(&vl, ksp);
+                rpc_stats_derive(&vl, ksp, "pool_flow_ctl_off", NULL);
+                rpc_stats_derive(&vl, ksp, "pool_flow_ctl_on", NULL);
+                rpc_stats_derive(&vl, ksp, "pool_overflow_off", NULL);
+                rpc_stats_derive(&vl, ksp, "pool_overflow_on", NULL);
+                rpc_stats_derive(&vl, ksp, "xprt_flow_ctl_off", NULL);
+                rpc_stats_derive(&vl, ksp, "xprt_flow_ctl_on", NULL);
+            }
+        }
+    }
+    return (0);
+}
+
+static int
+rpc_stats_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("rpc_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("rpc_stats", rpc_stats_init);
+    plugin_register_read ("rpc_stats", rpc_stats_read);
+}

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -193,7 +193,7 @@ int handle_putval (FILE *fh, char *buffer)
 			/* parse_option failed, buffer has been modified.
 			 * => we need to abort */
 			print_to_socket (fh, "-1 Misformatted option.\n");
-			return (-1);
+			goto error;
 		}
 		else if (status == 0)
 		{
@@ -209,7 +209,7 @@ int handle_putval (FILE *fh, char *buffer)
 		if (status != 0)
 		{
 			print_to_socket (fh, "-1 Misformatted value.\n");
-			return (-1);
+			goto error;
 		}
 		assert (string != NULL);
 
@@ -217,7 +217,7 @@ int handle_putval (FILE *fh, char *buffer)
 		if (status != 0)
 		{
 			/* An error has already been printed. */
-			return (-1);
+			goto error;
 		}
 		values_submitted++;
 	} /* while (*buffer != 0) */
@@ -230,6 +230,10 @@ int handle_putval (FILE *fh, char *buffer)
 	sfree (vl.values); 
 
 	return (0);
+
+error:
+	sfree (vl.values);
+	return (-1);
 } /* int handle_putval */
 
 int create_putval (char *ret, size_t ret_len, /* {{{ */

--- a/src/zfs_stats.c
+++ b/src/zfs_stats.c
@@ -1,0 +1,320 @@
+/*
+ * Coraid ZFS collectd data collector for ZFS global statistics.
+ *
+ * Suitable for illumos, OpenSolaris, and Solaris 11 derivatives.
+ *
+ * Copyright 2014 Coraid, Inc.
+ *
+ * MIT License
+ * ===========
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+extern kstat_ctl_t *kc;
+/*
+ * Many of the kstat counters for ARC stats are not gauges.
+ * For those that are, we pass as gauges. The rest are passed as derive.
+ * We also need to translate the most obscure kstat names into something
+ * a human might recognize. To do this, accept an override to the kstat
+ * statistic.
+ */
+
+/* pass the counters as collectd derive (int64_t) */
+void
+zfs_stats_derive(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].derive = (derive_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* pass the gauges (double) */
+void
+zfs_stats_gauge(value_list_t *vl, kstat_t *ksp, char *k, char *s)
+{
+    value_t v[1];
+    long long ll;
+
+    if ((ll = get_kstat_value(ksp, k)) == -1LL) return;
+    v[0].gauge = (gauge_t)ll;
+    vl->values = v;
+    vl->values_len = 1;
+    sstrncpy(vl->type_instance, (s == NULL ? k : s), sizeof(vl->type_instance));
+    plugin_dispatch_values(vl);
+}
+
+/* 
+ * Most of the work is done in the zfs_stats_read() callback.
+ * For brevity, a simplistic approach is taken to match a reasonable
+ * collectd and whisper-compatible namespace. The general form is:
+ *   ZFS-<subset>.[gauge|derive]-statistic
+ */
+static int
+zfs_stats_read(void)
+{
+    kstat_t *ksp = NULL;
+    value_list_t vl = VALUE_LIST_INIT;
+
+    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy(vl.plugin, "ZFS", sizeof (vl.plugin));
+
+    get_kstat(&ksp, "zfs", 0, "arcstats");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "ARC", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "gauge", sizeof (vl.type));
+        zfs_stats_gauge(&vl, ksp, "arc_meta_limit", NULL);
+        zfs_stats_gauge(&vl, ksp, "arc_meta_max", NULL);
+        zfs_stats_gauge(&vl, ksp, "arc_meta_used", NULL);
+        zfs_stats_gauge(&vl, ksp, "arc_no_grow", NULL);
+        zfs_stats_gauge(&vl, ksp, "buf_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "c", "target_max");
+        zfs_stats_gauge(&vl, ksp, "c_max", "arc_max");
+        zfs_stats_gauge(&vl, ksp, "c_min", "arc_min");
+        zfs_stats_gauge(&vl, ksp, "data_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "duplicate_buffers", NULL);
+        zfs_stats_gauge(&vl, ksp, "duplicate_buffers_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "hash_chain_max", NULL);
+        zfs_stats_gauge(&vl, ksp, "hash_elements_max", NULL);
+        zfs_stats_gauge(&vl, ksp, "hdr_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "l2_asize", NULL);
+        zfs_stats_gauge(&vl, ksp, "l2_hdr_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "l2_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "meta_limit", NULL);
+        zfs_stats_gauge(&vl, ksp, "meta_max", NULL);
+        zfs_stats_gauge(&vl, ksp, "meta_used", NULL);
+        zfs_stats_gauge(&vl, ksp, "other_size", NULL);
+        zfs_stats_gauge(&vl, ksp, "p", "mru_target_size");
+        zfs_stats_gauge(&vl, ksp, "size", "arc_size");
+
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "deleted", NULL);
+        zfs_stats_derive(&vl, ksp, "demand_data_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "demand_data_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "demand_metadata_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "demand_metadata_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "duplicate_reads", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_allocfail", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_l2_cached", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_l2_eligible", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_l2_ineligible", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_lock_drops", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_mfu", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_mru", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_skip", NULL);
+        zfs_stats_derive(&vl, ksp, "evict_user_bufs", NULL);
+        zfs_stats_derive(&vl, ksp, "hash_chains", NULL);
+        zfs_stats_derive(&vl, ksp, "hash_collisions", NULL);
+        zfs_stats_derive(&vl, ksp, "hash_elements", NULL);
+        zfs_stats_derive(&vl, ksp, "hits", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_abort_lowmem", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_cksum_bad", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_compress_failures", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_compress_successes", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_compress_zeros", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_evict_lock_retry", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_evict_reading", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_feeds", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_free_on_write", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_io_error", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_read_bytes", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_rw_clash", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_write_bytes", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_writes_done", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_writes_error", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_writes_hdr_miss", NULL);
+        zfs_stats_derive(&vl, ksp, "l2_writes_sent", NULL);
+        zfs_stats_derive(&vl, ksp, "memory_throttle_count", NULL);
+        zfs_stats_derive(&vl, ksp, "mfu_ghost_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "mfu_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "misses", NULL);
+        zfs_stats_derive(&vl, ksp, "mru_ghost_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "mru_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "mutex_miss", NULL);
+        zfs_stats_derive(&vl, ksp, "prefetch_data_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "prefetch_data_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "prefetch_metadata_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "prefetch_metadata_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "recycle_miss", NULL);
+        zfs_stats_derive(&vl, ksp, "shrinks", NULL);
+        zfs_stats_derive(&vl, ksp, "snaptime", "arcstats_snaptime");
+    }
+
+    get_kstat(&ksp, "unix", 0, "vopstats_zfs");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "VOps", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "naccess", NULL);
+        zfs_stats_derive(&vl, ksp, "naddmap", NULL);
+        zfs_stats_derive(&vl, ksp, "nclose", NULL);
+        zfs_stats_derive(&vl, ksp, "ncmp", NULL);
+        zfs_stats_derive(&vl, ksp, "ncreate", NULL);
+        zfs_stats_derive(&vl, ksp, "ndelmap", NULL);
+        zfs_stats_derive(&vl, ksp, "ndispose", NULL);
+        zfs_stats_derive(&vl, ksp, "ndump", NULL);
+        zfs_stats_derive(&vl, ksp, "ndumpctl", NULL);
+        zfs_stats_derive(&vl, ksp, "nfid", NULL);
+        zfs_stats_derive(&vl, ksp, "nfrlock", NULL);
+        zfs_stats_derive(&vl, ksp, "nfsync", NULL);
+        zfs_stats_derive(&vl, ksp, "ngetattr", NULL);
+        zfs_stats_derive(&vl, ksp, "ngetpage", NULL);
+        zfs_stats_derive(&vl, ksp, "ngetsecattr", NULL);
+        zfs_stats_derive(&vl, ksp, "ninactive", NULL);
+        zfs_stats_derive(&vl, ksp, "nioctl", NULL);
+        zfs_stats_derive(&vl, ksp, "nlink", NULL);
+        zfs_stats_derive(&vl, ksp, "nlookup", NULL);
+        zfs_stats_derive(&vl, ksp, "nmap", NULL);
+        zfs_stats_derive(&vl, ksp, "nmkdir", NULL);
+        zfs_stats_derive(&vl, ksp, "nopen", NULL);
+        zfs_stats_derive(&vl, ksp, "npageio", NULL);
+        zfs_stats_derive(&vl, ksp, "npathconf", NULL);
+        zfs_stats_derive(&vl, ksp, "npoll", NULL);
+        zfs_stats_derive(&vl, ksp, "nputpage", NULL);
+        zfs_stats_derive(&vl, ksp, "nread", NULL);
+        zfs_stats_derive(&vl, ksp, "nreaddir", NULL);
+        zfs_stats_derive(&vl, ksp, "nreadlink", NULL);
+        zfs_stats_derive(&vl, ksp, "nrealvp", NULL);
+        zfs_stats_derive(&vl, ksp, "nremove", NULL);
+        zfs_stats_derive(&vl, ksp, "nrename", NULL);
+        zfs_stats_derive(&vl, ksp, "nreqzcbuf", NULL);
+        zfs_stats_derive(&vl, ksp, "nretzcbuf", NULL);
+        zfs_stats_derive(&vl, ksp, "nrmdir", NULL);
+        zfs_stats_derive(&vl, ksp, "nrwlock", NULL);
+        zfs_stats_derive(&vl, ksp, "nrwunlock", NULL);
+        zfs_stats_derive(&vl, ksp, "nseek", NULL);
+        zfs_stats_derive(&vl, ksp, "nsetattr", NULL);
+        zfs_stats_derive(&vl, ksp, "nsetfl", NULL);
+        zfs_stats_derive(&vl, ksp, "nsetsecattr", NULL);
+        zfs_stats_derive(&vl, ksp, "nshrlock", NULL);
+        zfs_stats_derive(&vl, ksp, "nspace", NULL);
+        zfs_stats_derive(&vl, ksp, "nsymlink", NULL);
+        zfs_stats_derive(&vl, ksp, "nvnevent", NULL);
+        zfs_stats_derive(&vl, ksp, "nwrite", NULL);
+        zfs_stats_derive(&vl, ksp, "read_bytes", NULL);
+        zfs_stats_derive(&vl, ksp, "readdir_bytes", NULL);
+        zfs_stats_derive(&vl, ksp, "snaptime", NULL);
+        zfs_stats_derive(&vl, ksp, "write_bytes", NULL);
+    }
+
+    get_kstat(&ksp, "zfs", 0, "vdev_cache_stats");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "vdev-cache", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "delegations", NULL);
+        zfs_stats_derive(&vl, ksp, "hits", NULL);
+        zfs_stats_derive(&vl, ksp, "misses", NULL);
+        zfs_stats_derive(&vl, ksp, "snaptime", NULL);
+    }
+
+    get_kstat(&ksp, "zfs", 0, "xuio_stats");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "XUIO", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "onloan_read_buf", NULL);
+        zfs_stats_derive(&vl, ksp, "onloan_write_buf", NULL);
+        zfs_stats_derive(&vl, ksp, "read_buf_copied", NULL);
+        zfs_stats_derive(&vl, ksp, "read_buf_nocopy", NULL);
+        zfs_stats_derive(&vl, ksp, "snaptime", NULL);
+        zfs_stats_derive(&vl, ksp, "write_buf_copied", NULL);
+        zfs_stats_derive(&vl, ksp, "write_buf_nocopy", NULL);
+    }
+
+    get_kstat(&ksp, "zfs", 0, "zfetchstats");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "data-prefetch", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "bogus_streams", NULL);
+        zfs_stats_derive(&vl, ksp, "colinear_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "colinear_misses", NULL);
+        zfs_stats_derive(&vl, ksp, "hits", NULL);
+        zfs_stats_derive(&vl, ksp, "misses", NULL);
+        zfs_stats_derive(&vl, ksp, "reclaim_failures", NULL);
+        zfs_stats_derive(&vl, ksp, "reclaim_successes", NULL);
+        zfs_stats_derive(&vl, ksp, "snaptime", NULL);
+        zfs_stats_derive(&vl, ksp, "streams_noresets", NULL);
+        zfs_stats_derive(&vl, ksp, "streams_resets", NULL);
+        zfs_stats_derive(&vl, ksp, "stride_hits", NULL);
+        zfs_stats_derive(&vl, ksp, "stride_misses", NULL);
+    }
+
+    /* ARC-related kmem cache info */
+    get_kstat(&ksp, "unix", 0, "arc_buf_t");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "kmem", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "buf_inuse", "arc_buf_inuse");
+        zfs_stats_derive(&vl, ksp, "reap", "arc_buf_reap");
+    }
+    get_kstat(&ksp, "unix", 0, "kmem_alloc_32");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "kmem", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "buf_inuse", "alloc_32_buf_inuse");
+    }
+    get_kstat(&ksp, "unix", 0, "kmem_alloc_40");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "kmem", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "buf_inuse", "alloc_40_buf_inuse");
+    }
+    get_kstat(&ksp, "unix", 0, "dnode_t");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "kmem", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "reap", "arc_dnode_reap");
+        zfs_stats_derive(&vl, ksp, "move_callbacks", "arc_dnode_move_callbacks");
+    }
+    get_kstat(&ksp, "unix", 0, "zfs_znode_cache");
+    if (ksp != NULL) {
+        sstrncpy(vl.plugin_instance, "kmem", sizeof (vl.plugin_instance));
+        sstrncpy(vl.type, "derive", sizeof (vl.type));
+        zfs_stats_derive(&vl, ksp, "reap", "arc_znode_reap");
+        zfs_stats_derive(&vl, ksp, "move_callbacks", "arc_znode_move_callbacks");
+    }
+    return (0);
+}
+
+static int
+zfs_stats_init(void)
+{
+    /* the kstat chain is opened already, if not bail out */
+    if (kc == NULL) {
+        ERROR ("zfs_stats plugin: kstat chain control initialization failed");
+        return (-1);
+    }
+    return (0);
+}
+
+void
+module_register(void)
+{
+    plugin_register_init ("zfs_stats", zfs_stats_init);
+    plugin_register_read ("zfs_stats", zfs_stats_read);
+}


### PR DESCRIPTION
A check was missing in one path that wrote to the queue, allowing it to creep up beyond the boundary.
The original code would force a message once a second as the queue filled up (just what's needed when
running behind). I've reduced the frequency, limited messages to appear when the loss level
has changed, and ensured that if it later goes wrong again after recovering, it will again produce messages.

Separately, in error cases that were probably rare but possible, putval could leak value lists.
