### PR TITLE
exec plugin: log no such dataset registered error at INFO level

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2541,7 +2541,7 @@ const data_set_t *plugin_get_ds (const char *name)
 
 	if (c_avl_get (data_sets, name, (void *) &ds) != 0)
 	{
-		DEBUG ("No such dataset registered: %s", name);
+		INFO ("No such dataset registered: %s", name);
 		return (NULL);
 	}
 


### PR DESCRIPTION
Spent a few hours debugging and ended up having to recompile on a production server with debug enabled to get an error message about a configuration mistake. It seems like if you are sending metrics with unregistered types that should be readily available at the INFO level.