### PR TITLE
Set SNMP ASN_GAUGE values to unsigned.

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -924,8 +924,7 @@ static value_t csnmp_value_list_to_value (struct variable_list *vl, int type,
     tmp_unsigned = (uint32_t) *vl->val.integer;
     tmp_signed = (int32_t) *vl->val.integer;
 
-    if ((vl->type == ASN_INTEGER)
-        || (vl->type == ASN_GAUGE))
+    if ((vl->type == ASN_INTEGER))
       prefer_signed = 1;
 
     DEBUG ("snmp plugin: Parsed int32 value is %"PRIu64".", tmp_unsigned);

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -924,7 +924,7 @@ static value_t csnmp_value_list_to_value (struct variable_list *vl, int type,
     tmp_unsigned = (uint32_t) *vl->val.integer;
     tmp_signed = (int32_t) *vl->val.integer;
 
-    if ((vl->type == ASN_INTEGER))
+    if (vl->type == ASN_INTEGER)
       prefer_signed = 1;
 
     DEBUG ("snmp plugin: Parsed int32 value is %"PRIu64".", tmp_unsigned);


### PR DESCRIPTION
SNMP-SMIv2 specifies Gauge32 as unsigned, however the change to fix #50, which was this exact problem, set both Integer and Gauge to signed, when it should have only set Integer.

This patch sets Gauge32 to be unsigned.