### PR TITLE
Track process syscalls for AIX, solaris, and linux. Add Fork rate to AIX

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -849,6 +849,9 @@ processes_la_LIBADD =
 if BUILD_WITH_LIBKVM_GETPROCS
 processes_la_LIBADD += -lkvm
 endif
+if BUILD_WITH_PERFSTAT
+contextswitch_la_LIBADD += -lperfstat
+endif
 endif
 
 if BUILD_PLUGIN_PROTOCOLS

--- a/src/types.db
+++ b/src/types.db
@@ -74,6 +74,7 @@ file_size		value:GAUGE:0:U
 files			value:GAUGE:0:U
 flow			value:GAUGE:0:U
 fork_rate		value:DERIVE:0:U
+syscalls        value:DERIVE:0:U
 frequency_offset	value:GAUGE:-1000000:1000000
 frequency		value:GAUGE:0:U
 fscache_stat		value:DERIVE:0:U


### PR DESCRIPTION
This change set enhances the processes plugin on AIX, solaris, and linux

* A 'syscalls' metric is added to all three platforms. 
* AIX now tracks the fork_rate, similar to other platforms.