### PR TITLE
Added SSLCiphers into Instance section to select ciphers from client

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -48,6 +48,7 @@ struct apache_s
 	_Bool verify_peer;
 	_Bool verify_host;
 	char *cacert;
+	char *ssl_ciphers;
 	char *server; /* user specific server type */
 	char *apache_buffer;
 	char apache_curl_error[CURL_ERROR_SIZE];
@@ -72,6 +73,7 @@ static void apache_free (apache_t *st)
 	sfree (st->user);
 	sfree (st->pass);
 	sfree (st->cacert);
+	sfree (st->ssl_ciphers);
 	sfree (st->server);
 	sfree (st->apache_buffer);
 	if (st->curl) {
@@ -205,6 +207,8 @@ static int config_add (oconfig_item_t *ci)
 			status = cf_util_get_boolean (child, &st->verify_host);
 		else if (strcasecmp ("CACert", child->key) == 0)
 			status = cf_util_get_string (child, &st->cacert);
+		else if (strcasecmp ("SSLCiphers", child->key) == 0)
+			status = cf_util_get_string (child, &st->ssl_ciphers);
 		else if (strcasecmp ("Server", child->key) == 0)
 			status = cf_util_get_string (child, &st->server);
 		else
@@ -361,6 +365,8 @@ static int init_host (apache_t *st) /* {{{ */
 			st->verify_host ? 2L : 0L);
 	if (st->cacert != NULL)
 		curl_easy_setopt (st->curl, CURLOPT_CAINFO, st->cacert);
+	if (st->ssl_ciphers != NULL)
+		curl_easy_setopt (st->curl, CURLOPT_SSL_CIPHER_LIST,st->ssl_ciphers);
 
 	return (0);
 } /* }}} int init_host */

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -766,6 +766,11 @@ File that holds one or more SSL certificates. If you want to use HTTPS you will
 possibly need this option. What CA certificates come bundled with C<libcurl>
 and are checked by default depends on the distribution you use.
 
+=item B<SSLCiphers> I<list of ciphers>
+
+(SSL) Specifies which ciphers to use in the connection. The list of ciphers must 
+specify valid ciphers. Read up on SSL cipher list details on this URL:
+              http://www.openssl.org/docs/apps/ciphers.html
 =back
 
 =head2 Plugin C<apcups>


### PR DESCRIPTION
Libcurl and curl itself have disabled by default some ciphers by example RC4 from libcurl > 7.34 as you can see  in the following link.

http://curl.haxx.se/mail/tracker-2014-11/0046.html

"curl" tool client can force ciphers with --ciphers option.

With this new option  "SSLCiphers" you can force also any cipher suite from the apache plugin configuration.

take as example:

````
LoadPlugin apache
<Plugin apache>

  <Instance "test_0">
    URL "https://localhost:440/server-status?auto"
    CACert "/opt/collectd/etc/ca-bundle.crt"
    SSLCiphers "RC4-SHA"
    VerifyPeer false
    VerifyHost false
  </Instance>

</Plugin apache>
````
