### PR TITLE
Support specifying connection timeouts for curl and curl_json

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1190,6 +1190,7 @@ Sets the plugin instance to I<Instance>.
 =item B<CACert> I<file>
 =item B<Header> I<Header>
 =item B<Post> I<Body>
+=item B<Timeout> I<Timeout in miliseconds>
 
 These options behave exactly equivalent to the appropriate options of the
 I<cURL> plugin. Please see there for a detailed description.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1111,6 +1111,13 @@ used by the C<tail> plugin, so please see the documentation of the C<tail>
 plugin below on how matches are defined. If the B<MeasureResponseTime> option
 is set to B<true>, B<Match> blocks are optional.
 
+=item B<Timeout> I<Timeout in miliseconds>
+
+The B<Timeout> option sets the overall timeout for each request. Make sure that
+collectd is configured with enough C<ReadThreads>, otherwise an overly long
+timeout could block other plugins. By default, no timeout is configured (B<0>)
+and requests might hang indefinitely.
+
 =back
 
 =head2 Plugin C<curl_json>

--- a/src/curl.c
+++ b/src/curl.c
@@ -65,6 +65,7 @@ struct web_page_s /* {{{ */
   char *post_body;
   _Bool response_time;
   _Bool response_code;
+  int timeout;
 
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];
@@ -400,6 +401,7 @@ static int cc_page_init_curl (web_page_t *wp) /* {{{ */
     curl_easy_setopt (wp->curl, CURLOPT_HTTPHEADER, wp->headers);
   if (wp->post_body != NULL)
     curl_easy_setopt (wp->curl, CURLOPT_POSTFIELDS, wp->post_body);
+  curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout);
 
   return (0);
 } /* }}} int cc_page_init_curl */
@@ -430,6 +432,7 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
   page->verify_host = 1;
   page->response_time = 0;
   page->response_code = 0;
+  page->timeout = 0;
 
   page->instance = strdup (ci->values[0].value.string);
   if (page->instance == NULL)
@@ -468,6 +471,8 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
       status = cc_config_append_string ("Header", &page->headers, child);
     else if (strcasecmp ("Post", child->key) == 0)
       status = cf_util_get_string (child, &page->post_body);
+    else if (strcasecmp ("Timeout", child->key) == 0)
+      status = cf_util_get_int (child, &page->timeout);
     else
     {
       WARNING ("curl plugin: Option `%s' not allowed here.", child->key);

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -76,6 +76,7 @@ struct cj_s /* {{{ */
   char *cacert;
   struct curl_slist *headers;
   char *post_body;
+  int timeout;
 
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];
@@ -637,6 +638,7 @@ static int cj_init_curl (cj_t *db) /* {{{ */
     curl_easy_setopt (db->curl, CURLOPT_HTTPHEADER, db->headers);
   if (db->post_body != NULL)
     curl_easy_setopt (db->curl, CURLOPT_POSTFIELDS, db->post_body);
+  curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS, db->timeout);
 
   return (0);
 } /* }}} int cj_init_curl */
@@ -704,6 +706,8 @@ static int cj_config_add_url (oconfig_item_t *ci) /* {{{ */
       status = cf_util_get_string (child, &db->post_body);
     else if (strcasecmp ("Key", child->key) == 0)
       status = cj_config_add_key (db, child);
+    else if (db->url && strcasecmp ("Timeout", child->key) == 0)
+      status = cf_util_get_int (child, &db->timeout);
     else
     {
       WARNING ("curl_json plugin: Option `%s' not allowed here.", child->key);


### PR DESCRIPTION
Would be nice to do the same for curl_xml, but I don't currently use that plugin.