### PR TITLE
processes: correctly count processes on {free,open}BSD

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -2027,18 +2027,18 @@ static int ps_read (void)
 			pse.io_syscw = -1;
 
 			ps_list_add (procs[i].ki_comm, have_cmdline ? cmdline : NULL, &pse);
-		} /* if ((proc_ptr == NULL) || (proc_ptr->ki_pid != procs[i].ki_pid)) */
 
-		switch (procs[i].ki_stat)
-		{
-			case SSTOP: 	stopped++;	break;
-			case SSLEEP:	sleeping++;	break;
-			case SRUN:	running++;	break;
-			case SIDL:	idle++;		break;
-			case SWAIT:	wait++;		break;
-			case SLOCK:	blocked++;	break;
-			case SZOMB:	zombies++;	break;
-		}
+			switch (procs[i].ki_stat)
+			{
+				case SSTOP:	stopped++;	break;
+				case SSLEEP:	sleeping++;	break;
+				case SRUN:	running++;	break;
+				case SIDL:	idle++;		break;
+				case SWAIT:	wait++;		break;
+				case SLOCK:	blocked++;	break;
+				case SZOMB:	zombies++;	break;
+			}
+		} /* if ((proc_ptr == NULL) || (proc_ptr->ki_pid != procs[i].ki_pid)) */
 	}
 
 	kvm_close(kd);
@@ -2163,18 +2163,18 @@ static int ps_read (void)
 			pse.cswitch_invol = -1;
 
 			ps_list_add (procs[i].p_comm, have_cmdline ? cmdline : NULL, &pse);
-		} /* if ((proc_ptr == NULL) || (proc_ptr->p_pid != procs[i].p_pid)) */
 
-		switch (procs[i].p_stat)
-		{
-			case SSTOP: 	stopped++;	break;
-			case SSLEEP:	sleeping++;	break;
-			case SRUN:	running++;	break;
-			case SIDL:	idle++;		break;
-			case SONPROC:	onproc++;	break;
-			case SDEAD:	dead++;		break;
-			case SZOMB:	zombies++;	break;
-		}
+			switch (procs[i].p_stat)
+			{
+				case SSTOP:	stopped++;	break;
+				case SSLEEP:	sleeping++;	break;
+				case SRUN:	running++;	break;
+				case SIDL:	idle++;		break;
+				case SONPROC:	onproc++;	break;
+				case SDEAD:	dead++;		break;
+				case SZOMB:	zombies++;	break;
+			}
+		} /* if ((proc_ptr == NULL) || (proc_ptr->p_pid != procs[i].p_pid)) */
 	}
 
 	kvm_close(kd);


### PR DESCRIPTION
because actually we count threads instead of processes