### PR TITLE
git ignore src/daemon/test_utils_time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ src/daemon/test_meta_data
 src/daemon/test_utils_avltree
 src/daemon/test_utils_heap
 src/daemon/test_utils_subst
+src/daemon/test_utils_time


### PR DESCRIPTION
Add src/daemon/test_utils_time to .gitignore.
Probably forgotten when introducing db1391aaa66b8b8fad82219494f61f3452441f62