### PR TITLE
write_tsdb with metadata

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7198,6 +7198,75 @@ more than one DS.
 
 =back
 
+=head3 Note about rules and metadata
+
+The C<write_tsdb> plugin recognizes metadata :
+
+=over 4
+
+=item B<tsdb_prefix> B<Prefix>
+
+If set, metric name will be prefixed with B<Prefix>.
+
+Note : B<tsdb_prefix> also applies when you define B<tsdb_id>.
+
+=item B<tsdb_id> B<Id>
+
+When you define B<tsdb_id>, the metric name is not calculated but is B<Id> (with prefix if you defined B<tsdb_prefix>).
+
+=item B<tsdb_tag_plugin> B<tag_key>
+
+=item B<tsdb_tag_pluginInstance> B<tag_key>
+
+=item B<tsdb_tag_type> B<tag_key>
+
+=item B<tsdb_tag_typeInstance> B<tag_key>
+
+=item B<tsdb_tag_dsname> B<tag_key>
+
+If a B<tsdb_tag_*> is defined, the related item is removed from the metric name. If B<tag_key> is not empty,
+a tag will be added with key B<tag_key> and value the item.
+
+=back
+
+Example without B<tsdb_tag_*> :
+
+  cpu.1.cpu.user
+
+Same example with  :
+  tsdb_tag_pluginInstance = "cpu"
+  tsdb_tag_type = ""
+
+We get :
+  cpu.user cpu=1
+
+In this example, pluginInstance (named "1") is removed from the metric name and is set as a tag named "cpu".
+The type (named "cpu") is removed because B<tsdb_tag_type> is defined but is empty.
+
+You can define tags with filter rules and target_set :
+
+  <Chain "PreCache">
+    <Rule "opentsdb_cpu">
+      <Match "regex">
+        Plugin "^cpu$"
+      </Match>
+      <Target "set">
+        MetaDataSet "tsdb_tag_pluginInstance" "cpu"
+        MetaDataSet "tsdb_tag_type" ""
+      </Target>
+    </Rule>
+    <Rule "opentsdb_prefix">
+      <Match "regex">
+        Host "^"
+      </Match>
+      <Target "set">
+        MetaDataSet "tsdb_prefix" "sys."
+      </Target>
+    </Rule>
+  </Chain>
+
+This example will replace (for example) "cpu.1.cpu.user" with "sys.cpu.user cpu=1"
+
 =head2 Plugin C<write_mongodb>
 
 The I<write_mongodb plugin> will send values to I<MongoDB>, a schema-less

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8676,6 +8676,8 @@ Available options:
 
 =item B<TypeInstance> I<String>
 
+=item B<MetaDataSet> I<String> I<String>
+
 Set the appropriate field to the given string. The strings for plugin instance
 and type instance may be empty, the strings for host and plugin may not be
 empty. It's currently not possible to set the type of a value this way.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7227,13 +7227,15 @@ When you define B<tsdb_id>, the metric name is not calculated but is B<Id> (with
 If a B<tsdb_tag_*> is defined, the related item is removed from the metric name. If B<tag_key> is not empty,
 a tag will be added with key B<tag_key> and value the item.
 
-=item B<tsdb_tag> B<tag_key>=B<tag_value>
+=item B<tsdb_tag_add_XX> B<tag_value>
 
-When you define a B<tsdb_tag> B<tag_key>=B<tag_value> key-value pair, a tag is added (copy/pasted from
-the defined B<tag_key>=B<tag_value>). If you want to add more than one tag, put them on the same line and
-separe them with spaces. Example :
+When you define a B<tsdb_tag_add_XX>, a B<tag_key>=B<tag_value> key-value pair tag is added. The
+key comes from B<tsdb_tag_add_XX> and would be B<XX> here. Note that you cannot define the same tag twice.
+Examples: 
 
