### PR TITLE
Curl plugins connection timeout

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -53,6 +53,7 @@ struct apache_s
 	char apache_curl_error[CURL_ERROR_SIZE];
 	size_t apache_buffer_size;
 	size_t apache_buffer_fill;
+	int timeout;
 	CURL *curl;
 }; /* apache_s */
 
@@ -179,6 +180,8 @@ static int config_add (oconfig_item_t *ci)
 	}
 	memset (st, 0, sizeof (*st));
 
+	st->timeout = -1;
+
 	status = cf_util_get_string (ci, &st->name);
 	if (status != 0)
 	{
@@ -207,6 +210,8 @@ static int config_add (oconfig_item_t *ci)
 			status = cf_util_get_string (child, &st->cacert);
 		else if (strcasecmp ("Server", child->key) == 0)
 			status = cf_util_get_string (child, &st->server);
+		else if (strcasecmp ("Timeout", child->key) == 0)
+			status = cf_util_get_int (child, &st->timeout);
 		else
 		{
 			WARNING ("apache plugin: Option `%s' not allowed here.",
@@ -366,6 +371,12 @@ static int init_host (apache_t *st) /* {{{ */
 			st->verify_host ? 2L : 0L);
 	if (st->cacert != NULL)
 		curl_easy_setopt (st->curl, CURLOPT_CAINFO, st->cacert);
+
+	if (st->timeout >= 0)
+		curl_easy_setopt (st->curl, CURLOPT_TIMEOUT_MS, st->timeout);
+	else
+		curl_easy_setopt (st->curl, CURLOPT_TIMEOUT_MS,
+				CDTIME_T_TO_MS(plugin_get_interval()));
 
 	return (0);
 } /* }}} int init_host */

--- a/src/apache.c
+++ b/src/apache.c
@@ -373,7 +373,7 @@ static int init_host (apache_t *st) /* {{{ */
 		curl_easy_setopt (st->curl, CURLOPT_CAINFO, st->cacert);
 
 	if (st->timeout >= 0)
-		curl_easy_setopt (st->curl, CURLOPT_TIMEOUT_MS, st->timeout);
+		curl_easy_setopt (st->curl, CURLOPT_TIMEOUT_MS, (long) st->timeout);
 	else
 		curl_easy_setopt (st->curl, CURLOPT_TIMEOUT_MS,
 				CDTIME_T_TO_MS(plugin_get_interval()));

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -102,6 +102,7 @@ static char *pass        = NULL;
 static char *verify_peer = NULL;
 static char *verify_host = NULL;
 static char *cacert      = NULL;
+static char *timeout     = NULL;
 
 static CURL *curl = NULL;
 
@@ -117,7 +118,8 @@ static const char *config_keys[] =
   "Password",
   "VerifyPeer",
   "VerifyHost",
-  "CACert"
+  "CACert",
+  "Timeout",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
@@ -518,6 +520,8 @@ static int ascent_config (const char *key, const char *value) /* {{{ */
     return (config_set (&verify_host, value));
   else if (strcasecmp (key, "CACert") == 0)
     return (config_set (&cacert, value));
+  else if (strcasecmp (key, "Timeout") == 0)
+    return (config_set (&timeout, value));
   else
     return (-1);
 } /* }}} int ascent_config */
@@ -585,6 +589,12 @@ static int ascent_init (void) /* {{{ */
 
   if (cacert != NULL)
     curl_easy_setopt (curl, CURLOPT_CAINFO, cacert);
+
+  if (timeout != NULL)
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atoi(timeout));
+  else
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS,
+       CDTIME_T_TO_MS(plugin_get_interval()));
 
   return (0);
 } /* }}} int ascent_init */

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -591,7 +591,7 @@ static int ascent_init (void) /* {{{ */
     curl_easy_setopt (curl, CURLOPT_CAINFO, cacert);
 
   if (timeout != NULL)
-    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atoi(timeout));
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atol(timeout));
   else
     curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS,
        CDTIME_T_TO_MS(plugin_get_interval()));

--- a/src/bind.c
+++ b/src/bind.c
@@ -109,6 +109,7 @@ static int global_server_stats     = 1;
 static int global_zone_maint_stats = 1;
 static int global_resolver_stats   = 0;
 static int global_memory_stats     = 1;
+static int timeout                 = -1;
 
 static cb_view_t *views = NULL;
 static size_t     views_num = 0;
