### PR TITLE
write_redis: fix a few typos in manpage

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7611,7 +7611,7 @@ Synopsis:
 
 Values are submitted to I<Sorted Sets>, using the metric name as the key, and
 the timestamp as the score. Retrieving a date range can then be done using the
-C<ZRANGEBYSCORE> I<Redis> command. Additionnally, all the identifiers of these
+C<ZRANGEBYSCORE> I<Redis> command. Additionally, all the identifiers of these
 I<Sorted Sets> are kept in a I<Set> called C<collectd/values> (or
 C<${prefix}/values> if the B<Prefix> option was specified) and can be retrieved
 using the C<SMEMBERS> I<Redis> command. You can specify the database to use 
@@ -7631,9 +7631,9 @@ options are available:
 =item B<Node> I<Nodename>
 
 The B<Node> block identifies a new I<Redis> node, that is a new I<Redis>
-instance running in an specified host and port. The name for node is a
+instance running on a specified host and port. The node name is a
 canonical identifier which is used as I<plugin instance>. It is limited to
-64E<nbsp>characters in length.
+51E<nbsp>characters in length.
 
 =item B<Host> I<Hostname>
 


### PR DESCRIPTION
Also correct the maximum length of the node name.
The callback name is "write_redis/%s" so the maximum
length of a node name is DATA_MAX_NAME_LEN - strlen("write_redis") -1.