### PR TITLE
snmp plugin: don't read from uninitialized pointer

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1398,7 +1398,7 @@ static int csnmp_dispatch_table (host_definition_t *host, data_definition_t *dat
 static int csnmp_read_table (host_definition_t *host, data_definition_t *data)
 {
   struct snmp_pdu *req;
-  struct snmp_pdu *res;
+  struct snmp_pdu *res = NULL;
   struct variable_list *vb;
 
   const data_set_t *ds;


### PR DESCRIPTION
if the first snmp_pdu_create inside the loop returns an error,
we exit the loop with res uninitialized and then call snmp_free_pdu on it.

CID #38037