### PR TITLE
netlink plugin: metrics for drops, requeues, overlimits, qlen, backlog

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -536,6 +536,10 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       }
       if (q_stats.qs != NULL) {
         submit_one(dev, "if_tx_dropped", type_instance, q_stats.qs->drops);
+        submit_one(dev, "queue_length", type_instance, q_stats.qs->qlen);
+        submit_one(dev, "ipt_backlog", type_instance, q_stats.qs->backlog);
+        submit_one(dev, "ipt_requeues", type_instance, q_stats.qs->requeues);
+        submit_one(dev, "ipt_overlimits", type_instance, q_stats.qs->overlimits);
       }
     }
 
@@ -563,8 +567,10 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                 tc_inst);
 
+      submit_one(dev, "if_tx_dropped", type_instance, ts->drops);
       submit_one(dev, "ipt_bytes", type_instance, ts->bytes);
       submit_one(dev, "ipt_packets", type_instance, ts->packets);
+      submit_one(dev, "ipt_overlimits", type_instance, ts->overlimits);
     }
 
     break;

--- a/src/types.db
+++ b/src/types.db
@@ -118,6 +118,9 @@ io_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
 ipc                     value:GAUGE:0:U
 ipt_bytes               value:DERIVE:0:U
 ipt_packets             value:DERIVE:0:U
+ipt_backlog             value:GAUGE:0:U
+ipt_requeues            value:DERIVE:0:U
+ipt_overlimits          value:DERIVE:0:U
 irq                     value:DERIVE:0:U
 latency                 value:GAUGE:0:U
 links                   value:GAUGE:0:U


### PR DESCRIPTION
This feature was implemented by @mcq8 as part of a TC monitoring setup.

We're not sure if this is a useful feature or whether or not it needs to be hidden behind VerboseInterface, let us know what you think! (also, what about HAVE_TCA_STATS / tc_stats?)
