### PR TITLE
Use environmental variables from /etc/sysconfig/collectd

### DIFF
--- a/contrib/systemd.collectd.service
+++ b/contrib/systemd.collectd.service
@@ -5,6 +5,7 @@ Requires=local-fs.target network.target
 
 [Service]
 ExecStart=/usr/sbin/collectd
+EnvironmentFile=-/etc/sysconfig/collectd
 
 # Tell systemd it will receive a notification from collectd over it's control
 # socket once the daemon is ready. See systemd.service(5) for more details.


### PR DESCRIPTION
This may help in migrating from sysvinit to systemd
FWIW We use it to set `PYTHONDONTWRITEBYTECODE 1` so python plugins won't write `.pyc` files after puppet removes them