### PR TITLE
Change values_len and ds_num to size_t.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -460,6 +460,8 @@ pkglib_LTLIBRARIES += ipvs.la
 ipvs_la_SOURCES = ipvs.c
 if IP_VS_H_NEEDS_KERNEL_CFLAGS
 ipvs_la_CFLAGS = $(AM_CFLAGS) $(KERNEL_CFLAGS)
+else
+ipvs_la_CFLAGS = $(AM_CFLAGS)
 endif
 ipvs_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -407,7 +407,7 @@ static int get_reference_temperature(double * result)
 
     gauge_t * values = NULL;   /**< rate values */
     size_t    values_num = 0;  /**< number of rate values */
-    int i;
+    size_t i;
 
     gauge_t values_history[REF_TEMP_AVG_NUM];
 
@@ -447,9 +447,8 @@ static int get_reference_temperature(double * result)
 
             for(i=0; i<values_num; ++i)
             {
-                DEBUG ("barometer: get_reference_temperature - rate %d: %lf **",
-                       i,
-                       values[i]);
+                DEBUG ("barometer: get_reference_temperature - rate %zu: %lf **",
+                       i, values[i]);
                 if(!isnan(values[i]))
                 {
                     avg_sum += values[i];
@@ -477,9 +476,8 @@ static int get_reference_temperature(double * result)
             
         for(i=0; i<REF_TEMP_AVG_NUM*list->num_values; ++i)
         {
-            DEBUG ("barometer: get_reference_temperature - history %d: %lf",
-                   i,
-                   values_history[i]);
+            DEBUG ("barometer: get_reference_temperature - history %zu: %lf",
+                   i, values_history[i]);
             if(!isnan(values_history[i]))
             {
                 avg_sum += values_history[i];
@@ -503,9 +501,8 @@ static int get_reference_temperature(double * result)
 
             for(i=0; i<values_num; ++i)
             {
-                DEBUG ("barometer: get_reference_temperature - rate last %d: %lf **",
-                       i,
-                       values[i]);
+                DEBUG ("barometer: get_reference_temperature - rate last %zu: %lf **",
+                       i, values[i]);
                 if(!isnan(values[i]))
                 {
                     avg_sum += values[i];

--- a/src/csv.c
+++ b/src/csv.c
@@ -45,7 +45,7 @@ static int value_list_to_string (char *buffer, int buffer_len,
 {
 	int offset;
 	int status;
-	int i;
+	size_t i;
 	gauge_t *rates = NULL;
 
 	assert (0 == strcmp (ds->type, vl->type));
@@ -184,7 +184,7 @@ static int value_list_to_filename (char *buffer, size_t buffer_size,
 static int csv_create_file (const char *filename, const data_set_t *ds)
 {
 	FILE *csv;
-	int i;
+	size_t i;
 
 	if (check_create_dir (filename))
 		return (-1);

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -563,7 +563,7 @@ static int cj_config_add_key (cj_t *db, /* {{{ */
       if (*ptr == '/')
       {
         c_avl_tree_t *value;
-        int len;
+        size_t len;
 
         len = ptr-name;
         if (len == 0)

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -50,7 +50,7 @@ struct cx_xpath_s /* {{{ */
   char *path;
   char *type;
   cx_values_t *values;
-  int values_len;
+  size_t values_len;
   char *instance_prefix;
   char *instance;
   int is_table;
@@ -240,7 +240,7 @@ static int cx_check_type (const data_set_t *ds, cx_xpath_t *xpath) /* {{{ */
 
   if (ds->ds_num != xpath->values_len)
   {
-    WARNING ("curl_xml plugin: DataSet `%s' requires %i values, but config talks about %i",
+    WARNING ("curl_xml plugin: DataSet `%s' requires %zu values, but config talks about %zu",
         xpath->type, ds->ds_num, xpath->values_len);
     return (-1);
   }
@@ -356,7 +356,7 @@ static int cx_handle_all_value_xpaths (xmlXPathContextPtr xpath_ctx, /* {{{ */
 {
   value_t values[xpath->values_len];
   int status;
-  int i;
+  size_t i;
 
   assert (xpath->values_len > 0);
   assert (xpath->values_len == vl->values_len);
@@ -689,7 +689,7 @@ static int cx_config_add_values (const char *name, cx_xpath_t *xpath, /* {{{ */
   xpath->values = (cx_values_t *) malloc (sizeof (cx_values_t) * ci->values_num);
   if (xpath->values == NULL)
     return (-1);
-  xpath->values_len = ci->values_num;
+  xpath->values_len = (size_t) ci->values_num;
 
   /* populate cx_values_t structure */
   for (i = 0; i < ci->values_num; i++)

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -491,8 +491,8 @@ size_t strstripnewline (char *buffer)
 
 int escape_slashes (char *buffer, size_t buffer_size)
 {
-	int i;
 	size_t buffer_len;
+	size_t i;
 
 	buffer_len = strlen (buffer);
 
@@ -946,7 +946,7 @@ int format_values (char *ret, size_t ret_len, /* {{{ */
 {
         size_t offset = 0;
         int status;
-        int i;
+        size_t i;
         gauge_t *rates = NULL;
 
         assert (0 == strcmp (ds->type, vl->type));

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -231,6 +231,62 @@ DEF_TEST(strunescape)
   return (0);
 }
 
+DEF_TEST(parse_values)
+{
+  struct {
+    char buffer[64];
+    int status;
+    gauge_t value;
+  } cases[] = {
+    {"1435044576:42",     0, 42.0},
+    {"1435044576:42:23", -1,  NAN},
+    {"1435044576:U",      0,  NAN},
+    {"N:12.3",            0, 12.3},
+    {"N:42.0:23",        -1,  NAN},
+    {"N:U",               0,  NAN},
+    {"T:42.0",           -1,  NAN},
+  };
+
+  size_t i;
+  for (i = 0; i < STATIC_ARRAY_SIZE (cases); i++)
+  {
+    data_source_t dsrc = {
+      .name = "value",
+      .type = DS_TYPE_GAUGE,
+      .min = 0.0,
+      .max = NAN,
+    };
+    data_set_t ds = {
+      .type = "example",
+      .ds_num = 1,
+      .ds = &dsrc,
+    };
+
+    value_t v = {
+      .gauge = NAN,
+    };
+    value_list_t vl = {
+      .values = &v,
+      .values_len = 1,
+      .time = 0,
+      .interval = 0,
+      .host = "example.com",
+      .plugin = "common_test",
+      .type = "example",
+      .meta = NULL,
+    };
+
+    int status = parse_values (cases[i].buffer, &vl, &ds);
+    OK(status == cases[i].status);
+    if (status != 0)
+      continue;
+
+    OK(cases[i].value == vl.values[0].gauge);
+  }
+
+  return (0);
+}
+
 int main (void)
 {
   RUN_TEST(sstrncpy);
@@ -239,6 +295,7 @@ int main (void)
   RUN_TEST(strsplit);
   RUN_TEST(strjoin);
   RUN_TEST(strunescape);
+  RUN_TEST(parse_values);
 
   END_TEST;
 }

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2137,8 +2137,8 @@ static int plugin_dispatch_values_internal (value_list_t *vl)
 	if (ds->ds_num != vl->values_len)
 	{
 		ERROR ("plugin_dispatch_values: ds->type = %s: "
-				"(ds->ds_num = %i) != "
-				"(vl->values_len = %i)",
+				"(ds->ds_num = %zu) != "
+				"(vl->values_len = %zu)",
 				ds->type, ds->ds_num, vl->values_len);
 		return (-1);
 	}

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -889,7 +889,7 @@ static void start_write_threads (size_t num) /* {{{ */
 static void stop_write_threads (void) /* {{{ */
 {
 	write_queue_t *q;
-	int i;
+	size_t i;
 
 	if (write_threads == NULL)
 		return;
@@ -930,7 +930,7 @@ static void stop_write_threads (void) /* {{{ */
 
 	if (i > 0)
 	{
-		WARNING ("plugin: %i value list%s left after shutting down "
+		WARNING ("plugin: %zu value list%s left after shutting down "
 				"the write threads.",
 				i, (i == 1) ? " was" : "s were");
 	}
@@ -1440,7 +1440,7 @@ static void plugin_free_data_sets (void)
 int plugin_register_data_set (const data_set_t *ds)
 {
 	data_set_t *ds_copy;
-	int i;
+	size_t i;
 
 	if ((data_sets != NULL)
 			&& (c_avl_get (data_sets, ds->type, NULL) == 0))

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -97,7 +97,7 @@ typedef union value_u value_t;
 struct value_list_s
 {
 	value_t *values;
-	int      values_len;
+	size_t   values_len;
 	cdtime_t time;
 	cdtime_t interval;
 	char     host[DATA_MAX_NAME_LEN];
@@ -125,7 +125,7 @@ typedef struct data_source_s data_source_t;
 struct data_set_s
 {
 	char           type[DATA_MAX_NAME_LEN];
-	int            ds_num;
+	size_t         ds_num;
 	data_source_t *ds;
 };
 typedef struct data_set_s data_set_t;

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -101,7 +101,7 @@ static void parse_line (char *buf)
   char  *fields[64];
   size_t fields_num;
   data_set_t *ds;
-  int i;
+  size_t i;
 
   fields_num = strsplit (buf, fields, 64);
   if (fields_num < 2)
@@ -128,7 +128,7 @@ static void parse_line (char *buf)
     if (parse_ds (ds->ds + i, fields[i + 1], strlen (fields[i + 1])) != 0)
     {
       sfree (ds->ds);
-      ERROR ("types_list: parse_line: Cannot parse data source #%i "
+      ERROR ("types_list: parse_line: Cannot parse data source #%zu "
 	  "of data set %s", i, ds->type);
       return;
     }

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -128,7 +128,7 @@ static void cache_free (cache_entry_t *ce)
 
 static void uc_check_range (const data_set_t *ds, cache_entry_t *ce)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < ds->ds_num; i++)
   {
@@ -144,9 +144,9 @@ static void uc_check_range (const data_set_t *ds, cache_entry_t *ce)
 static int uc_insert (const data_set_t *ds, const value_list_t *vl,
     const char *key)
 {
-  int i;
   char *key_copy;
   cache_entry_t *ce;
+  size_t i;
 
   /* `cache_lock' has been locked by `uc_update' */
 
@@ -373,7 +373,7 @@ int uc_update (const data_set_t *ds, const value_list_t *vl)
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int status;
-  int i;
+  size_t i;
 
   if (FORMAT_VL (name, sizeof (name), vl) != 0)
   {
@@ -465,7 +465,7 @@ int uc_update (const data_set_t *ds, const value_list_t *vl)
 	return (-1);
     } /* switch (ds->ds[i].type) */
 
-    DEBUG ("uc_update: %s: ds[%i] = %lf", name, i, ce->values_gauge[i]);
+    DEBUG ("uc_update: %s: ds[%zu] = %lf", name, i, ce->values_gauge[i]);
   } /* for (i) */
 
   /* Update the history if it exists. */

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -37,7 +37,7 @@
 typedef struct cache_entry_s
 {
 	char name[6 * DATA_MAX_NAME_LEN];
-	int        values_num;
+	size_t     values_num;
 	gauge_t   *values_gauge;
 	value_t   *values_raw;
 	/* Time contained in the package
@@ -79,7 +79,7 @@ static int cache_compare (const cache_entry_t *a, const cache_entry_t *b)
   return (strcmp (a->name, b->name));
 } /* int cache_compare */
 
-static cache_entry_t *cache_alloc (int values_num)
+static cache_entry_t *cache_alloc (size_t values_num)
 {
   cache_entry_t *ce;
 
@@ -161,7 +161,7 @@ static int uc_insert (const data_set_t *ds, const value_list_t *vl,
   if (ce == NULL)
   {
     sfree (key_copy);
-    ERROR ("uc_insert: cache_alloc (%i) failed.", ds->ds_num);
+    ERROR ("uc_insert: cache_alloc (%zu) failed.", ds->ds_num);
     return (-1);
   }
 
@@ -565,7 +565,7 @@ gauge_t *uc_get_rate (const data_set_t *ds, const value_list_t *vl)
    * values are returned. */
   if (ret_num != (size_t) ds->ds_num)
   {
-    ERROR ("utils_cache: uc_get_rate: ds[%s] has %i values, "
+    ERROR ("utils_cache: uc_get_rate: ds[%s] has %zu values, "
 	"but uc_get_rate_by_name returned %zu.",
 	ds->type, ds->ds_num, ret_num);
     sfree (ret);

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -89,11 +89,13 @@ size_t cdtime_to_iso8601 (char *s, size_t max, cdtime_t t) /* {{{ */
 
   if (max - len > 2) {
     int n = snprintf (s + len, max - len, ".%09i", (int)t_spec.tv_nsec);
-    len += (n < max - len) ? n : max - len;
+    len += (n < 0) ? 0
+      : (((size_t) n) < (max - len)) ? ((size_t) n)
+      : (max - len);
   }
 
   if (max - len > 3) {
-    int n = strftime (s + len, max - len, "%z", &t_tm);
+    size_t n = strftime (s + len, max - len, "%z", &t_tm);
     len += (n < max - len) ? n : max - len;
   }
 

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -351,6 +351,7 @@ static int cdbi_config_add_database (oconfig_item_t *ci) /* {{{ */
 
   while ((status == 0) && (db->queries_num > 0))
   {
+    size_t j;
     db->q_prep_areas = (udb_query_preparation_area_t **) calloc (
         db->queries_num, sizeof (*db->q_prep_areas));
 
@@ -361,12 +362,12 @@ static int cdbi_config_add_database (oconfig_item_t *ci) /* {{{ */
       break;
     }
 
-    for (i = 0; i < db->queries_num; ++i)
+    for (j = 0; j < db->queries_num; ++j)
     {
-      db->q_prep_areas[i]
-        = udb_query_allocate_preparation_area (db->queries[i]);
+      db->q_prep_areas[j]
+        = udb_query_allocate_preparation_area (db->queries[j]);
 
-      if (db->q_prep_areas[i] == NULL)
+      if (db->q_prep_areas[j] == NULL)
       {
         WARNING ("dbi plugin: udb_query_allocate_preparation_area failed");
         status = -1;

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -83,12 +83,12 @@ typedef struct staging_entry_s staging_entry_t;
 
 struct metric_map_s
 {
-  char *ganglia_name;
-  char *type;
-  char *type_instance;
-  char *ds_name;
-  int   ds_type;
-  int   ds_index;
+  char  *ganglia_name;
+  char  *type;
+  char  *type_instance;
+  char  *ds_name;
+  int    ds_type;
+  size_t ds_index;
 };
 typedef struct metric_map_s metric_map_t;
 
@@ -166,7 +166,7 @@ static metric_map_t *metric_lookup (const char *key) /* {{{ */
     return (NULL);
 
   /* Look up the DS type and ds_index. */
-  if ((map[i].ds_type < 0) || (map[i].ds_index < 0)) /* {{{ */
+  if (map[i].ds_type < 0) /* {{{ */
   {
     const data_set_t *ds;
 
@@ -191,7 +191,7 @@ static metric_map_t *metric_lookup (const char *key) /* {{{ */
     }
     else
     {
-      int j;
+      size_t j;
 
       for (j = 0; j < ds->ds_num; j++)
         if (strcasecmp (ds->ds[j].name, map[i].ds_name) == 0)
@@ -511,7 +511,7 @@ static int staging_entry_submit (const char *host, const char *name, /* {{{ */
 
 static int staging_entry_update (const char *host, const char *name, /* {{{ */
     const char *type, const char *type_instance,
-    int ds_index, int ds_type, value_t value)
+    size_t ds_index, int ds_type, value_t value)
 {
   const data_set_t *ds;
   staging_entry_t *se;
@@ -525,7 +525,7 @@ static int staging_entry_update (const char *host, const char *name, /* {{{ */
 
   if (ds->ds_num <= ds_index)
   {
-    ERROR ("gmond plugin: Invalid index %i: %s has only %i data source(s).",
+    ERROR ("gmond plugin: Invalid index %zu: %s has only %zu data source(s).",
         ds_index, ds->type, ds->ds_num);
     return (-1);
   }

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -197,7 +197,7 @@ static int get_pi (struct ip_vs_service_entry *se, char *pi, size_t size)
 			(se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
 			ntohs (se->port));
 
-	if ((0 > len) || (size <= len)) {
+	if ((0 > len) || (size <= ((size_t) len))) {
 		log_err ("plugin instance truncated: %s", pi);
 		return -1;
 	}
@@ -220,7 +220,7 @@ static int get_ti (struct ip_vs_dest_entry *de, char *ti, size_t size)
 	len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr),
 			ntohs (de->port));
 
-	if ((0 > len) || (size <= len)) {
+	if ((0 > len) || (size <= ((size_t) len))) {
 		log_err ("type instance truncated: %s", ti);
 		return -1;
 	}
@@ -292,7 +292,7 @@ static void cipvs_submit_service (struct ip_vs_service_entry *se)
 
 	char pi[DATA_MAX_NAME_LEN];
 
-	int i = 0;
+	size_t i;
 
 	if (0 != get_pi (se, pi, sizeof (pi)))
 	{
@@ -314,7 +314,7 @@ static void cipvs_submit_service (struct ip_vs_service_entry *se)
 static int cipvs_read (void)
 {
 	struct ip_vs_get_services *services = NULL;
-	int i = 0;
+	size_t i;
 
 	if (sockfd < 0)
 		return (-1);

--- a/src/java.c
+++ b/src/java.c
@@ -618,7 +618,7 @@ static jobject ctoj_data_set (JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
   jmethodID m_add;
   jobject o_type;
   jobject o_dataset;
-  int i;
+  size_t i;
 
   /* Look up the org/collectd/api/DataSet class */
   c_dataset = (*jvm_env)->FindClass (jvm_env, "org/collectd/api/DataSet");
@@ -763,7 +763,7 @@ static jobject ctoj_value_list (JNIEnv *jvm_env, /* {{{ */
   jmethodID m_valuelist_constructor;
   jobject o_valuelist;
   int status;
-  int i;
+  size_t i;
 
   /* First, create a new ValueList instance..
    * Look up the class.. */

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -368,14 +368,14 @@ static int init_state = 0;
 static inline int item_watched(int i)
 {
 	assert (i >= 0);
-	assert (i < ((STATIC_ARRAY_SIZE (watch_items) + 1) * 32));
+	assert (((size_t) i) < ((STATIC_ARRAY_SIZE (watch_items) + 1) * 32));
 	return watch_items[i / 32] & FLAG (i);
 }
 
 static inline int item_summed(int i)
 {
 	assert (i >= 0);
-	assert (i < ((STATIC_ARRAY_SIZE (misc_items) + 1) * 32));
+	assert (((size_t) i) < ((STATIC_ARRAY_SIZE (misc_items) + 1) * 32));
 	return misc_items[i / 32] & FLAG (i);
 }
 
@@ -420,8 +420,8 @@ static int watchitem_find (const char *name)
 
 static int madwifi_real_init (void)
 {
-	int max = STATIC_ARRAY_SIZE (specs);
-	int i;
+	size_t max = STATIC_ARRAY_SIZE (specs);
+	size_t i;
 
 	for (i = 0; i < STATIC_ARRAY_SIZE (bounds); i++)
 		bounds[i] = 0;
@@ -618,7 +618,7 @@ process_stat_struct (int which, const void *ptr, const char *dev, const char *ma
 	int i;
 
 	assert (which >= 1);
-	assert (which < STATIC_ARRAY_SIZE (bounds));
+	assert (((size_t) which) < STATIC_ARRAY_SIZE (bounds));
 
 	for (i = bounds[which - 1]; i < bounds[which]; i++)
 	{
@@ -754,7 +754,8 @@ process_stations (int sk, const char *dev)
 	uint8_t buf[24*1024];
 	struct iwreq iwr;
 	uint8_t *cp;
-	int len, nodes;
+	int nodes;
+	size_t len;
 	int status;
 
 	memset (&iwr, 0, sizeof (iwr));

--- a/src/match_empty_counter.c
+++ b/src/match_empty_counter.c
@@ -80,7 +80,7 @@ static int mec_match (const data_set_t __attribute__((unused)) *ds, /* {{{ */
 {
   int num_counters;
   int num_empty;
-  int i;
+  size_t i;
 
   if ((user_data == NULL) || (*user_data == NULL))
     return (-1);

--- a/src/match_value.c
+++ b/src/match_value.c
@@ -58,7 +58,7 @@ struct mv_match_s
  */
 static void mv_free_match (mv_match_t *m) /* {{{ */
 {
-  int i;
+  size_t i;
   
   if (m == NULL)
     return;
@@ -277,7 +277,7 @@ static int mv_match (const data_set_t *ds, const value_list_t *vl, /* {{{ */
   mv_match_t *m;
   gauge_t *values;
   int status;
-  int i;
+  size_t i;
 
   if ((user_data == NULL) || (*user_data == NULL))
     return (-1);

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -440,7 +440,7 @@ static int mb_read_data (mb_host_t *host, mb_slave_t *slave, /* {{{ */
 
   if (ds->ds_num != 1)
   {
-    ERROR ("Modbus plugin: The type \"%s\" has %i data sources. "
+    ERROR ("Modbus plugin: The type \"%s\" has %zu data sources. "
         "I can only handle data sets with only one data source.",
         data->type, ds->ds_num);
     return (-1);

--- a/src/network.c
+++ b/src/network.c
@@ -2443,7 +2443,7 @@ static int network_receive (void) /* {{{ */
 	char buffer[network_config_packet_size];
 	int  buffer_len;
 
-	int i;
+	size_t i;
 	int status = 0;
 
 	receive_list_entry_t *private_list_head;

--- a/src/network.c
+++ b/src/network.c
@@ -772,7 +772,7 @@ static int write_part_string (char **ret_buffer, int *ret_buffer_len,
 } /* int write_part_string */
 
 static int parse_part_values (void **ret_buffer, size_t *ret_buffer_len,
-		value_t **ret_values, int *ret_num_values)
+		value_t **ret_values, size_t *ret_num_values)
 {
 	char *buffer = *ret_buffer;
 	size_t buffer_len = *ret_buffer_len;
@@ -876,7 +876,7 @@ static int parse_part_values (void **ret_buffer, size_t *ret_buffer_len,
 
 	*ret_buffer     = buffer;
 	*ret_buffer_len = buffer_len - pkg_length;
-	*ret_num_values = pkg_numval;
+	*ret_num_values = (size_t) pkg_numval;
 	*ret_values     = pkg_values;
 
 	sfree (pkg_types);

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -265,7 +265,7 @@ static char *refclock_names[] =
 	"JJY",        "TT_IRIG",      "GPS_ZYFER",  "GPS_RIPENCC", /* 40-43 */
 	"NEOCLK4X"                                                 /* 44    */
 };
-static int refclock_names_num = STATIC_ARRAY_SIZE (refclock_names);
+static size_t refclock_names_num = STATIC_ARRAY_SIZE (refclock_names);
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * End of the copied stuff..                                         *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -868,7 +868,7 @@ static int ntpd_get_name_refclock (char *buffer, size_t buffer_size,
 	uint32_t refclock_id = ntpd_get_refclock_id (peer_info);
 	uint32_t unit_id = ntohl (peer_info->srcadr) & 0x00FF;
 
-	if (refclock_id >= refclock_names_num)
+	if (((size_t) refclock_id) >= refclock_names_num)
 		return (ntpd_get_name_from_address (buffer, buffer_size,
 					peer_info,
 					/* do_reverse_lookup = */ 0));

--- a/src/perl.c
+++ b/src/perl.c
@@ -301,33 +301,32 @@ static int hv2data_source (pTHX_ HV *hash, data_source_t *ds)
 	return 0;
 } /* static int hv2data_source (HV *, data_source_t *) */
 
-static int av2value (pTHX_ char *name, AV *array, value_t *value, int len)
+/* av2value converts at most "len" elements from "array" to "value". Returns the
+ * number of elements converted or zero on error. */
+static size_t av2value (pTHX_ char *name, AV *array, value_t *value, size_t array_len)
 {
 	const data_set_t *ds;
+	size_t i;
 
-	int i = 0;
-
-	if ((NULL == name) || (NULL == array) || (NULL == value))
-		return -1;
-
-	if (av_len (array) < len - 1)
-		len = av_len (array) + 1;
-
-	if (0 >= len)
-		return -1;
+	if ((NULL == name) || (NULL == array) || (NULL == value) || (array_len == 0))
+		return 0;
 
 	ds = plugin_get_ds (name);
 	if (NULL == ds) {
 		log_err ("av2value: Unknown dataset \"%s\"", name);
-		return -1;
+		return 0;
 	}
 
-	if (ds->ds_num < len) {
-		log_warn ("av2value: Value length exceeds data set length.");
-		len = ds->ds_num;
+	if (array_len < ds->ds_num) {
+		log_warn ("av2value: array does not contain enough elements for type \"%s\": got %zu, want %zu",
+				name, array_len, ds->ds_num);
+		return 0;
+	} else if (array_len > ds->ds_num) {
+		log_warn ("av2value: array contains excess elements for type \"%s\": got %zu, want %zu",
+				name, array_len, ds->ds_num);
 	}
 
-	for (i = 0; i < len; ++i) {
+	for (i = 0; i < ds->ds_num; ++i) {
 		SV **tmp = av_fetch (array, i, 0);
 
 		if (NULL != tmp) {
@@ -341,11 +340,12 @@ static int av2value (pTHX_ char *name, AV *array, value_t *value, int len)
 				value[i].absolute = SvIV (*tmp);
 		}
 		else {
-			return -1;
+			return 0;
 		}
 	}
-	return len;
-} /* static int av2value (char *, AV *, value_t *, int) */
+
+	return ds->ds_num;
+} /* static size_t av2value (char *, AV *, value_t *, size_t) */
 
 /*
  * value list:
@@ -380,16 +380,14 @@ static int hv2value_list (pTHX_ HV *hash, value_list_t *vl)
 
 	{
 		AV  *array = (AV *)SvRV (*tmp);
-		int len    = av_len (array) + 1;
-
-		if (len <= 0)
+		/* av_len returns the highest index, not the actual length. */
+		size_t array_len = (size_t) (av_len (array) + 1);
+		if (array_len == 0)
 			return -1;
 
-		vl->values     = (value_t *)smalloc (len * sizeof (value_t));
-		vl->values_len = av2value (aTHX_ vl->type, (AV *)SvRV (*tmp),
-				vl->values, len);
-
-		if (-1 == vl->values_len) {
+		vl->values     = calloc (array_len, sizeof (*vl->values));
+		vl->values_len = av2value (aTHX_ vl->type, (AV *)SvRV (*tmp), vl->values, array_len);
+		if (vl->values_len == 0) {
 			sfree (vl->values);
 			return -1;
 		}
@@ -604,7 +602,7 @@ static int hv2notification (pTHX_ HV *hash, notification_t *n)
 
 static int data_set2av (pTHX_ data_set_t *ds, AV *array)
 {
-	int i = 0;
+	size_t i;
 
 	if ((NULL == ds) || (NULL == array))
 		return -1;
@@ -640,24 +638,17 @@ static int data_set2av (pTHX_ data_set_t *ds, AV *array)
 static int value_list2hv (pTHX_ value_list_t *vl, data_set_t *ds, HV *hash)
 {
 	AV *values = NULL;
-
-	int i   = 0;
-	int len = 0;
+	size_t i;
 
 	if ((NULL == vl) || (NULL == ds) || (NULL == hash))
 		return -1;
 
-	len = vl->values_len;
-
-	if (ds->ds_num < len) {
-		log_warn ("value2av: Value length exceeds data set length.");
-		len = ds->ds_num;
-	}
-
 	values = newAV ();
-	av_extend (values, len - 1);
+	/* av_extend takes the last *index* to which the array should be extended. */
+	av_extend (values, vl->values_len - 1);
 
-	for (i = 0; i < len; ++i) {
+	assert (ds->ds_num == vl->values_len);
+	for (i = 0; i < vl->values_len; ++i) {
 		SV *val = NULL;
 
 		if (DS_TYPE_COUNTER == ds->ds[i].type)

--- a/src/ping.c
+++ b/src/ping.c
@@ -210,7 +210,8 @@ static int ping_dispatch_all (pingobj_t *pingobj) /* {{{ */
       hl->pkg_missed++;
 
     /* if the host did not answer our last N packages, trigger a resolv. */
-    if (ping_max_missed >= 0 && hl->pkg_missed >= ping_max_missed)
+    if ((ping_max_missed >= 0)
+        && (hl->pkg_missed >= ((uint32_t) ping_max_missed)))
     { /* {{{ */
       /* we reset the missed package counter here, since we only want to
        * trigger a resolv every N packages and not every package _AFTER_ N

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -615,7 +615,7 @@ static int c_psql_read (user_data_t *ud)
 	c_psql_database_t *db;
 
 	int success = 0;
-	int i;
+	size_t i;
 
 	if ((ud == NULL) || (ud->data == NULL)) {
 		log_err ("c_psql_read: Invalid user data.");
@@ -663,8 +663,7 @@ static char *values_name_to_sqlarray (const data_set_t *ds,
 {
 	char  *str_ptr;
 	size_t str_len;
-
-	int i;
+	size_t i;
 
 	str_ptr = string;
 	str_len = string_len;
@@ -702,8 +701,7 @@ static char *values_type_to_sqlarray (const data_set_t *ds,
 {
 	char  *str_ptr;
 	size_t str_len;
-
-	int i;
+	size_t i;
 
 	str_ptr = string;
 	str_len = string_len;
@@ -751,8 +749,7 @@ static char *values_to_sqlarray (const data_set_t *ds, const value_list_t *vl,
 	size_t str_len;
 
 	gauge_t *rates = NULL;
-
-	int i;
+	size_t i;
 
 	str_ptr = string;
 	str_len = string_len;
@@ -837,7 +834,7 @@ static int c_psql_write (const data_set_t *ds, const value_list_t *vl,
 	const char *params[9];
 
 	int success = 0;
-	int i;
+	size_t i;
 
 	if ((ud == NULL) || (ud->data == NULL)) {
 		log_err ("c_psql_write: Invalid user data.");

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -650,12 +650,12 @@ static int powerdns_update_recursor_command (list_item_t *li) /* {{{ */
       return (-1);
     }
     buffer[sizeof (buffer) - 1] = 0;
-    int i = strlen (buffer);
-    if (i < sizeof (buffer) - 2)
+    size_t len = strlen (buffer);
+    if (len < sizeof (buffer) - 2)
     {
-      buffer[i++] = ' ';
-      buffer[i++] = '\n';
-      buffer[i++] = '\0';
+      buffer[len++] = ' ';
+      buffer[len++] = '\n';
+      buffer[len++] = '\0';
     }
   }
 

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -298,7 +298,7 @@ static void submit (const char *plugin_instance, /* {{{ */
 
   if (ds->ds_num != 1)
   {
-    ERROR ("powerdns plugin: type `%s' has %i data sources, "
+    ERROR ("powerdns plugin: type `%s' has %zu data sources, "
         "but I can only handle one.",
         type, ds->ds_num);
     return;

--- a/src/python.c
+++ b/src/python.c
@@ -345,7 +345,7 @@ static int cpy_read_callback(user_data_t *data) {
 }
 
 static int cpy_write_callback(const data_set_t *ds, const value_list_t *value_list, user_data_t *data) {
-	int i;
+	size_t i;
 	cpy_callback_t *c = data->data;
 	PyObject *ret, *list, *temp, *dict = NULL;
 	Values *v;
@@ -358,22 +358,13 @@ static int cpy_write_callback(const data_set_t *ds, const value_list_t *value_li
 		}
 		for (i = 0; i < value_list->values_len; ++i) {
 			if (ds->ds[i].type == DS_TYPE_COUNTER) {
-				if ((long) value_list->values[i].counter == value_list->values[i].counter)
-					PyList_SetItem(list, i, PyInt_FromLong(value_list->values[i].counter));
-				else
-					PyList_SetItem(list, i, PyLong_FromUnsignedLongLong(value_list->values[i].counter));
+				PyList_SetItem(list, i, PyLong_FromUnsignedLongLong(value_list->values[i].counter));
 			} else if (ds->ds[i].type == DS_TYPE_GAUGE) {
 				PyList_SetItem(list, i, PyFloat_FromDouble(value_list->values[i].gauge));
 			} else if (ds->ds[i].type == DS_TYPE_DERIVE) {
-				if ((long) value_list->values[i].derive == value_list->values[i].derive)
-					PyList_SetItem(list, i, PyInt_FromLong(value_list->values[i].derive));
-				else
-					PyList_SetItem(list, i, PyLong_FromLongLong(value_list->values[i].derive));
+				PyList_SetItem(list, i, PyLong_FromLongLong(value_list->values[i].derive));
 			} else if (ds->ds[i].type == DS_TYPE_ABSOLUTE) {
-				if ((long) value_list->values[i].absolute == value_list->values[i].absolute)
-					PyList_SetItem(list, i, PyInt_FromLong(value_list->values[i].absolute));
-				else
-					PyList_SetItem(list, i, PyLong_FromUnsignedLongLong(value_list->values[i].absolute));
+				PyList_SetItem(list, i, PyLong_FromUnsignedLongLong(value_list->values[i].absolute));
 			} else {
 				Py_BEGIN_ALLOW_THREADS
 				ERROR("cpy_write_callback: Unknown value type %d.", ds->ds[i].type);
@@ -569,7 +560,7 @@ static PyObject *float_or_none(float number) {
 }
 
 static PyObject *cpy_get_dataset(PyObject *self, PyObject *args) {
-	int i;
+	size_t i;
 	char *name;
 	const data_set_t *ds;
 	PyObject *list, *tuple;

--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -502,9 +502,9 @@ static meta_data_t *cpy_build_meta(PyObject *meta) {
 }
 
 static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
-	int i, ret;
+	int ret;
 	const data_set_t *ds;
-	int size;
+	size_t size, i;
 	value_t *value;
 	value_list_t value_list = VALUE_LIST_INIT;
 	PyObject *values = self->values, *meta = self->meta;
@@ -542,15 +542,15 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 		PyErr_Format(PyExc_TypeError, "meta must be a dict");
 		return NULL;
 	}
-	size = (int) PySequence_Length(values);
+	size = (size_t) PySequence_Length(values);
 	if (size != ds->ds_num) {
-		PyErr_Format(PyExc_RuntimeError, "type %s needs %d values, got %i", value_list.type, ds->ds_num, size);
+		PyErr_Format(PyExc_RuntimeError, "type %s needs %zu values, got %zu", value_list.type, ds->ds_num, size);
 		return NULL;
 	}
-	value = malloc(size * sizeof(*value));
+	value = calloc(size, sizeof(*value));
 	for (i = 0; i < size; ++i) {
 		PyObject *item, *num;
-		item = PySequence_Fast_GET_ITEM(values, i); /* Borrowed reference. */
+		item = PySequence_Fast_GET_ITEM(values, (int) i); /* Borrowed reference. */
 		if (ds->ds->type == DS_TYPE_COUNTER) {
 			num = PyNumber_Long(item); /* New reference. */
 			if (num != NULL) {
@@ -611,9 +611,9 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 }
 
 static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
-	int i, ret;
+	int ret;
 	const data_set_t *ds;
-	int size;
+	size_t size, i;
 	value_t *value;
 	value_list_t value_list = VALUE_LIST_INIT;
 	PyObject *values = self->values, *meta = self->meta;
@@ -646,12 +646,12 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
 		PyErr_Format(PyExc_TypeError, "values must be list or tuple");
 		return NULL;
 	}
-	size = (int) PySequence_Length(values);
+	size = (size_t) PySequence_Length(values);
 	if (size != ds->ds_num) {
-		PyErr_Format(PyExc_RuntimeError, "type %s needs %d values, got %i", value_list.type, ds->ds_num, size);
+		PyErr_Format(PyExc_RuntimeError, "type %s needs %zu values, got %zu", value_list.type, ds->ds_num, size);
 		return NULL;
 	}
-	value = malloc(size * sizeof(*value));
+	value = calloc(size, sizeof(*value));
 	for (i = 0; i < size; ++i) {
 		PyObject *item, *num;
 		item = PySequence_Fast_GET_ITEM(values, i); /* Borrowed reference. */

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -69,7 +69,7 @@ static int value_list_to_string (char *buffer, int buffer_len,
 {
   int offset;
   int status;
-  int i;
+  size_t i;
   time_t t;
 
   assert (0 == strcmp (ds->type, vl->type));

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -204,7 +204,7 @@ static int value_list_to_string_multiple (char *buffer, int buffer_len,
 	int offset;
 	int status;
 	time_t tt;
-	int i;
+	size_t i;
 
 	memset (buffer, '\0', buffer_len);
 

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -61,7 +61,7 @@ struct data_definition_s
   instance_t instance;
   char *instance_prefix;
   oid_t *values;
-  int values_len;
+  size_t values_len;
   double scale;
   double shift;
   struct data_definition_s *next;
@@ -313,7 +313,7 @@ static int csnmp_config_add_data_values (data_definition_t *dd, oconfig_item_t *
   dd->values = (oid_t *) malloc (sizeof (oid_t) * ci->values_num);
   if (dd->values == NULL)
     return (-1);
-  dd->values_len = ci->values_num;
+  dd->values_len = (size_t) ci->values_num;
 
   for (i = 0; i < ci->values_num; i++)
   {
@@ -459,7 +459,7 @@ static int csnmp_config_add_data (oconfig_item_t *ci)
     return (-1);
   }
 
-  DEBUG ("snmp plugin: dd = { name = %s, type = %s, is_table = %s, values_len = %i }",
+  DEBUG ("snmp plugin: dd = { name = %s, type = %s, is_table = %s, values_len = %zu }",
       dd->name, dd->type, (dd->is_table != 0) ? "true" : "false", dd->values_len);
 
   if (data_head == NULL)
@@ -1220,7 +1220,7 @@ static int csnmp_dispatch_table (host_definition_t *host, data_definition_t *dat
   csnmp_list_instances_t *instance_list_ptr;
   csnmp_table_values_t **value_table_ptr;
 
-  int i;
+  size_t i;
   _Bool have_more;
   oid_t current_suffix;
 
@@ -1235,7 +1235,7 @@ static int csnmp_dispatch_table (host_definition_t *host, data_definition_t *dat
 
   instance_list_ptr = instance_list;
 
-  value_table_ptr = calloc ((size_t) data->values_len, sizeof (*value_table_ptr));
+  value_table_ptr = calloc (data->values_len, sizeof (*value_table_ptr));
   if (value_table_ptr == NULL)
     return (-1);
   for (i = 0; i < data->values_len; i++)
@@ -1416,7 +1416,7 @@ static int csnmp_read_table (host_definition_t *host, data_definition_t *data)
 
   if (ds->ds_num != data->values_len)
   {
-    ERROR ("snmp plugin: DataSet `%s' requires %i values, but config talks about %i",
+    ERROR ("snmp plugin: DataSet `%s' requires %zu values, but config talks about %zu",
         data->type, ds->ds_num, data->values_len);
     return (-1);
   }
@@ -1680,7 +1680,7 @@ static int csnmp_read_value (host_definition_t *host, data_definition_t *data)
 
   if (ds->ds_num != data->values_len)
   {
-    ERROR ("snmp plugin: DataSet `%s' requires %i values, but config talks about %i",
+    ERROR ("snmp plugin: DataSet `%s' requires %zu values, but config talks about %zu",
         data->type, ds->ds_num, data->values_len);
     return (-1);
   }

--- a/src/table.c
+++ b/src/table.c
@@ -352,9 +352,9 @@ static int tbl_prepare (tbl_t *tbl)
 			return -1;
 		}
 
-		if (res->values_num != (size_t)res->ds->ds_num) {
+		if (res->values_num != res->ds->ds_num) {
 			log_err ("Invalid type \"%s\". Expected %zu data source%s, "
-					"got %i.", res->type, res->values_num,
+					"got %zu.", res->type, res->values_num,
 					(1 == res->values_num) ? "" : "s",
 					res->ds->ds_num);
 			return -1;

--- a/src/table.c
+++ b/src/table.c
@@ -42,12 +42,12 @@
  */
 
 typedef struct {
-	char  *type;
-	char  *instance_prefix;
-	int   *instances;
-	size_t instances_num;
-	int   *values;
-	size_t values_num;
+	char   *type;
+	char   *instance_prefix;
+	size_t *instances;
+	size_t  instances_num;
+	size_t *values;
+	size_t  values_num;
 
 	const data_set_t *ds;
 } tbl_result_t;
@@ -139,11 +139,11 @@ static int tbl_config_set_s (char *name, char **var, oconfig_item_t *ci)
 	return 0;
 } /* tbl_config_set_separator */
 
-static int tbl_config_append_array_i (char *name, int **var, size_t *len,
+static int tbl_config_append_array_i (char *name, size_t **var, size_t *len,
 		oconfig_item_t *ci)
 {
-	int *tmp;
-
+	size_t *tmp;
+	size_t num;
 	size_t i;
 
 	if (1 > ci->values_num) {
@@ -151,26 +151,28 @@ static int tbl_config_append_array_i (char *name, int **var, size_t *len,
 		return 1;
 	}
 
-	for (i = 0; i < ci->values_num; ++i) {
+	num = (size_t) ci->values_num;
+	for (i = 0; i < num; ++i) {
 		if (OCONFIG_TYPE_NUMBER != ci->values[i].type) {
 			log_err ("\"%s\" expects numerical arguments only.", name);
 			return 1;
 		}
 	}
 
-	*len += ci->values_num;
-	tmp = (int *)realloc (*var, *len * sizeof (**var));
+	tmp = realloc (*var, ((*len) + num) * sizeof (**var));
 	if (NULL == tmp) {
 		char errbuf[1024];
 		log_err ("realloc failed: %s.",
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return -1;
 	}
-
 	*var = tmp;
 
-	for (i = *len - ci->values_num; i < *len; ++i)
-		(*var)[i] = (int)ci->values[i].value.number;
+	for (i = 0; i < num; ++i) {
+		(*var)[*len] = (size_t) ci->values[i].value.number;
+		(*len)++;
+	}
+
 	return 0;
 } /* tbl_config_append_array_s */
 
@@ -179,7 +181,7 @@ static int tbl_config_result (tbl_t *tbl, oconfig_item_t *ci)
 	tbl_result_t *res;
 
 	int status = 0;
-	size_t i;
+	int i;
 
 	if (0 != ci->values_num) {
 		log_err ("<Result> does not expect any arguments.");
@@ -266,7 +268,7 @@ static int tbl_config_table (oconfig_item_t *ci)
 	tbl = tables + tables_num - 1;
 	tbl_setup (tbl, ci->values[0].value.string);
 
-	for (i = 0; i < ci->children_num; ++i) {
+	for (i = 0; i < ((size_t) ci->children_num); ++i) {
 		oconfig_item_t *c = ci->children + i;
 
 		if (0 == strcasecmp (c->key, "Separator"))
@@ -321,7 +323,7 @@ static int tbl_config_table (oconfig_item_t *ci)
 
 static int tbl_config (oconfig_item_t *ci)
 {
-	size_t i;
+	int i;
 
 	for (i = 0; i < ci->children_num; ++i) {
 		oconfig_item_t *c = ci->children + i;

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -33,23 +33,23 @@
 #include <string.h>
 
 struct metric_definition_s {
-    char *name;
-    char *type;
-    char *instance;
-    int data_source_type;
-    int value_from;
+    char   *name;
+    char   *type;
+    char   *instance;
+    int     data_source_type;
+    ssize_t value_from;
     struct metric_definition_s *next;
 };
 typedef struct metric_definition_s metric_definition_t;
 
 struct instance_definition_s {
-    char *instance;
-    char *path;
-    cu_tail_t *tail;
+    char                 *instance;
+    char                 *path;
+    cu_tail_t            *tail;
     metric_definition_t **metric_list;
-    size_t metric_list_len;
-    cdtime_t interval;
-    int time_from;
+    size_t                metric_list_len;
+    cdtime_t              interval;
+    ssize_t               time_from;
     struct instance_definition_s *next;
 };
 typedef struct instance_definition_s instance_definition_t;
@@ -100,37 +100,37 @@ static int tcsv_read_metric (instance_definition_t *id,
         char **fields, size_t fields_num)
 {
     value_t v;
-    cdtime_t t;
+    cdtime_t t = 0;
     int status;
 
     if (md->data_source_type == -1)
         return (EINVAL);
 
-    if (md->value_from >= fields_num)
+    assert (md->value_from >= 0);
+    if (((size_t) md->value_from) >= fields_num)
         return (EINVAL);
-
-    if (id->time_from >= 0 && (id->time_from >= fields_num))
-        return (EINVAL);
-
-    t = 0;
-    if (id->time_from >= 0)
-        t = parse_time (fields[id->time_from]);
 
     status = parse_value (fields[md->value_from], &v, md->data_source_type);
     if (status != 0)
         return (status);
 
+    if (id->time_from >= 0) {
+        if (((size_t) id->time_from) >= fields_num)
+            return (EINVAL);
+        t = parse_time (fields[id->time_from]);
+    }
+
     return (tcsv_submit (id, md, v, t));
 }
 
-static _Bool tcsv_check_index (int index, size_t fields_num, char const *name)
+static _Bool tcsv_check_index (ssize_t index, size_t fields_num, char const *name)
 {
     if (index < 0)
         return 1;
     else if (((size_t) index) < fields_num)
         return 1;
 
-    ERROR ("tail_csv plugin: Metric \"%s\": Request for index %i when "
+    ERROR ("tail_csv plugin: Metric \"%s\": Request for index %zd when "
             "only %zu fields are available.",
             name, index, fields_num);
     return (0);
@@ -267,30 +267,27 @@ static void tcsv_metric_definition_destroy(void *arg){
     tcsv_metric_definition_destroy (next);
 }
 
-static int tcsv_config_get_index(oconfig_item_t *ci, int *ret_index) {
-    int index;
-
+static int tcsv_config_get_index(oconfig_item_t *ci, ssize_t *ret_index) {
     if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)){
         WARNING("tail_csv plugin: The \"%s\" config option needs exactly one "
                 "integer argument.", ci->key);
         return (-1);
     }
 
-    index = (int) ci->values[0].value.number;
-    if (index < 0) {
+    if (ci->values[0].value.number < 0) {
         WARNING("tail_csv plugin: The \"%s\" config option must be positive "
                 "(or zero).", ci->key);
         return (-1);
     }
 
-    *ret_index = index;
+    *ret_index = (ssize_t) ci->values[0].value.number;
     return (0);
 }
 
 /* Parse metric  */
 static int tcsv_config_add_metric(oconfig_item_t *ci){
     metric_definition_t *md;
-    int status = 0;
+    int status;
     int i;
 
     md = (metric_definition_t *)malloc(sizeof(*md));

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -542,7 +542,7 @@ static int tcsv_init(void) { /* {{{ */
         }
         else if (ds->ds_num != 1)
         {
-            ERROR ("tail_csv plugin: The type \"%s\" has %i data sources. "
+            ERROR ("tail_csv plugin: The type \"%s\" has %zu data sources. "
                     "Only types with a single data soure are supported.",
                     ds->type, ds->ds_num);
             continue;

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -199,7 +199,7 @@ static int tn_invoke (const data_set_t *ds, value_list_t *vl, /* {{{ */
   gauge_t *rates;
   int rates_failed;
 
-  int i;
+  size_t i;
 
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
     return (-EINVAL);

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -458,7 +458,7 @@ static int ts_invoke (const data_set_t *ds, value_list_t *vl, /* {{{ */
 		notification_meta_t __attribute__((unused)) **meta, void **user_data)
 {
 	ts_data_t *data;
-	int i;
+	size_t i;
 
 	if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
 		return (-EINVAL);

--- a/src/ted.c
+++ b/src/ted.c
@@ -147,7 +147,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage)
             WARNING ("ted plugin: Received EOF from file descriptor.");
             return (-1);
         }
-        else if (receive_buffer_length > sizeof (receive_buffer))
+        else if (((size_t) receive_buffer_length) > sizeof (receive_buffer))
         {
             ERROR ("ted plugin: read(2) returned invalid value %zi.",
                     receive_buffer_length);

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -553,7 +553,7 @@ static int ut_report_state (const data_set_t *ds,
     {
       gauge_t value;
       gauge_t sum;
-      int i;
+      size_t i;
 
       sum = 0.0;
       for (i = 0; i < vl->values_len; i++)
@@ -701,7 +701,7 @@ static int ut_check_one_threshold (const data_set_t *ds,
 { /* {{{ */
   int ret = -1;
   int ds_index = -1;
-  int i;
+  size_t i;
   gauge_t values_copy[ds->ds_num];
 
   memcpy (values_copy, values, sizeof (values_copy));

--- a/src/utils_cmd_flush.c
+++ b/src/utils_cmd_flush.c
@@ -124,7 +124,7 @@ int handle_flush (FILE *fh, char *buffer)
 	for (i = 0; (i == 0) || (i < plugins_num); i++)
 	{
 		char *plugin = NULL;
-		int j;
+		size_t j;
 
 		if (plugins_num != 0)
 			plugin = plugins[i];

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -131,18 +131,18 @@ int handle_getval (FILE *fh, char *buffer)
     return (-1);
   }
 
-  if ((size_t) ds->ds_num != values_num)
+  if (ds->ds_num != values_num)
   {
-    ERROR ("ds[%s]->ds_num = %i, "
-	"but uc_get_rate_by_name returned %u values.",
-	ds->type, ds->ds_num, (unsigned int) values_num);
+    ERROR ("ds[%s]->ds_num = %zu, "
+	"but uc_get_rate_by_name returned %zu values.",
+	ds->type, ds->ds_num, values_num);
     print_to_socket (fh, "-1 Error reading value from cache.\n");
     sfree (values);
     sfree (identifier_copy);
     return (-1);
   }
 
-  print_to_socket (fh, "%u Value%s found\n", (unsigned int) values_num,
+  print_to_socket (fh, "%zu Value%s found\n", values_num,
       (values_num == 1) ? "" : "s");
   for (i = 0; i < values_num; i++)
   {

--- a/src/utils_db_query.c
+++ b/src/utils_db_query.c
@@ -371,10 +371,10 @@ static int udb_result_prepare_result (udb_result_t const *r, /* {{{ */
     BAIL_OUT (-1);
   }
 
-  if (((size_t) prep_area->ds->ds_num) != r->values_num)
+  if (prep_area->ds->ds_num != r->values_num)
   {
     ERROR ("db query utils: udb_result_prepare_result: The type `%s' "
-        "requires exactly %i value%s, but the configuration specifies %zu.",
+        "requires exactly %zu value%s, but the configuration specifies %zu.",
         r->type,
         prep_area->ds->ds_num, (prep_area->ds->ds_num == 1) ? "" : "s",
         r->values_num);

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -305,7 +305,7 @@ rfc1035NameUnpack(const char *buf, size_t sz, off_t * off, char *name, size_t ns
     if (ns <= 0)
 	return 4;		/* probably compression loop */
     do {
-	if ((*off) >= sz)
+	if ((*off) >= ((off_t) sz))
 	    break;
 	c = *(buf + (*off));
 	if (c > 191) {
@@ -317,11 +317,11 @@ rfc1035NameUnpack(const char *buf, size_t sz, off_t * off, char *name, size_t ns
 	    s = ntohs(s);
 	    (*off) += sizeof(s);
 	    /* Sanity check */
-	    if ((*off) >= sz)
+	    if ((*off) >= ((off_t) sz))
 		return 1;	/* message too short */
 	    ptr = s & 0x3FFF;
 	    /* Make sure the pointer is inside this message */
-	    if (ptr >= sz)
+	    if (ptr >= ((off_t) sz))
 		return 2;	/* bad compression ptr */
 	    if (ptr < DNS_MSG_HDR_SZ)
 		return 2;	/* bad compression ptr */
@@ -355,7 +355,7 @@ rfc1035NameUnpack(const char *buf, size_t sz, off_t * off, char *name, size_t ns
     if (no > 0)
 	*(name + no - 1) = '\0';
     /* make sure we didn't allow someone to overflow the name buffer */
-    assert(no <= ns);
+    assert(no <= ((off_t) ns));
     return 0;
 }
 

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -188,7 +188,7 @@ int format_graphite (char *buffer, size_t buffer_size,
     unsigned int flags)
 {
     int status = 0;
-    int i;
+    size_t i;
     int buffer_pos = 0;
 
     gauge_t *rates = NULL;

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -81,7 +81,7 @@ static int values_to_json (char *buffer, size_t buffer_size, /* {{{ */
                 const data_set_t *ds, const value_list_t *vl, int store_rates)
 {
   size_t offset = 0;
-  int i;
+  size_t i;
   gauge_t *rates = NULL;
 
   memset (buffer, 0, buffer_size);
@@ -160,7 +160,7 @@ static int dstypes_to_json (char *buffer, size_t buffer_size, /* {{{ */
                 const data_set_t *ds)
 {
   size_t offset = 0;
-  int i;
+  size_t i;
 
   memset (buffer, 0, buffer_size);
 
@@ -197,7 +197,7 @@ static int dsnames_to_json (char *buffer, size_t buffer_size, /* {{{ */
                 const data_set_t *ds)
 {
   size_t offset = 0;
-  int i;
+  size_t i;
 
   memset (buffer, 0, buffer_size);
 

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -284,7 +284,7 @@ static int ds_get (char ***ret, /* {{{ */
     const rrdcreate_config_t *cfg)
 {
   char **ds_def;
-  int ds_num;
+  size_t ds_num;
 
   char min[32];
   char max[32];

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -778,35 +778,33 @@ static int riemann_notification(const notification_t *n, user_data_t *ud) /* {{{
 } /* }}} int riemann_notification */
 
 static int riemann_write(const data_set_t *ds, /* {{{ */
-	      const value_list_t *vl,
-	      user_data_t *ud)
+		const value_list_t *vl,
+		user_data_t *ud)
 {
 	int			 status = 0;
 	int			 statuses[vl->values_len];
 	struct riemann_host	*host = ud->data;
-	Msg			*msg;
 
-	if (host->check_thresholds)
-		write_riemann_threshold_check(ds, vl, statuses);
+	if (host->check_thresholds) {
+		status = write_riemann_threshold_check(ds, vl, statuses);
+		if (status != 0)
+			return status;
+	}
 
-    if (host->use_tcp == 1 && host->batch_mode) {
+	if (host->use_tcp == 1 && host->batch_mode) {
+		riemann_batch_add_value_list (host, ds, vl, statuses);
+	} else {
+		Msg *msg = riemann_value_list_to_protobuf (host, ds, vl, statuses);
+		if (msg == NULL)
+			return (-1);
 
-        riemann_batch_add_value_list (host, ds, vl, statuses);
+		status = riemann_send (host, msg);
+		if (status != 0)
+			ERROR ("write_riemann plugin: riemann_send failed with status %i", status);
 
+		riemann_msg_protobuf_free (msg);
+	}
 
-    } else {
-
-        msg = riemann_value_list_to_protobuf (host, ds, vl, statuses);
-        if (msg == NULL)
-            return (-1);
-
-        status = riemann_send (host, msg);
-        if (status != 0)
-            ERROR ("write_riemann plugin: riemann_send failed with status %i",
-                   status);
-
-        riemann_msg_protobuf_free (msg);
-    }
 	return status;
 } /* }}} int riemann_write */
 

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -365,7 +365,7 @@ static Msg *riemann_notification_to_protobuf(struct riemann_host *host, /* {{{ *
 	char service_buffer[6 * DATA_MAX_NAME_LEN];
 	char const *severity;
 	notification_meta_t *meta;
-	int i;
+	size_t i;
 
 	msg = malloc (sizeof (*msg));
 	if (msg == NULL)
@@ -474,7 +474,7 @@ static Event *riemann_value_to_protobuf(struct riemann_host const *host, /* {{{ 
 	char name_buffer[5 * DATA_MAX_NAME_LEN];
 	char service_buffer[6 * DATA_MAX_NAME_LEN];
 	double ttl;
-	int i;
+	size_t i;
 
 	event = malloc (sizeof (*event));
 	if (event == NULL)
@@ -744,8 +744,8 @@ static int riemann_batch_add_value_list (struct riemann_host *host, /* {{{ */
 
 	len = msg__get_packed_size(host->batch_msg);
     ret = 0;
-    if (len >= host->batch_max) {
-        ret = riemann_batch_flush_nolock(0, host);
+    if ((host->batch_max < 0) || (((size_t) host->batch_max) <= len)) {
+	    ret = riemann_batch_flush_nolock(0, host);
     }
 
     pthread_mutex_unlock(&host->lock);

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -133,7 +133,7 @@ static int ut_check_one_threshold (const data_set_t *ds,
     int *statuses)
 { /* {{{ */
   int ret = -1;
-  int i;
+  size_t i;
   int status;
   gauge_t values_copy[ds->ds_num];
 

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -202,7 +202,9 @@ int write_riemann_threshold_check (const data_set_t *ds, const value_list_t *vl,
   gauge_t *values;
   int status;
 
+  assert (vl->values_len > 0);
   memset(statuses, 0, vl->values_len * sizeof(*statuses));
+
   if (threshold_tree == NULL)
 	  return 0;
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -329,7 +329,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
 {
 	char name_buffer[5 * DATA_MAX_NAME_LEN];
 	char service_buffer[6 * DATA_MAX_NAME_LEN];
-	int i;
+	size_t i;
 	char *ret_str;
 	char *temp_str;
 	char *value_str;
@@ -641,7 +641,7 @@ static char *sensu_notification_to_json(struct sensu_host *host, /* {{{ */
 	char *ret_str;
 	char *temp_str;
 	int status;
-	int i;
+	size_t i;
 	int res;
 	// add the severity/status
 	switch (n->severity) {
@@ -883,7 +883,7 @@ static int sensu_write(const data_set_t *ds, /* {{{ */
 	int statuses[vl->values_len];
 	struct sensu_host	*host = ud->data;
 	gauge_t *rates = NULL;
-	int i;
+	size_t i;
 	char *msg;
 
 	pthread_mutex_lock(&host->lock);
@@ -897,7 +897,7 @@ static int sensu_write(const data_set_t *ds, /* {{{ */
 			return -1;
 		}
 	}
-	for (i = 0; i < (size_t) vl->values_len; i++) {
+	for (i = 0; i < vl->values_len; i++) {
 		msg = sensu_value_to_json(host, ds, vl, (int) i, rates, statuses[i]);
 		if (msg == NULL) {
 			sfree(rates);


### PR DESCRIPTION
Clang's static code analysis tripped up several times, because it assumed `(value_list_t).values_len` and `(data_set_t).ds_num` to have negative values. That these two fields were `int` was an ancient artifact that needs to be cleaned up at some point. This time is now 🙌

With the exception of the *tcpconns plugin*, which trips over the `NLMSG_OK()` macro, all plugins that compile on Ubuntu will pass Clang's `-Wsign-compare`.