### PR TITLE
processes.c: plug memory leak in error path

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -288,6 +288,7 @@ static void ps_list_register (const char *name, const char *regexp)
 		{
 			DEBUG ("ProcessMatch: compiling the regular expression \"%s\" failed.", regexp);
 			sfree(new->re);
+			sfree(new);
 			return;
 		}
 	}


### PR DESCRIPTION
Found with Infer (http://fbinfer.com/)