### PR TITLE
Add missing kstat definitions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,9 @@ check_PROGRAMS += test_utils_vl_lookup
 TESTS += test_utils_vl_lookup
 test_utils_vl_lookup_SOURCES = utils_vl_lookup_test.c testing.h
 test_utils_vl_lookup_LDADD = liblookup.la daemon/libcommon.la daemon/libplugin_mock.la
+if BUILD_WITH_LIBKSTAT
+test_utils_vl_lookup_LDADD += -lkstat
+endif
 
 noinst_LTLIBRARIES += libmount.la
 libmount_la_SOURCES = utils_mount.c utils_mount.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,7 +44,9 @@ check_PROGRAMS += test_utils_mount
 TESTS += test_utils_mount
 test_utils_mount_SOURCES = utils_mount_test.c testing.h
 test_utils_mount_LDADD = libmount.la daemon/libcommon.la daemon/libplugin_mock.la
-
+if BUILD_WITH_LIBKSTAT
+test_utils_mount_LDADD += -lkstat
+endif
 
 sbin_PROGRAMS = collectdmon
 bin_PROGRAMS = collectd-nagios collectdctl collectd-tg

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -27,6 +27,10 @@
 #include "testing.h"
 #include "common.h"
 
+#if HAVE_LIBKSTAT
+kstat_ctl_t *kc;
+#endif /* HAVE_LIBKSTAT */
+
 DEF_TEST(sstrncpy)
 {
   char buffer[16] = "";

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -29,6 +29,10 @@
 #include "common.h" /* for STATIC_ARRAY_SIZE */
 #include "utils_subst.h"
 
+#if HAVE_LIBKSTAT
+kstat_ctl_t *kc;
+#endif /* HAVE_LIBKSTAT */
+
 DEF_TEST(subst)
 {
   struct {

--- a/src/utils_mount_test.c
+++ b/src/utils_mount_test.c
@@ -28,6 +28,10 @@
 #include "collectd.h"
 #include "utils_mount.h"
 
+#if HAVE_LIBKSTAT
+kstat_ctl_t *kc;
+#endif /* HAVE_LIBKSTAT */
+
 DEF_TEST(cu_mount_checkoption)
 {
   char line_opts[] = "foo=one,bar=two,qux=three";

--- a/src/utils_vl_lookup.c
+++ b/src/utils_vl_lookup.c
@@ -33,6 +33,10 @@
 #include "utils_vl_lookup.h"
 #include "utils_avltree.h"
 
+#if HAVE_LIBKSTAT
+kstat_ctl_t *kc;
+#endif /* HAVE_LIBKSTAT */
+
 #if BUILD_TEST
 # define sstrncpy strncpy
 # define plugin_log(s, ...) do { \


### PR DESCRIPTION
Without these an undefined `*kc` is reported and kstat symbols are missing.