### PR TITLE
ltdl: only compile included libltdl when needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,12 @@
 ACLOCAL_AMFLAGS = -I libltdl/m4
 
-SUBDIRS = libltdl src bindings .
+SUBDIRS =
+
+if BUILD_INCLUDED_LTDL
+SUBDIRS += libltdl
+endif
+
+SUBDIRS += src bindings .
 
 AM_CPPFLAGS = $(LTDLINCL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ m4_ifdef([LT_PACKAGE_VERSION],
 	]
 )
 
+AM_CONDITIONAL([BUILD_INCLUDED_LTDL], [test "x$LTDLDEPS" != "x"])
+
 AM_INIT_AUTOMAKE([tar-pax dist-bzip2 foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_LANG(C)


### PR DESCRIPTION
If configure finds an external libltdl, it's going to
use it, so there's no use in compiling the shipped libltdl.