@@ -1695,6 +1696,8 @@ static int bind_config (oconfig_item_t *ci) /* {{{ */
       bind_config_add_view (child);
     else if (strcasecmp ("ParseTime", child->key) == 0)
       cf_util_get_boolean (child, &config_parse_time);
+    else if (strcasecmp ("Timeout", child->key) == 0)
+      cf_util_get_int (child, &timeout);
     else
     {
       WARNING ("bind plugin: Unknown configuration option "
@@ -1724,6 +1727,9 @@ static int bind_init (void) /* {{{ */
   curl_easy_setopt (curl, CURLOPT_URL, (url != NULL) ? url : BIND_DEFAULT_URL);
   curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt (curl, CURLOPT_MAXREDIRS, 50L);
+  curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, (timeout >= 0) ?
+      timeout : CDTIME_T_TO_MS(plugin_get_interval()));
+
 
   return (0);
 } /* }}} int bind_init */

--- a/src/bind.c
+++ b/src/bind.c
@@ -1728,7 +1728,7 @@ static int bind_init (void) /* {{{ */
   curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt (curl, CURLOPT_MAXREDIRS, 50L);
   curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, (timeout >= 0) ?
-      timeout : CDTIME_T_TO_MS(plugin_get_interval()));
+      (long) timeout : CDTIME_T_TO_MS(plugin_get_interval()));
 
 
   return (0);

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -4114,6 +4114,12 @@ File that holds one or more SSL certificates. If you want to use HTTPS you will
 possibly need this option. What CA certificates come bundled with C<libcurl>
 and are checked by default depends on the distribution you use.
 
+=item B<Timeout> I<Milliseconds>
+
+The B<Timeout> option sets the overall timeout for HTTP requests, in
+milliseconds. By default, the configured B<Interval> is used to set the
+timeout.
+
 =back
 
 =head2 Plugin C<notify_desktop>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1673,6 +1673,8 @@ Examples:
 
 =item B<Post> I<Body>
 
+=item B<Timeout> I<Milliseconds>
+
 These options behave exactly equivalent to the appropriate options of the
 I<cURL plugin>. Please see there for a detailed description.
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1562,6 +1562,7 @@ URL. By default the global B<Interval> setting will be used.
 =item B<Header> I<Header>
 
 =item B<Post> I<Body>
+=item B<Timeout> I<Timeout in miliseconds>
 
 These options behave exactly equivalent to the appropriate options of the
 I<cURL> plugin. Please see there for a detailed description.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1133,6 +1133,12 @@ Collect global memory statistics.
 
 Default: Enabled.
 
+=item B<Timeout> I<Milliseconds>
+
+The B<Timeout> option sets the overall timeout for HTTP requests, in
+milliseconds. By default, the configured B<Interval> is used to set the
+timeout.
+
 =item B<View> I<Name>
 
 Collect statistics about a specific I<"view">. BIND can behave different,

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1469,6 +1469,14 @@ plugin below on how matches are defined. If the B<MeasureResponseTime> or
 B<MeasureResponseCode> options are set to B<true>, B<Match> blocks are
 optional.
 
+=item B<Timeout> I<Timeout in miliseconds>
+
+The B<Timeout> option sets the overall timeout for each request. Make sure that
+collectd is configured with enough C<ReadThreads>, otherwise an overly long
+timeout could block other plugins. By default or when set to B<0>, a timeout
+equal to the B<Interval> is used. Prior to version 5.5.0, there was no timeout
+and requests might hang indefinitely.
+
 =back
 
 =head2 Plugin C<curl_json>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -775,6 +775,12 @@ File that holds one or more SSL certificates. If you want to use HTTPS you will
 possibly need this option. What CA certificates come bundled with C<libcurl>
 and are checked by default depends on the distribution you use.
 
+=item B<Timeout> I<Milliseconds>
+
+The B<Timeout> option sets the overall timeout for HTTP requests, in
+milliseconds. By default, the configured B<Interval> is used to set the
+timeout.
+
 =back
 
 =head2 Plugin C<apcups>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1455,6 +1455,10 @@ C<application/x-www-form-urlencoded>).
 Measure response time for the request. If this setting is enabled, B<Match>
 blocks (see below) are optional. Disabled by default.
 
