### PR TITLE
write_redis plugin: Add StoreRates support and option to limit size of sorted sets

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7661,6 +7661,10 @@ is recommended but not required to include a trailing slash in I<Prefix>.
 
 This index selects the redis database to use for writing operations. Defaults to C<0>.
 
+=item B<MaxSetSize> I<Items>
+
+The B<MaxSetSize> option limits the number of items that the I<Sorted Sets> can hold to I<Items>. Negative values for I<Items> set no limit, which is the default behavior.
+
 =back
 
 =head2 Plugin C<write_riemann>
@@ -8857,3 +8861,4 @@ L<sensors(1)>
 Florian Forster E<lt>octo@collectd.orgE<gt>
 
 =cut
+

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7611,7 +7611,7 @@ Synopsis:
 
 Values are submitted to I<Sorted Sets>, using the metric name as the key, and
 the timestamp as the score. Retrieving a date range can then be done using the
-C<ZRANGEBYSCORE> I<Redis> command. Additionnally, all the identifiers of these
+C<ZRANGEBYSCORE> I<Redis> command. Additionally, all the identifiers of these
 I<Sorted Sets> are kept in a I<Set> called C<collectd/values> (or
 C<${prefix}/values> if the B<Prefix> option was specified) and can be retrieved
 using the C<SMEMBERS> I<Redis> command. You can specify the database to use 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7606,6 +7606,8 @@ Synopsis:
         Timeout 1000
         Prefix "collectd/"
         Database 1
+        MaxSetSize -1
+        StoreRates true
     </Node>
   </Plugin>
 
@@ -7664,6 +7666,15 @@ This index selects the redis database to use for writing operations. Defaults to
 =item B<MaxSetSize> I<Items>
 
 The B<MaxSetSize> option limits the number of items that the I<Sorted Sets> can hold to I<Items>. Negative values for I<Items> set no limit, which is the default behavior.
+
+=item B<StoreRates> B<true>|B<false>
+
+If set to B<true> (the default), convert counter values to rates. If set to
+B<false> counter values are stored as is, i.e. as an increasing integer number.
+
+This will be reflected in the C<collectd_data_source_type> tag: If
+B<StoreRates> is enabled, converted values will have "rate" appended to the
+data source type, e.g.  C<collectd_data_source_type:derive:rate>.
 
 =back
 

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -124,7 +124,7 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   {
     rr = redisCommand (node->conn, "ZREMRANGEBYRANK %s %d %d", key, 0, (-1 * node->max_set_size) - 1);
     if (rr == NULL)
-      WARNING("ZREMRANGEBYRANK command error. database:%d message:%s", node->database, node->conn->errstr);
+      WARNING("ZREMRANGEBYRANK command error. key:%s message:%s", key, node->conn->errstr);
     else
       freeReplyObject (rr);
   }

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -68,7 +68,6 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   char *value_ptr;
   int status;
   redisReply   *rr;
-  int i;
 
   status = FORMAT_VL (ident, sizeof (ident), vl);
   if (status != 0)
@@ -81,39 +80,6 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   memset (value, 0, sizeof (value));
   value_size = sizeof (value);
   value_ptr = &value[0];
-
-#define APPEND(...) do {                                             \
-  status = snprintf (value_ptr, value_size, __VA_ARGS__);            \
-  if (((size_t) status) > value_size)                                \
-  {                                                                  \
-    value_ptr += value_size;                                         \
-    value_size = 0;                                                  \
-  }                                                                  \
-  else                                                               \
-  {                                                                  \
-    value_ptr += status;                                             \
-    value_size -= status;                                            \
-  }                                                                  \
-} while (0)
-
-  APPEND ("%s:", time);
-
-  for (i = 0; i < ds->ds_num; i++)
-  {
-    if (ds->ds[i].type == DS_TYPE_COUNTER)
-      APPEND ("%llu", vl->values[i].counter);
-    else if (ds->ds[i].type == DS_TYPE_GAUGE)
-      APPEND (GAUGE_FORMAT, vl->values[i].gauge);
-    else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      APPEND ("%"PRIi64, vl->values[i].derive);
-    else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)
-      APPEND ("%"PRIu64, vl->values[i].absolute);
-    else
-      assert (23 == 42);
-  }
-
-#undef APPEND
-
   status = format_values (value_ptr, value_size, ds, vl, /* store rates = */ 0);
   pthread_mutex_lock (&node->lock);
   if (status != 0)

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -46,6 +46,7 @@ struct wr_node_s
   struct timeval timeout;
   char *prefix;
   int database;
+  int max_set_size;
 
   redisContext *conn;
   pthread_mutex_t lock;
@@ -118,6 +119,15 @@ static int wr_write (const data_set_t *ds, /* {{{ */
     WARNING("ZADD command error. key:%s message:%s", key, node->conn->errstr);
   else
     freeReplyObject (rr);
+  
+  if (node->max_set_size >= 0)
+  {
+    rr = redisCommand (node->conn, "ZREMRANGEBYRANK %s %d %d", key, 0, (-1 * node->max_set_size) - 1);
+    if (rr == NULL)
+      WARNING("SELECT command error. database:%d message:%s", node->database, node->conn->errstr);
+    else
+      freeReplyObject (rr);
+  }
 
   /* TODO(octo): This is more overhead than necessary. Use the cache and
    * metadata to determine if it is a new metric and call SADD only once for
@@ -170,6 +180,7 @@ static int wr_config_node (oconfig_item_t *ci) /* {{{ */
   node->conn = NULL;
   node->prefix = NULL;
   node->database = 0;
+  node->max_set_size = -1;
   pthread_mutex_init (&node->lock, /* attr = */ NULL);
 
   status = cf_util_get_string_buffer (ci, node->name, sizeof (node->name));
@@ -203,6 +214,9 @@ static int wr_config_node (oconfig_item_t *ci) /* {{{ */
     }
     else if (strcasecmp ("Database", child->key) == 0) {
       status = cf_util_get_int (child, &node->database);
+    }
+    else if (strcasecmp ("MaxSetSize", child->key) == 0) {
+      status = cf_util_get_int (child, &node->max_set_size);
     }
     else
       WARNING ("write_redis plugin: Ignoring unknown config option \"%s\".",

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -124,7 +124,7 @@ static int wr_write (const data_set_t *ds, /* {{{ */
   {
     rr = redisCommand (node->conn, "ZREMRANGEBYRANK %s %d %d", key, 0, (-1 * node->max_set_size) - 1);
     if (rr == NULL)
-      WARNING("SELECT command error. database:%d message:%s", node->database, node->conn->errstr);
+      WARNING("ZREMRANGEBYRANK command error. database:%d message:%s", node->database, node->conn->errstr);
     else
       freeReplyObject (rr);
   }


### PR DESCRIPTION
This PR has two parts. The first fixes a bug that causes added values to look like `"1436983727.331209660:0.920.860.521436983727.331:0.92:0.86:0.52"` instead of `"1436983717.723:1.09:0.89:0.53"`. I think this was caused by a mixed up merge as the `APPEND` macro and associated code should have been removed in  #1070. The second part gives the user the option to limit the size of the sorted sets where collectd writes. For example, with the configuration `MaxSetSize 10`, only the ten latest values will be stored by redis. The limit is disabled with any negative value.

Edit (7/30): This PR now also adds support for the StoreRates option.