### PR TITLE
fix memory initialization in tail plugin

### DIFF
--- a/src/tail.c
+++ b/src/tail.c
@@ -340,6 +340,8 @@ static int ctail_init (void)
     WARNING ("tail plugin: File list is empty. Returning an error.");
     return (-1);
   }
+  
+  memset(&ud, '\0', sizeof(ud));
 
   for (i = 0; i < tail_match_list_num; i++)
   {


### PR DESCRIPTION
Tail plugin doesn't initialize a stack allocated structure user_data_t in function ctail_init. This structure contains random data in free_func member. Handling this data as a function pointer causes a segmentation fault during collectd shutdown:

#0  0x00007fca9ec1b1a8 in ?? ()
#1  0x000000000040cbeb in destroy_callback (cf=0x23220b0) at plugin.c:199
#2  0x000000000040cd24 in destroy_read_heap () at plugin.c:244
#3  0x000000000040fbc5 in plugin_shutdown_all () at plugin.c:1858
#4  0x0000000000406928 in do_shutdown () at collectd.c:384
#5  0x0000000000407299 in main (argc=4, argv=0x7ffde7bf11d8) at collectd.c:710
