### PR TITLE
Allow empty Plugin blocks.

### DIFF
--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -73,7 +73,7 @@ typedef struct cf_complex_callback_s
 typedef struct cf_value_map_s
 {
 	char *key;
-	int (*func) (const oconfig_item_t *);
+	int (*func) (oconfig_item_t *);
 } cf_value_map_t;
 
 typedef struct cf_global_option_s
@@ -86,9 +86,10 @@ typedef struct cf_global_option_s
 /*
  * Prototypes of callback functions
  */
-static int dispatch_value_typesdb (const oconfig_item_t *ci);
-static int dispatch_value_plugindir (const oconfig_item_t *ci);
-static int dispatch_loadplugin (const oconfig_item_t *ci);
+static int dispatch_value_typesdb (oconfig_item_t *ci);
+static int dispatch_value_plugindir (oconfig_item_t *ci);
+static int dispatch_loadplugin (oconfig_item_t *ci);
+static int dispatch_block_plugin (oconfig_item_t *ci);
 
 /*
  * Private variables
@@ -100,7 +101,8 @@ static cf_value_map_t cf_value_map[] =
 {
 	{"TypesDB",    dispatch_value_typesdb},
 	{"PluginDir",  dispatch_value_plugindir},
-	{"LoadPlugin", dispatch_loadplugin}
+	{"LoadPlugin", dispatch_loadplugin},
+	{"Plugin",     dispatch_block_plugin}
 };
 static int cf_value_map_num = STATIC_ARRAY_SIZE (cf_value_map);
 
@@ -225,7 +227,7 @@ static int dispatch_global_option (const oconfig_item_t *ci)
 	return (-1);
 } /* int dispatch_global_option */
 
-static int dispatch_value_typesdb (const oconfig_item_t *ci)
+static int dispatch_value_typesdb (oconfig_item_t *ci)
 {
 	int i = 0;
 
@@ -251,7 +253,7 @@ static int dispatch_value_typesdb (const oconfig_item_t *ci)
 	return (0);
 } /* int dispatch_value_typesdb */
 
-static int dispatch_value_plugindir (const oconfig_item_t *ci)
+static int dispatch_value_plugindir (oconfig_item_t *ci)
 {
 	assert (strcasecmp (ci->key, "PluginDir") == 0);
 	
@@ -264,7 +266,7 @@ static int dispatch_value_plugindir (const oconfig_item_t *ci)
 	return (0);
 }
 
-static int dispatch_loadplugin (const oconfig_item_t *ci)
+static int dispatch_loadplugin (oconfig_item_t *ci)
 {
 	int i;
 	const char *name;
@@ -348,7 +350,7 @@ static int dispatch_value_plugin (const char *plugin, oconfig_item_t *ci)
 	return (cf_dispatch (plugin, ci->key, buffer_ptr));
 } /* int dispatch_value_plugin */
 
-static int dispatch_value (const oconfig_item_t *ci)
+static int dispatch_value (oconfig_item_t *ci)
 {
 	int ret = -2;
 	int i;


### PR DESCRIPTION
If you use templates for the config file you can get a empty block plugin (by the conditions) and if you use autoload the plugin  is not loaded.