-  MetaDataSet "tsdb_tag" "k1=v1 k2=v2 k3=v3"
+  MetaDataSet "tsdb_tag_add_k1" "v1"
+  MetaDataSet "tsdb_tag_add_k2" "v2"
+  MetaDataSet "tsdb_tag_add_k3" "v3"
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7230,7 +7230,10 @@ a tag will be added with key B<tag_key> and value the item.
 =item B<tsdb_tag> B<tag_key>=B<tag_value>
 
 When you define a B<tsdb_tag> B<tag_key>=B<tag_value> key-value pair, a tag is added (copy/pasted from
-the defined B<tag_key>=B<tag_value>)
+the defined B<tag_key>=B<tag_value>). If you want to add more than one tag, put them on the same line and
+separe them with spaces. Example :
+
+  MetaDataSet "tsdb_tag" "k1=v1 k2=v2 k3=v3"
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7227,6 +7227,11 @@ When you define B<tsdb_id>, the metric name is not calculated but is B<Id> (with
 If a B<tsdb_tag_*> is defined, the related item is removed from the metric name. If B<tag_key> is not empty,
 a tag will be added with key B<tag_key> and value the item.
 
+=item B<tsdb_tag> B<tag_key>=B<tag_value>
+
+When you define a B<tsdb_tag> B<tag_key>=B<tag_value> key-value pair, a tag is added (copy/pasted from
+the defined B<tag_key>=B<tag_value>)
+
 =back
 
 Example without B<tsdb_tag_*> :

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7158,6 +7158,7 @@ Synopsis:
 
  <Plugin write_tsdb>
    DNS_Cache_TTL 60
+   DNS_Random_Cache_TTL 60
    <Node "example">
      Host "tsd-1.my.domain"
      Port "4242"
@@ -7174,10 +7175,22 @@ Global directives are:
 
 =item B<DNS_Cache_TTL> I<ttl>
 
+=item B<DNS_Random_Cache_TTL> I<ttl>
+
 When Collectd connects to a TSDB node, it will request the DNS. This can become
 a problem is the TSDN node is unavailable or badly configured because Collected
 will request DNS in order to reconnect for every metric, which can flood your DNS.
-So you can cache the last value for C<ttl> seconds (default: 60s).
+So you can cache the last value for C<ttl> seconds (default: 600s e.g; 10 min).
+
+You can also define a random ttl. This prevents all your Collectd servers to
+request the DNS at the same time when the connection fails. Default value is
+15 * the write_tsdb interval (or the global interval if write_tsdb interval is not
+defined).
+
+Note : if the DNS resolution has already been successful, if the socket closes,
+the plugin will try to reconnect as soon as possible with the cached information.
+DNS is queried only when the socket is closed for a long time (DNS_Cache_TTL + 
+DNS_Random_Cache_TTL)
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7157,6 +7157,7 @@ packets.
 Synopsis:
 
  <Plugin write_tsdb>
+   DNS_Cache_TTL 60
    <Node "example">
      Host "tsd-1.my.domain"
      Port "4242"
@@ -7165,7 +7166,22 @@ Synopsis:
  </Plugin>
 
 The configuration consists of one or more E<lt>B<Node>E<nbsp>I<Name>E<gt>
-blocks. Inside the B<Node> blocks, the following options are recognized:
+blocks and global directives.
+
+Global directives are:
+
+=over 4
+
+=item B<DNS_Cache_TTL> I<ttl>
+
+When Collectd connects to a TSDB node, it will request the DNS. This can become
+a problem is the TSDN node is unavailable or badly configured because Collected
+will request DNS in order to reconnect for every metric, which can flood your DNS.
+So you can cache the last value for C<ttl> seconds (default: 60s).
+
+=back
+
+Inside the B<Node> blocks, the following options are recognized:
 
 =over 4
 

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -106,12 +106,15 @@ static meta_entry_t *md_entry_alloc (const char *key) /* {{{ */
   return (e);
 } /* }}} meta_entry_t *md_entry_alloc */
 
-static meta_entry_t *md_entry_clone (const meta_entry_t *orig) /* {{{ */
+/* XXX: The lock on md must be held while calling this function! */
+static meta_entry_t *md_entry_clone_contents (const meta_entry_t *orig) /* {{{ */
 {
   meta_entry_t *copy;
 
-  if (orig == NULL)
-    return (NULL);
+  /* WARNINGS :
+   *  - we do not check that orig != NULL here. You should have done it before.
+   *  - we do not set copy->next. DO NOT FORGET TO SET copy->next IN YOUR FUNCTION
+   */
 
   copy = md_entry_alloc (orig->key);
   copy->type = orig->type;
@@ -119,6 +122,18 @@ static meta_entry_t *md_entry_clone (const meta_entry_t *orig) /* {{{ */
     copy->value.mv_string = strdup (orig->value.mv_string);
   else
     copy->value = orig->value;
+
+  return (copy);
+} /* }}} meta_entry_t *md_entry_clone_contents */
+
+static meta_entry_t *md_entry_clone (const meta_entry_t *orig) /* {{{ */
+{
+  meta_entry_t *copy;
+
+  if (orig == NULL)
+    return (NULL);
+
+  copy = md_entry_clone_contents(orig);
 
   copy->next = md_entry_clone (orig->next);
   return (copy);
@@ -196,6 +211,63 @@ static int md_entry_insert (meta_data_t *md, meta_entry_t *e) /* {{{ */
 } /* }}} int md_entry_insert */
 
 /* XXX: The lock on md must be held while calling this function! */
