### PR TITLE
Update meta_data.c

### DIFF
--- a/src/meta_data.c
+++ b/src/meta_data.c
@@ -489,7 +489,7 @@ int meta_data_get_string (meta_data_t *md, /* {{{ */
 
   if (e->type != MD_TYPE_STRING)
   {
-    ERROR ("meta_data_get_signed_int: Type mismatch for key `%s'", e->key);
+    ERROR ("meta_data_get_string: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock (&md->lock);
     return (-ENOENT);
   }


### PR DESCRIPTION
In the function meta_data_get_string(), when the type mismatchs,the ERROR statement should be 
ERROR ("meta_data_get_string: Type mismatch for key `%s'", e->key);
not
ERROR ("meta_data_get_signed_int: Type mismatch for key `%s'", e->key);