### PR TITLE
Fix libmodbus detection on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2562,7 +2562,7 @@ then
 	SAVE_CPPFLAGS="$CPPFLAGS"
 	CPPFLAGS="$CPPFLAGS $with_libmodbus_cflags"
 
-	AC_CHECK_HEADERS(modbus/modbus.h, [], [with_libmodbus="no (modbus/modbus.h not found)"])
+	AC_CHECK_HEADERS(modbus.h, [], [with_libmodbus="no (modbus.h not found)"])
 
 	CPPFLAGS="$SAVE_CPPFLAGS"
 fi

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -27,7 +27,7 @@
 
 #include <netdb.h>
 
-#include <modbus/modbus.h>
+#include <modbus.h>
 
 #ifndef LIBMODBUS_VERSION_CHECK
 /* Assume version 2.0.3 */


### PR DESCRIPTION
We look for modbus/modbus.h in /usr/local/include/modbus
but we should look for modbus.h

This is only an issue on FreeBSD since /usr/local/include is not
in the default search path.