### PR TITLE
Add utils_parse_option.c/h to amqp plugin source files list

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ if BUILD_PLUGIN_AMQP
 pkglib_LTLIBRARIES += amqp.la
 amqp_la_SOURCES = amqp.c \
 		  utils_cmd_putval.c utils_cmd_putval.h \
+  	          utils_parse_option.c utils_parse_option.h \
 		  utils_format_graphite.c utils_format_graphite.h \
 		  utils_format_json.c utils_format_json.h
 amqp_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBRABBITMQ_LDFLAGS)


### PR DESCRIPTION
Issue: lt_dlopen of amqp.so fails on aix. After debugging, the errors are the following
rtld: 0712-001 Symbol parse_string was referenced
      from module /opt/inf/collectd/embedded/lib/collectd/amqp.so(), but a 
runtime definition
      of the symbol was not found.
rtld: 0712-001 Symbol parse_option was referenced
      from module /opt/inf/collectd/embedded/lib/collectd/amqp.so(), but a 
runtime definition
      of the symbol was not found.
Cause:  amqp.c references utils_cmd_putval.c which in turn references parse_string function defined in  utils_parse_option.c but utils_parse_option.c/h are not in sources to build amqp.so

Fix is to include sources for utils_parse_option.c/.h while building amqp.so plugin file

 