### PR TITLE
adding patch from #1291

### DIFF
--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -68,6 +68,7 @@ class GenericJMXConfValue
   private List<String> _attributes;
   private String _instance_prefix;
   private List<String> _instance_from;
+  private String _plugin_name;
   private boolean _is_table;
 
   /**
@@ -436,6 +437,7 @@ class GenericJMXConfValue
     this._attributes = new ArrayList<String> ();
     this._instance_prefix = null;
     this._instance_from = new ArrayList<String> ();
+    this._plugin_name = null;
     this._is_table = false;
 
     /*
@@ -484,6 +486,12 @@ class GenericJMXConfValue
         String tmp = getConfigString (child);
         if (tmp != null)
           this._instance_from.add (tmp);
+        else if (child.getKey ().equalsIgnoreCase ("PluginName"))
+        {
+          String tmp = getConfigString (child);
+          if (tmp != null )
+            this._plugin_name = tmp;
+        }
       }
       else
         throw (new IllegalArgumentException ("Unknown option: "
@@ -538,6 +546,10 @@ class GenericJMXConfValue
 
     vl = new ValueList (pd);
     vl.setType (this._ds_name);
+    if (this._plugin_name != null)
+    {
+      vl.setPlugin (this._plugin_name);
+    }
 
     /*
      * Build the instnace prefix from the fixed string prefix and the


### PR DESCRIPTION
This adds the `PluginName` support from #1291 (without the previous tabular data patch) to support reducing length of metric names. We're currently suffering with some truncated data as well due to insanely long names that we can't really control.

Note that I didn't bother to fire up the IDE for this. I'm waiting on a build to finish locally but I wanted to get the patch out there. The original author in #1291 did all the work, I just made it into a PR that might have more traction.