### PR TITLE
Remove check for ip_compat.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -634,8 +634,6 @@ AC_CHECK_HEADERS(netinet/if_ether.h, [], [],
 #endif
 ])
 
-AC_CHECK_HEADERS(netinet/ip_compat.h)
-
 have_net_pfvar_h="no"
 AC_CHECK_HEADERS(net/pfvar.h,
                [have_net_pfvar_h="yes"],

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -62,9 +62,6 @@
 #if HAVE_NETINET_IP6_H
 # include <netinet/ip6.h>
 #endif
-#if HAVE_NETINET_IP_COMPAT_H
-# include <netinet/ip_compat.h>
-#endif
 #if HAVE_NETINET_IF_ETHER_H
 # include <netinet/if_ether.h>
 #endif


### PR DESCRIPTION
Solaris needed this at one point but since
a621ced we check for ip6_ext without including this
header and that seems to succeed to.