### PR TITLE
Added TCP plugin and tunneling to collectd-nagios

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5630,6 +5630,7 @@ AC_PLUGIN([target_scale],[yes],                [The scale target])
 AC_PLUGIN([target_set],  [yes],                [The set target])
 AC_PLUGIN([target_v5upgrade], [yes],           [The v5upgrade target])
 AC_PLUGIN([tcpconns],    [$plugin_tcpconns],   [TCP connection statistics])
+AC_PLUGIN([tcpsock],     [yes],                [Tcpsock communication plugin])
 AC_PLUGIN([teamspeak2],  [yes],                [TeamSpeak2 server statistics])
 AC_PLUGIN([ted],         [$plugin_ted],        [Read The Energy Detective values])
 AC_PLUGIN([thermal],     [$plugin_thermal],    [Linux ACPI thermal zone statistics])
@@ -6007,6 +6008,7 @@ Configuration:
     target_set  . . . . . $enable_target_set
     target_v5upgrade  . . $enable_target_v5upgrade
     tcpconns  . . . . . . $enable_tcpconns
+    tcpsock   . . . . . . $enable_tcpsock
     teamspeak2  . . . . . $enable_teamspeak2
     ted . . . . . . . . . $enable_ted
     thermal . . . . . . . $enable_thermal

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1309,6 +1309,7 @@ dist_man_MANS = collectd.1 \
 		collectd-tg.1 \
 		collectd-threshold.5 \
 		collectd-unixsock.5 \
+		collectd-tcpsock.5 \
 		types.db.5
 
 #collectd_1_SOURCES = collectd.pod
@@ -1329,6 +1330,7 @@ EXTRA_DIST +=   collectd.conf.pod \
 		collectd-tg.pod \
 		collectd-threshold.pod \
 		collectd-unixsock.pod \
+		collectd-tcpsock.pod \
 		postgresql_default.conf \
 		types.db.pod
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1046,6 +1046,20 @@ tcpconns_la_LIBADD += -lkvm
 endif
 endif
 
+if BUILD_PLUGIN_TCPSOCK
+pkglib_LTLIBRARIES += tcpsock.la
+tcpsock_la_SOURCES  = tcpsock.c \
+		      utils_cmd_flush.h utils_cmd_flush.c \
+		      utils_cmd_getval.h utils_cmd_getval.c \
+		      utils_cmd_getthreshold.h utils_cmd_getthreshold.c \
+		      utils_cmd_listval.h utils_cmd_listval.c \
+		      utils_cmd_putval.h utils_cmd_putval.c \
+		      utils_cmd_putnotif.h utils_cmd_putnotif.c \
+		      utils_parse_option.h utils_parse_option.c
+tcpsock_la_LDFLAGS  = $(PLUGIN_LDFLAGS)
+tcpsock_la_LIBADD   = -lpthread
+endif
+
 if BUILD_PLUGIN_TEAMSPEAK2
 pkglib_LTLIBRARIES += teamspeak2.la
 teamspeak2_la_SOURCES = teamspeak2.c

--- a/src/collectd-nagios.c
+++ b/src/collectd-nagios.c
@@ -671,6 +671,7 @@ int main (int argc, char **argv)
 				break;
 			case 't':
 				use_tcp_g = 1;
+				break;
 			case 'n':
 				value_string_g = optarg;
 				break;

--- a/src/collectd-nagios.c
+++ b/src/collectd-nagios.c
@@ -94,6 +94,7 @@ typedef struct range_s range_t;
 extern char *optarg;
 extern int optind, opterr, optopt;
 
+static int   use_tcp_g = 0;
 static char *socket_file_g = NULL;
 static char *value_string_g = NULL;
 static char *hostname_g = NULL;
@@ -251,6 +252,7 @@ static void usage (const char *name)
 			"\n"
 			"Valid options are:\n"
 			"  -s <socket>    Path to collectd's UNIX-socket.\n"
