### PR TITLE
write_graphite plugin: Add SendTimeout

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1267,6 +1267,7 @@
 #    Host "localhost"
 #    Port "2003"
 #    Protocol "tcp"
+#    SendTimeout 60
 #    LogSendErrors true
 #    Prefix "collectd"
 #    Postfix "collectd"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6777,6 +6777,7 @@ Synopsis:
      Host "localhost"
      Port "2003"
      Protocol "tcp"
+     SendTimeout 60
      LogSendErrors true
      Prefix "collectd"
    </Node>
@@ -6798,6 +6799,12 @@ Service name or port number to connect to. Defaults to C<2003>.
 =item B<Protocol> I<String>
 
 Protocol to use when connecting to I<Graphite>. Defaults to C<tcp>.
+
+=item B<SendTimeout> I<Seconds>
+
+Timeout to use when sending data to I<Graphite>. Defaults to C<infinite>.
+If the timeout is reached, data will be lost and an error will be logged.
+Useful for when your I<Graphite> instance is on a remote network.
 
 =item B<LogSendErrors> B<false>|B<true>
 


### PR DESCRIPTION
When sending metrics to remote networks, occasionally the write_graphite plugin will hang in a socket write call waiting for the write to succeed. This can hang indefinitely, causing metrics to not be reported until the service is forcibly killed.

This pull request does not change the default behavior, but adds a SendTimeout to the write_graphite plugin configuration to abort sending metrics after a certain amount of time has passed while stuck in a write. All unwritten data is lost and this is treated as a failure.
