### PR TITLE
readlink: null-terminate result of readlink

### DIFF
--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -821,14 +821,15 @@ check_devname (const char *dev)
 
 	if (dev[0] == '.')
 		return 0;
-	
-	ssnprintf (buf, sizeof (buf), "/sys/class/net/%s/device/driver", dev);
-	buf[sizeof (buf) - 1] = 0;
 
-	memset (buf2, 0, sizeof (buf2));
+	ssnprintf (buf, sizeof (buf), "/sys/class/net/%s/device/driver", dev);
+	buf[sizeof (buf) - 1] = '\0';
+
 	i = readlink (buf, buf2, sizeof (buf2) - 1);
 	if (i < 0)
 		return 0;
+
+	buf2[i] = '\0';
 
 	if (strstr (buf2, "/drivers/ath_") == NULL)
 		return 0;


### PR DESCRIPTION
readlink doesn't do it for us.

CID #38027