### PR TITLE
apache: Extended the number of lines to parse from mod_status

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -517,13 +517,14 @@ static void submit_scoreboard (char *buf, apache_t *st)
 	}
 }
 
+#define _MAX_LINES 64
 static int apache_read_host (user_data_t *user_data) /* {{{ */
 {
 	int i;
 
 	char *ptr;
 	char *saveptr;
-	char *lines[16];
+	char *lines[_MAX_LINES];
 	int   lines_num = 0;
 
 	char *fields[4];
@@ -569,7 +570,7 @@ static int apache_read_host (user_data_t *user_data) /* {{{ */
 		ptr = NULL;
 		lines_num++;
 
-		if (lines_num >= 16)
+		if (lines_num >= _MAX_LINES)
 			break;
 	}
 


### PR DESCRIPTION
mod_status of Apache 2.4.17 changed the layout of its output. The collectd module only parsed the first 16 lines. It ignored all the rest of the output and therefore ignored some values. Extending the number of lines to parse to 64 fixes this. It may be necessary to extend the number to a higher value in the future or rewrite the code to parse the output.