### PR TITLE
implement optional reporting of active state

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1393,6 +1393,17 @@ When set to B<true>, the default, reports per-state metrics, e.g. "system",
 When set to B<false>, aggregates (sums) all I<non-idle> states into one
 "active" metric.
 
+=item B<ReportStateActive> B<false>|B<true>
+
+When set to B<true>, aggregates (sums) all I<non-idle> states into one
+"active" metric.
+
+When B<ReportByState> is set to B<false>, it is already the case and
+this option is ignored (redundant with B<ReportByState>).
+
+When B<ReportByState> is set to B<true>, "active" metric is not reported
+by default. You need to enable it explicitely with B<ReportStateActive>.
+
 =item B<ReportByCpu> B<true>|B<false>
 
 When set to B<true>, the default, reports per-CPU (per-core) metrics.

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -190,12 +190,14 @@ static size_t global_cpu_num = 0;
 
 static _Bool report_by_cpu = 1;
 static _Bool report_by_state = 1;
+static _Bool report_state_active = 0;
 static _Bool report_percent = 0;
 
 static const char *config_keys[] =
 {
 	"ReportByCpu",
 	"ReportByState",
+	"ReportStateActive",
 	"ValuesPercentage"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
@@ -208,6 +210,8 @@ static int cpu_config (char const *key, char const *value) /* {{{ */
 		report_percent = IS_TRUE (value) ? 1 : 0;
 	else if (strcasecmp (key, "ReportByState") == 0)
 		report_by_state = IS_TRUE (value) ? 1 : 0;
+	else if (strcasecmp (key, "ReportStateActive") == 0)
+		report_state_active = IS_TRUE (value) ? 1 : 0;
 	else
 		return (-1);
 
@@ -438,11 +442,11 @@ static void cpu_commit_one (int cpu_num, /* {{{ */
 	sum = rates[COLLECTD_CPU_STATE_ACTIVE];
 	RATE_ADD (sum, rates[COLLECTD_CPU_STATE_IDLE]);
 
-	if (!report_by_state)
+	if (report_state_active || (!report_by_state))
 	{
 		gauge_t percent = 100.0 * rates[COLLECTD_CPU_STATE_ACTIVE] / sum;
 		submit_percent (cpu_num, COLLECTD_CPU_STATE_ACTIVE, percent);
-		return;
+		if (!report_by_state) return;
 	}
 
 	for (state = 0; state < COLLECTD_CPU_STATE_ACTIVE; state++)


### PR DESCRIPTION
Hello,

I want to report CPU metrics
* by state
* by cpu
* aggregated by state as "active".

However, reportbystate and aggregated as "active" are mutually exclusive in current code. I'm wondering why.
So I added a new option : `ReportStateActive`

Here is the doc (from collectd.conf.pod) : 
```
       ReportStateActive false|true
           When set to true, aggregates (sums) all non-idle states into one "active" metric.

           When ReportByState is set to false, it is already the case and this option is ignored (redundant with ReportByState).

           When ReportByState is set to true, "active" metric is not reported by default. You need to enable it explicitely with
           ReportStateActive.
```

The idea is that when `reportByState` is true (e.g. "active" state is not reported), we can force it to be reported with `ReportStateActive true`.

Regards,
Yves