### PR TITLE
Fix compile issue when doing make install before make dist after a clean.

### DIFF
--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -98,7 +98,7 @@ static void exit_usage (const char *name, int status) {
       "Hostname defaults to the local hostname if omitted (e.g., uptime/uptime).\n"
       "No error is returned if the specified identifier does not exist.\n"
 
-      "\n"PACKAGE" "VERSION", http://collectd.org/\n"
+      "\n"PACKAGE_NAME" "PACKAGE_VERSION", http://collectd.org/\n"
       "by Florian octo Forster <octo@collectd.org>\n"
       "for contributions see `AUTHORS'\n"
       , name);

--- a/src/collectdmon.c
+++ b/src/collectdmon.c
@@ -80,7 +80,7 @@ static void exit_usage (char *name)
 
 			"\nFor <collectd options> see collectd.conf(5).\n"
 
-			"\n"PACKAGE" "VERSION", http://collectd.org/\n"
+			"\n"PACKAGE_NAME" "PACKAGE_VERSION", http://collectd.org/\n"
 			"by Florian octo Forster <octo@collectd.org>\n"
 			"for contributions see `AUTHORS'\n", name);
 	exit (0);

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -270,7 +270,7 @@ static void update_kstat (void)
  */
 static void exit_usage (int status)
 {
-	printf ("Usage: "PACKAGE" [OPTIONS]\n\n"
+	printf ("Usage: "PACKAGE_NAME" [OPTIONS]\n\n"
 
 			"Available options:\n"
 			"  General:\n"
@@ -289,7 +289,7 @@ static void exit_usage (int status)
 			"  PID file          "PIDFILE"\n"
 			"  Plugin directory  "PLUGINDIR"\n"
 			"  Data directory    "PKGLOCALSTATEDIR"\n"
-			"\n"PACKAGE" "VERSION", http://collectd.org/\n"
+			"\n"PACKAGE_NAME" "PACKAGE_VERSION", http://collectd.org/\n"
 			"by Florian octo Forster <octo@collectd.org>\n"
 			"for contributions see `AUTHORS'\n");
 	exit (status);


### PR DESCRIPTION
If you do a clean, configure and make you get a compile error since PACKAGE and VERSION aren't defined. Should be using PACKAGE_NAME and PACKAGE_VERSION so they're correctly defined by AC_INIT.