### PR TITLE
FreeBSD jail fixes

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1791,7 +1791,7 @@ static int ps_read (void)
 	int wait     = 0;
 
 	kvm_t *kd;
-	char errbuf[1024];
+	char errbuf[_POSIX2_LINE_MAX];
 	struct kinfo_proc *procs;          /* array of processes */
 	struct kinfo_proc *proc_ptr = NULL;
 	int count;                         /* returns number of processes */

--- a/src/processes.c
+++ b/src/processes.c
@@ -1803,7 +1803,7 @@ static int ps_read (void)
 	ps_list_reset ();
 
 	/* Open the kvm interface, get a descriptor */
-	kd = kvm_open (NULL, NULL, NULL, 0, errbuf);
+	kd = kvm_openfiles (NULL, "/dev/null", NULL, 0, errbuf);
 	if (kd == NULL)
 	{
 		ERROR ("processes plugin: Cannot open kvm interface: %s",

--- a/src/swap.c
+++ b/src/swap.c
@@ -157,6 +157,8 @@ static int swap_init (void) /* {{{ */
 /* #endif defined(VM_SWAPUSAGE) */
 
 #elif HAVE_LIBKVM_GETSWAPINFO
+	char errbuf[1024];
+
 	if (kvm_obj != NULL)
 	{
 		kvm_close (kvm_obj);
@@ -165,14 +167,11 @@ static int swap_init (void) /* {{{ */
 
 	kvm_pagesize = getpagesize ();
 
-	if ((kvm_obj = kvm_open (NULL, /* execfile */
-					NULL, /* corefile */
-					NULL, /* swapfile */
-					O_RDONLY, /* flags */
-					NULL)) /* errstr */
-			== NULL)
+	kvm_obj = kvm_openfiles (NULL, "/dev/null", NULL, O_RDONLY, errbuf);
+
+	if (kvm_obj == NULL)
 	{
-		ERROR ("swap plugin: kvm_open failed.");
+		ERROR ("swap plugin: kvm_open failed, %s", errbuf);
 		return (-1);
 	}
 /* #endif HAVE_LIBKVM_GETSWAPINFO */

--- a/src/swap.c
+++ b/src/swap.c
@@ -157,7 +157,7 @@ static int swap_init (void) /* {{{ */
 /* #endif defined(VM_SWAPUSAGE) */
 
 #elif HAVE_LIBKVM_GETSWAPINFO
-	char errbuf[1024];
+	char errbuf[_POSIX2_LINE_MAX];
 
 	if (kvm_obj != NULL)
 	{
@@ -171,7 +171,7 @@ static int swap_init (void) /* {{{ */
 
 	if (kvm_obj == NULL)
 	{
-		ERROR ("swap plugin: kvm_open failed, %s", errbuf);
+		ERROR ("swap plugin: kvm_openfiles failed, %s", errbuf);
 		return (-1);
 	}
 /* #endif HAVE_LIBKVM_GETSWAPINFO */


### PR DESCRIPTION
Currently the process and swap plugins does not work inside Jail on FreeBSD, this patch fixes that.