### PR TITLE
Fix type instance sanitization in bind plugin

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -266,7 +266,7 @@ static void submit (time_t ts, const char *plugin_instance, /* {{{ */
   if (type_instance) {
     sstrncpy(vl.type_instance, type_instance,
         sizeof(vl.type_instance));
-    replace_special (vl.plugin_instance, sizeof (vl.plugin_instance));
+    replace_special (vl.type_instance, sizeof (vl.type_instance));
   }
   plugin_dispatch_values(&vl);
 } /* }}} void submit */


### PR DESCRIPTION
Noticed this copy-paste bug. Happy to send this PR, but I'm not readily equipped to build or test this... found it while browsing the code to determine the behavior of another plugin.