### PR TITLE
apache: parse whole response, not only the first 16 lines

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -585,12 +585,9 @@ static void submit_scoreboard (char *buf, apache_t *st)
 
 static int apache_read_host (user_data_t *user_data) /* {{{ */
 {
-	int i;
-
 	char *ptr;
 	char *saveptr;
-	char *lines[16];
-	int   lines_num = 0;
+	char *line;
 
 	char *fields[4];
 	int   fields_num;
@@ -630,18 +627,10 @@ static int apache_read_host (user_data_t *user_data) /* {{{ */
 
 	ptr = st->apache_buffer;
 	saveptr = NULL;
-	while ((lines[lines_num] = strtok_r (ptr, "\n\r", &saveptr)) != NULL)
+	while ((line = strtok_r (ptr, "\n\r", &saveptr)) != NULL)
 	{
 		ptr = NULL;
-		lines_num++;
-
-		if (lines_num >= 16)
-			break;
-	}
-
-	for (i = 0; i < lines_num; i++)
-	{
-		fields_num = strsplit (lines[i], fields, 4);
+		fields_num = strsplit (line, fields, 4);
 
 		if (fields_num == 3)
 		{


### PR DESCRIPTION
mod_status recently started reporting more statistics. According to
http://www.apache.org/dist/httpd/CHANGES_2.4 `mod_proxy, mod_ssl,
mod_cache_socache, mod_socache_*: Support machine readable server-status
produced when using the "?auto" query string.` for version 2.4.13 onwards.

As we can't assume everything we need will be included in the first 16
lines of output anymore, we now simply scan through the whole output.