### PR TITLE
write_redis: Increase parsability of multi-valued keys by insterting …

### DIFF
--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -92,6 +92,10 @@ static int wr_write (const data_set_t *ds, /* {{{ */
 
   for (i = 0; i < ds->ds_num; i++)
   {
+    // Increase parsability by delimiting the individual values
+    if (ds->ds_num > 1 && i > 0)
+      APPEND ("%s", "|");
+
     if (ds->ds[i].type == DS_TYPE_COUNTER)
       APPEND ("%llu", vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -72,7 +72,7 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   memset (value, 0, sizeof (value));
   value_size = sizeof (value);
   value_ptr = &value[0];
-  format_values(value_ptr, value_size, ds, vl, 0);
+  assert (format_values(value_ptr, value_size, ds, vl, 0) == 0);
   
   pthread_mutex_lock (&node->lock);
 


### PR DESCRIPTION
This PR modifies the write_redis plugin so that it inserts delimiting `|` characters into values that have multiple parts. Previously, certain values were difficult to parse (such as those collected by the load plugin) or impossible to parse (such as those collected by the disk plugin).

For instance, a value for load could look like this ` "1433876308.933760881:00.010"` corresponding to load values of `0 0.01 0`. This PR changes the plugin to produce values like this: `"1433876308.933760881:0|0.01|0"`