+static int md_entry_insert_clone (meta_data_t *md, meta_entry_t *orig) /* {{{ */
+{
+  meta_entry_t *e;
+  meta_entry_t *this;
+  meta_entry_t *prev;
+
+  /* WARNINGS :
+   *  - we do not check that md and e != NULL here. You should have done it before.
+   *  - we do not use the lock. You should have set it before.
+   */
+
+  e = md_entry_clone_contents(orig);
+
+  prev = NULL;
+  this = md->head;
+  while (this != NULL)
+  {
+    if (strcasecmp (e->key, this->key) == 0)
+      break;
+
+    prev = this;
+    this = this->next;
+  }
+
+  if (this == NULL)
+  {
+    /* This key does not exist yet. */
+    if (md->head == NULL)
+      md->head = e;
+    else
+    {
+      assert (prev != NULL);
+      prev->next = e;
+    }
+
+    e->next = NULL;
+  }
+  else /* (this != NULL) */
+  {
+    if (prev == NULL)
+      md->head = e;
+    else
+      prev->next = e;
+
+    e->next = this->next;
+  }
+
+  if (this != NULL)
+  {
+    this->next = NULL;
+    md_entry_free (this);
+  }
+
+  return (0);
+} /* }}} int md_entry_insert_clone */
+
+/* XXX: The lock on md must be held while calling this function! */
 static meta_entry_t *md_entry_lookup (meta_data_t *md, /* {{{ */
     const char *key)
 {
@@ -249,6 +321,27 @@ meta_data_t *meta_data_clone (meta_data_t *orig) /* {{{ */
 
   return (copy);
 } /* }}} meta_data_t *meta_data_clone */
+
+int meta_data_clone_merge (meta_data_t **dest, meta_data_t *orig) /* {{{ */
+{
+  meta_entry_t *e;
+
+  if (orig == NULL)
+    return (0);
+
+  if(NULL == *dest) {
+    *dest = meta_data_clone(orig);
+    return(0);
+  }
+
+  pthread_mutex_lock (&orig->lock);
+  for(e=orig->head; NULL != e; e = e->next) {
+    md_entry_insert_clone((*dest), e);
+  }
+  pthread_mutex_unlock (&orig->lock);
+
+  return (0);
+} /* }}} int meta_data_clone_merge */
 
 void meta_data_destroy (meta_data_t *md) /* {{{ */
 {

--- a/src/daemon/meta_data.h
+++ b/src/daemon/meta_data.h
@@ -43,6 +43,7 @@ typedef struct meta_data_s meta_data_t;
 
 meta_data_t *meta_data_create (void);
 meta_data_t *meta_data_clone (meta_data_t *orig);
+int meta_data_clone_merge (meta_data_t **dest, meta_data_t *orig);
 void meta_data_destroy (meta_data_t *md);
 
 int meta_data_exists (meta_data_t *md, const char *key);

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -1,0 +1,129 @@
+/**
+ * collectd - src/daemon/utils_subst_test.c
+ * Copyright (C) 2015       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#include "testing.h"
+#include "collectd.h"
+#include "common.h" /* for STATIC_ARRAY_SIZE */
+#include "utils_subst.h"
+
+DEF_TEST(subst)
+{
+  struct {
+    char *str;
+    int off1;
+    int off2;
+    char *rplmt;
+    char *want;
+  } cases[] = {
+    {"foo_____bar", 3, 8, " - ", "foo - bar"}, /* documentation example */
+    {"foo bar", 0, 2, "m",     "mo bar"},    /* beginning, shorten */
+    {"foo bar", 0, 1, "m",     "moo bar"},   /* beginning, same length */
+    {"foo bar", 0, 3, "milk",  "milk bar"},  /* beginning, extend */
+    {"foo bar", 3, 6, "de",    "fooder"},    /* center, shorten */
+    {"foo bar", 2, 6, "rste",  "forster"},   /* center, same length */
+    {"foo bar", 1, 3, "ish",   "fish bar"},  /* center, extend */
+    {"foo bar", 2, 7, "ul",    "foul"},      /* end, shorten */
+    {"foo bar", 3, 7, "lish",  "foolish"},   /* end, same length */
+    {"foo bar", 3, 7, "dwear", "foodwear"},  /* end, extend */
+    /* truncation (buffer is 16 chars) */
+    {"01234567890123",        8, 8,    "", "01234567890123"},
+    {"01234567890123",        8, 8,   "*", "01234567*890123"},
+    {"01234567890123",        8, 8,  "**", "01234567**89012"},
+    /* input > buffer */
+    {"012345678901234----",   0,  0,   "", "012345678901234"},
+    {"012345678901234----",  17, 18,   "", "012345678901234"},
+    {"012345678901234----",   0,  3,   "", "345678901234---"},
+    {"012345678901234----",   0,  4,   "", "45678901234----"},
+    {"012345678901234----",   0,  5,   "", "5678901234----"},
+    {"012345678901234----",   8,  8,  "#", "01234567#890123"},
+    {"012345678901234----",  12, 12, "##", "012345678901##2"},
+    {"012345678901234----",  13, 13, "##", "0123456789012##"},
+    {"012345678901234----",  14, 14, "##", "01234567890123#"},
+    {"012345678901234----",  15, 15, "##", "012345678901234"},
+    {"012345678901234----",  16, 16, "##", "012345678901234"},
+    /* error cases */
+    {NULL,       3,  4, "_",  NULL}, /* no input */
+    {"foo bar",  3, 10, "_",  NULL}, /* offset exceeds input */
+    {"foo bar", 10, 13, "_",  NULL}, /* offset exceeds input */
+    {"foo bar",  4,  3, "_",  NULL}, /* off1 > off2 */
+    {"foo bar",  3,  4, NULL, NULL}, /* no replacement */
+  };
+  size_t i;
+
+  for (i = 0; i < STATIC_ARRAY_SIZE (cases); i++) {
+    char buffer[16] = "!!!!!!!!!!!!!!!";
+
+    if (cases[i].want == NULL) {
+      OK(subst (buffer, sizeof (buffer), cases[i].str, cases[i].off1, cases[i].off2, cases[i].rplmt) == NULL);
+      continue;
+    }
+
+    OK(subst (buffer, sizeof (buffer), cases[i].str, cases[i].off1, cases[i].off2, cases[i].rplmt) == &buffer[0]);
+    STREQ(cases[i].want, buffer);
+  }
+
+  return 0;
+}
+
+DEF_TEST(subst_string)
+{
+  struct {
+    char *str;          char *srch; char *rplmt; char *want;
+  } cases[] = {
+    {"Hello %{name}",    "%{name}", "world", "Hello world"},
+    {"abcccccc",         "abc",     "cab",   "ccccccab"},
+    {"(((()(())))())",   "()",      "",      ""},
+    {"food booth",       "oo",      "ee",    "feed beeth"},
+    {"foo bar",          "baz",     "qux",   "foo bar"},
+    {"foo bar",          "oo",      "oo",    "foo bar"},
+    {"sixteen chars",    "chars",   "characters", "sixteen charact"},
+  };
+  size_t i;
+
+  for (i = 0; i < STATIC_ARRAY_SIZE (cases); i++) {
+    char buffer[16];
+
+    if (cases[i].want == NULL) {
+      OK(subst_string (buffer, sizeof (buffer), cases[i].str, cases[i].srch, cases[i].rplmt) == NULL);
+      continue;
+    }
+
+    OK(subst_string (buffer, sizeof (buffer), cases[i].str, cases[i].srch, cases[i].rplmt) == buffer);
+    STREQ(cases[i].want, buffer);
+  }
+
+  return 0;
+}
+
+int main (void)
+{
+  RUN_TEST(subst);
+  RUN_TEST(subst_string);
+
+  END_TEST;
+}
+
+/* vim: set sw=2 sts=2 et : */

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -35,8 +35,26 @@ struct ts_data_s
   char *plugin_instance;
   /* char *type; */
   char *type_instance;
+  meta_data_t *meta;
 };
 typedef struct ts_data_s ts_data_t;
