### PR TITLE
Plugin rrd: in synchronous file creation use lock_file

### DIFF
--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -709,18 +709,32 @@ int cu_rrd_create_file (const char *filename, /* {{{ */
   }
   else /* synchronous */
   {
-    status = srrd_create (filename, stepsize, last_up,
-        argc, (const char **) argv);
-
+    status = lock_file (filename);
     if (status != 0)
     {
-      WARNING ("cu_rrd_create_file: srrd_create (%s) returned status %i.",
-          filename, status);
+      if (status == EEXIST)
+        NOTICE ("cu_rrd_create_file: File \"%s\" is already being created.",
+            filename);
+      else
+        ERROR ("cu_rrd_create_file: Unable to lock file \"%s\".",
+            filename);
     }
     else
     {
-      DEBUG ("cu_rrd_create_file: Successfully created RRD file \"%s\".",
-          filename);
+      status = srrd_create (filename, stepsize, last_up,
+          argc, (const char **) argv);
+
+      if (status != 0)
+      {
+        WARNING ("cu_rrd_create_file: srrd_create (%s) returned status %i.",
+            filename, status);
+      }
+      else
+      {
+        DEBUG ("cu_rrd_create_file: Successfully created RRD file \"%s\".",
+            filename);
+      }
+      unlock_file (filename);
     }
   }
 


### PR DESCRIPTION
To prevent the creation of the same file at the same time multiple times and obtain a corrupt rrd file.

If you delete some rrd files or have a lot of new hosts and the rrd files are not created in 10 seconds (the default interval), you may get two threads creating the same file.