### PR TITLE
enlarge the DATA_MAX_NAME_LEN for plugins

### DIFF
--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -39,7 +39,7 @@
 
 #define PLUGIN_FLAGS_GLOBAL 0x0001
 
-#define DATA_MAX_NAME_LEN 64
+#define DATA_MAX_NAME_LEN 128
 
 #define DS_TYPE_COUNTER  0
 #define DS_TYPE_GAUGE    1


### PR DESCRIPTION
For application running as docker container and also part of AWS ESC service, the metric folder name follows the naming conversion defined by AWS ECS, which is like `ecs-<ecs cluster name>-<service name>-<task definition name>-<container name>-<20 random characters>`. As a result, long name tends to be a reasonable name to be handled.