### PR TITLE
teamspeak2: fix potential use after close

### DIFF
--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -257,6 +257,7 @@ static int tss2_get_socket (FILE **ret_read_fh, FILE **ret_write_fh)
 			WARNING ("teamspeak2 plugin: connect failed: %s",
 					sstrerror (errno, errbuf, sizeof (errbuf)));
 			close (sd);
+			sd = -1;
 			continue;
 		}
 


### PR DESCRIPTION
If connecting to the last host fails, we exit the loop
with a closed fd, which we try to fdopen() later on.

CID #38038