### PR TITLE
contrib/redhat/collectd.spec: added bison and flex

### DIFF
--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -226,7 +226,7 @@ Source:		http://collectd.org/files/%{name}-%{version}.tar.bz2
 License:	GPLv2
 Group:		System Environment/Daemons
 BuildRoot:	%{_tmppath}/%{name}-%{version}-root
-BuildRequires:	libgcrypt-devel, kernel-headers, libtool-ltdl-devel, libcap-devel
+BuildRequires:	libgcrypt-devel, kernel-headers, libtool-ltdl-devel, libcap-devel, flex, bison
 Vendor:		collectd development team <collectd@verplant.org>
 
 %if 0%{?el7:1}
@@ -1584,6 +1584,9 @@ Collectd utilities
 %else
 %define _with_zookeeper --disable-zookeeper
 %endif
+
+export YACC=bison
+export YFLAGS=-y
 
 %configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW=\"RTLD_LAZY|RTLD_GLOBAL\"" \
 	--disable-static \


### PR DESCRIPTION
Current .spec does not work due to missing bison and flex dependencies.
This fix lets install bison and flex into the build environment as well as
define YACC and YFLAGS environment variables.