### PR TITLE
libnotify: Don't output multiple lines of errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5125,11 +5125,8 @@ AM_CONDITIONAL(BUILD_WITH_LIBATASMART, test "x$with_libatasmart" = "xyes")
 
 PKG_CHECK_MODULES([LIBNOTIFY], [libnotify],
 		[with_libnotify="yes"],
-		[if test "x$LIBNOTIFY_PKG_ERRORS" = "x"; then
-			 with_libnotify="no"
-		 else
-			 with_libnotify="no ($LIBNOTIFY_PKG_ERRORS)"
-		 fi])
+		[with_libnotify="no (pkg-config doesn't know libnotify)"]
+)
 
 # Check for enabled/disabled features
 #


### PR DESCRIPTION
The errors pkg-config returns are not very helpful and they
break our nicely formatted list of found and absent libraries.

Just say that the package can't be found, like we do for the rest
of the packages we need.