### PR TITLE
Don't divide by 0 when doing percentages (e.g. with the swap plugin).

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2402,7 +2402,7 @@ int plugin_dispatch_multivalue (value_list_t const *template, /* {{{ */
 		case DS_TYPE_GAUGE:
 			vl->values[0].gauge = va_arg (ap, gauge_t);
 			if (store_percentage)
-				vl->values[0].gauge *= 100.0 / sum;
+				vl->values[0].gauge *= sum ? (100.0 / sum) : 0;
 			break;
 		case DS_TYPE_ABSOLUTE:
 			vl->values[0].absolute = va_arg (ap, absolute_t);


### PR DESCRIPTION
Prior to this change, if all the values being sent sum to zero, then the
calculated percentage is a division by 0 which is either Inf or NaN
depending on the numerator.

This is not a theoretical concern: it can easily happen if all the input
gauges are 0.

This change forces the output to be zero if the denominator is zero.