### PR TITLE
rrdtool plugin : fix segfault when processing DataDir value from config

### DIFF
--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -1018,11 +1018,11 @@ static int rrd_config (const char *key, const char *value)
 			return (1);
 		}
 
-		len = strlen (datadir);
-		while ((len > 0) && (datadir[len - 1] == '/'))
+		len = strlen (tmp);
+		while ((len > 0) && (tmp[len - 1] == '/'))
 		{
 			len--;
-			datadir[len] = 0;
+			tmp[len] = 0;
 		}
 
 		if (len == 0)
@@ -1032,7 +1032,6 @@ static int rrd_config (const char *key, const char *value)
 			return (1);
 		}
 
-		sfree (datadir);
 		datadir = tmp;
 	}
 	else if (strcasecmp ("StepSize", key) == 0)


### PR DESCRIPTION


```
(gdb) bt
#0  0x00000034d833357f in __strlen_sse42 () from /lib64/libc.so.6
#1  0x00007ffff5da29ab in rrd_config (key=<value optimized out>, value=<value optimized out>)
    at rrdtool.c:1021
#2  0x000000000040842a in cf_dispatch (plugin=0x643390 "rrdtool", ci=<value optimized out>)
    at configfile.c:192
#3  dispatch_value_plugin (plugin=0x643390 "rrdtool", ci=<value optimized out>) at configfile.c:356
#4  0x0000000000408910 in dispatch_block_plugin (ci=0x63a390) at configfile.c:448
#5  0x0000000000408d28 in dispatch_block (filename=<value optimized out>) at configfile.c:470
#6  cf_read (filename=<value optimized out>) at configfile.c:1141
#7  0x0000000000406589 in main (argc=4, argv=0x7fffffffe6b8) at collectd.c:589
(gdb)
 
```