### PR TITLE
routeros: Add support for temperature and voltage data

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1124,6 +1124,7 @@
 #		CollectMemory true
 #		CollectDF true
 #		CollectDisk true
+#		CollectHealth true
 #	</Router>
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6304,6 +6304,7 @@ multiple routers:
       CollectRegistrationTable true
       CollectDF true
       CollectDisk true
+      CollectHealth true
     </Router>
   </Plugin>
 
@@ -6362,6 +6363,12 @@ Defaults to B<false>.
 =item B<CollectDisk> B<true>|B<false>
 
 When enabled, the number of sectors written and bad blocks will be collected.
+Defaults to B<false>.
+
+=item B<CollectHealth> B<true>|B<false>
+
+When enabled, the health statistics will be collected. This includes the
+voltage and temperature on supported hardware.
 Defaults to B<false>.
 
 =back


### PR DESCRIPTION
This has to be merged after my changes in librouteros (https://github.com/manio/routeros-api). Maybe some additional ifdefs regards librouteros version will be needed - it's up to you.
