### PR TITLE
write_redis: Correct and improve connection failure detection and logging

### DIFF
--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -125,11 +125,11 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   assert (node->conn != NULL);
   rr = redisCommand (node->conn, "ZADD %s %s %s", key, time, value);
   if (rr==NULL)
-    WARNING("ZADD command error. key:%s", key);
+    WARNING("ZADD command error. key:%s message:%s", key, node->conn->errstr);
 
   rr = redisCommand (node->conn, "SADD collectd/values %s", ident);
   if (rr==NULL)
-    WARNING("SADD command error. ident:%s", ident);
+    WARNING("SADD command error. ident:%s message:%s", ident, node->conn->errstr);
 
   pthread_mutex_unlock (&node->lock);
 

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -111,11 +111,12 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   if (node->conn == NULL)
   {
     node->conn = redisConnectWithTimeout ((char *)node->host, node->port, node->timeout);
-    if (node->conn == NULL)
+    if (node->conn != NULL && node->conn->err)
     {
-      ERROR ("write_redis plugin: Connecting to host \"%s\" (port %i) failed.",
+      ERROR ("write_redis plugin: Connecting to host \"%s\" (port %i) failed: %s",
           (node->host != NULL) ? node->host : "localhost",
-          (node->port != 0) ? node->port : 6379);
+          (node->port != 0) ? node->port : 6379,
+          node->conn->errstr);
       pthread_mutex_unlock (&node->lock);
       return (-1);
     }


### PR DESCRIPTION
Previously, the plugin did not actually check if it failed to connect to the redis server and would not print an error to the log. This corrects that and also prints the error responses from the server.