### PR TITLE
Fixed duplicate interface metrics for Solaris

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -476,6 +476,7 @@
 #<Plugin interface>
 #	Interface "eth0"
 #	IgnoreSelected false
+#	UniqueName false
 #</Plugin>
 
 #<Plugin ipmi>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2002,6 +2002,17 @@ do that: By setting B<IgnoreSelected> to I<true> the effect of
 B<Interface> is inverted: All selected interfaces are ignored and all
 other interfaces are collected.
 
+=item B<UniqueName> I<true>|I<false>
+
+Interface name is not unique on Solaris (KSTAT), interface name is unique 
+only within a module/instance. Following tuple is considered unique: 
+   (ks_module, ks_instance, ks_name)
+If this option is set to true, interface name contains above three fields
+separated by an underscore. For more info on KSTAT, visit
+L<http://docs.oracle.com/cd/E23824_01/html/821-1468/kstat-3kstat.html#REFMAN3Ekstat-3kstat>
+
+This option is only available on Solaris.
+
 =back
 
 =head2 Plugin C<ipmi>

--- a/src/interface.c
+++ b/src/interface.c
@@ -288,6 +288,7 @@ static int interface_read (void)
 	int i;
 	derive_t rx;
 	derive_t tx;
+	char iname[DATA_MAX_NAME_LEN];
 
 	if (kc == NULL)
 		return (-1);
@@ -296,6 +297,8 @@ static int interface_read (void)
 	{
 		if (kstat_read (kc, ksp[i], NULL) == -1)
 			continue;
+
+		snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module, ksp[i]->ks_instance, ksp[i]->ks_name);
 
 		/* try to get 64bit counters */
 		rx = get_kstat_value (ksp[i], "rbytes64");
@@ -306,7 +309,7 @@ static int interface_read (void)
 		if (tx == -1LL)
 			tx = get_kstat_value (ksp[i], "obytes");
 		if ((rx != -1LL) || (tx != -1LL))
-			if_submit (ksp[i]->ks_name, "if_octets", rx, tx);
+			if_submit (iname, "if_octets", rx, tx);
 
 		/* try to get 64bit counters */
 		rx = get_kstat_value (ksp[i], "ipackets64");
@@ -317,13 +320,13 @@ static int interface_read (void)
 		if (tx == -1LL)
 			tx = get_kstat_value (ksp[i], "opackets");
 		if ((rx != -1LL) || (tx != -1LL))
-			if_submit (ksp[i]->ks_name, "if_packets", rx, tx);
+			if_submit (iname, "if_packets", rx, tx);
 
 		/* no 64bit error counters yet */
 		rx = get_kstat_value (ksp[i], "ierrors");
 		tx = get_kstat_value (ksp[i], "oerrors");
 		if ((rx != -1LL) || (tx != -1LL))
-			if_submit (ksp[i]->ks_name, "if_errors", rx, tx);
+			if_submit (iname, "if_errors", rx, tx);
 	}
 /* #endif HAVE_LIBKSTAT */
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -92,6 +92,7 @@ static const char *config_keys[] =
 static int config_keys_num = 2;
 
 static ignorelist_t *ignorelist = NULL;
+static _Bool unique_name = 0;
 
 #ifdef HAVE_LIBKSTAT
 #define MAX_NUMIF 256
@@ -115,6 +116,11 @@ static int interface_config (const char *key, const char *value)
 		if (IS_TRUE (value))
 			invert = 0;
 		ignorelist_set_invert (ignorelist, invert);
+	}
+	else if (strcasecmp (key, "UniqueName") == 0)
+	{
+		if (IS_TRUE (value))
+			unique_name = 1;
 	}
 	else
 	{
@@ -298,7 +304,10 @@ static int interface_read (void)
 		if (kstat_read (kc, ksp[i], NULL) == -1)
 			continue;
 
-		snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module, ksp[i]->ks_instance, ksp[i]->ks_name);
+		if (unique_name)
+			snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module, ksp[i]->ks_instance, ksp[i]->ks_name);
+		else
+			snprintf(iname, sizeof(iname), "%s", ksp[i]->ks_name);
 
 		/* try to get 64bit counters */
 		rx = get_kstat_value (ksp[i], "rbytes64");


### PR DESCRIPTION
On Solaris, interface plugin publishes duplicate metrics, ie for the same time interval (with the same epoch) it publishes multiple data points for the same interface name.

Collectd interface plugin uses kstat on Solaris. As per kstat documents (http://docs.oracle.com/cd/E23824_01/html/821-1468/kstat-3kstat.html#REFMAN3Ekstat-3kstat), interface name is unique ONLY within a module/instance. Following tuple is considered unique:

```  
<ks_module, ks_instance, ks_name>
```

This fix publishes above tuple as plugin_instance instead of just ks_name and avoids duplicate metrics.