### PR TITLE
liboconfig: really fix lex warnings

### DIFF
--- a/src/liboconfig/scanner.l
+++ b/src/liboconfig/scanner.l
@@ -27,12 +27,6 @@
  */
 
 %{
-/* lex and yacc do some weird stuff, so turn off some warnings. */
-#if defined(__clang__)
-# pragma clang diagnostic ignored "-Wunused-function"
-# pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-#endif
-
 #include <stdlib.h>
 #include "oconfig.h"
 #include "aux_types.h"
@@ -56,6 +50,8 @@ static void ml_append (char *);
 %}
 %option yylineno
 %option noyywrap
+%option noinput
+%option nounput
 %x ML
 WHITE_SPACE [\ \t\b]
 NON_WHITE_SPACE [^\ \t\b]


### PR DESCRIPTION
Flex has two options to disable input and unput.
Turn them on.