### PR TITLE
.gitignore: ignore test_plugin_ceph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ src/tests/mock/.dirstamp
 src/test_utils_latency
 src/test_utils_mount
 src/test_utils_vl_lookup
+src/test_plugin_ceph
 test*.log
 *.trs
 


### PR DESCRIPTION
I did not noticed it in my previous #1403 since i do not always compile the whole collectd source tree, but it sounds like ``test_plugin_ceph``should be added to .gitignore too.

Cheers,
CH