+			"  -t             Connect to a listening TCP socket instead of a UNIX socket\n"
 			"  -n <v_spec>    Value specification to get from collectd.\n"
 			"                 Format: `plugin-instance/type-instance'\n"
 			"  -d <ds>        Select the DS to examine. May be repeated to examine multiple\n"
@@ -652,7 +654,7 @@ int main (int argc, char **argv)
 	{
 		int c;
 
-		c = getopt (argc, argv, "w:c:s:n:H:g:d:hm");
+		c = getopt (argc, argv, "w:c:s:n:H:g:d:hmt");
 		if (c < 0)
 			break;
 
@@ -667,6 +669,8 @@ int main (int argc, char **argv)
 			case 's':
 				socket_file_g = optarg;
 				break;
+			case 't':
+				use_tcp_g = 1;
 			case 'n':
 				value_string_g = optarg;
 				break;
@@ -727,7 +731,12 @@ int main (int argc, char **argv)
 		usage (argv[0]);
 	}
 
-	snprintf (address, sizeof (address), "unix:%s", socket_file_g);
+	if (use_tcp_g)
+	{
+		snprintf (address, sizeof (address), "%s", socket_file_g);
+	} else {
+		snprintf (address, sizeof (address), "unix:%s", socket_file_g);
+	}
 	address[sizeof (address) - 1] = 0;
 
 	connection = NULL;

--- a/src/collectd-nagios.pod
+++ b/src/collectd-nagios.pod
@@ -29,6 +29,10 @@ as no argument is passed more than once.
 
 Path of the UNIX socket opened by collectd's C<unixsock plugin>.
 
+=item B<-t>
+
+If this option is given, collectd-nagios connects via TCP to B<-s> I<socket>, opened by collectd's C<tcpsock plugin>.
+
 =item B<-n> I<value_spec>
 
 The value to read from collectd. The argument is in the form

--- a/src/collectd-tcpsock.pod
+++ b/src/collectd-tcpsock.pod
@@ -1,0 +1,50 @@
+=encoding UTF-8
+
+=head1 NAME
+
+collectd-tcpsock - Documentation of collectd's C<tcpsock plugin>
+
+=head1 SYNOPSIS
+
+  # See collectd.conf(5)
+  LoadPlugin tcpsock
+  <Plugin tcpsock>
+    Listen "127.0.0.1"
+    Port   "5576"
+  </Plugin>
+
+=head1 DESCRIPTION
+
+The C<tcpsock plugin> opens an TCP socket over which one can interact with
+the daemon. This can be used to use the values collected by collectd in other
+applications, such as monitoring solutions, or submit externally collected
+values to collectd.
+
+Functionallity is very similar to L<collectd-unixsock(5)>, but using
+TCP sockets instead of UNIX sockets eases tunneling data between hosts.
+
+For further information, see the manual of the L<collectd-unixsock(5)> plugin.
+
+=head1 EXAMPLES
+Setup two hosts: collectd.example.com (collecting push data from agents) and icinga.example.com (Monitoring system)
+On collectd.example.com: Enable plugin as shown above, enable ssh and make sure GatewayPorts (L<sshd_config(5)>) is not disabled.
+On icinga.example.com
+  make tunnel via SSH: ssh -nNTR 5576:localhost:5576 collectd.example.com
+  Test connection: collectd-nagios -s 127.0.0.1:5576 -t -H <SOME-MACHINE> -n df-var/percent_bytes-free -w 20: -c 10:
+Integrate collectd-nagios into Icinga/Nagios/Naemon/... as documented.
+
+
+=head1 SEE ALSO
+
+L<collectd(1)>,
+L<collectd.conf(5)>,
+L<collectd-unixsock(5)>,
+L<collectd-nagios(1)>,
+
+=head1 AUTHOR
+
+Written by Claudius Zingerli E<lt>czingerl@gmail.comE<gt> based on Florian Forster's E<lt>octo@collectd.orgE<gt>
+C<unixsock plugin>
+
+=head1 
+=cut

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -180,6 +180,7 @@
 #@BUILD_PLUGIN_TAIL_CSV_TRUE@LoadPlugin tail_csv
 #@BUILD_PLUGIN_TAPE_TRUE@LoadPlugin tape
 #@BUILD_PLUGIN_TCPCONNS_TRUE@LoadPlugin tcpconns
