### PR TITLE
Support specifying connection timeouts for curl and curl_json

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1562,6 +1562,7 @@ URL. By default the global B<Interval> setting will be used.
 =item B<Header> I<Header>
 
 =item B<Post> I<Body>
+=item B<Timeout> I<Timeout in miliseconds>
 
 These options behave exactly equivalent to the appropriate options of the
 I<cURL> plugin. Please see there for a detailed description.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1469,6 +1469,14 @@ plugin below on how matches are defined. If the B<MeasureResponseTime> or
 B<MeasureResponseCode> options are set to B<true>, B<Match> blocks are
 optional.
 
+=item B<Timeout> I<Timeout in miliseconds>
+
+The B<Timeout> option sets the overall timeout for each request. Make sure that
+collectd is configured with enough C<ReadThreads>, otherwise an overly long
+timeout could block other plugins. By default or when set to B<0>, a timeout
+equal to the B<Interval> is used. Prior to version 5.5.0, there was no timeout
+and requests might hang indefinitely.
+
 =back
 
 =head2 Plugin C<curl_json>

--- a/src/curl.c
+++ b/src/curl.c
@@ -66,6 +66,7 @@ struct web_page_s /* {{{ */
   char *post_body;
   _Bool response_time;
   _Bool response_code;
+  int timeout;
 
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];
@@ -409,6 +410,7 @@ static int cc_page_init_curl (web_page_t *wp) /* {{{ */
     curl_easy_setopt (wp->curl, CURLOPT_HTTPHEADER, wp->headers);
   if (wp->post_body != NULL)
     curl_easy_setopt (wp->curl, CURLOPT_POSTFIELDS, wp->post_body);
+  curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout > 0 ? wp->timeout : cf_get_default_interval ());
 
   return (0);
 } /* }}} int cc_page_init_curl */
@@ -440,6 +442,7 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
   page->verify_host = 1;
   page->response_time = 0;
   page->response_code = 0;
+  page->timeout = 0;
 
   page->instance = strdup (ci->values[0].value.string);
   if (page->instance == NULL)
@@ -480,6 +483,8 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
       status = cc_config_append_string ("Header", &page->headers, child);
     else if (strcasecmp ("Post", child->key) == 0)
       status = cf_util_get_string (child, &page->post_body);
+    else if (strcasecmp ("Timeout", child->key) == 0)
+      status = cf_util_get_int (child, &page->timeout);
     else
     {
       WARNING ("curl plugin: Option `%s' not allowed here.", child->key);


### PR DESCRIPTION
Continuing from #982.

TODO: by default, use the configured interval rather than "no timeout".