### PR TITLE
libstatgrab: fix detection of libstatgrab >= 0.90

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4139,10 +4139,11 @@ fi
 if test "x$with_libstatgrab" = "xyes"
 then
   SAVE_CFLAGS="$CFLAGS"
-  SAVE_LDFLAGS="$LDFLAGS"
+  SAVE_LIBS="$LIBS"
 
   CFLAGS="$CFLAGS $with_libstatgrab_cflags"
   LDFLAGS="$LDFLAGS $with_libstatgrab_ldflags"
+  LIBS="-lstatgrab $LIBS"
 
   AC_CACHE_CHECK([if libstatgrab >= 0.90],
           [c_cv_have_libstatgrab_0_90],
@@ -4162,6 +4163,7 @@ then
 
   CFLAGS="$SAVE_CFLAGS"
   LDFLAGS="$SAVE_LDFLAGS"
+  LIBS="$SAVE_LIBS"
 fi
 
 AM_CONDITIONAL(BUILD_WITH_LIBSTATGRAB, test "x$with_libstatgrab" = "xyes")


### PR DESCRIPTION
Ensure linking is done after compilation of the test program, otherwise
symbols cannot be found. `LDFLAGS` and `CFLAGS` are placed before the
test program on gcc command line while `LIBS` is placed after. Even if
in our case, `LDFLAGS` also contain the lib, being put before the
program while the linking phase is done with the same command leads to
`sg_init()` never found which is misinterpreted as requiring an
argument.

This has been tested with both libstatgrab 0.90 and 0.17.