### PR TITLE
sensors: Report sensor readings by descriptive labels

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6031,6 +6031,12 @@ few ones. This option enables you to do that: By setting B<IgnoreSelected> to
 I<true> the effect of B<Sensor> is inverted: All selected sensors are ignored
 and all other sensors are collected.
 
+=item B<UseLabels> I<true>|I<false>
+
+Configures how sensor readings are reported. When set to I<true>, sensor
+readings are reported using their descriptive label (e.g. "VCore"). When set to
+I<false> (the default) the sensor name is used ("in0").
+
 =back
 
 =head2 Plugin C<sigrok>


### PR DESCRIPTION
Adds an option UseLabels to configure how sensor readings are reported. The default reports readings using the sensor name (e.g. "in0"). With this option set to true, the readings are reported using the label (e.g. "VCore").

A similar patch has been sent to the mailing list ([by Jakob Haufe sur5r@sur5r.net in 02/2010](http://mailman.verplant.org/pipermail/collectd/2010-February/003588.html)) but never got merged.
This version adds the UseLabels configuration option as suggested in the review.