+
+int ts_util_get_key_and_string_wo_strdup (const oconfig_item_t *ci, char **ret_key, char **ret_string) /* {{{ */
+{
+  if ((ci->values_num != 2)
+      || (ci->values[0].type != OCONFIG_TYPE_STRING)
+      || (ci->values[1].type != OCONFIG_TYPE_STRING))
+  {
+    ERROR ("ts_util_get_key_and_string_wo_strdup: The %s option requires "
+        "exactly two string argument.", ci->key);
+    return (-1);
+  }
+
+  *ret_key = ci->values[0].value.string;
+  *ret_string = ci->values[1].value.string;
+
+  return (0);
+} /* }}} int ts_util_get_key_and_string_wo_strdup */
 
 static int ts_config_add_string (char **dest, /* {{{ */
     const oconfig_item_t *ci, int may_be_empty)
@@ -60,6 +78,42 @@ static int ts_config_add_string (char **dest, /* {{{ */
   return (0);
 } /* }}} int ts_config_add_string */
 
+static int ts_config_add_meta (meta_data_t **dest, /* {{{ */
+    const oconfig_item_t *ci, int may_be_empty)
+{
+  char *key = NULL;
+  char *string = NULL;
+  int status;
+
+  status = ts_util_get_key_and_string_wo_strdup (ci, &key, &string);
+  if (status != 0)
+    return (status);
+
+  if (strlen (key) == 0)
+  {
+    ERROR ("Target `set': The `%s' option does not accept empty string as first argument.",
+        ci->key);
+    return (-1);
+  }
+
+  if (!may_be_empty && (strlen (string) == 0))
+  {
+    ERROR ("Target `set': The `%s' option does not accept empty string as second argument.",
+        ci->key);
+    return (-1);
+  }
+
+  if(NULL == (*dest)) {
+    // Create a new meta_data_t
+    if( NULL == (*dest = meta_data_create())) {
+      ERROR ("Target `set': failed to create a meta data for `%s'.", ci->key);
+      return (-1);
+    }
+  }
+
+  return(meta_data_add_string (*dest, key, string));
+} /* }}} int ts_config_add_meta */
+
 static int ts_destroy (void **user_data) /* {{{ */
 {
   ts_data_t *data;
@@ -76,6 +130,7 @@ static int ts_destroy (void **user_data) /* {{{ */
   free (data->plugin_instance);
   /* free (data->type); */
   free (data->type_instance);
+  meta_data_destroy(data->meta);
   free (data);
 
   return (0);
@@ -100,6 +155,7 @@ static int ts_create (const oconfig_item_t *ci, void **user_data) /* {{{ */
   data->plugin_instance = NULL;
   /* data->type = NULL; */
   data->type_instance = NULL;
+  data->meta = NULL;
 
   status = 0;
   for (i = 0; i < ci->children_num; i++)
@@ -121,8 +177,8 @@ static int ts_create (const oconfig_item_t *ci, void **user_data) /* {{{ */
       status = ts_config_add_string (&data->type, child,
           /* may be empty = */ 0);
 #endif
-    else if (strcasecmp ("TypeInstance", child->key) == 0)
-      status = ts_config_add_string (&data->type_instance, child,
+    else if (strcasecmp ("MetaDataSet", child->key) == 0)
+      status = ts_config_add_meta (&data->meta, child,
           /* may be empty = */ 1);
     else
     {
@@ -142,10 +198,12 @@ static int ts_create (const oconfig_item_t *ci, void **user_data) /* {{{ */
         && (data->plugin == NULL)
         && (data->plugin_instance == NULL)
         /* && (data->type == NULL) */
-        && (data->type_instance == NULL))
+        && (data->type_instance == NULL)
+        && (data->meta == NULL))
     {
       ERROR ("Target `set': You need to set at least one of `Host', "
-          "`Plugin', `PluginInstance' or `TypeInstance'.");
+          "`Plugin', `PluginInstance', `TypeInstance', "
+          "`MetaDataSet' or `MetaDataEval'.");
       status = -1;
     }
 
