### PR TITLE
Fix "Dead assignment" warnings (collectd-5.4).

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -696,7 +696,7 @@ static void *camqp_subscribe_thread (void *user_data) /* {{{ */
             continue;
         }
 
-        status = camqp_read_header (conf);
+        camqp_read_header (conf);
 
         amqp_maybe_release_buffers (conf->connection);
     } /* while (subscriber_threads_running) */

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -549,7 +549,6 @@ static int cj_config_add_key (cj_t *db, /* {{{ */
       db->tree = cj_avl_create();
 
     tree = db->tree;
-    name = key->path;
     ptr = key->path;
     if (*ptr == '/')
       ++ptr;

--- a/src/email.c
+++ b/src/email.c
@@ -251,8 +251,6 @@ static void *collect (void *arg)
 	collector_t *this = (collector_t *)arg;
 
 	while (1) {
-		int loop = 1;
-
 		conn_t *connection;
 
 		pthread_mutex_lock (&conns_mutex);
@@ -277,15 +275,13 @@ static void *collect (void *arg)
 		log_debug ("collect: handling connection on fd #%i",
 				fileno (this->socket));
 
-		while (loop) {
+		while (42) {
 			/* 256 bytes ought to be enough for anybody ;-) */
 			char line[256 + 1]; /* line + '\0' */
 			int  len = 0;
 
 			errno = 0;
 			if (NULL == fgets (line, sizeof (line), this->socket)) {
-				loop = 0;
-
 				if (0 != errno) {
 					char errbuf[1024];
 					log_err ("collect: reading from socket (fd #%i) "
@@ -358,7 +354,7 @@ static void *collect (void *arg)
 			else {
 				log_err ("collect: unknown type '%c'", line[0]);
 			}
-		} /* while (loop) */
+		} /* while (42) */
 
 		log_debug ("Shutting down connection on fd #%i",
 				fileno (this->socket));

--- a/src/filter_chain.c
+++ b/src/filter_chain.c
@@ -387,7 +387,6 @@ static int fc_config_add_rule (fc_chain_t *chain, /* {{{ */
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Match", option->key) == 0)
       status = fc_config_add_match (&rule->matches, option);
@@ -471,7 +470,6 @@ static int fc_config_add_chain (const oconfig_item_t *ci) /* {{{ */
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Rule", option->key) == 0)
       status = fc_config_add_rule (chain, option);

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -660,7 +660,7 @@ static int mc_handle_value_msg (Ganglia_value_msg *msg) /* {{{ */
     if ((map->ds_type == DS_TYPE_COUNTER)
         || (map->ds_type == DS_TYPE_ABSOLUTE))
       val_copy = value_counter;
-    if (map->ds_type == DS_TYPE_GAUGE)
+    else if (map->ds_type == DS_TYPE_GAUGE)
       val_copy = value_gauge;
     else if (map->ds_type == DS_TYPE_DERIVE)
       val_copy = value_derive;

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -500,7 +500,6 @@ static int lcc_open_netsocket (lcc_connection_t *c, /* {{{ */
     if (fd < 0)
     {
       status = errno;
-      fd = -1;
       continue;
     }
 
@@ -509,7 +508,6 @@ static int lcc_open_netsocket (lcc_connection_t *c, /* {{{ */
     {
       status = errno;
       close (fd);
-      fd = -1;
       continue;
     }
 
@@ -518,7 +516,6 @@ static int lcc_open_netsocket (lcc_connection_t *c, /* {{{ */
     {
       status = errno;
       close (fd);
-      fd = -1;
       continue;
     }
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -414,7 +414,6 @@ static int mb_read_data (mb_host_t *host, mb_slave_t *slave, /* {{{ */
   else
     values_num = 1;
 
-  status = 0;
   if (host->connection == NULL)
   {
     status = EBADF;
@@ -677,7 +676,6 @@ static int mb_config_add_data (oconfig_item_t *ci) /* {{{ */
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *child = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Type", child->key) == 0)
       status = cf_util_get_string_buffer (child,
@@ -816,7 +814,6 @@ static int mb_config_add_slave (mb_host_t *host, oconfig_item_t *ci) /* {{{ */
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *child = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Instance", child->key) == 0)
       status = cf_util_get_string_buffer (child,

--- a/src/network.c
+++ b/src/network.c
@@ -2538,10 +2538,6 @@ static int network_receive (void) /* {{{ */
 		receive_list_tail = private_list_tail;
 		receive_list_length += private_list_length;
 
-		private_list_head = NULL;
-		private_list_tail = NULL;
-		private_list_length = 0;
-
 		pthread_cond_signal (&receive_list_cond);
 		pthread_mutex_unlock (&receive_list_lock);
 	}

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -664,7 +664,6 @@ static int ntpd_receive_response (int *res_items, int *res_size,
 				(items_num + pkt_item_num) * res_item_size);
 		if (items == NULL)
 		{
-			items = *res_data;
 			ERROR ("ntpd plugin: realloc failed.");
 			continue;
 		}

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -171,7 +171,6 @@ static int cow_read_values (const char *path, const char *name,
     if (endptr == NULL)
     {
       ERROR ("onewire plugin: Buffer is not a number: %s", buffer);
-      status = -1;
       continue;
     }
 

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -187,8 +187,6 @@ static int single_read (char *name, FILE *fh)
 	post_compress = 0;
 	pre_decompress = 0;
 	post_decompress = 0;
-	overhead_rx = 0;
-	overhead_tx = 0;
 
 	while (fgets (buffer, sizeof (buffer), fh) != NULL)
 	{

--- a/src/ping.c
+++ b/src/ping.c
@@ -354,7 +354,7 @@ static void *ping_thread (void *arg) /* {{{ */
      * `ts_wait'. */
     time_calc (&ts_wait, &ts_int, &tv_begin, &tv_end);
 
-    status = pthread_cond_timedwait (&ping_cond, &ping_lock, &ts_wait);
+    pthread_cond_timedwait (&ping_cond, &ping_lock, &ts_wait);
     if (ping_thread_loop <= 0)
       break;
   } /* while (ping_thread_loop > 0) */

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -447,6 +447,12 @@ static int powerdns_get_data_stream (list_item_t *item, /* {{{ */
   timeout.tv_sec=5;
   timeout.tv_usec=0;
   status = setsockopt (sd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof (timeout));
+  if (status != 0)
+  {
+    FUNC_ERROR ("setsockopt");
+    close (sd);
+    return (-1);
+  }
 
   status = connect (sd, (struct sockaddr *) &item->sockaddr,
       sizeof (item->sockaddr));
@@ -494,7 +500,6 @@ static int powerdns_get_data_stream (list_item_t *item, /* {{{ */
     buffer[buffer_size] = 0;
   } /* while (42) */
   close (sd);
-  sd = -1;
 
   if (status < 0)
   {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -402,7 +402,6 @@ static int csnmp_config_add_data (oconfig_item_t *ci)
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Type", option->key) == 0)
       status = csnmp_config_add_data_type (dd, option);

--- a/src/tail.c
+++ b/src/tail.c
@@ -211,7 +211,6 @@ static int ctail_config_add_file (oconfig_item_t *ci)
   cu_tail_match_t *tm;
   char *plugin_instance = NULL;
   int num_matches = 0;
-  int status;
   int i;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING))
@@ -228,10 +227,10 @@ static int ctail_config_add_file (oconfig_item_t *ci)
     return (-1);
   }
 
-  status = 0;
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
+    int status;
 
     if (strcasecmp ("Match", option->key) == 0)
     {

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -312,7 +312,6 @@ static int tcsv_config_add_metric(oconfig_item_t *ci){
 
     for (i = 0; i < ci->children_num; ++i){
         oconfig_item_t *option = ci->children + i;
-        status = 0;
 
         if (strcasecmp("Type", option->key) == 0)
             status = cf_util_get_string(option, &md->type);

--- a/src/ted.c
+++ b/src/ted.c
@@ -104,7 +104,6 @@ static int ted_read_value(double *ret_power, double *ret_voltage)
 
     /* Loop until we find the end of the package */
     end_flag = 0;
-    escape_flag = 0;
     package_buffer_pos = 0;
     while (end_flag == 0)
     {

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -361,7 +361,6 @@ static int ut_config_type (const threshold_t *th_orig, oconfig_item_t *ci)
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Instance", option->key) == 0)
       status = ut_config_type_instance (&th, option);
@@ -449,7 +448,6 @@ static int ut_config_plugin (const threshold_t *th_orig, oconfig_item_t *ci)
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Type", option->key) == 0)
       status = ut_config_type (&th, option);
@@ -496,7 +494,6 @@ static int ut_config_host (const threshold_t *th_orig, oconfig_item_t *ci)
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Type", option->key) == 0)
       status = ut_config_type (&th, option);
@@ -997,7 +994,6 @@ int ut_config (oconfig_item_t *ci)
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-    status = 0;
 
     if (strcasecmp ("Type", option->key) == 0)
       status = ut_config_type (&th, option);


### PR DESCRIPTION
Fixes all "Dead assignment" errors found by clang's *scan-build* static code analysis in the *collectd-5.4* branch.