### PR TITLE
build: add libavltree, libcommon & libheap dependencies

### DIFF
--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -73,7 +73,7 @@ collectd_CPPFLAGS =  $(AM_CPPFLAGS) $(LTDLINCL)
 collectd_CFLAGS = $(AM_CFLAGS)
 collectd_LDFLAGS = -export-dynamic
 collectd_LDADD = libavltree.la libcommon.la libheap.la -lm $(COMMON_LIBS)
-collectd_DEPENDENCIES =
+collectd_DEPENDENCIES = libavltree.la libcommon.la libheap.la
 
 # The daemon needs to call sg_init, so we need to link it against libstatgrab,
 # too. -octo


### PR DESCRIPTION
Otherwise it can break on very parallel builds since collectd link time
arrives before one or more of these were built.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>