+#@BUILD_PLUGIN_TCPSOCK_TRUE@LoadPlugin tcpsock
 #@BUILD_PLUGIN_TEAMSPEAK2_TRUE@LoadPlugin teamspeak2
 #@BUILD_PLUGIN_TED_TRUE@LoadPlugin ted
 #@BUILD_PLUGIN_THERMAL_TRUE@LoadPlugin thermal
@@ -1187,6 +1188,11 @@
 #	AllPortsSummary false
 #	LocalPort "25"
 #	RemotePort "25"
+#</Plugin>
+
+#<Plugin tcpsock>
+#	Listen "127.0.0.1"
+#	Port "5576"
 #</Plugin>
 
 #<Plugin teamspeak2>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6553,6 +6553,24 @@ are collectd. This option defaults to I<false>.
 
 =back
 
+=head2 Plugin C<tcpsock>
+
+The I<tcpsock> plugin creates a listening socket on I<Address>:I<Name> for incoming connections,
+similar to the L<unixsock> plugin.
+
+=over 4
+
+=item B<Listen> I<Address>
+
+Sets the listening address. Nummeric IPv4/IPv6 addresses or names are permitted
+
+=item B<Port> I<Name>
+
+Sets the listening port. Instead of a nummeric value, names from /etc/services
+can be used, too.
+
+=back
+
 =head2 Plugin C<thermal>
 
 =over 4

