### PR TITLE
Fix Unixsock.pm

### DIFF
--- a/bindings/perl/lib/Collectd/Unixsock.pm
+++ b/bindings/perl/lib/Collectd/Unixsock.pm
@@ -137,13 +137,13 @@ sub _parse_identifier
 
 sub _escape_argument
 {
-	local $_ = shift;
+    my $arg = shift;
 
-	return $_ if /^\w+$/;
+	return $arg if $arg =~ /^\w+$/;
 
-	s#\\#\\\\#g;
-	s#"#\\"#g;
-	return "\"$_\"";
+	$arg =~ s#\\#\\\\#g;
+	$arg =~ s#"#\\"#g;
+	return "\"$arg\"";
 }
 
 # Send a command on a socket, including any required argument escaping.

--- a/bindings/perl/t/01_methods.t
+++ b/bindings/perl/t/01_methods.t
@@ -16,7 +16,7 @@ sub test_query {
     my ($nresults, $resultdata) = @$results;
     my $r = $s->getval(%{Collectd::Unixsock::_parse_identifier($attr)});
     is(ref $r, 'HASH', "Got a result for $attr");
-    is(scalar keys $r, $nresults, "$nresults result result for $attr");
+    is(scalar keys %$r, $nresults, "$nresults result result for $attr");
     is_deeply($r, $resultdata, "Data or $attr matches");
 }
 


### PR DESCRIPTION
I just noticed a small problem with the Unixsock code I wrote a few months ago:
[On Perls older than 5.14](http://search.cpan.org/~rjbs/perl-5.22.0/pod/perlsub.pod#Localization_of_special_variables), if you called `getval()` while having `$_` aliased to a variable marked Readonly (using Readonly.pm that does some tie magic behind the scenes), `_escape_argument()` would error out with "modification of read-only value attempted". This was due to `local $_` not being thorough enough in stripping the magic off `$_` so the readonly-ness would stay while the variable was localized. The fix is trivial and just makes the little helper sub a bit more verbose.

While I was at it, I also fixed an autoderef in one of the tests that should never have been there in the first place; it causes warnings on recent Perls and will probably fail on 5.22.