@@ -175,6 +233,10 @@ static int ts_invoke (const data_set_t *ds, value_list_t *vl, /* {{{ */
   {
     ERROR ("Target `set': Invoke: `data' is NULL.");
     return (-EINVAL);
+  }
+
+  if(NULL != data->meta) {
+    meta_data_clone_merge(&(vl->meta), data->meta);
   }
 
 #define SET_FIELD(f) if (data->f != NULL) { sstrncpy (vl->f, data->f, sizeof (vl->f)); }

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -980,7 +980,7 @@ static int wt_config(oconfig_item_t *ci)
 
         if (strcasecmp("Node", child->key) == 0)
             wt_config_tsd(child);
-        if (strcasecmp("DNS_Cache_TTL", child->key) == 0)
+        else if (strcasecmp("DNS_Cache_TTL", child->key) == 0)
         {
             int ttl;
             cf_util_get_int(child, &ttl);

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -313,7 +313,6 @@ static int wt_callback_init(struct wt_callback *cb)
         ERROR("write_tsdb plugin: Connecting to %s:%s failed. "
               "The last error was: %s", node, service,
               sstrerror (errno, errbuf, sizeof(errbuf)));
-        close(cb->sock_fd);
         return -1;
     }
 

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -464,8 +464,9 @@ static int wt_format_tags(char *ret, int ret_len,
 #define TSDB_STRING_APPEND_SPRINTF(key, value) do { \
         int n; \
         const char *k = (key); \
-        if(k[0] != '\0') { \
-            n = ssnprintf(ptr, remaining_len, " %s=%s", k, value); \
+        const char *v = (value); \
+        if(k[0] != '\0' && v[0] != '\0') { \
+            n = ssnprintf(ptr, remaining_len, " %s=%s", k, v); \
             if(n >= remaining_len) { \
                 ptr[0] = '\0'; \
             } else { \

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -28,9 +28,11 @@
  * write_tsdb Authors:
  *   Brett Hawn <bhawn at llnw.com>
  *   Kevin Bowling <kbowling@llnw.com>
+ *   Yves Mettier <ymettier@free.fr>
  **/
 
 /* write_tsdb plugin configuation example
+ * --------------------------------------
  *
  * <Plugin write_tsdb>
  *   <Node>
@@ -39,6 +41,85 @@
  *     HostTags "status=production deviceclass=www"
  *   </Node>
  * </Plugin>
+ *
+ * write_tsdb meta_data
+ * --------------------
+ *  - tsdb_prefix : Will prefix the OpenTSDB <metric> (also prefix tsdb_id if defined)
+ *  - tsdb_id     : Replace the metric with this tag
+ *
+ *  - tsdb_tag_plugin         : When defined, tsdb_tag_* removes the related
+ *  - tsdb_tag_pluginInstance : item from metric id.
+ *  - tsdb_tag_type           : If it is not empty, it will be the key of an
+ *  - tsdb_tag_typeInstance   : opentsdb tag (the value is the item itself)
+ *  - tsdb_tag_dsname         : If it is empty, no tag is defined.
+ *
+ * write_tsdb plugin filter rules example
+ * --------------------------------------
+ *
+ * <Chain "PreCache">
+ *   <Rule "opentsdb_cpu">
+ *     <Match "regex">
+ *       Plugin "^cpu$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_tag_pluginInstance" "cpu"
+ *       MetaDataSet "tsdb_tag_type" ""
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ *   <Rule "opentsdb_df">
+ *     <Match "regex">
+ *       Plugin "^df$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_tag_pluginInstance" "mount"
+ *       MetaDataSet "tsdb_tag_type" ""
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ *   <Rule "opentsdb_disk">
+ *     <Match "regex">
+ *       Plugin "^disk$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_tag_pluginInstance" "disk"
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ *   <Rule "opentsdb_interface">
+ *     <Match "regex">
+ *       Plugin "^interface$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_tag_pluginInstance" "iface"
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ *   <Rule "opentsdb_load">
+ *     <Match "regex">
+ *       Plugin "^loac$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_tag_type" ""
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ *   <Rule "opentsdb_swap">
+ *     <Match "regex">
+ *       Plugin "^swap$"
+ *     </Match>
+ *     <Target "set">
+ *       MetaDataSet "tsdb_prefix" "sys."
+ *     </Target>
+ *   </Rule>
+ * </Chain>
+ *
+ * IMPORTANT WARNING
+ * -----------------
+ * OpenTSDB allows no more than 8 tags.
+ * Collectd admins should be aware of this when defining filter rules and host
+ * tags.
+ *
  */
 
 #include "collectd.h"
@@ -68,6 +149,20 @@
 #ifndef WT_SEND_BUF_SIZE
 # define WT_SEND_BUF_SIZE 1428
 #endif
+
+/* Meta data definitions about tsdb tags */
+#define TSDB_TAG_PLUGIN 0
+#define TSDB_TAG_PLUGININSTANCE 1
+#define TSDB_TAG_TYPE 2
+#define TSDB_TAG_TYPEINSTANCE 3
+#define TSDB_TAG_DSNAME 4
+static const char *meta_tag[] = {
+    "tsdb_tag_plugin",
+    "tsdb_tag_pluginInstance",
+    "tsdb_tag_type",
+    "tsdb_tag_typeInstance",
+    "tsdb_tag_dsname"
+};
 
 /*
  * Private variables
@@ -341,15 +436,106 @@ static int wt_format_values(char *ret, size_t ret_len,
     return 0;
 }
 
-static int wt_format_name(char *ret, int ret_len,
+static int wt_format_tags(char *ret, int ret_len,
                           const value_list_t *vl,
                           const struct wt_callback *cb,
                           const char *ds_name)
 {
     int status;
     char *temp = NULL;
-    char *prefix = "";
+    char *ptr = ret;
+    size_t remaining_len = ret_len;
+
+#define TSDB_META_DATA_GET_STRING(tag) do { \
+        temp = NULL; \
+        status = meta_data_get_string(vl->meta, tag, &temp); \
+        if (status == -ENOENT) { \
+            temp = NULL; \
+            /* defaults to empty string */ \
+        } else if (status < 0) { \
+            sfree(temp); \
+            return status; \
+        } \
+    } while(0)
+
+#define TSDB_STRING_APPEND_SPRINTF(key, value) do { \
+        int n; \
+        const char *k = (key); \
+        if(k[0] != '\0') { \
+            n = ssnprintf(ptr, remaining_len, " %s=%s", k, value); \
+            if(n >= remaining_len) { \
+                ptr[0] = '\0'; \
+            } else { \
+                char *ptr2 = ptr+1; \
+                while(NULL != (ptr2 = strchr(ptr2, ' '))) ptr2[0] = '_';  \
+                ptr += n; \
+                remaining_len -= n; \
+            } \
+        } \
+    } while(0)
+
+    if (vl->meta) {
+        TSDB_META_DATA_GET_STRING(meta_tag[TSDB_TAG_PLUGIN]);
+        if(temp) {
+            TSDB_STRING_APPEND_SPRINTF(temp, vl->plugin);
+            sfree(temp);
+        }
+
+        TSDB_META_DATA_GET_STRING(meta_tag[TSDB_TAG_PLUGININSTANCE]);
+        if(temp) {
+            TSDB_STRING_APPEND_SPRINTF(temp, vl->plugin_instance);
+            sfree(temp);
+        }
+
+        TSDB_META_DATA_GET_STRING(meta_tag[TSDB_TAG_TYPE]);
+        if(temp) {
+            TSDB_STRING_APPEND_SPRINTF(temp, vl->type);
+            sfree(temp);
+        }
+
+        TSDB_META_DATA_GET_STRING(meta_tag[TSDB_TAG_TYPEINSTANCE]);
+        if(temp) {
+            TSDB_STRING_APPEND_SPRINTF(temp, vl->type_instance);
+            sfree(temp);
+        }
+
+        if(ds_name) {
+            TSDB_META_DATA_GET_STRING(meta_tag[TSDB_TAG_DSNAME]);
+            if(temp) {
+                TSDB_STRING_APPEND_SPRINTF(temp, ds_name);
+                sfree(temp);
+            }
+        }
+    } else {
+        ret[0] = '\0';
+    }
+
+#undef TSDB_META_DATA_GET_STRING
+#undef TSDB_STRING_APPEND_SPRINTF
+
+    return 0;
+}
+
+static int wt_format_name(char *ret, int ret_len,
+                          const value_list_t *vl,
+                          const struct wt_callback *cb,
+                          const char *ds_name)
+{
+    int status;
+    int i;
+    char *temp = NULL;
+    char *prefix = NULL;
     const char *meta_prefix = "tsdb_prefix";
+    char *tsdb_id = NULL;
+    const char *meta_id = "tsdb_id";
+
+    _Bool include_in_id[] = {
+        /* plugin =          */ 1,
+        /* plugin instance = */ (vl->plugin_instance[0] == '\0')?0:1,
+        /* type =            */ 1,
+        /* type instance =   */ (vl->type_instance[0] == '\0')?0:1,
+        /* ds_name =         */ (ds_name == NULL)?0:1
+    };
 
     if (vl->meta) {
         status = meta_data_get_string(vl->meta, meta_prefix, &temp);
@@ -361,54 +547,92 @@ static int wt_format_name(char *ret, int ret_len,
         } else {
             prefix = temp;
         }
-    }
 
-    if (ds_name != NULL) {
-        if (vl->plugin_instance[0] == '\0') {
-            if (vl->type_instance[0] == '\0') {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
-                        vl->type, ds_name);
-            } else {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
-                        vl->type, vl->type_instance, ds_name);
-            }
-        } else { /* vl->plugin_instance != "" */
-            if (vl->type_instance[0] == '\0') {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
-                        vl->plugin_instance, vl->type, ds_name);
-            } else {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s.%s.%s", prefix,
-                        vl->plugin, vl->plugin_instance, vl->type,
-                        vl->type_instance, ds_name);
-            }
+        status = meta_data_get_string(vl->meta, meta_id, &temp);
+        if (status == -ENOENT) {
+            /* defaults to empty string */
+        } else if (status < 0) {
+            sfree(temp);
+            return status;
+        } else {
+            tsdb_id = temp;
         }
