### PR TITLE
write_riemann: remove unneeded include

### DIFF
--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -33,7 +33,6 @@
 #include "utils_threshold.h"
 
 #include <assert.h>
-#include <ltdl.h>
 #include <pthread.h>
 
 /*


### PR DESCRIPTION
Fixes build on NetBSD:

Making all in daemon
  CC       write_riemann_threshold.lo
write_riemann_threshold.c:36:18: fatal error: ltdl.h: No such file or directory
 #include <ltdl.h>
                  ^
compilation terminated.
*** Error code 1

Stop.
make[3]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make[2]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make[1]: stopped in /home/ruben/src/collectd/src
*** Error code 1

Stop.
make: stopped in /home/ruben/src/collectd