### PR TITLE
make distcheck breaks in java bindings directory

### DIFF
--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -24,7 +24,7 @@ EXTRA_DIST = org/collectd/api/CollectdConfigInterface.java \
 	     org/collectd/java/GenericJMX.java \
 	     org/collectd/java/JMXMemory.java
 
-java-build-stamp: org/collectd/api/*.java org/collectd/java/*.java
+java-build-stamp: $(srcdir)/org/collectd/api/*.java $(srcdir)/org/collectd/java/*.java
 	$(JAVAC) -d "." "$(srcdir)/org/collectd/api"/*.java
 	$(JAVAC) -d "." "$(srcdir)/org/collectd/java"/*.java
 	mkdir -p .libs


### PR DESCRIPTION
Making all in java
make[3]: Entering directory
'/home/ruben/src/collectd/collectd-5.4.2.924.ga51e76ad9513/_build/sub/bindings/java'
make[3]: *** No rule to make target 'org/collectd/api/*.java', needed by
'java-build-stamp'.  Stop.
make[3]: Leaving directory
'/home/ruben/src/collectd/collectd-5.4.2.924.ga51e76ad9513/_build/sub/bindings/java'
Makefile:529: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory
'/home/ruben/src/collectd/collectd-5.4.2.924.ga51e76ad9513/_build/sub/bindings'
Makefile:551: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory
'/home/ruben/src/collectd/collectd-5.4.2.924.ga51e76ad9513/_build/sub'
Makefile:756: recipe for target 'distcheck' failed
make: *** [distcheck] Error 1

The prerequisites of the target are in $(srcdir), not $(builddir)