### PR TITLE
Fix NTP kerninfo offset/estimated error scaling

### DIFF
--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -904,6 +904,7 @@ static int ntpd_read (void)
 
 	int status;
 	int i;
+	double tscale = 1e-6;
 
 	ik      = NULL;
 	ik_num  = 0;
@@ -932,13 +933,13 @@ static int ntpd_read (void)
 			"  pll offset    = %.8f\n"
 			"  pll frequency = %.8f\n" /* drift compensation */
 			"  est error     = %.8f\n",
-			ntpd_read_fp (ik->offset),
+			(int32_t)ntohl(ik->offset) * tscale,
 			ntpd_read_fp (ik->freq),
-			ntpd_read_fp (ik->esterror));
+			(u_long)ntohl(ik->esterror) * 1e-6);
 
 	ntpd_submit ("frequency_offset", "loop",  ntpd_read_fp (ik->freq));
-	ntpd_submit ("time_offset",      "loop",  ntpd_read_fp (ik->offset));
-	ntpd_submit ("time_offset",      "error", ntpd_read_fp (ik->esterror));
+	ntpd_submit ("time_offset",      "loop",  (int32_t)ntohl(ik->offset) * tscale);
+	ntpd_submit ("time_offset",      "error", (u_long)ntohl(ik->esterror) * 1e-6);
 
 	free (ik);
 	ik = NULL;


### PR DESCRIPTION
This pull requests fix #1300 

The scaling was taken from ntp-4.2.6, from ntpdc/ntpdc_ops.c , function kerninfo

Tested with ntp from Ubuntu vivid (1:4.2.6.p5+dfsg-3ubuntu6), value are the correct one with this patch.

Code from ntpdc_ops.c looks like:
```C
  [...]
  struct info_kernel *ik;
  double tscale = 1e-6;
  [...]
#ifdef STA_NANO                                                                 
    if (status & STA_NANO)                                                      
        tscale = 1e-9;                                                          
#endif
    (void)fprintf(fp, "pll offset:           %g s\n",
        (int32)ntohl(ik->offset) * tscale);
    (void)fprintf(fp, "pll frequency:        %s ppm\n",
        fptoa((s_fp)ntohl(ik->freq), 3));
    (void)fprintf(fp, "estimated error:      %g s\n",
        (u_long)ntohl(ik->esterror) * 1e-6);
```

Note: on my proposed patch tscale is always 1e-6 ... I didn't find where/how STA_NANO could be defined. I've assumed it could only be defined with customized/patched build of ntp.