### PR TITLE
Remove duplicate call to pthread_mutex_destroy.

### DIFF
--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -255,7 +255,6 @@ void meta_data_destroy (meta_data_t *md) /* {{{ */
   if (md == NULL)
     return;
 
-  pthread_mutex_destroy(&md->lock);
   md_entry_free (md->head);
   pthread_mutex_destroy (&md->lock);
   free (md);


### PR DESCRIPTION
Destroying the same mutex twice was probably not intentional.