-    } else { /* ds_name == NULL */
-        if (vl->plugin_instance[0] == '\0') {
-            if (vl->type_instance[0] == '\0') {
-                ssnprintf(ret, ret_len, "%s%s.%s", prefix, vl->plugin,
-                        vl->type);
+
+        for(i=0; i < (sizeof(meta_tag)/sizeof(*meta_tag)); i++) {
+            if(0 == meta_data_exists(vl->meta, meta_tag[i])) {
+                /* defaults to already initialized format */
             } else {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
-                        vl->type_instance, vl->type);
-            }
-        } else { /* vl->plugin_instance != "" */
-            if (vl->type_instance[0] == '\0') {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
-                        vl->plugin_instance, vl->type);
-            } else {
-                ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
-                        vl->plugin_instance, vl->type, vl->type_instance);
+                include_in_id[i] = 0;
             }
         }
     }
+    if(tsdb_id) {
+        ssnprintf(ret, ret_len, "%s%s", prefix?prefix:"", tsdb_id);
+    } else {
+#define TSDB_STRING_APPEND_STRING(string) do { \
+    const char *str = (string); \
+    size_t len = strlen(str); \
+    if(len > (remaining_len - 1)) { \
+        ptr[0] = '\0'; \
+        return(-ENOSPC); \
+    } \
+    if(len > 0) {  \
+        memcpy(ptr, str, len); \
+        ptr += len; \
+        remaining_len -= len; \
+    } \
+} while(0)
 
