### PR TITLE
processes: revert re-introduction of ps_read_tasks

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -897,33 +897,6 @@ static procstat_t *ps_read_tasks_status (int pid, procstat_t *ps)
 	return (ps);
 } /* int *ps_read_tasks_status */
 
-static int ps_read_tasks (int pid)
-{
-	char           dirname[64];
-	DIR           *dh;
-	struct dirent *ent;
-	int count = 0;
-
-	ssnprintf (dirname, sizeof (dirname), "/proc/%i/task", pid);
-
-	if ((dh = opendir (dirname)) == NULL)
-	{
-		DEBUG ("Failed to open directory `%s'", dirname);
-		return (-1);
-	}
-
-	while ((ent = readdir (dh)) != NULL)
-	{
-		if (!isdigit ((int) ent->d_name[0]))
-			continue;
-		else
-			count++;
-	}
-	closedir (dh);
-
-	return ((count >= 1) ? count : 1);
-} /* int *ps_read_tasks */
-
 /* Read data from /proc/pid/status */
 static procstat_t *ps_read_status (int pid, procstat_t *ps)
 {


### PR DESCRIPTION
This commit partially revert 30eeeee996124de666f907877f8196e5580101ed
which solved incorrectly the merge conflict

Signed-off-by: Arthur Gautier <baloo@gandi.net>