### PR TITLE
Ceph: do not define _BSD_SOURCE

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -21,6 +21,7 @@
  *   Dan Ryder <daryder@cisco.com>
  **/
 
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 
 #include "collectd.h"


### PR DESCRIPTION
As far as I can see it doesn't need any definitions
exposed by this define.

Fixes:
make[3]: Entering directory '/home/ruben/src/collectd/src'
  CC       ceph_la-ceph.lo
In file included from /usr/include/stdio.h:27:0,
                 from ./daemon/collectd.h:34,
                 from ceph.c:26:
/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and
_SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use
 # _DEFAULT_SOURCE"
   ^
cc1: all warnings being treated as errors
Makefile:4120: recipe for target 'ceph_la-ceph.lo' failed
make[3]: *** [ceph_la-ceph.lo] Error 1
make[3]: Leaving directory '/home/ruben/src/collectd/src'
Makefile:5096: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/home/ruben/src/collectd/src'
Makefile:3142: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/ruben/src/collectd/src'
Makefile:551: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1