### PR TITLE
avoid using CURLOPT_USERPWD when possible

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -283,8 +283,6 @@ static int config (oconfig_item_t *ci)
 /* initialize curl for each host */
 static int init_host (apache_t *st) /* {{{ */
 {
-	static char credentials[1024];
-
 	assert (st->url != NULL);
 	/* (Assured by `config_add') */
 
@@ -334,6 +332,12 @@ static int init_host (apache_t *st) /* {{{ */
 
 	if (st->user != NULL)
 	{
+#ifdef HAVE_CURLOPT_USERNAME
+		curl_easy_setopt (st->curl, CURLOPT_USERNAME, st->user);
+		curl_easy_setopt (st->curl, CURLOPT_PASSWORD,
+				(st->pass == NULL) ? "" : st->pass);
+#else
+		static char credentials[1024];
 		int status;
 
 		status = ssnprintf (credentials, sizeof (credentials), "%s:%s",
@@ -349,6 +353,7 @@ static int init_host (apache_t *st) /* {{{ */
 		}
 
 		curl_easy_setopt (st->curl, CURLOPT_USERPWD, credentials);
+#endif
 	}
 
 	curl_easy_setopt (st->curl, CURLOPT_URL, st->url);

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -524,8 +524,6 @@ static int ascent_config (const char *key, const char *value) /* {{{ */
 
 static int ascent_init (void) /* {{{ */
 {
-  static char credentials[1024];
-
   if (url == NULL)
   {
     WARNING ("ascent plugin: ascent_init: No URL configured, "
@@ -551,6 +549,11 @@ static int ascent_init (void) /* {{{ */
 
   if (user != NULL)
   {
+#ifdef HAVE_CURLOPT_USERNAME
+    curl_easy_setopt (curl, CURLOPT_USERNAME, user);
+    curl_easy_setopt (curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
+#else
+    static char credentials[1024];
     int status;
 
     status = ssnprintf (credentials, sizeof (credentials), "%s:%s",
@@ -563,6 +566,7 @@ static int ascent_init (void) /* {{{ */
     }
 
     curl_easy_setopt (curl, CURLOPT_USERPWD, credentials);
+#endif
   }
 
   curl_easy_setopt (curl, CURLOPT_URL, url);

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -113,8 +113,6 @@ static int config (const char *key, const char *value)
 
 static int init (void)
 {
-  static char credentials[1024];
-
   if (curl != NULL)
     curl_easy_cleanup (curl);
 
@@ -131,6 +129,11 @@ static int init (void)
 
   if (user != NULL)
   {
+#ifdef HAVE_CURLOPT_USERNAME
+    curl_easy_setopt (curl, CURLOPT_USERNAME, user);
+    curl_easy_setopt (curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
+#else
+    static char credentials[1024];
     int status = ssnprintf (credentials, sizeof (credentials),
 	"%s:%s", user, pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t) status >= sizeof (credentials)))
@@ -140,6 +143,7 @@ static int init (void)
     }
 
     curl_easy_setopt (curl, CURLOPT_USERPWD, credentials);
+#endif
   }
 
   if (url != NULL)

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -140,6 +140,11 @@ static int wh_callback_init (wh_callback_t *cb) /* {{{ */
 
         if (cb->user != NULL)
         {
+#ifdef HAVE_CURLOPT_USERNAME
+                curl_easy_setopt (cb->curl, CURLOPT_USERNAME, cb->user);
+                curl_easy_setopt (cb->curl, CURLOPT_PASSWORD,
+                        (cb->pass == NULL) ? "" : cb->pass);
+#else
                 size_t credentials_size;
 
                 credentials_size = strlen (cb->user) + 2;
@@ -156,6 +161,7 @@ static int wh_callback_init (wh_callback_t *cb) /* {{{ */
                 ssnprintf (cb->credentials, credentials_size, "%s:%s",
                                 cb->user, (cb->pass == NULL) ? "" : cb->pass);
                 curl_easy_setopt (cb->curl, CURLOPT_USERPWD, cb->credentials);
+#endif
                 curl_easy_setopt (cb->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
         }
 


### PR DESCRIPTION
CURLOPT_USERPWD chokes on colons inside usernames or passwords, so use
CURLOPT_USERNAME and CURLOPT_PASSWORD if curl 7.19.1 or newer is found.

Follow-up to 0af75dc13 for the rest of the plugins based on libcurl.