### PR TITLE
Normalize interval

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -139,6 +139,12 @@ defined in this plugin. By default, this is disabled.
 
 Specifies the value of the timeout argument of the flush callback.
 
+=item B<NormalizeInterval> B<false>|B<true>
+
+When set to B<true> will normalize the time in which collect metrics for this
+plugin and the timestamp of resulting metrics as a multiple of the interval.
+The default value is B<false>.
+
 =back
 
 =item B<AutoLoadPlugin> B<false>|B<true>
@@ -264,11 +270,6 @@ to get data.
 
 This options limits the maximum value of the interval. The default value is
 B<86400>.
-
-=item B<NormalizeInterval> B<false>|B<true>
-
-When set to B<true> normalize the time in which query the read plugins
-to be a multiple of the interval. The default value is B<false>.
 
 =item B<Timeout> I<Iterations>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -265,6 +265,11 @@ to get data.
 This options limits the maximum value of the interval. The default value is
 B<86400>.
 
+=item B<NormalizeInterval> B<false>|B<true>
+
+When set to B<true> normalize the time in which query the read plugins
+to be a multiple of the interval. The default value is B<false>.
+
 =item B<Timeout> I<Iterations>
 
 Consider a value list "missing" when no update has been read or received for

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -115,7 +115,8 @@ static cf_global_option_t cf_global_options[] = {
     {"CollectInternalStats", NULL, 0, "false"},
     {"PreCacheChain", NULL, 0, "PreCache"},
     {"PostCacheChain", NULL, 0, "PostCache"},
-    {"MaxReadInterval", NULL, 0, "86400"}};
+    {"MaxReadInterval", NULL, 0, "86400"}
+	{"NormalizeInterval", NULL, "false"}};
 static int cf_global_options_num = STATIC_ARRAY_SIZE(cf_global_options);
 
 static int cf_default_typesdb = 1;

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -115,8 +115,7 @@ static cf_global_option_t cf_global_options[] = {
     {"CollectInternalStats", NULL, 0, "false"},
     {"PreCacheChain", NULL, 0, "PreCache"},
     {"PostCacheChain", NULL, 0, "PostCache"},
-    {"MaxReadInterval", NULL, 0, "86400"}
-	{"NormalizeInterval", NULL, "false"}};
+    {"MaxReadInterval", NULL, 0, "86400"}};
 static int cf_global_options_num = STATIC_ARRAY_SIZE(cf_global_options);
 
 static int cf_default_typesdb = 1;
@@ -303,6 +302,8 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
       cf_util_get_cdtime(child, &ctx.flush_interval);
     else if (strcasecmp("FlushTimeout", child->key) == 0)
       cf_util_get_cdtime(child, &ctx.flush_timeout);
+    else if (strcasecmp("NormalizeInterval", child->key) == 0)
+      cf_util_get_boolean(child, &ctx.normalize_interval);
     else {
       WARNING("Ignoring unknown LoadPlugin option \"%s\" "
               "for plugin \"%s\"",
@@ -814,7 +815,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
   return root;
 } /* oconfig_item_t *cf_read_generic */
-  /* #endif HAVE_WORDEXP_H */
+/* #endif HAVE_WORDEXP_H */
 
 #else  /* if !HAVE_WORDEXP_H */
 static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -185,6 +185,7 @@ struct plugin_ctx_s {
   cdtime_t interval;
   cdtime_t flush_interval;
   cdtime_t flush_timeout;
+  bool normalize_interval;
 };
 typedef struct plugin_ctx_s plugin_ctx_t;
 


### PR DESCRIPTION
ChangeLog: Add NormalizeInterval option per plugin to round the time of the collection of the metrics to the interval.

For example if you are counting the number of orders per minute you can get some strange number when you store the data in rrd, for example 6.5 orders  in the last minute ¿?

The rrdtool do a normalization of the data if the time are not normalize with the interval. This is explained here:

http://www.vandenbogaerdt.nl/rrdtool/process.php

With this patch you execute the plugins in a time that is multiple of the interval, for example with a `Interval` of `10` if the plugin will read at `1432308122.088` the patch change this to  `1432308130.000`.
