### PR TITLE
swrite: Check for closed peer connection before send

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -49,6 +49,8 @@
 #include <sys/socket.h>
 #include <netdb.h>
 
+#include <poll.h>
+
 #if HAVE_NETINET_IN_H
 # include <netinet/in.h>
 #endif
@@ -270,9 +272,23 @@ ssize_t swrite (int fd, const void *buf, size_t count)
 	const char *ptr;
 	size_t      nleft;
 	ssize_t     status;
+	struct      pollfd pfd;
 
 	ptr   = (const char *) buf;
 	nleft = count;
+	
+	/* checking for closed peer connection */
+	pfd.fd = fd;
+	pfd.events = POLLIN | POLLHUP | POLLRDNORM;
+	pfd.revents = 0;
+	if (poll(&pfd, 1, 0) > 0) {
+		char buffer[32];
+		if (recv(fd, buffer, sizeof(buffer), MSG_PEEK | MSG_DONTWAIT) == 0) {
+			// if recv returns zero (even though poll() said there is data to be read),
+			// that means the connection has been closed
+			return -1;
+		}
+	}
 
 	while (nleft > 0)
 	{

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -279,7 +279,7 @@ ssize_t swrite (int fd, const void *buf, size_t count)
 	
 	/* checking for closed peer connection */
 	pfd.fd = fd;
-	pfd.events = POLLIN | POLLHUP | POLLRDNORM;
+	pfd.events = POLLIN | POLLHUP;
 	pfd.revents = 0;
 	if (poll(&pfd, 1, 0) > 0) {
 		char buffer[32];


### PR DESCRIPTION
The issue is described here: http://stackoverflow.com/a/11552492/1824548
And I got the solution from here: http://stefan.buettcher.org/cs/conn_closed.html

I have been running two docker containers, one with Graphite and another with collectd on two separate vbox machines (using TCP). When restarting the Graphite instance (docker stop && docker start) I noticed that collectd would stop sending data - it just sits there for like an hour before it realizes (if it realizes) that the connection is gone.
Weirdly when using netcat instead of the Graphite server (outside of the Graphite docker container), collectd worked as expected (detected the disconnect), so it must be something with docker - not closing the connected sockets, just killing the peer process silently.
But even then, on the collectd container the connnection goes into CLOSE_WAIT, indicating that it's the client (collectd) that should close the connection, so I searched around a bit, and came up with a solution to detect and resolve this scenario.
This PR captures the idea at least - given that I am no C coder, it is likely lacking style/error handling/etc...