### PR TITLE
liboconfig: Fix implicit declaration warning

### DIFF
--- a/src/liboconfig/scanner.l
+++ b/src/liboconfig/scanner.l
@@ -28,6 +28,7 @@
 
 %{
 #include <stdlib.h>
+#include <string.h>
 #include "oconfig.h"
 #include "aux_types.h"
 #include "parser.h"


### PR DESCRIPTION
strlen declaration is in string.h