+Beware that requests will get aborted if they take too long to complete. Adjust
+B<Timeout> accordingly if you expect B<MeasureResponseTime> to report such slow
+requests.
+
 =item B<MeasureResponseCode> B<true>|B<false>
 
 Measure response code for the request. If this setting is enabled, B<Match>
@@ -1469,13 +1473,17 @@ plugin below on how matches are defined. If the B<MeasureResponseTime> or
 B<MeasureResponseCode> options are set to B<true>, B<Match> blocks are
 optional.
 
-=item B<Timeout> I<Timeout in miliseconds>
+=item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for each request. Make sure that
-collectd is configured with enough C<ReadThreads>, otherwise an overly long
-timeout could block other plugins. By default or when set to B<0>, a timeout
-equal to the B<Interval> is used. Prior to version 5.5.0, there was no timeout
-and requests might hang indefinitely.
+The B<Timeout> option sets the overall timeout for HTTP requests, in
+milliseconds. By default, the configured B<Interval> is used to set the
+timeout. Prior to version 5.5.0, there was no timeout and requests could hang
+indefinitely. This legacy behaviour can be achieved by setting the value of
+B<Timeout> to 0.
+
+If B<Timeout> is 0 or bigger than the B<Interval>, keep in mind that each slow
+network connection will stall one read thread. Adjust the B<ReadThreads> global
+setting accordingly to prevent this from blocking other plugins.
 
 =back
 
@@ -1562,7 +1570,8 @@ URL. By default the global B<Interval> setting will be used.
 =item B<Header> I<Header>
 
 =item B<Post> I<Body>
-=item B<Timeout> I<Timeout in miliseconds>
+
+=item B<Timeout> I<Milliseconds>
 
 These options behave exactly equivalent to the appropriate options of the
 I<cURL> plugin. Please see there for a detailed description.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -777,7 +777,7 @@ and are checked by default depends on the distribution you use.
 
 =item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for HTTP requests, in
+The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout.
 
@@ -871,7 +871,7 @@ and are checked by default depends on the distribution you use.
 
 =item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for HTTP requests, in
+The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout.
 
@@ -1141,7 +1141,7 @@ Default: Enabled.
 
 =item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for HTTP requests, in
+The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout.
 
@@ -1493,7 +1493,7 @@ optional.
 
 =item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for HTTP requests, in
+The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout. Prior to version 5.5.0, there was no timeout and requests could hang
 indefinitely. This legacy behaviour can be achieved by setting the value of
@@ -4122,7 +4122,7 @@ and are checked by default depends on the distribution you use.
 
 =item B<Timeout> I<Milliseconds>
 
-The B<Timeout> option sets the overall timeout for HTTP requests, in
+The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout.
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -869,6 +869,12 @@ File that holds one or more SSL certificates. If you want to use HTTPS you will
 possibly need this option. What CA certificates come bundled with C<libcurl>
 and are checked by default depends on the distribution you use.
 
+=item B<Timeout> I<Milliseconds>
+
+The B<Timeout> option sets the overall timeout for HTTP requests, in
+milliseconds. By default, the configured B<Interval> is used to set the
+timeout.
+
 =back
 
 =head2 Plugin C<barometer>

--- a/src/curl.c
+++ b/src/curl.c
@@ -66,6 +66,7 @@ struct web_page_s /* {{{ */
   char *post_body;
   _Bool response_time;
   _Bool response_code;
+  int timeout;
 
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];
@@ -409,6 +410,7 @@ static int cc_page_init_curl (web_page_t *wp) /* {{{ */
     curl_easy_setopt (wp->curl, CURLOPT_HTTPHEADER, wp->headers);
   if (wp->post_body != NULL)
     curl_easy_setopt (wp->curl, CURLOPT_POSTFIELDS, wp->post_body);
+  curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout > 0 ? wp->timeout : cf_get_default_interval ());
 
   return (0);
 } /* }}} int cc_page_init_curl */
@@ -440,6 +442,7 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
   page->verify_host = 1;
   page->response_time = 0;
   page->response_code = 0;
+  page->timeout = 0;
 
   page->instance = strdup (ci->values[0].value.string);
   if (page->instance == NULL)
@@ -480,6 +483,8 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
       status = cc_config_append_string ("Header", &page->headers, child);
     else if (strcasecmp ("Post", child->key) == 0)
       status = cf_util_get_string (child, &page->post_body);