-    sfree(temp);
+#define TSDB_STRING_APPEND_DOT do { \
+    if(remaining_len > 2) {  \
+        ptr[0] = '.'; \
+        ptr ++; \
+        remaining_len --; \
+    } else {\
+        ptr[0] = '\0'; \
+        return(-ENOSPC); \
+    } \
+} while(0)
+
+        char *ptr = ret;
+        size_t remaining_len = ret_len;
+        if(prefix) {
+            TSDB_STRING_APPEND_STRING(prefix);
+        }
+        if(include_in_id[TSDB_TAG_PLUGIN]) {
+            TSDB_STRING_APPEND_STRING(vl->plugin);
+        }
+
+        if(include_in_id[TSDB_TAG_PLUGININSTANCE]) {
+            TSDB_STRING_APPEND_DOT;
+            TSDB_STRING_APPEND_STRING(vl->plugin_instance);
+        }
+        if(include_in_id[TSDB_TAG_TYPE]) {
+            TSDB_STRING_APPEND_DOT;
+            TSDB_STRING_APPEND_STRING(vl->type);
+        }
+        if(include_in_id[TSDB_TAG_TYPEINSTANCE]) {
+            TSDB_STRING_APPEND_DOT;
+            TSDB_STRING_APPEND_STRING(vl->type_instance);
+        }
+        if(include_in_id[TSDB_TAG_DSNAME]) {
+            TSDB_STRING_APPEND_DOT;
+            TSDB_STRING_APPEND_STRING(ds_name);
+        }
+        ptr[0] = '\0';
+#undef TSDB_STRING_APPEND_STRING
+#undef TSDB_STRING_APPEND_DOT
+    }
+
+    sfree(tsdb_id);
+    sfree(prefix);
     return 0;
 }
 
 static int wt_send_message (const char* key, const char* value,
+                            const char* value_tags,
                             cdtime_t time, struct wt_callback *cb,
-                            const char* host, meta_data_t *md)
+                            const value_list_t *vl)
 {
     int status;
     size_t message_len;
@@ -417,6 +641,8 @@ static int wt_send_message (const char* key, const char* value,
     char message[1024];
     char *host_tags = cb->host_tags ? cb->host_tags : "";
     const char *meta_tsdb = "tsdb_tags";
+    const char* host = vl->host;
+    meta_data_t *md = vl->meta;
 
     /* skip if value is NaN */
     if (value[0] == 'n')
@@ -438,11 +664,12 @@ static int wt_send_message (const char* key, const char* value,
 
     status = ssnprintf (message,
                              sizeof(message),
-                             "put %s %.0f %s fqdn=%s %s %s\r\n",
+                             "put %s %.0f %s fqdn=%s %s %s %s\r\n",
                              key,
                              CDTIME_T_TO_DOUBLE(time),
                              value,
                              host,
+                             value_tags,
                              tags,
                              host_tags);
     sfree(temp);
@@ -507,6 +734,7 @@ static int wt_write_messages(const data_set_t *ds, const value_list_t *vl,
 {
     char key[10*DATA_MAX_NAME_LEN];
     char values[512];
+    char tags[10*DATA_MAX_NAME_LEN];
 
     int status;
     size_t i;
@@ -545,8 +773,18 @@ static int wt_write_messages(const data_set_t *ds, const value_list_t *vl,
             return status;
         }
 
+        /* Copy tags from p-pi/t-ti ds notation into tags */
+        tags[0] = '\0';
+        status = wt_format_tags(tags, sizeof(tags), vl, cb, ds_name);
+        if (status != 0)
+        {
+            ERROR("write_tsdb plugin: error with format_tags");
+            return status;
+        }
+        
+
         /* Send the message to tsdb */
-        status = wt_send_message(key, values, vl->time, cb, vl->host, vl->meta);
+        status = wt_send_message(key, values, tags, vl->time, cb, vl);
         if (status != 0)
         {
             ERROR("write_tsdb plugin: error with "


### PR DESCRIPTION
Hello,

First of all, PR #1106 is a pre-requisite for this PR. This is why I based my work on that branch.

This patch allows use metadata to completely rewrite some metrics for OpenTSDB.
The problem is best explained in issue #709 and #887 : some metric names should not include the instance in their name but in a tag. For example, `cpu.1.cpu.user` should become `cpu.user` with an additional tag `cpu=1`

This patch is a proposition of a solution for this problem.

I added some metadata : 

<table>
<tr><th>metadata</th><th>explanation</th></tr>
<tr>
<td>tsdb_prefix</td><td>Will prefix the OpenTSDB &lt;metric&gt; (also prefix tsdb_id if defined)</td></tr>
<tr><td>tsdb_id</td><td>Replace the metric with this tag</td></tr>

<tr><td>tsdb_tag_plugin<br/>
tsdb_tag_pluginInstance<br/>
tsdb_tag_type<br/>
tsdb_tag_typeInstance<br/>
tsdb_tag_dsname</td>
<td>When defined, tsdb_tag_* removes the related item from metric id.<br />
If it is not empty, it will be the key of an opentsdb tag (the value is the item itself)<br />
If it is empty, no tag is defined.</td>
</tr></table>

Here is how I use them for commonly used plugins cpu, df, disk, interface, load and swap : 
```
<Chain "PreCache">
   <Rule "opentsdb_cpu">
     <Match "regex">
       Plugin "^cpu$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_tag_pluginInstance" "cpu"
       MetaDataSet "tsdb_tag_type" ""
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
   <Rule "opentsdb_df">
     <Match "regex">
       Plugin "^df$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_tag_pluginInstance" "mount"
       MetaDataSet "tsdb_tag_type" ""
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
   <Rule "opentsdb_disk">
     <Match "regex">
       Plugin "^disk$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_tag_pluginInstance" "disk"
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
   <Rule "opentsdb_interface">
     <Match "regex">
       Plugin "^interface$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_tag_pluginInstance" "iface"
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
   <Rule "opentsdb_load">
     <Match "regex">
       Plugin "^loac$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_tag_type" ""
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
   <Rule "opentsdb_swap">
     <Match "regex">
       Plugin "^swap$"
     </Match>
     <Target "set">
       MetaDataSet "tsdb_prefix" "sys."
     </Target>
   </Rule>
 </Chain>
```

Of course, when you do not define metadata, it works just as before.

Regards,
Yves


