### PR TITLE
Clang fixes

### DIFF
--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -25,6 +25,7 @@
 #include "oconfig.h"
 
 extern FILE *yyin;
+extern int yyparse (void);
 
 oconfig_item_t *ci_root;
 const char     *c_file;

--- a/src/liboconfig/scanner.l
+++ b/src/liboconfig/scanner.l
@@ -18,6 +18,12 @@
  */
 
 %{
+/* lex and yacc do some weird stuff, so turn off some warnings. */
+#if defined(__clang__)
+# pragma clang diagnostic ignored "-Wunused-function"
+# pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#endif
+
 #include <stdlib.h>
 #include "oconfig.h"
 #include "aux_types.h"


### PR DESCRIPTION
This should fix / evade errors created by yacc in liboconfig. For the most part, this is switching off unused function checking, because yacc / bison will generate a bunch of functions and not all of them are used. Ignoring those problems in that particular case should be quite harmless I hope.