### PR TITLE
Fixes for zfs_arc and processes plugins on Solaris

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5228,6 +5228,7 @@ fi
 if test "x$with_kstat" = "xyes"
 then
 	plugin_nfs="yes"
+	plugin_processes="yes"
 	plugin_uptime="yes"
 	plugin_zfs_arc="yes"
 fi

--- a/src/processes.c
+++ b/src/processes.c
@@ -1209,7 +1209,7 @@ static const char *ps_get_cmdline (pid_t pid, /* {{{ */
 	snprintf(path, sizeof (path), "/proc/%i/psinfo", pid);
 
 	status = read_file_contents (path, (void *) &info, sizeof (info));
-	if (status != ((int) buffer_size))
+	if (status != sizeof (info))
 	{
 		ERROR ("processes plugin: Unexpected return value "
 				"while reading \"%s\": "

--- a/src/processes.c
+++ b/src/processes.c
@@ -1214,14 +1214,14 @@ static int read_fork_rate ()
 #endif /*KERNEL_LINUX */
 
 #if KERNEL_SOLARIS
-static const char *ps_get_cmdline (pid_t pid, /* {{{ */
+static const char *ps_get_cmdline (long pid, /* {{{ */
 		char *buffer, size_t buffer_size)
 {
 	char path[PATH_MAX];
 	psinfo_t info;
 	int status;
 
-	snprintf(path, sizeof (path), "/proc/%i/psinfo", pid);
+	snprintf(path, sizeof (path), "/proc/%li/psinfo", pid);
 
 	status = read_file_contents (path, (void *) &info, sizeof (info));
 	if (status != sizeof (info))
@@ -1245,7 +1245,7 @@ static const char *ps_get_cmdline (pid_t pid, /* {{{ */
  * The values for input and ouput chars are calculated "by hand"
  * Added a few "solaris" specific process states as well
  */
-static int ps_read_process(int pid, procstat_t *ps, char *state)
+static int ps_read_process(long pid, procstat_t *ps, char *state)
 {
 	char filename[64];
 	char f_psinfo[64], f_usage[64];
@@ -1255,9 +1255,9 @@ static int ps_read_process(int pid, procstat_t *ps, char *state)
 	psinfo_t *myInfo;
 	prusage_t *myUsage;
 
-	snprintf(filename, sizeof (filename), "/proc/%i/status", pid);
-	snprintf(f_psinfo, sizeof (f_psinfo), "/proc/%i/psinfo", pid);
-	snprintf(f_usage, sizeof (f_usage), "/proc/%i/usage", pid);
+	snprintf(filename, sizeof (filename), "/proc/%li/status", pid);
+	snprintf(f_psinfo, sizeof (f_psinfo), "/proc/%li/psinfo", pid);
+	snprintf(f_usage, sizeof (f_usage), "/proc/%li/usage", pid);
 
 
 	buffer = malloc(sizeof (pstatus_t));
@@ -2239,14 +2239,16 @@ static int ps_read (void)
 
 	while ((ent = readdir(proc)) != NULL)
 	{
-		int pid;
+		long pid;
 		struct procstat ps;
 		procstat_entry_t pse;
+		char *endptr;
 
 		if (!isdigit ((int) ent->d_name[0]))
 			continue;
 
-		if ((pid = atoi (ent->d_name)) < 1)
+		pid = strtol (ent->d_name, &endptr, 10);
+		if (*endptr != 0) /* value didn't completely parse as a number */
 			continue;
 
 		status = ps_read_process (pid, &ps, &state);
@@ -2296,8 +2298,7 @@ static int ps_read (void)
 
 
 		ps_list_add (ps.name,
-				ps_get_cmdline ((pid_t) pid,
-					cmdline, sizeof (cmdline)),
+				ps_get_cmdline (pid, cmdline, sizeof (cmdline)),
 				&pse);
 	} /* while(readdir) */
 	closedir (proc);

--- a/src/processes.c
+++ b/src/processes.c
@@ -112,7 +112,22 @@
 /* #endif HAVE_PROCINFO_H */
 
 #elif KERNEL_SOLARIS
+/* Hack: Avoid #error when building a 32-bit binary with
+ * _FILE_OFFSET_BITS=64. There is a reason for this #error, as one
+ * of the structures in <sys/procfs.h> uses an off_t, but that
+ * isn't relevant to our usage of procfs. */
+#if !defined(_LP64) && _FILE_OFFSET_BITS == 64
+#  define SAVE_FOB_64
+#  undef _FILE_OFFSET_BITS
+#endif
+
 # include <procfs.h>
+
+#ifdef SAVE_FOB_64
+#  define _FILE_OFFSET_BITS 64
+#  undef SAVE_FOB_64
+#endif
+
 # include <dirent.h>
 /* #endif KERNEL_SOLARIS */
 

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -251,7 +251,14 @@ static int za_read (void)
 
 	/* Sizes */
 	za_read_gauge (ksp, "size",    "cache_size", "arc");
-	za_read_gauge (ksp, "l2_size", "cache_size", "L2");
+
+	/* The "l2_size" value has disappeared from Solaris some time in
+	 * early 2013, and has only reappeared recently in Solaris 11.2.
+	 * Stop trying if we ever fail to read it, so we don't spam the log.
+	 */
+	static int l2_size_avail = 1;
+	if (l2_size_avail && za_read_gauge (ksp, "l2_size", "cache_size", "L2") != 0)
+		l2_size_avail = 0;
 
 	/* Operations */
 	za_read_derive (ksp, "deleted",  "cache_operation", "deleted");


### PR DESCRIPTION
- zfs_arc: Silence errors about failure to read the "l2_size" value from the zfs:0:arcstats kstat. This value is missing on several versions of Solaris.

- processes: Several fixes to make the plugin work on Solaris in 32-bit and 64-bit builds. Enable the plugin by default.