### PR TITLE
Plugin process: in Linux read the number of threads from   /proc/pid/status

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -778,33 +778,6 @@ static void ps_submit_fork_rate (derive_t value)
 
 /* ------- additional functions for KERNEL_LINUX/HAVE_THREAD_INFO ------- */
 #if KERNEL_LINUX
-static int ps_read_tasks (int pid)
-{
-	char           dirname[64];
-	DIR           *dh;
-	struct dirent *ent;
-	int count = 0;
-
-	ssnprintf (dirname, sizeof (dirname), "/proc/%i/task", pid);
-
-	if ((dh = opendir (dirname)) == NULL)
-	{
-		DEBUG ("Failed to open directory `%s'", dirname);
-		return (-1);
-	}
-
-	while ((ent = readdir (dh)) != NULL)
-	{
-		if (!isdigit ((int) ent->d_name[0]))
-			continue;
-		else
-			count++;
-	}
-	closedir (dh);
-
-	return ((count >= 1) ? count : 1);
-} /* int *ps_read_tasks */
-
 /* Read data from /proc/pid/status */
 static procstat_t *ps_read_status (int pid, procstat_t *ps)
 {
@@ -1023,11 +996,7 @@ int ps_read_process (int pid, procstat_t *ps, char *state)
 		}
 		if ( ps->num_lwp <= 0)
 		{
-			if ( (ps->num_lwp = ps_read_tasks (pid)) == -1 )
-			{
-				/* returns -1 => kernel 2.4 */
-				ps->num_lwp = 1;
-			}
+			ps->num_lwp = 1;
 		}
 		ps->num_proc = 1;
 	}

--- a/src/processes.c
+++ b/src/processes.c
@@ -828,7 +828,7 @@ static procstat_t *ps_read_status (int pid, procstat_t *ps)
 		char *endptr;
 
 		if (strncmp (buffer, "Vm", 2) != 0
-				|| strncmp (buffer, "Threads", 7) != 0)
+				&& strncmp (buffer, "Threads", 7) != 0)
 			continue;
 
 		numfields = strsplit (buffer, fields,

--- a/src/processes.c
+++ b/src/processes.c
@@ -811,10 +811,10 @@ static procstat_t *ps_read_status (int pid, procstat_t *ps)
 	FILE *fh;
 	char buffer[1024];
 	char filename[64];
-	unsigned long long lib = 0;
-	unsigned long long exe = 0;
-	unsigned long long data = 0;
-	unsigned long long threads = 0;
+	unsigned long lib = 0;
+	unsigned long exe = 0;
+	unsigned long data = 0;
+	unsigned long threads = 0;
 	char *fields[8];
 	int numfields;
 
@@ -824,7 +824,7 @@ static procstat_t *ps_read_status (int pid, procstat_t *ps)
 
 	while (fgets (buffer, sizeof(buffer), fh) != NULL)
 	{
-		long long tmp;
+		unsigned long tmp;
 		char *endptr;
 
 		if (strncmp (buffer, "Vm", 2) != 0
@@ -839,7 +839,7 @@ static procstat_t *ps_read_status (int pid, procstat_t *ps)
 
 		errno = 0;
 		endptr = NULL;
-		tmp = strtoll (fields[1], &endptr, /* base = */ 10);
+		tmp = strtoul (fields[1], &endptr, /* base = */ 10);
 		if ((errno == 0) && (endptr != fields[1]))
 		{
 			if (strncmp (buffer, "VmData", 6) == 0)


### PR DESCRIPTION
In Linux read the number of threads from  /proc/pid/status instead of counter the number of files in
/proc/pid/task/*.