### PR TITLE
Only run git describe when we're in a git repo

### DIFF
--- a/version-gen.sh
+++ b/version-gen.sh
@@ -2,7 +2,9 @@
 
 DEFAULT_VERSION="5.5.0.git"
 
-VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | grep collectd | sed -e 's/^collectd-//' -e 's/-/./g'`"
+if [ -d .git ]; then
+	VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | grep collectd | sed -e 's/^collectd-//' -e 's/-/./g'`"
+fi
 
 if test -z "$VERSION"; then
 	VERSION="$DEFAULT_VERSION"


### PR DESCRIPTION
This fixes an issue I see when extracting a collectd
tarball into another git repo (the Fedora collectd rpm one).
In that case version-gen.sh picked up the last tag from the Fedora
repo, which is the wrong one.