### PR TITLE
Don't send warning if the old and new callback is the same

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -296,12 +296,14 @@ static int register_callback (llist_t **list, /* {{{ */
 		old_cf = le->value;
 		le->value = cf;
 
-		WARNING ("plugin: register_callback: "
+		if (old_cf->cf_callback != cf->cf_callback) {
+			WARNING ("plugin: register_callback: "
 				"a callback named `%s' already exists - "
 				"overwriting the old entry!", name);
+		}
 
 		destroy_callback (old_cf);
-		sfree (key);
+		free (key);
 	}
 
 	return (0);


### PR DESCRIPTION
This patch removes the warning generated if a plugins registers itself several time as threshold does. If the old and new callback are the same then the warning is suppressed.

I have also replaced a call to sfree() with free() as this is, I believe more appropriate.