### PR TITLE
Plugin process:  in Linux count open file descriptors.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5422,6 +5422,10 @@ dispatched to the daemon using the specified I<name> as an identifier. This
 allows to "group" several processes together. I<name> must not contain
 slashes.
 
+=item B<CollectFileDescriptor> I<Boolean>
+
+Collect open file descriptors of the process.
+
 =back
 
 =head2 Plugin C<protocols>

--- a/src/types.db
+++ b/src/types.db
@@ -166,6 +166,7 @@ ps_cputime		user:DERIVE:0:U, syst:DERIVE:0:U
 ps_data			value:GAUGE:0:9223372036854775807
 ps_disk_octets		read:DERIVE:0:U, write:DERIVE:0:U
 ps_disk_ops		read:DERIVE:0:U, write:DERIVE:0:U
+ps_fd		value:GAUGE:0:9223372036854775807
 ps_pagefaults		minflt:DERIVE:0:U, majflt:DERIVE:0:U
 ps_rss			value:GAUGE:0:9223372036854775807
 ps_stacksize		value:GAUGE:0:9223372036854775807


### PR DESCRIPTION
Add the option CollectFileDescriptor since it's count the files in ``/proc/pid/fd/*`` and it's add some overhead.