### PR TITLE
Rework Solaris kstat handling, avoiding repeated plugin_init_all() calls

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -724,6 +724,55 @@ long long get_kstat_value (kstat_t *ksp, char *name)
 
 	return (retval);
 }
+
+
+int kstat_set_init (kstat_set_t *set)
+{
+	memset (set, 0, sizeof (*set));
+	set->alloc = 32;
+	set->items = malloc (set->alloc * sizeof (*set->items));
+	if (set->items == NULL)
+	{
+		ERROR ("kstat_set_init: out of memory");
+		return -1;
+	}
+	return 0;
+}
+
+
+int kstat_set_add (kstat_set_t *set, kstat_t *kstat)
+{
+	if (set->len == set->alloc)
+	{
+		unsigned new_alloc = set->alloc << 1;
+		void *new_items = realloc (set->items, new_alloc * sizeof (*set->items));
+		if (new_items == NULL)
+		{
+			ERROR ("kstat_set_add: out of memory");
+			return (-1);
+		}
+		set->items = new_items;
+		set->alloc = new_alloc;
+	}
+
+	set->items[set->len].kstat = kstat;
+	set->items[set->len].id = kstat->ks_kid;
+	set->len++;
+
+	return (0);
+}
+
+
+void kstat_set_remove (kstat_set_t *set, kid_t id)
+{
+	unsigned i;
+	for (i = 0; i < set->len; i++)
+		if (set->items[i].id == id)
+		{
+			set->len--;
+			set->items[i] = set->items[set->len];
+		}
+}
 #endif /* HAVE_LIBKSTAT */
 
 #ifndef HAVE_HTONLL

--- a/src/common.h
+++ b/src/common.h
@@ -255,6 +255,23 @@ int check_create_dir (const char *file_orig);
 #ifdef HAVE_LIBKSTAT
 int get_kstat (kstat_t **ksp_ptr, char *module, int instance, char *name);
 long long get_kstat_value (kstat_t *ksp, char *name);
+
+struct kstat_set_s {
+	unsigned len, alloc;
+	struct {
+		kstat_t *kstat;
+		kid_t id;
+		/* id is duplicated here as when a kstat gets removed, the
+		 * pointer will already be invalid and we can no more access
+		 * ks_id from the kstat pointer. */
+	} *items;
+};
+
+typedef struct kstat_set_s kstat_set_t;
+
+int kstat_set_init (kstat_set_t *set);
+int kstat_set_add (kstat_set_t *set, kstat_t *kstat);
+void kstat_set_remove (kstat_set_t *set, kid_t id);
 #endif
 
 #ifndef HAVE_HTONLL

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -70,6 +70,15 @@ struct read_func_s
 };
 typedef struct read_func_s read_func_t;
 
+#if HAVE_LIBKSTAT
+struct kstat_func_s
+{
+	callback_func_t kf_super;
+	const kstat_filter_t *kf_filter;
+};
+typedef struct kstat_func_s kstat_func_t;
+#endif /* HAVE_LIBKSTAT */
+
 struct write_queue_s;
 typedef struct write_queue_s write_queue_t;
 struct write_queue_s
@@ -91,6 +100,9 @@ static llist_t *list_missing;
 static llist_t *list_shutdown;
 static llist_t *list_log;
 static llist_t *list_notification;
+#if HAVE_LIBKSTAT
+static llist_t *list_kstat;
+#endif
 
 static fc_chain_t *pre_cache_chain = NULL;
 static fc_chain_t *post_cache_chain = NULL;
@@ -1289,6 +1301,55 @@ int plugin_register_notification (const char *name,
 				(void *) callback, ud));
 } /* int plugin_register_log */
 
