### PR TITLE
configure.ac: send output of check to /dev/null

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,7 +396,7 @@ AC_CHECK_HEADERS(sys/sysctl.h, [], [],
 AC_MSG_CHECKING([for sysctl kern.cp_times])
 if test -x /sbin/sysctl
 then
-	/sbin/sysctl kern.cp_times 2>/dev/null
+	/sbin/sysctl kern.cp_times >/dev/null 2>&1
 	if test $? -eq 0
 	then
 		AC_MSG_RESULT([yes])


### PR DESCRIPTION
The output is quite a long line:
kern.cp_times: 10336 0 9848 499639 7613098 18834 0 11963 115 8101970 16444 0 14368 1672 8100398 17584 0 14149 1358 8099791

And we have no use for the result, we just want to know if the sysctl exists.