### PR TITLE
memcached_connections is of type GAUGE, needs to be submitted as a gauge.

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -439,7 +439,7 @@ static int memcached_read (user_data_t *user_data)
     }
     else if (FIELD_IS ("listen_disabled_num"))
     {
-      submit_derive ("memcached_connections", "listen_disabled", atof (fields[2]), st);
+      submit_gauge ("memcached_connections", "listen_disabled", atof (fields[2]), st);
     }
 
     /*


### PR DESCRIPTION
Put another way, line 442 needs to be consistent with line 438.

(credit: Jason Lawrence (https://github.com/chroniton) for finding this).

