### PR TITLE
Fix make check on OmniOS

### DIFF
--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -24,8 +24,8 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
 #include "common.h"
+#include "testing.h"
 
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;

--- a/src/daemon/meta_data_test.c
+++ b/src/daemon/meta_data_test.c
@@ -24,9 +24,9 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
-#include "collectd.h"
 #include "common.h" /* for STATIC_ARRAY_SIZE */
+#include "collectd.h"
+#include "testing.h"
 #include "meta_data.h"
 
 DEF_TEST(base)

--- a/src/daemon/utils_avltree_test.c
+++ b/src/daemon/utils_avltree_test.c
@@ -24,10 +24,10 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
-#include "collectd.h"
-#include "utils_avltree.h"
 #include "common.h" /* STATIC_ARRAY_SIZE */
+#include "collectd.h"
+#include "testing.h"
+#include "utils_avltree.h"
 
 static int compare_total_count = 0;
 #define RESET_COUNTS() do { compare_total_count = 0; } while (0)

--- a/src/daemon/utils_heap_test.c
+++ b/src/daemon/utils_heap_test.c
@@ -24,8 +24,8 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
 #include "collectd.h"
+#include "testing.h"
 #include "utils_heap.h"
 
 static int compare (void const *v0, void const *v1)

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -24,9 +24,9 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
-#include "collectd.h"
 #include "common.h" /* for STATIC_ARRAY_SIZE */
+#include "collectd.h"
+#include "testing.h"
 #include "utils_subst.h"
 
 #if HAVE_LIBKSTAT

--- a/src/daemon/utils_time_test.c
+++ b/src/daemon/utils_time_test.c
@@ -26,8 +26,8 @@
 
 #define DBL_PRECISION 1e-3
 
-#include "testing.h"
 #include "collectd.h"
+#include "testing.h"
 #include "utils_time.h"
 
 DEF_TEST(conversion)

--- a/src/utils_latency_test.c
+++ b/src/utils_latency_test.c
@@ -26,9 +26,9 @@
 
 #define DBL_PRECISION 1e-9
 
-#include "testing.h"
-#include "collectd.h"
 #include "common.h" /* for STATIC_ARRAY_SIZE */
+#include "collectd.h"
+#include "testing.h"
 #include "utils_time.h"
 #include "utils_latency.h"
 

--- a/src/utils_mount_test.c
+++ b/src/utils_mount_test.c
@@ -24,8 +24,8 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
 #include "collectd.h"
+#include "testing.h"
 #include "utils_mount.h"
 
 #if HAVE_LIBKSTAT

--- a/src/utils_vl_lookup_test.c
+++ b/src/utils_vl_lookup_test.c
@@ -24,8 +24,8 @@
  *   Florian Forster <octo at collectd.org>
  **/
 
-#include "testing.h"
 #include "collectd.h"
+#include "testing.h"
 #include "utils_vl_lookup.h"
 
 static _Bool expect_new_obj = 0;


### PR DESCRIPTION
We need the defines from config.h before
we include <testing.h>, or we get the following error on OmniOS:

make  test_common test_meta_data  test_utils_avltree test_utils_heap  test_utils_time test_utils_subst
gcc -DHAVE_CONFIG_H -I. -I../../src  -I../../src -DPREFIX='"/opt/collectd"'  -DCONFIGFILE='"/opt/collectd/etc/collectd.conf"'  -DLOCALSTATEDIR='"/opt/collectd/var"'  -DPKGLOCALSTATEDIR='"/opt/collectd/var/lib/collectd"'  -DPIDFILE='"/opt/collectd/var/run/collectd.pid"' -DPLUGINDIR='"/opt/collectd/lib/collectd"'  -DPKGDATADIR='"/opt/collectd/share/collectd"'   -Wall -Werror -g -O2 -c -o common_test.o common_test.c
In file included from collectd.h:31:0,
                 from common.h:31,
                 from common_test.c:28:
../../src/config.h:1631:0: error: "_FILE_OFFSET_BITS" redefined [-Werror]
 #define _FILE_OFFSET_BITS 64
 ^
In file included from /usr/include/inttypes.h:41:0,
                 from ../../src/testing.h:30,
                 from common_test.c:27:
/opt/gcc-5.1.0/lib/gcc/i386-pc-solaris2.11/5.1.0/include-fixed/sys/feature_tests.h:231:0: note: this is the location of the previous definition
 #define _FILE_OFFSET_BITS 32
 ^
cc1: all warnings being treated as errors
*** Error code 1
make: Fatal error: Command failed for target `common_test.o'