### PR TITLE
df plugin fails on btrfs if ReportInodes and ValuesPercentage are enabled

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -320,7 +320,7 @@ static int df_read (void)
 		}
 
 		/* inode handling */
-		if (report_inodes)
+		if (report_inodes && statbuf.f_files != 0 && statbuf.f_ffree != 0)
 		{
 			uint64_t inode_free;
 			uint64_t inode_reserved;


### PR DESCRIPTION
fstatfs called on btrfs returns with undefined fields f_files and f_ffree. Read function for df plugin returns -1 if f_files is equal or below 0 and plugin stops to report values. This patch adds additional check for filesystems which don't provide inodes info.