+    else if (strcasecmp ("Timeout", child->key) == 0)
+      status = cf_util_get_int (child, &page->timeout);
     else
     {
       WARNING ("curl plugin: Option `%s' not allowed here.", child->key);

--- a/src/curl.c
+++ b/src/curl.c
@@ -410,7 +410,12 @@ static int cc_page_init_curl (web_page_t *wp) /* {{{ */
     curl_easy_setopt (wp->curl, CURLOPT_HTTPHEADER, wp->headers);
   if (wp->post_body != NULL)
     curl_easy_setopt (wp->curl, CURLOPT_POSTFIELDS, wp->post_body);
-  curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout > 0 ? wp->timeout : cf_get_default_interval ());
+
+  if (wp->timeout >= 0)
+    curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout);
+  else
+    curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS,
+       CDTIME_T_TO_MS(plugin_get_interval()));
 
   return (0);
 } /* }}} int cc_page_init_curl */
@@ -442,7 +447,7 @@ static int cc_config_add_page (oconfig_item_t *ci) /* {{{ */
   page->verify_host = 1;
   page->response_time = 0;
   page->response_code = 0;
-  page->timeout = 0;
+  page->timeout = -1;
 
   page->instance = strdup (ci->values[0].value.string);
   if (page->instance == NULL)

--- a/src/curl.c
+++ b/src/curl.c
@@ -412,7 +412,7 @@ static int cc_page_init_curl (web_page_t *wp) /* {{{ */
     curl_easy_setopt (wp->curl, CURLOPT_POSTFIELDS, wp->post_body);
 
   if (wp->timeout >= 0)
-    curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, wp->timeout);
+    curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS, (long) wp->timeout);
   else
     curl_easy_setopt (wp->curl, CURLOPT_TIMEOUT_MS,
        CDTIME_T_TO_MS(plugin_get_interval()));

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -652,7 +652,7 @@ static int cj_init_curl (cj_t *db) /* {{{ */
     curl_easy_setopt (db->curl, CURLOPT_POSTFIELDS, db->post_body);
 
   if (db->timeout >= 0)
-    curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS, db->timeout);
+    curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS, (long) db->timeout);
   else if (db->interval > 0)
     curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS,
         CDTIME_T_TO_MS(db->timeout));

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -886,7 +886,7 @@ static int cx_init_curl (cx_t *db) /* {{{ */
     curl_easy_setopt (db->curl, CURLOPT_POSTFIELDS, db->post_body);
 
   if (db->timeout >= 0)
-    curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS, db->timeout);
+    curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS, (long) db->timeout);
   else
     curl_easy_setopt (db->curl, CURLOPT_TIMEOUT_MS,
        CDTIME_T_TO_MS(plugin_get_interval()));

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -183,7 +183,7 @@ static int init (void)
 
   if (timeout != NULL)
   {
-    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atoi(timeout));
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atol(timeout));
   }
   else
   {

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -39,6 +39,7 @@ static char *pass        = NULL;
 static char *verify_peer = NULL;
 static char *verify_host = NULL;
 static char *cacert      = NULL;
+static char *timeout     = NULL;
 
 static CURL *curl = NULL;
 
@@ -53,7 +54,8 @@ static const char *config_keys[] =
   "Password",
   "VerifyPeer",
   "VerifyHost",
-  "CACert"
+  "CACert",
+  "Timeout"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
@@ -107,6 +109,8 @@ static int config (const char *key, const char *value)
     return (config_set (&verify_host, value));
   else if (strcasecmp (key, "cacert") == 0)
     return (config_set (&cacert, value));
+  else if (strcasecmp (key, "timeout") == 0)
+    return (config_set (&timeout, value));
   else
     return (-1);
 } /* int config */
@@ -175,6 +179,16 @@ static int init (void)
   if (cacert != NULL)
   {
     curl_easy_setopt (curl, CURLOPT_CAINFO, cacert);
+  }
+
+  if (timeout != NULL)
+  {
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS, atoi(timeout));
+  }
+  else
+  {
+    curl_easy_setopt (curl, CURLOPT_TIMEOUT_MS,
+       CDTIME_T_TO_MS(plugin_get_interval()));
   }
 
   return (0);


### PR DESCRIPTION
This is a followup to #983. It changes/improves 2 things:
 - the default timeout is the effective plugin/plugin instance interval, not the global configured default.
 - it accepts `Timeout 0` which disables the timeout completely.