### PR TITLE
utils_mount.c: check for null before dereferencing

### DIFF
--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -760,13 +760,13 @@ void cu_mount_freelist (cu_mount_t *list)
 char *
 cu_mount_checkoption(char *line, char *keyword, int full)
 {
-	char *line2, *l2;
-	int l = strlen(keyword);
-	char *p1, *p2;
+	char *line2, *l2, *p1, *p2;
+	int l;
 
 	if(line == NULL || keyword == NULL) {
 		return NULL;
 	}
+
 	if(full != 0) {
 		full = 1;
 	}
@@ -780,6 +780,7 @@ cu_mount_checkoption(char *line, char *keyword, int full)
 		l2++;
 	}
 
+	l = strlen(keyword);
 	p1 = line - 1;
 	p2 = strchr(line, ',');
 	do {


### PR DESCRIPTION
CID #38025