### PR TITLE
oconfig: fix oconfig_free to free all elements

### DIFF
--- a/src/java.c
+++ b/src/java.c
@@ -3078,10 +3078,8 @@ static int cjni_init (void) /* {{{ */
 
   if (config_block != NULL)
   {
-
     cjni_config_perform (config_block);
     oconfig_free (config_block);
-    config_block = NULL;
   }
 
   if (jvm == NULL)

--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -195,7 +195,7 @@ oconfig_item_t *oconfig_clone (const oconfig_item_t *ci_orig)
   return (ci_copy);
 } /* oconfig_item_t *oconfig_clone */
 
-void oconfig_free (oconfig_item_t *ci)
+void oconfig_free_all (oconfig_item_t *ci)
 {
   int i;
 
@@ -214,10 +214,17 @@ void oconfig_free (oconfig_item_t *ci)
     free (ci->values);
 
   for (i = 0; i < ci->children_num; i++)
-    oconfig_free (ci->children + i);
+    oconfig_free_all (ci->children + i);
 
   if (ci->children != NULL)
     free (ci->children);
+}
+
+void oconfig_free (oconfig_item_t *ci)
+{
+  oconfig_free_all (ci);
+  free (ci);
+  ci = NULL;
 }
 
 /*


### PR DESCRIPTION
The recursive nature of this function made it difficult to free the root
node of the config tree. Splitting it in 2 allows to work around this
problem.