### PR TITLE
  Fix "Dead assignment" warnings (collectd-5.5).

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -556,7 +556,7 @@ static int read_acpi_full_capacity (char const *dir, /* {{{ */
 
 	ssnprintf (filename, sizeof (filename), "%s/%s/info", dir, power_supply);
 	fh = fopen (filename, "r");
-	if ((fh = fopen (filename, "r")) == NULL)
+	if (fh == NULL)
 		return (errno);
 
 	/* last full capacity:      40090 mWh */
@@ -615,7 +615,7 @@ static int read_acpi_callback (char const *dir, /* {{{ */
 
 	ssnprintf (filename, sizeof (filename), "%s/%s/state", dir, power_supply);
 	fh = fopen (filename, "r");
-	if ((fh = fopen (filename, "r")) == NULL)
+	if (fh == NULL)
 	{
 		if ((errno == EAGAIN) || (errno == EINTR) || (errno == ENOENT))
 			return (0);

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -506,6 +506,7 @@ static int nfs_submit_nfs4_client (const char *instance, char **fields,
 		case 42:
 		case 44:
 			proc40_names_num = 36;
+			break;
 		case 46:
 		case 47:
 		case 51:

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -384,7 +384,6 @@ static int cow_read_values (const char *path, const char *name,
     if (endptr == NULL)
     {
       ERROR ("onewire plugin: Buffer is not a number: %s", buffer);
-      status = -1;
       continue;
     }
 
@@ -528,7 +527,6 @@ static int cow_simple_read (void)
       if (endptr == NULL)
       {
           ERROR ("onewire plugin: Buffer is not a number: %s", buffer);
-          status = -1;
           continue;
       }
 


### PR DESCRIPTION
Fixes all "Dead assignment" errors found by clang's *scan-build* static code analysis in the *collectd-5.5* branch.