### PR TITLE
Plugin network: flush the write buffer at the specified timeout.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -769,6 +769,8 @@
 #		AuthFile "/etc/collectd/passwd"
 #		Interface "eth0"
 #	</Listen>
+#	ReapTime 0
+#	MaxAge 0
 #	MaxPacketSize 1452
 #
 #	# proxy setup (client and server as above):

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -4100,6 +4100,18 @@ multicast, and IPv4 and IPv6 packets. The default is to not change this value.
 That means that multicast packets will be sent with a TTL of C<1> (one) on most
 operating systems.
 
+=item B<ReapTime> I<Milliseconds>
+
+Specifies the the interval, in milliseconds, between runs of the thread to
+check if data in send buffer is older than B<MaxAge>. Set to zero to disable
+time based flushing (this is the default).
+
+=item B<MaxAge> I<Milliseconds>
+
+Flush the data in send buffer when the oldest data in the buffer is older
+than B<MaxAge>. Set to zero to disable time based flushing
+(this is the default).
+
 =item B<MaxPacketSize> I<1024-65535>
 
 Set the maximum size for datagrams received over the network. Packets larger


### PR DESCRIPTION
This patch create a thread that run at the interval specified in ``ReadTime`` and flushed the network buffer if the data is older that ``MaxAge``.

This solve the following problems:
- if you have a high interval some data may remain in the buffer and the network plugin will send in the next interval if the buffer is full or until the buffer is full.
- If you send few indicators they are not sent until the buffer is full
- if you have in time (``t1``) some data of ``host/plugin-plugin_instance/type...`` (``d1``) that remains in the buffer because it's not full, in the next interval ``t2``  you may get data for the same  ``d1`` in the same packet. If in destination the data of the second interval is processed  before data of ``t1`` you lost this data.
- The same previous problem if you get data in different packets and they arrive out of order. That happen to me
