### PR TITLE
Fix varnish detection on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4838,11 +4838,11 @@ then
 
 	CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
 
-	AC_CHECK_HEADERS(varnish/vapi/vsc.h,
+	AC_CHECK_HEADERS(vapi/vsc.h,
 		[AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
-		[AC_CHECK_HEADERS(varnish/vsc.h,
+		[AC_CHECK_HEADERS(vsc.h,
 			[AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support])],
-			[AC_CHECK_HEADERS(varnish/varnishapi.h,
+			[AC_CHECK_HEADERS(varnishapi.h,
 				[AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
 				[with_libvarnish="no (found none of the varnish header files)"])])])
 

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -29,19 +29,19 @@
 #include "configfile.h"
 
 #if HAVE_VARNISH_V4
-#include <varnish/vapi/vsm.h>
-#include <varnish/vapi/vsc.h>
+#include <vapi/vsm.h>
+#include <vapi/vsc.h>
 typedef struct VSC_C_main c_varnish_stats_t;
 #endif
 
 #if HAVE_VARNISH_V3
-#include <varnish/varnishapi.h>
-#include <varnish/vsc.h>
+#include <varnishapi.h>
+#include <vsc.h>
 typedef struct VSC_C_main c_varnish_stats_t;
 #endif
 
 #if HAVE_VARNISH_V2
-#include <varnish/varnishapi.h>
+#include <varnishapi.h>
 typedef struct varnish_stats c_varnish_stats_t;
 #endif
 


### PR DESCRIPTION
We look for varnish/vapi/vsc.h in /usr/include/varnish
but we should look for vapi/vsc.h

This is only an issue on FreeBSD since /usr/local/include is not
in the default search path.