### PR TITLE
snmp: accept to use IpAddress for instances

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1106,6 +1106,14 @@ static int csnmp_strvbcopy (char *dst, /* {{{ */
     src = (char *) vb->val.string;
   else if (vb->type == ASN_BIT_STR)
     src = (char *) vb->val.bitstring;
+  else if (vb->type == ASN_IPADDRESS)
+  {
+    return ssnprintf (dst, dst_size, "%d.%d.%d.%d",
+          (uint8_t)vb->val.string[0],
+          (uint8_t)vb->val.string[1],
+          (uint8_t)vb->val.string[2],
+          (uint8_t)vb->val.string[3]);
+  }
   else
   {
     dst[0] = 0;
@@ -1171,7 +1179,7 @@ static int csnmp_instance_list_add (csnmp_list_instances_t **head,
   }
 
   /* Get instance name */
-  if ((vb->type == ASN_OCTET_STR) || (vb->type == ASN_BIT_STR))
+  if ((vb->type == ASN_OCTET_STR) || (vb->type == ASN_BIT_STR) || (vb->type == ASN_IPADDRESS))
   {
     char *ptr;
 


### PR DESCRIPTION
Some interesting MIB are indexed with an IP address (for example,
BGP4-MIB). Make collectd able to use those indexes as instances. Format
the IP as string. IPv6 are usually encoded as Octet String, so, they
should be already supported.

Is the use of dot problematic? When used with graphite, it is a separator. Should I replace with a special dot (unicode) or a dash?
