### PR TITLE
df: remove legacy code skipping "rootfs" monitoring

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -271,11 +271,7 @@ static int df_read (void)
 		else
 		{
 			if (strcmp (mnt_ptr->dir, "/") == 0)
-			{
-				if (strcmp (mnt_ptr->type, "rootfs") == 0)
-					continue;
 				sstrncpy (disk_name, "root", sizeof (disk_name));
-			}
 			else
 			{
 				int i, len;


### PR DESCRIPTION
3512bb1 added code to skip duplicate reporting of `rootfs` mounted on `/`.
f9c1c5b and f0398d0 added generic code to skip any volume mounted twice.

Depending on the order of the entries in `/etc/mtab`, reporting for `/` was
entirely skipped.

This patch basically reverts the first, non-generic patch, as it's
superseded by the 2 others.

Fixes #1402