### PR TITLE
Start write threads after plugin initialization.

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1725,8 +1725,6 @@ void plugin_init_all (void)
 		write_threads_num = 5;
 	}
 
-	start_write_threads ((size_t) write_threads_num);
-
 	if ((list_init == NULL) && (read_heap == NULL))
 		return;
 
@@ -1761,6 +1759,8 @@ void plugin_init_all (void)
 
 		le = le->next;
 	}
+
+	start_write_threads ((size_t) write_threads_num);
 
 	max_read_interval = global_option_get_time ("MaxReadInterval",
 			DEFAULT_MAX_READ_INTERVAL);


### PR DESCRIPTION
Some plugins such as "network" create own threads from within their
init callbacks which can then start submitting data to the queue
right away, even if the read threads haven't been started yet.

If write threads are started before plugin initialization, this can
result in a race where a plugin's write callback gets called before
that plugin's init callback has completed.

To fix this, delay starting the write threads until after all plugins
have been initialized.