### PR TITLE
Added Prefix Parameter to write_redis plugin

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7491,7 +7491,7 @@ Synopsis:
 Values are submitted to I<Sorted Sets>, using the metric name as the key, and
 the timestamp as the score. Retrieving a date range can then be done using the
 C<ZRANGEBYSCORE> I<Redis> command. Additionnally, all the identifiers of these
-I<Sorted Sets> are kept in a I<Set> called C<collectd/values> or C<Prefix/collectd/values> if a Prefix was specified and can be
+I<Sorted Sets> are kept in a I<Set> called C<collectd/values> or C<Prefix/values> if a Prefix was specified and can be
 retrieved using the C<SMEMBERS> I<Redis> command. See
 L<http://redis.io/commands#sorted_set> and L<http://redis.io/commands#set> for
 details.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7484,13 +7484,14 @@ Synopsis:
         Host "localhost"
         Port "6379"
         Timeout 1000
+        Prefix "examplePrefix"
     </Node>
   </Plugin>
 
 Values are submitted to I<Sorted Sets>, using the metric name as the key, and
 the timestamp as the score. Retrieving a date range can then be done using the
 C<ZRANGEBYSCORE> I<Redis> command. Additionnally, all the identifiers of these
-I<Sorted Sets> are kept in a I<Set> called C<collectd/values> and can be
+I<Sorted Sets> are kept in a I<Set> called C<collectd/values> or C<Prefix/collectd/values> if a Prefix was specified and can be
 retrieved using the C<SMEMBERS> I<Redis> command. See
 L<http://redis.io/commands#sorted_set> and L<http://redis.io/commands#set> for
 details.

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -72,7 +72,7 @@ static int wr_write (const data_set_t *ds, /* {{{ */
     ssnprintf (key, sizeof (key), "collectd/%s", ident);
   }
   else {
-    ssnprintf (key, sizeof (key), "%s/collectd/%s", node->prefix, ident);
+    ssnprintf (key, sizeof (key), "%s/%s", node->prefix, ident);
   }
   ssnprintf (time, sizeof (time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -40,6 +40,7 @@ struct wr_node_s
   char *host;
   int port;
   struct timeval timeout;
+  char *prefix;
 
   redisContext *conn;
   pthread_mutex_t lock;
@@ -67,7 +68,12 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   status = FORMAT_VL (ident, sizeof (ident), vl);
   if (status != 0)
     return (status);
-  ssnprintf (key, sizeof (key), "collectd/%s", ident);
+  if (node->prefix == NULL) {
+    ssnprintf (key, sizeof (key), "collectd/%s", ident);
+  }
+  else {
+    ssnprintf (key, sizeof (key), "%s/collectd/%s", node->prefix, ident);
+  }
   ssnprintf (time, sizeof (time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   memset (value, 0, sizeof (value));
@@ -176,6 +182,7 @@ static int wr_config_node (oconfig_item_t *ci) /* {{{ */
   node->timeout.tv_sec = 0;
   node->timeout.tv_usec = 1000;
   node->conn = NULL;
+  node->prefix = NULL;
   pthread_mutex_init (&node->lock, /* attr = */ NULL);
 
   status = cf_util_get_string_buffer (ci, node->name, sizeof (node->name));
@@ -203,6 +210,9 @@ static int wr_config_node (oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp ("Timeout", child->key) == 0) {
       status = cf_util_get_int (child, &timeout);
       if (status == 0) node->timeout.tv_usec = timeout;
+    }
+    else if (strcasecmp ("Prefix", child->key) == 0) {
+      status = cf_util_get_string (child, &node->prefix);
     }
     else
       WARNING ("write_redis plugin: Ignoring unknown config option \"%s\".",


### PR DESCRIPTION
At the moment it is not possible to add further prefixes to the key when you use write_redis plugin. I've added an option "Prefix" so you can add custom prefixes if you need them.