### PR TITLE
fix openldap segfault when ldapi is used

### DIFF
--- a/src/openldap.c
+++ b/src/openldap.c
@@ -604,7 +604,8 @@ static int cldap_config_add (oconfig_item_t *ci) /* {{{ */
 				st->name, st->url);
 			status = -1;
 		}
-		else if (ludpp->lud_host != NULL)
+
+		if ((status == 0) && (ludpp->lud_host != NULL))
 		{
 			st->host = strdup (ludpp->lud_host);
 		}

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -604,7 +604,7 @@ static int cldap_config_add (oconfig_item_t *ci) /* {{{ */
 				st->name, st->url);
 			status = -1;
 		}
-		else
+		else if (ludpp->lud_host != NULL)
 		{
 			st->host = strdup (ludpp->lud_host);
 		}


### PR DESCRIPTION
If LDAPI protocol is used in configuration, e.g. URL "ldapi://", ldap_url_parse returns NULL in `ludpp->lud_host`. Strdup has undefined behaviour if NULL argument is used and segmentation fault can also occur.
