### PR TITLE
curl_json: handle boolean values in a more useful way

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -203,12 +203,6 @@ static void cj_cb_inc_array_index (void *ctx, _Bool update_key)
 #define CJ_CB_ABORT    0
 #define CJ_CB_CONTINUE 1
 
-static int cj_cb_boolean (void * ctx, int boolVal)
-{
-  cj_cb_inc_array_index (ctx, /* update_key = */ 0);
-  return (CJ_CB_CONTINUE);
-}
-
 static int cj_cb_null (void * ctx)
 {
   cj_cb_inc_array_index (ctx, /* update_key = */ 0);
@@ -309,6 +303,11 @@ static int cj_cb_string (void *ctx, const unsigned char *val,
   /* Handle the string as if it was a number. */
   return (cj_cb_number (ctx, (const char *) val, len));
 } /* int cj_cb_string */
+
+static int cj_cb_boolean (void * ctx, int boolVal)
+{
+  return (cj_cb_number (ctx, (boolVal)? "1":"0", 1));
+}
 
 static int cj_cb_start (void *ctx)
 {


### PR DESCRIPTION
Currently curl_json will barely ignore boolean values in a non erroneous
way, so that if you have an array like this: `{ foo: [false, 123] }`
you will be able to access the 123 number like `foo[1]`

We now rather call our number parser with "0" for false, "1" for true.
