### PR TITLE
memcached plugin: Implement the "Alias" option.

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -269,6 +269,7 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
           sizeof (vl->host));
       }
       sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
+    }
   }
 }
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -63,6 +63,7 @@ static void memcached_free (memcached_t *st)
   sfree (st->socket);
   sfree (st->host);
   sfree (st->port);
+  sfree (st->alias);
 }
 
 static int memcached_connect_unix (memcached_t *st)
@@ -254,22 +255,21 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
   else
   {
     if (st->socket != NULL)
-      sstrncpy (vl->host, hostname_g, sizeof (vl->host));
-	}
+        sstrncpy (vl->host, hostname_g, sizeof (vl->host));
     else
-	{
-	    if (st->alias != NULL)
-	    {
-			sstrncpy(vl->host, st->alias, sizeof(st->alias));
+    {
+        if (st->alias != NULL)
+        {
+            sstrncpy(vl->host, st->alias, sizeof(st->alias));
         }
         else
         {
             sstrncpy (vl->host,
                 (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
                 sizeof (vl->host));
-		}
-    sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
-  }
+        }
+        sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
+    }
 }
 
 static void submit_derive (const char *type, const char *type_inst,

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -255,21 +255,21 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
   else
   {
     if (st->socket != NULL)
-        sstrncpy (vl->host, hostname_g, sizeof (vl->host));
+      sstrncpy (vl->host, hostname_g, sizeof (vl->host));
     else
     {
-        if (st->alias != NULL)
-        {
-            sstrncpy(vl->host, st->alias, sizeof(st->alias));
-        }
-        else
-        {
-            sstrncpy (vl->host,
-                (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
-                sizeof (vl->host));
-        }
-        sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
-    }
+      if (st->alias != NULL)
+      {
+         sstrncpy(vl->host, st->alias, sizeof(st->alias));
+      }
+      else
+      {
+        sstrncpy (vl->host,
+          (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
+          sizeof (vl->host));
+      }
+      sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
+  }
 }
 
 static void submit_derive (const char *type, const char *type_inst,
@@ -653,7 +653,7 @@ static int config_add_instance(oconfig_item_t *ci)
     return (-1);
   }
 
-	return (0);
+  return (0);
 }
 
 static int memcached_config (oconfig_item_t *ci)

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -260,7 +260,7 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
     {
       if (st->alias != NULL)
       {
-         sstrncpy(vl->host, st->alias, sizeof(st->alias));
+         sstrncpy (vl->host, st->alias, sizeof (vl->host));
       }
       else
       {
@@ -609,6 +609,7 @@ static int config_add_instance(oconfig_item_t *ci)
   st->socket = NULL;
   st->host = NULL;
   st->port = NULL;
+  st->alias = NULL;
 
   if (strcasecmp (ci->key, "Plugin") == 0) /* default instance */
     st->name = sstrdup ("__legacy__");

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -48,6 +48,7 @@ struct memcached_s
   char *socket;
   char *host;
   char *port;
+  char *alias;
 };
 typedef struct memcached_s memcached_t;
 
@@ -254,10 +255,19 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
   {
     if (st->socket != NULL)
       sstrncpy (vl->host, hostname_g, sizeof (vl->host));
+	}
     else
-      sstrncpy (vl->host,
-          (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
-          sizeof (vl->host));
+	{
+	    if (st->alias != NULL)
+	    {
+			sstrncpy(vl->host, st->alias, sizeof(st->alias));
+        }
+        else
+        {
+            sstrncpy (vl->host,
+                (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST,
+                sizeof (vl->host));
+		}
     sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
   }
 }
@@ -621,6 +631,8 @@ static int config_add_instance(oconfig_item_t *ci)
       status = cf_util_get_string (child, &st->host);
     else if (strcasecmp ("Port", child->key) == 0)
       status = cf_util_get_service (child, &st->port);
+    else if (strcasecmp("Alias", child->key) == 0)
+      status = cf_util_get_service(child, &st->alias);
     else
     {
       WARNING ("memcached plugin: Option `%s' not allowed here.",
@@ -641,7 +653,7 @@ static int config_add_instance(oconfig_item_t *ci)
     return (-1);
   }
 
-  return (0);
+	return (0);
 }
 
 static int memcached_config (oconfig_item_t *ci)
@@ -693,6 +705,7 @@ static int memcached_init (void)
   st->socket = NULL;
   st->host = NULL;
   st->port = NULL;
+  st->alias = NULL;
 
   status = memcached_add_read_callback (st);
   if (status == 0)


### PR DESCRIPTION
We have two ip addresses for memcached:
One backbone address and one internal address.

Our hostfile looks a bit like this:
```
1.2.3.1 mc0 mc0.example.com # Internal address (only available from company office)
1.2.3.2 mc0 mc0.example.com # Backbone address (only available from datacenter)
```

We need the backbone address for security reasons here to avoid that somebody
from the office can accidentally flush the cache from the office :wink: 

In our collectd.conf we have the following settings:
```
LoadPlugin memcached
<Plugin memcached>
    <Instance "default">
        Host "1.2.3.2"
        Port "11211"
    </Instance>
    <Instance "pool_one">
        Host "1.2.3.2"
        Port "11212"
    </Instance>
    <Instance "pool_two">
        Host "1.2.3.2"
        Port "11213"
    </Instance>
</Plugin>
```

We can’t use the fqdn in our config file because it would resolve to the internal address (which comes first in the host file) instead of the backbone address.
The end result is, that our series names contain the IP address instead of the fqdn. 
So 
`datacenter.memcached.1.2.3.2.memcached-data.memcached_command-get.mean`
instead of
`datacenter.memcached.mc0.memcached-data.memcached_command-get.mean`

To fix this, I’ve added an `alias` parameter to the memcached plugin.
If it is given, the alias will appear in the series name.
If not, the normal behavior (using IP or fqdn as before) will be used.

This can also be useful if you have multiple memcached instances on one machine which are completely
separate from each other. They can all have a separate alias, as if they were running on different machines.

It would be nice to have this functionality upstream. What do you think?