### PR TITLE
Fix an autoreconf warning

### DIFF
--- a/libltdl/config/.gitignore
+++ b/libltdl/config/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/libltdl/m4/.gitignore
+++ b/libltdl/m4/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Check in the 2 empty dirs autoreconf needs.

Fixes:
+ autoreconf -vif
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I libltdl/m4
aclocal: warning: couldn't open directory 'libltdl/m4': No such file or
directory
autoreconf: configure.ac: tracing
autoreconf: configure.ac: subdirectory libltdl not present
autoreconf: configure.ac: creating directory libltdl/config
autoreconf: cannot create libltdl/config: No such file or directory