--- a/src/tcpsock.c
+++ b/src/tcpsock.c
@@ -1,0 +1,468 @@
+/**
+ * collectd - src/tcpsock.c
+ * Copyright (C) 2015 Claudius Zingerli
+ * most of the code is based on unixsock plugin:
+ * Copyright (C) 2007,2008  Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Claudius Zingerli <collectd-tcpsockmail at zeuz.ch>
+ **/
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+#include "configfile.h"
+
+#include "utils_cmd_flush.h"
+#include "utils_cmd_getval.h"
+#include "utils_cmd_getthreshold.h"
+#include "utils_cmd_listval.h"
+#include "utils_cmd_putval.h"
+#include "utils_cmd_putnotif.h"
+
+/* Folks without pthread will need to disable this plugin. */
+#include <pthread.h>
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <netdb.h>
+
+#include <grp.h>
+
+#ifndef UNIX_PATH_MAX
+# define UNIX_PATH_MAX sizeof (((struct sockaddr_un *)0)->sun_path)
+#endif
+
+#define US_DEFAULT_PATH LOCALSTATEDIR"/run/"PACKAGE_NAME"-tcpsock"
+
+/*
+ * Private variables
+ */
+/* valid configuration file keys */
+static const char *config_keys[] =
+{
+	"Listen",
+	"Port",
+};
+static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
+
+static int loop = 0;
+
+/* socket configuration */
+static int   sock_fd    = -1;
+static char *sock_addr  = NULL;
+static char *sock_port  = NULL;
+static int   sock_backlog = 10;
+static int   sock_type  = SOCK_STREAM;
+
+static pthread_t listen_thread = (pthread_t) 0;
+
+/*
+ * Functions
+ */
+static int tcps_open_socket (void)
+{
+	struct addrinfo hints, *result;
+	memset(&hints, 0, sizeof(struct addrinfo));
+
+	hints.ai_flags    = 0;
+	hints.ai_socktype = sock_type;
+	hints.ai_family   = AF_UNSPEC;
+
+	int rc = getaddrinfo(sock_addr, sock_port, &hints, &result);
+	if (rc != 0)
+	{
+		ERROR ("getaddrinfo(p_host, p_service, &hints, &result);");
+		return -1;
+	}
+
+	struct addrinfo *now_result = result;
+	while (now_result)
+	{
+		sock_fd = socket(now_result->ai_family, now_result->ai_socktype, now_result->ai_protocol);
+		if (sock_fd == -1)
+		{
+			now_result = now_result->ai_next;
+			continue;
+		}
+
+#if HAVE_DECL_SO_REUSEPORT
+		int one = 1;
+		if (setsockopt(sock_fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) != 0)
+		{
+			ERROR("setsockopt(f_socket, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one): %s", strerror(errno));
+			return -1;
+		}
+#endif
+		if (now_result->ai_family == AF_INET6)
+		{
+			//Allow listening on IPv4 and IPv6
+			int zero = 0;
+			if (setsockopt(sock_fd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&zero, sizeof(zero)))
+			{
+				ERROR("setsockopt(f_socket, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&zero, sizeof(zero)): %s", strerror(errno));
+				return -1;
+			}
+		}
+
+
+		if (bind(sock_fd, now_result->ai_addr, now_result->ai_addrlen) == 0)
+		{
+			break;
+		}
+
+		close(sock_fd);
+		sock_fd = -1;
+		now_result = now_result->ai_next;
+	}
+	if (sock_fd == -1)
+	{
+		freeaddrinfo(result);
+		ERROR("binding socket");
+		return -1;
+	}
+
+	if (listen(sock_fd, sock_backlog) == -1)
+	{
+		ERROR("listen(f_socket, p_backlog): %s", strerror(errno));
+		return -1;
+	}
+#if 0
+	if (status != 0)
+	{
+		char errbuf[1024];
+		sstrerror (errno, errbuf, sizeof (errbuf));
+		ERROR ("tcpsock plugin: bind failed: %s", errbuf);
+		close (sock_fd);
+		sock_fd = -1;
+		return (-1);
+	}
+#endif
+
+	return 0;
+} /* int tcps_open_socket */
+
+static void *tcps_handle_client (void *arg)
+{
+	int fdin;
+	int fdout;
+	FILE *fhin, *fhout;
+
+	fdin = *((int *) arg);
+	free (arg);
+	arg = NULL;
+
+	DEBUG ("tcpsock plugin: tcps_handle_client: Reading from fd #%i", fdin);
+
+	fdout = dup (fdin);
+	if (fdout < 0)
+	{
+		char errbuf[1024];
+		ERROR ("tcpsock plugin: dup failed: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		close (fdin);
+		pthread_exit ((void *) 1);
+	}
+
+	fhin  = fdopen (fdin, "r");
+	if (fhin == NULL)
+	{
+		char errbuf[1024];
+		ERROR ("tcpsock plugin: fdopen failed: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		close (fdin);
+		close (fdout);
+		pthread_exit ((void *) 1);
+		return ((void *) 1);
+	}
+
+	fhout = fdopen (fdout, "w");
+	if (fhout == NULL)
+	{
+		char errbuf[1024];
+		ERROR ("tcpsock plugin: fdopen failed: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		fclose (fhin); /* this closes fdin as well */
+		close (fdout);
+		pthread_exit ((void *) 1);
+		return ((void *) 1);
+	}
+
+	/* change output buffer to line buffered mode */
+	if (setvbuf (fhout, NULL, _IOLBF, 0) != 0)
+	{
+		char errbuf[1024];
+		ERROR ("tcpsock plugin: setvbuf failed: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		fclose (fhin);
+		fclose (fhout);
+		pthread_exit ((void *) 1);
+		return ((void *) 0);
+	}
+
+	while (42)
+	{
+		char buffer[1024];
+		char buffer_copy[1024];
+		char *fields[128];
+		int   fields_num;
+		int   len;
+
+		errno = 0;
+		if (fgets (buffer, sizeof (buffer), fhin) == NULL)
+		{
+			if ((errno == EINTR) || (errno == EAGAIN))
+				continue;
+
+			if (errno != 0)
+			{
+				char errbuf[1024];
+				WARNING ("tcpsock plugin: failed to read from socket #%i: %s",
+						fileno (fhin),
+						sstrerror (errno, errbuf, sizeof (errbuf)));
+			}
+			break;
+		}
+
+		len = strlen (buffer);
+		while ((len > 0)
+				&& ((buffer[len - 1] == '\n') || (buffer[len - 1] == '\r')))
+			buffer[--len] = '\0';
+
+		if (len == 0)
+			continue;
+
+		sstrncpy (buffer_copy, buffer, sizeof (buffer_copy));
+
+		fields_num = strsplit (buffer_copy, fields,
+				sizeof (fields) / sizeof (fields[0]));
+		if (fields_num < 1)
+		{
+			fprintf (fhout, "-1 Internal error\n");
+			fclose (fhin);
+			fclose (fhout);
+			pthread_exit ((void *) 1);
+			return ((void *) 1);
+		}
+
+		if (strcasecmp (fields[0], "getval") == 0)
+		{
+			handle_getval (fhout, buffer);
+		}
+		else if (strcasecmp (fields[0], "getthreshold") == 0)
+		{
+			handle_getthreshold (fhout, buffer);
+		}
+		else if (strcasecmp (fields[0], "putval") == 0)
+		{
+			handle_putval (fhout, buffer);
+		}
+		else if (strcasecmp (fields[0], "listval") == 0)
+		{
+			handle_listval (fhout, buffer);
+		}
+		else if (strcasecmp (fields[0], "putnotif") == 0)
+		{
+			handle_putnotif (fhout, buffer);
+		}
+		else if (strcasecmp (fields[0], "flush") == 0)
+		{
+			handle_flush (fhout, buffer);
+		}
+		else
+		{
+			if (fprintf (fhout, "-1 Unknown command: %s\n", fields[0]) < 0)
+			{
+				char errbuf[1024];
+				WARNING ("tcpsock plugin: failed to write to socket #%i: %s",
+						fileno (fhout),
+						sstrerror (errno, errbuf, sizeof (errbuf)));
+				break;
+			}
+		}
+	} /* while (fgets) */
+
+	DEBUG ("tcpsock plugin: tcps_handle_client: Exiting..");
+	fclose (fhin);
+	fclose (fhout);
+
+	pthread_exit ((void *) 0);
+	return ((void *) 0);
+} /* void *tcps_handle_client */
+
+static void *tcps_server_thread (void __attribute__((unused)) *arg)
+{
+	int  status;
+	int *remote_fd;
+	pthread_t th;
+	pthread_attr_t th_attr;
+
+	pthread_attr_init (&th_attr);
+	pthread_attr_setdetachstate (&th_attr, PTHREAD_CREATE_DETACHED);
+
+	if (tcps_open_socket () != 0)
+		pthread_exit ((void *) 1);
+
+	while (loop != 0)
+	{
+		DEBUG ("tcpsock plugin: Calling accept..");
+		status = accept (sock_fd, NULL, NULL);
+		if (status < 0)
+		{
+			char errbuf[1024];
+
+			if (errno == EINTR)
+				continue;
+
+			ERROR ("tcpsock plugin: accept failed: %s",
+					sstrerror (errno, errbuf, sizeof (errbuf)));
+			close (sock_fd);
+			sock_fd = -1;
+			pthread_attr_destroy (&th_attr);
+			pthread_exit ((void *) 1);
+		}
+
+		remote_fd = (int *) malloc (sizeof (int));
+		if (remote_fd == NULL)
+		{
+			char errbuf[1024];
+			WARNING ("tcpsock plugin: malloc failed: %s",
+					sstrerror (errno, errbuf, sizeof (errbuf)));
+			close (status);
+			continue;
+		}
+		*remote_fd = status;
+
+		DEBUG ("Spawning child to handle connection on fd #%i", *remote_fd);
+
+		status = plugin_thread_create (&th, &th_attr,
+				tcps_handle_client, (void *) remote_fd);
+		if (status != 0)
+		{
+			char errbuf[1024];
+			WARNING ("tcpsock plugin: pthread_create failed: %s",
+					sstrerror (errno, errbuf, sizeof (errbuf)));
+			close (*remote_fd);
+			free (remote_fd);
+			continue;
+		}
+	} /* while (loop) */
+
+	close (sock_fd);
+	sock_fd = -1;
+	pthread_attr_destroy (&th_attr);
+
+#if 0
+	status = unlink ((sock_file != NULL) ? sock_file : US_DEFAULT_PATH);
+	if (status != 0)
+	{
+		char errbuf[1024];
+		NOTICE ("tcpsock plugin: unlink (%s) failed: %s",
+				(sock_file != NULL) ? sock_file : US_DEFAULT_PATH,
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+	}
+#endif
+	return ((void *) 0);
+} /* void *tcps_server_thread */
+
+static int tcps_config (const char *key, const char *val)
+{
+	if (strcasecmp (key, "Listen") == 0)
+	{
+		char *new_sock_addr = strdup (val);
+		if (new_sock_addr == NULL)
+		{
+			return 1;
+		}
+		sfree (sock_addr);
+		sock_addr = new_sock_addr;
+	} else if (strcasecmp (key, "Port") == 0)
+	{
+		char *new_sock_port= strdup (val);
+		if (new_sock_port == NULL)
+		{
+			return 1;
+		}
+		sfree (sock_port);
+		sock_port = new_sock_port;
+	}
+	else
+	{
+		return (-1);
+	}
+
+	return (0);
+} /* int tcps_config */
+
+static int tcps_init (void)
+{
+	static int have_init = 0;
+
+	int status;
+
+	/* Initialize only once. */
+	if (have_init != 0)
+		return (0);
+	have_init = 1;
+
+	loop = 1;
+
+	status = plugin_thread_create (&listen_thread, NULL,
+			tcps_server_thread, NULL);
+	if (status != 0)
+	{
+		char errbuf[1024];
+		ERROR ("tcpsock plugin: pthread_create failed: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		return (-1);
+	}
+
+	return (0);
+} /* int tcps_init */
+
+static int tcps_shutdown (void)
+{
+	void *ret;
+
+	loop = 0;
+
+	if (listen_thread != (pthread_t) 0)
+	{
+		pthread_kill (listen_thread, SIGTERM);
+		pthread_join (listen_thread, &ret);
+		listen_thread = (pthread_t) 0;
+	}
+
+	plugin_unregister_init ("tcpsock");
+	plugin_unregister_shutdown ("tcpsock");
+
+	return (0);
+} /* int tcps_shutdown */
+
+void module_register (void)
+{
+	plugin_register_config ("tcpsock", tcps_config,
+			config_keys, config_keys_num);
+	plugin_register_init ("tcpsock", tcps_init);
+	plugin_register_shutdown ("tcpsock", tcps_shutdown);
+} /* void module_register (void) */
+
+/* vim: set sw=4 ts=4 sts=4 tw=78 : */


### PR DESCRIPTION
Hi,
We have a split setup (collectd push receiver on one host, Nagios-style monitoring system on another host), so we cannot easily integrate collectd results into the monitoring system. (ssh version <6.7 (as on RHEL 5-7) does not support unix socket tunneling).
Therefore I added support for tcp sockets to collectd-nagios (-t) and wrote a collectd plugin (tcpsock) that opens a listening (tcp)socket (mostly based on the unixsock plugin code).

Test (on the monitoring host):
ssh -nNTL 5576:localhost:5576 collect-host &
collectd-nagios -s 127.0.0.1:5576 -t -H <SOME_HOST> -n load/load