### PR TITLE
dns: fix compilation on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3292,11 +3292,6 @@ then
 fi
 if test "x$with_libpcap" = "xyes"
 then
-	AC_CHECK_HEADERS(pcap-bpf.h,,
-			 [with_libpcap="no (pcap-bpf.h not found)"])
-fi
-if test "x$with_libpcap" = "xyes"
-then
 	AC_CACHE_CHECK([whether libpcap has PCAP_ERROR_IFACE_NOT_UP],
 		       [c_cv_libpcap_have_pcap_error_iface_not_up],
 		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(

--- a/src/dns.c
+++ b/src/dns.c
@@ -34,7 +34,6 @@
 #include <poll.h>
 
 #include <pcap.h>
-#include <pcap-bpf.h>
 
 /*
  * Private data types


### PR DESCRIPTION
OpenBSD doesn't have pcap-bpf.h

pcap.h has been including pcap/bpf.h since 2006.
Since we require a pcap which has PCAP_ERROR_IFACE_NOT_UP, introduced in 2008
this shouldn't break anything.