### PR TITLE
the swrite interface is 'non-zero'

### DIFF
--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -113,7 +113,7 @@ static int wg_send_buffer (struct wg_callback *cb)
     ssize_t status = 0;
 
     status = swrite (cb->sock_fd, cb->send_buf, strlen (cb->send_buf));
-    if (status < 0)
+    if (status != 0)
     {
         if (cb->log_send_errors)
         {


### PR DESCRIPTION
In many other implementations status is checked to be "non-zero", as per the interface definition to `swrite`.