### PR TITLE
redis plugin: fix build error on NetBSD

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -304,7 +304,7 @@ int redis_handle_info (char *node, char const *info_line, char const *type, char
     int i;
 
     str += strlen (field_name) + 1; /* also skip the ':' */
-    for(i=0;(*str && (isdigit(*str) || *str == '.'));i++,str++)
+    for(i=0;(*str && (isdigit((unsigned char)*str) || *str == '.'));i++,str++)
       buf[i] = *str;
     buf[i] ='\0';
 


### PR DESCRIPTION
Making all in daemon
  CC       redis_la-redis.lo
redis.c: In function 'redis_handle_info':
redis.c:307:5: error: array subscript has type 'char' [-Werror=char-subscripts]
     for(i=0;(*str && (isdigit(*str) || *str == '.'));i++,str++)
     ^
cc1: all warnings being treated as errors
*** Error code 1

Stop.
make[3]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make[2]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make[1]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make: stopped in /home/ruben/src/collectd