### PR TITLE
/bin/sh on OSX doesn't understand -n

### DIFF
--- a/version-gen.sh
+++ b/version-gen.sh
@@ -10,4 +10,4 @@ fi
 
 VERSION="`echo \"$VERSION\" | sed -e 's/-/./g'`"
 
-echo -n "$VERSION"
+printf "%s" "$VERSION"


### PR DESCRIPTION
This breaks PACKAGEVERSION since the -n is left verbatim in the string.
Use the more portable printf instead