### PR TITLE
[configure.ac] allow percona to provide libmysql

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2717,15 +2717,15 @@ then
 	then
 		with_libmysql="no ($with_mysql_config failed)"
 	else
-		AC_CHECK_LIB(mysqlclient, mysql_init,
+		AC_CHECK_LIB(c, mysql_init, # Hack to allow percona
 		 [with_libmysql="yes"],
 		 [with_libmysql="no (symbol 'mysql_init' not found)"],
-		 [$with_mysql_libs])
+		 [$with_mysql_libs]) # The appropriate percona or mysql libs are here
 
-		AC_CHECK_LIB(mysqlclient, mysql_get_server_version,
+		AC_CHECK_LIB(c, mysql_get_server_version, # Hack to allow percona
 		 [with_libmysql="yes"],
 		 [with_libmysql="no (symbol 'mysql_get_server_version' not found)"],
-		 [$with_mysql_libs])
+		 [$with_mysql_libs]) # The appropriate percona or mysql libs are here
 	fi
 fi
 if test "x$with_libmysql" = "xyes"


### PR DESCRIPTION
This allows the mysql_config tool provided by percona
to satisfy the build dependencies.
E.G.
mysql_config --libs_r
-L/usr/lib/x86_64-linux-gnu -lperconaserverclient_r -lpthread -lm -lssl -lcrypto -ldl

Notice perconaserverclient_r instead of mysqlclient_r

Previously the explicit name of libmysqlclient would prevent this
alternative from building.

I suspect this approach will also allow other alternatives such as
MariaDB to work as well.

I have tested this *only* with percona. Further testing with vanilla mysql (and perhaps even with MariaDB) is suggested.