### PR TITLE
send notifications from tail

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6386,6 +6386,12 @@ their configuration can be found in L<types.db(5)>.
 
 This optional setting sets the type instance to use.
 
+=item B<NotifyLevel> B<OKAY>|B<WARNING>|B<FAILURE>
+
+Controls whether the matching line sends a notification at this level instead of 
+a datapoint, which is the default. The behavior of notifications differs from 
+datapoints in that it will only emit an event if the there's a new value.
+
 =back
 
 =head2 Plugin C<tail_csv>

--- a/src/daemon/utils_match.c
+++ b/src/daemon/utils_match.c
@@ -79,6 +79,7 @@ static int default_callback (const char __attribute__((unused)) *str,
 {
   cu_match_value_t *data = (cu_match_value_t *) user_data;
 
+  data->ds_type |= UTILS_MATCH_FOUND;
   if (data->ds_type & UTILS_MATCH_DS_TYPE_GAUGE)
   {
     gauge_t value;

--- a/src/daemon/utils_match.h
+++ b/src/daemon/utils_match.h
@@ -35,6 +35,12 @@
  *          ^             <- Type bit
  *           ^^^^^^^^^^^^ <- Subtype bits
  */
+#define UTILS_MATCH_NOTIF         0x010000
+#define UTILS_MATCH_NOTIF_OKAY    0x020000
+#define UTILS_MATCH_NOTIF_FAILURE 0x040000
+#define UTILS_MATCH_NOTIF_WARNING 0x080000
+#define UTILS_MATCH_FOUND         0x100000
+
 #define UTILS_MATCH_DS_TYPE_GAUGE    0x1000
 #define UTILS_MATCH_DS_TYPE_COUNTER  0x2000
 #define UTILS_MATCH_DS_TYPE_DERIVE   0x4000

--- a/src/tail.c
+++ b/src/tail.c
@@ -152,7 +152,6 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
   for (i = 0; i < ci->children_num; i++)
   {
     oconfig_item_t *option = ci->children + i;
-
     if (strcasecmp ("Regex", option->key) == 0)
       status = cf_util_get_string (option, &cm.regex);
     else if (strcasecmp ("ExcludeRegex", option->key) == 0)
@@ -163,7 +162,18 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
       status = cf_util_get_string (option, &cm.type);
     else if (strcasecmp ("Instance", option->key) == 0)
       status = cf_util_get_string (option, &cm.type_instance);
-    else
+    else if (strcasecmp ("NotifyLevel", option->key) == 0) {
+      cm.flags |= UTILS_MATCH_NOTIF;
+      char *severity = NULL;
+      status = cf_util_get_string (option, &severity);
+      if (strcasecmp (severity, "FAILURE") == 0)
+        cm.flags |= UTILS_MATCH_NOTIF_FAILURE;
+      else if (strcmp (severity, "OKAY") == 0)
+        cm.flags |= UTILS_MATCH_NOTIF_OKAY;
+      else if ((strcmp (severity, "WARNING") == 0)
+               || (strcmp (severity, "WARN") == 0))
+        cm.flags |= UTILS_MATCH_NOTIF_WARNING;
+    } else
     {
       WARNING ("tail plugin: Option `%s' not allowed here.", option->key);
       status = -1;


### PR DESCRIPTION
Added a flag NotifyLevel that controls whether the matching line sends a notification at this level instead ofa datapoint, which is the default. The behavior of notifications differs from datapoints in that it will only emit an event if the there's a new value.