### PR TITLE
ipmi: use SIGIO instead of SIGUSR2 to avoid conflict with JVM

### DIFF
--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -557,7 +557,7 @@ static int thread_init (os_handler_t **ret_os_handler)
   ipmi_domain_id_t domain_id;
   int status;
 
-  os_handler = ipmi_posix_thread_setup_os_handler (SIGUSR2);
+  os_handler = ipmi_posix_thread_setup_os_handler (SIGIO);
   if (os_handler == NULL)
   {
     ERROR ("ipmi plugin: ipmi_posix_thread_setup_os_handler failed.");


### PR DESCRIPTION
Java uses SIGUSR2 to suspend/resume threads. The OpenIPMI plugins also
need a signal to resume its event loop when setting a timer. They can't
both use the same signal. We ask OpenIPMI to use SIGIO instead.

This should fix #114.