### PR TITLE
Implement kafka custom output format

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1239,6 +1239,7 @@ pkglib_LTLIBRARIES += write_kafka.la
 write_kafka_la_SOURCES = write_kafka.c \
                         utils_format_graphite.c utils_format_graphite.h \
                         utils_format_json.c utils_format_json.h \
+                        utils_format_kafka_custom.c utils_format_kafka_custom.h \
                         utils_cmd_putval.c utils_cmd_putval.h \
                         utils_crc32.c utils_crc32.h
 write_kafka_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBRDKAFKA_CPPFLAGS)

--- a/src/utils_format_kafka_custom.c
+++ b/src/utils_format_kafka_custom.c
@@ -1,0 +1,78 @@
+/**
+ * collectd - src/utils_format_kafka_custom.c
+ * Copyright (C) 2009       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ *   Yves Mettier <ymettier at free dot fr>
+ **/
+
+#include "collectd.h"
+#include "plugin.h"
+#include "common.h"
+
+#include "utils_cache.h"
+#include "utils_format_kafka_custom.h"
+
+/*
+ * IMPORTANT : see utils_format_kafka_custom.h for more
+ * information on how to implement custom format.
+ */
+
+/*
+ * Do not set KAFKA_FORMAT_CUSTOM_1 here.
+ */
+#ifdef KAFKA_FORMAT_CUSTOM_1
+
+int format_kafka_custom_initialize (char *buffer, /* {{{ */
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    uint8_t format)
+{
+/*
+ * Implement your own format_kafka_custom_initialize() function here.
+ */
+
+  return (0);
+} /* }}} int format_kafka_custom_initialize */
+
+int format_kafka_custom_finalize (char *buffer, /* {{{ */
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    uint8_t format)
+{
+/*
+ * Implement your own format_kafka_custom_finalize() function here.
+ */
+
+  return (0);
+} /* }}} int format_kafka_custom_finalize */
+
+int format_kafka_custom_value_list (char *buffer, /* {{{ */
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    const data_set_t *ds, const value_list_t *vl,
+    int store_rates, uint8_t format)
+{
+
+  return (0);
+} /* }}} int format_kafka_custom_value_list */
+
+#endif
+
+/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kafka_custom.h
+++ b/src/utils_format_kafka_custom.h
@@ -1,0 +1,105 @@
+/**
+ * collectd - src/utils_format_kafka_custom.h
+ * Copyright (C) 2015       Yves Mettier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Yves Mettier <ymettier at free dot fr>
+ **/
+
+#ifndef UTILS_FORMAT_KAFKA_CUSTOM_H
+#define UTILS_FORMAT_KAFKA_CUSTOM_H 1
+
+#include "collectd.h"
+#include "plugin.h"
+
+/*   DOCUMENTATION
+ * --=============--
+ *
+ * OK, you want to implement your own custom format to send
+ * data to kafka. You can do that in utils_format_kafka_custom.c
+ *
+ * 1/ Do not edit utils_format_kafka_custom.h
+ * 2/ Do not edit write_kafka.c
+ *
+ * How do you write your custom code ?
+ * -----------------------------------
+ *
+ * 1/ Define IMPLEMENT_KAFKA_FORMAT_CUSTOM_1 at compilation time :
+ *
+ * ./configure CPPFLAGS=-DIMPLEMENT_KAFKA_FORMAT_CUSTOM_1
+ * make
+ * [...]
+ *
+ *
+ * 2/ Implement the 3 fonctions defined below.
+ * Reading utils_format_json.c can help you a lot.
+ *
+ * 3/ Rebuild Collectd (with IMPLEMENT_KAFKA_FORMAT_CUSTOM_1 defined)
+ *
+ * 4/ Edit your configuration file and set :
+ *   <Topic "your-topic-name">
+ *       Format CUSTOM1
+ *   </Topic>
+ *
+ * 5/ Start Collectd, enjoy...
+ *
+ *
+ * Functions description
+ * ---------------------
+ * When a value is received from write_kafka, it will
+ * 1/ initialize a buffer
+ * 2/ call format_kafka_custom_initialize()
+ * 3/ call format_kafka_custom_value_list() one time (and maybe multiple times in the future)
+ * 4/ call format_kafka_custom_finalize()
+ * 5/ send the buffer to Kafka
+ *
+ * Note that last argument (named format) is set to KAFKA_FORMAT_CUSTOM_1 for now.
+ * If one day write_kafka.c allows more than one custom format, it should be easy to
+ * use the same callbacks and dispatch to other functions according to the format.
+ */
+
+/*
+#define IMPLEMENT_KAFKA_FORMAT_CUSTOM_1
+*/
+
+
+#ifdef IMPLEMENT_KAFKA_FORMAT_CUSTOM_1
+
+#ifndef KAFKA_FORMAT_CUSTOM_1
+#define KAFKA_FORMAT_CUSTOM_1    3
+
+
+int format_kafka_custom_initialize (char *buffer,
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    uint8_t format);
+int format_kafka_custom_value_list (char *buffer,
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    const data_set_t *ds, const value_list_t *vl, int store_rates,
+    uint8_t format);
+int format_kafka_custom_finalize (char *buffer,
+    size_t *ret_buffer_fill, size_t *ret_buffer_free,
+    uint8_t format);
+#endif
+#endif
+
+#endif /* UTILS_FORMAT_KAFKA_CUSTOM_H */
+
+


### PR DESCRIPTION
Hello,

I want to be able to customize my own format to send to Kafka. How can I do it ?
* hack the current `src/utils_format_json.c` ? Bad idea because somebody else may want to customize another way.
* use a 3rd party tool that would push to Kafka. Use a compatible write plugin to push to that 3rd party tool ? No. Too complex.
* improve `src/write_kafka.c` and implement a language to describe the output ? Yes, but too complex, and that would break the perfs of Collectd. If you care about perfs, you cannot use an interpretation layer.
* fork `src/write_kafka.c` and maintain my own plugin (which would be unpublished).No, fork is bad here.

This PR is a mix of 1st, 3rd and 4th ideas above. The idea is to provide a source file similar to `src/utils_format_json.c` to hack.
* If you don't need it, it will not be compiled. You will never hear of it.
* If you want to customize your output, you can work on `src/utils_format_kafka_custom.c`. This file is provided specificallly for users who want to code their own format. You need to define `IMPLEMENT_KAFKA_FORMAT_CUSTOM_1` constant to take your work into account.

This PR does not provide my own customization of the format. Probably nobody cares about it.

This PR provides the "framework" in order to let  users develop their own format :
* define `IMPLEMENT_KAFKA_FORMAT_CUSTOM_1` constant to take your work into account. See `src/utils_format_kafka_custom.h` to know how to use it.
* `src/utils_format_kafka_custom.c` (and `src/utils_format_kafka_custom.h`) template file
* new format `CUSTOM1` defined in `write_kafka.c`. This is because nobody should hack `write_kafka.c` to enable their own format. Note : I named the new format `CUSTOM1` in order to be able to have more than one custom format later.

About documentation : I chose to write it in `src/utils_format_kafka_custom.h` because I think that only users with C development skills may use this feature. Such users will have a look in `write_kafka.c` and easily find the framework.

Regards,
Yves


