### PR TITLE
Protect reference to field 're' with an #if guard.

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -314,7 +314,9 @@ static void ps_list_register (const char *name, const char *regexp)
 					"`ProcessMatch' with the same name. "
 					"All but the first setting will be "
 					"ignored.");
+#if HAVE_REGEX_H
 			sfree (new->re);
+#endif
 			sfree (new);
 			return;
 		}


### PR DESCRIPTION
The field 're' only exists if HAVE_REGEX_H is defined (see definition at line 194). So, consistent with all other usages, this should be protected with an #if guard.
