### PR TITLE
Fix 64 bit check issue in issue #1077

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ then
 	AC_DEFINE(_REENTRANT,               1, [Define to enable reentrancy interfaces.])
 
 	AC_MSG_CHECKING([whether compiler builds 64bit binaries])
-	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 			   #ifndef _LP64
 			   # error "Compiler not in 64bit mode."
 			   #endif


### PR DESCRIPTION
Just running the preprocessor does not honor CFLAGS which is important, as CFLAGS contains the relevant -m64.