+#if HAVE_LIBKSTAT
+int plugin_register_kstat (const char *name,
+		plugin_kstat_cb callback, user_data_t *user_data,
+		const kstat_filter_t *filter)
+{
+	kstat_func_t *kf;
+
+	kf = malloc (sizeof (*kf));
+	if (kf == NULL) {
+		ERROR ("plugin_register_kstat: out of memory");
+		return (ENOMEM);
+	}
+
+	memset (kf, 0, sizeof (*kf));
+	kf->kf_super.cf_callback = callback;
+	kf->kf_super.cf_ctx = plugin_get_ctx ();
+	kf->kf_super.cf_udata = *user_data;
+	kf->kf_filter = filter;
+
+	return register_callback (&list_kstat, name, (callback_func_t *) kf);
+}
+
+
+static void kstat_set_cb (kstat_action_t action, const kstat_info_t *info,
+		user_data_t *user_data)
+{
+	kstat_set_t *set = user_data->data;
+	switch (action) {
+		case KSTAT_ADDED:
+			kstat_set_add (set, info->kstat);
+			break;
+		case KSTAT_REMOVED:
+			kstat_set_remove (set, info->id);
+			break;
+	}
+}
+
+
+int plugin_register_kstat_set (const char *name,
+		kstat_set_t *set,
+		const kstat_filter_t *filter)
+{
+	user_data_t user_data = {
+		.data = set,
+	};
+	return plugin_register_kstat (name, kstat_set_cb, &user_data, filter);
+}
+#endif /* HAVE_LIBKSTAT */
+
 int plugin_unregister_config (const char *name)
 {
 	cf_unregister (name);
@@ -1452,6 +1513,13 @@ int plugin_unregister_notification (const char *name)
 {
 	return (plugin_unregister (list_notification, name));
 }
+
+#if HAVE_LIBKSTAT
+int plugin_unregister_kstat (const char *name)
+{
+	return (plugin_unregister (list_kstat, name));
+}
+#endif
 
 void plugin_init_all (void)
 {
@@ -1783,6 +1851,10 @@ void plugin_shutdown_all (void)
 	destroy_all_callbacks (&list_notification);
 	destroy_all_callbacks (&list_shutdown);
 	destroy_all_callbacks (&list_log);
+
+#if HAVE_LIBKSTAT
+	destroy_all_callbacks (&list_kstat);
+#endif
 
 	plugin_free_loaded ();
 	plugin_free_data_sets ();
@@ -2128,6 +2200,42 @@ int plugin_dispatch_notification (const notification_t *notif)
 
 	return (0);
 } /* int plugin_dispatch_notification */
+
+#if HAVE_LIBKSTAT
+static int kstat_filter_match (const kstat_info_t *info,
+		const kstat_filter_t *filter)
+{
+	if (filter->module != NULL && strcmp (filter->module, info->module) != 0)
+		return (-1);
+	if (filter->instance != -1 && filter->instance != info->instance)
+		return (-1);
+	if (filter->name != NULL && strcmp (filter->name, info->name) != 0)
+		return (-1);
+	if (filter->class != NULL && strcmp (filter->class, info->class) != 0)
+		return (-1);
+	if (filter->type != -1 && filter->type != info->type)
+		return (-1);
+	if (filter->filter_func != NULL && filter->filter_func (info) != 0)
+		return (-1);
+	return (0);
+}
+
+void plugin_dispatch_kstat (kstat_action_t action, const kstat_info_t *info)
+{
+	llentry_t *le;
+
+	if (list_kstat == NULL)
+		return;
+
+	for (le = llist_head (list_kstat); le != NULL; le = le->next)
+	{
+		kstat_func_t *const kf = le->value;
+		const plugin_kstat_cb callback = kf->kf_super.cf_callback;
+		if (kstat_filter_match (info, kf->kf_filter) == 0)
+			callback (action, info, &kf->kf_super.cf_udata);
+	}
+}
+#endif /* HAVE_LIBKSTAT */
 
 void plugin_log (int level, const char *format, ...)
 {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -188,6 +188,29 @@ typedef void (*plugin_log_cb) (int severity, const char *message,
 typedef int (*plugin_shutdown_cb) (void);
 typedef int (*plugin_notification_cb) (const notification_t *,
 		user_data_t *);
+#if HAVE_LIBKSTAT
+enum kstat_action_e {
+	KSTAT_ADDED,
+	KSTAT_REMOVED
+};
+typedef enum kstat_action_e kstat_action_t;
+
+/* This structure copies some of the information in
+ * a kstat_t, to ensure we still have it available
+ * when a kstat has been removed from the chain. */
+struct kstat_info_s {
+	kstat_t *kstat; /* will be NULL on removal */
+	kid_t id;
+	char module[KSTAT_STRLEN];
+	int instance;
+	char name[KSTAT_STRLEN];
+	char class[KSTAT_STRLEN];
+	int type;
+};
+typedef struct kstat_info_s kstat_info_t;
+
+typedef void (*plugin_kstat_cb) (kstat_action_t, const kstat_info_t *, user_data_t *);
+#endif
 
 /*
  * NAME
@@ -298,6 +321,34 @@ int plugin_register_log (const char *name,
 		plugin_log_cb callback, user_data_t *user_data);
 int plugin_register_notification (const char *name,
 		plugin_notification_cb callback, user_data_t *user_data);
+#if HAVE_LIBKSTAT
+struct kstat_filter_s {
+	const char *module;
+	int instance;
+	const char *name;
+	const char *class;
+	int type;
+	/* If non-NULL, this function is called if everything else
+	 * matches. It can implement additional checks. It shall
+	 * return zero in case of a match, non-zero otherwise. */
+	int (*filter_func) (const kstat_info_t *);
+};
+typedef struct kstat_filter_s kstat_filter_t;
+
+#define KSTAT_FILTER_INIT \
+	{ \
+		.instance = -1, \
+		.type = -1 \
+	}
+
+int plugin_register_kstat (const char *name,
+		plugin_kstat_cb callback, user_data_t *user_data,
+		const kstat_filter_t *filter);
+struct kstat_set_s;
+int plugin_register_kstat_set (const char *name,
+		struct kstat_set_s *set,
+		const kstat_filter_t *filter);
+#endif
 
 int plugin_unregister_config (const char *name);
 int plugin_unregister_complex_config (const char *name);
@@ -311,6 +362,9 @@ int plugin_unregister_shutdown (const char *name);
 int plugin_unregister_data_set (const char *name);
 int plugin_unregister_log (const char *name);
 int plugin_unregister_notification (const char *name);
+#if HAVE_LIBKSTAT
+int plugin_unregister_kstat (const char *name);
+#endif
 
 
 /*
@@ -331,6 +385,10 @@ int plugin_dispatch_values (value_list_t const *vl);
 int plugin_dispatch_missing (const value_list_t *vl);
 
 int plugin_dispatch_notification (const notification_t *notif);
+
+#if HAVE_LIBKSTAT
+void plugin_dispatch_kstat (kstat_action_t action, const kstat_info_t *info);
+#endif
 
 void plugin_log (int level, const char *format, ...)
 	__attribute__ ((format(printf,2,3)));


### PR DESCRIPTION
It has been noted in some issues such as #864 and #869 that on Solaris, plugin_init_all() gets called repeatedly, namely every time kstat_chain_update() indicates that the kstat chain has been updated.

It was also noted that on many Solaris systems, kstat_chain_update() will _very_ frequently indicate a kstat chain update (basically, this will happen on every collectd interval), so even if plugins had a "reload" callback to be called instead of repeated calls to the init callback, we would still end up calling this reload callback way too frequently.

This patch attempts to solve this in a somewhat more complex way, maintaining a hash table that reflects the current state of the kstat chain, and on chain updates, it will compare the new chain against the saved state in the hash table to figure out what kstat items exactly have appeared and disappeared.

Plugins can register a callback function to be notified about added/removed kstats. They can specify filters to ensure plugin's callback function only gets invoked for kstats which the plugin is actually interested in. Additionally, a standard callback function is provided which maintains a "set" of relevant kstats in a data structure that a plugin's read function can simply iterate over.

This adds some complexity to core, but in turn makes it slightly simpler to write plugins making use of kstats that may change dynamically.

I've also converted those plugins for which it makes sense to use this new kstat infrastructure. This affects the cpu, disk, interface, processes and tape plugins. There are some more plugins using kstat, but those can stay as they are, as they don't utilize any kstats which would be expected to dynamically appear or disappear at run time.