### PR TITLE
Fix header condition in users.c

### DIFF
--- a/src/users.c
+++ b/src/users.c
@@ -40,9 +40,6 @@
 #elif HAVE_UTMP_H
 # include <utmp.h>
 /* #endif HAVE_UTMP_H */
-
-#else
-# error "No applicable input method."
 #endif
 
 static void users_submit (gauge_t value)


### PR DESCRIPTION
The dependency is either UTMPX or UTMP or Statgrab. The inclusion above hasn't statgrab.h in the elif-chain, that means compilation fails when only libstatgrab is available. The line can safely be taken out as the same condition is checked in #L120.