### PR TITLE
Ignore -f when compiled with --disable-daemon

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -504,9 +504,9 @@ int main (int argc, char **argv)
 	{
 		int c;
 
-		c = getopt (argc, argv, "htTC:"
+		c = getopt (argc, argv, "htTfC:"
 #if COLLECT_DAEMON
-				"fP:"
+				"P:"
 #endif
 		);
 
@@ -535,6 +535,9 @@ int main (int argc, char **argv)
 				break;
 			case 'f':
 				daemonize = 0;
+				break;
+#else
+			case 'f':
 				break;
 #endif /* COLLECT_DAEMON */
 			case 'h':


### PR DESCRIPTION
`--disable-daemon` configure option means collectd can't fork to background, so it can only work as if `-f` option was given to normal collectd. However collectdmon adds `-f` to collectd arguments regarless of this flag, and collectd crashes since it does not know the option `-f` anymore. Let's ignore the `-f` option if compiled like this, since collectd does work the same way as if this this option were available and provided.

ChangeLog: collectd: Recognize the `-f` command line option, even if the daemon was compiled with `--disable-daemon`.