### PR TITLE
drbd plugin: improve header lines identification

### DIFF
--- a/src/drbd.c
+++ b/src/drbd.c
@@ -142,8 +142,12 @@ static int drbd_read (void)
 				fields, STATIC_ARRAY_SIZE (fields));
 
 		/* ignore headers (first two iterations) */
-		if (fields_num < 4)
+		if ((strcmp(fields[0], "version:") == 0) ||
+				(strcmp(fields[0], "srcversion:") == 0) ||
+				(strcmp(fields[0], "GIT-hash:") == 0))
+		{
 			continue;
+		}
 
 		if (isdigit(fields[0][0]))
 		{


### PR DESCRIPTION
Recent DRBD versions display more detailed build information in
`/proc/drbd`, which caused the header identification to fail.

Comparing the first part of each line against all known header prefixes
will hopefully make this more robust.

Fixes #1514