### PR TITLE
Fix harmless build warnings with newer binutils

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,11 @@ AC_CONFIG_SRCDIR(src/)
 AC_CONFIG_HEADERS(src/config.h)
 AC_CONFIG_AUX_DIR([libltdl/config])
 
+dnl older automake's default of ARFLAGS=cru is noisy on newer binutils;
+dnl we don't really need the 'u' even in older toolchains.  Then there is
+dnl older libtool, which spelled it AR_FLAGS
+m4_divert_text([DEFAULTS], [: "${ARFLAGS=cr} ${AR_FLAGS=cr}"])
+
 m4_ifdef([LT_PACKAGE_VERSION],
 	# libtool >= 2.2
 	[


### PR DESCRIPTION
I see a lot of those on Rawhide:
ar: `u' modifier ignored since `D' is the default (see `U')

It's going to take a while to get this fixed upstream.
Meanwhile, silence the warnings.

Macro copied from libvirt.