### PR TITLE
generate configure script correctly when build rpm from git work copy

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,12 +8,15 @@ check_for_application ()
 	do
 		which "$PROG" >/dev/null 2>&1
 		if test $? -ne 0; then
-			cat >&2 <<EOF
+			[ "$PROG" = "yacc" ] && which bison >/dev/null 2>&1
+			if test $? -ne 0; then
+				cat >&2 <<EOF
 WARNING: \`$PROG' not found!
     Please make sure that \`$PROG' is installed and is in one of the
     directories listed in the PATH environment variable.
 EOF
-			GLOBAL_ERROR_INDICATOR=1
+				GLOBAL_ERROR_INDICATOR=1
+			fi
 		fi
 	done
 }

--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -228,7 +228,7 @@ Source:		http://collectd.org/files/%{name}-%{version}.tar.bz2
 License:	GPLv2
 Group:		System Environment/Daemons
 BuildRoot:	%{_tmppath}/%{name}-%{version}-root
-BuildRequires:	libgcrypt-devel, kernel-headers, libtool-ltdl-devel, libcap-devel
+BuildRequires:	autoconf, automake, which, flex, bison, libgcrypt-devel, kernel-headers, libtool, libtool-ltdl-devel, libcap-devel
 Vendor:		collectd development team <collectd@verplant.org>
 
 %if 0%{?el7:1}
@@ -1618,6 +1618,8 @@ Collectd utilities
 %else
 %define _with_zookeeper --disable-zookeeper
 %endif
+
+test -e configure || ./build.sh
 
 %configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW=\"RTLD_LAZY|RTLD_GLOBAL\"" \
 	--disable-static \


### PR DESCRIPTION
build.sh requires extra build dependencies such as libgcrypt-devel to
copy their m4 files, and the mock build environment requires flex, bison
and libtool packages to correctly build.

My build steps:

```bash
docker run -it --privileged --name collectd_build centos:6 bash

# as root in container
yum install -y epel-release
yum install -y mock bzip2 sudo
adduser builder
usermod -a -G mock builder
usermod -a -G wheel builder
sed -i -e 's/^\s*#\s*\(%wheel.*NOPASSWD:\)/\1/' /etc/sudoers
su builder

# as builder in container
cd && mkdir -p rpmbuild/{SOURCES,SPECS}
git clone https://github.com/collectd/collectd.git collectd-5.5.0
# ... apply this patch...
tar cjf collectd-5.5.0.tar.bz2 collectd-5.5.0/

cp collectd-5.5.0/contrib/redhat/collectd.spec rpmbuild/SPECS
mv collectd-5.5.0.tar.bz2 rpmbuild/SOURCES

sudo mock -r epel-6-x86_64 --enablerepo=epel --buildsrpm --spec ~/rpmbuild/SPECS/collectd.spec --sources ~/rpmbuild/SOURCES/
sudo mock -r epel-6-x86_64 --enablerepo=epel --no-clean --rebuild /var/lib/mock/epel-6-x86_64/result/collectd-5.5.0-1.el6.src.rpm
ls /var/lib/mock/epel-6-x86_64/result/
```
