### PR TITLE
Fix a libtool warning

### DIFF
--- a/src/liboconfig/Makefile.am
+++ b/src/liboconfig/Makefile.am
@@ -6,5 +6,5 @@ AM_YFLAGS = -d
 
 noinst_LTLIBRARIES = liboconfig.la
 
-liboconfig_la_LDFLAGS = -version-info 0:0:0 $(LEXLIB)
+liboconfig_la_LDFLAGS = -avoid-version $(LEXLIB)
 liboconfig_la_SOURCES = oconfig.c oconfig.h aux_types.h scanner.l parser.y


### PR DESCRIPTION
libtool: warning: '-version-info/-version-number' is ignored for
convenience libraries