### PR TITLE
Fix Perl errors in contrib/collectd2html.pl

### DIFF
--- a/contrib/collectd2html.pl
+++ b/contrib/collectd2html.pl
@@ -216,7 +216,7 @@ for (my $i = 0; $i < scalar(@rrds); ++$i) {
 END
 
 	# graph various ranges
-	foreach my $span qw(1hour 1day 1week 1month){
+	foreach my $span (qw(1hour 1day 1week 1month)){
 		system("mkdir -p $IMG_DIR/" . dirname($bn));
 		my $img = "$IMG_DIR/${bn}-$span$IMG_SFX";
 


### PR DESCRIPTION
"my" variable $cmd masks earlier declaration in same scope at /tmp/contrib_collectd2html.pl line 223.
syntax error at /tmp/contrib_collectd2html.pl line 219, near "$span qw(1hour 1day 1week 1month)"
Global symbol "$span" requires explicit package name at /tmp/contrib_collectd2html.pl line 221.
Global symbol "$span" requires explicit package name at /tmp/contrib_collectd2html.pl line 224.
Global symbol "$span" requires explicit package name at /tmp/contrib_collectd2html.pl line 225.
Global symbol "$span" requires explicit package name at /tmp/contrib_collectd2html.pl line 232.
Global symbol "$span" requires explicit package name at /tmp/contrib_collectd2html.pl line 237.
syntax error at /tmp/contrib_collectd2html.pl line 245, near "}"