### PR TITLE
irq: skip FIQ line in /proc/interrupts

### DIFF
--- a/src/irq.c
+++ b/src/irq.c
@@ -155,6 +155,10 @@ static int irq_read (void)
 		if (irq_name[irq_name_len - 1] != ':')
 			continue;
 
+		/* Is it the the ARM fast interrupt (FIQ)? */
+		if (irq_name_len == 4 && (strncmp(irq_name, "FIQ:", 4) == 0))
+			continue;
+
 		irq_name[irq_name_len - 1] = 0;
 		irq_name_len--;
 


### PR DESCRIPTION
/proc/interrupts on my Raspberry PI contains:
FIQ:              usb_fiq

This line doesn't contain any per cpu counters
but we try to parse it anyway, resulting in:
parse_value: Failed to parse string as derive: usb_fiq.

Fixes #971