### PR TITLE
logstash: initialize conf struct to 0

### DIFF
--- a/src/log_logstash.c
+++ b/src/log_logstash.c
@@ -208,7 +208,7 @@ static void log_logstash_log (int severity, const char *msg,
 {
 	yajl_gen g;
 #if !defined(HAVE_YAJL_V2)
-	yajl_gen_config conf;
+	yajl_gen_config conf = {};
 
 	conf.beautify = 0;
 #endif
@@ -252,7 +252,7 @@ static int log_logstash_notification (const notification_t *n,
 #if HAVE_YAJL_V2
 	g = yajl_gen_alloc(NULL);
 #else
-	yajl_gen_config conf;
+	yajl_gen_config conf = {};
 
 	conf.beautify = 0;
 	g = yajl_gen_alloc(&conf, NULL);


### PR DESCRIPTION
With YAJL 1 (at least on Ubuntu Precise), if `conf.indentString` is not
initialized correctly, we would get a segfault even when `conf.beautify`
is set to 0. We avoid this case by initializing the whole structure to
0. `conf.beautify = 0` is kept for explicitness.

Using C99 designated initializer. Already used at some other places, including when empty (in `curl_json` plugin for example).