### PR TITLE
Report* Flags added to DF configuration, to disable undesired metrics

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -350,30 +350,30 @@ static int df_read (void)
 		if (values_absolute)
 		{
 			if (report_free) 
-                df_submit_one (disk_name, "df_complex", "free",
-                    (gauge_t) (blk_free * blocksize));
+				df_submit_one (disk_name, "df_complex", "free",
+					(gauge_t) (blk_free * blocksize));
 			if (report_reserved)
-                df_submit_one (disk_name, "df_complex", "reserved",
-                    (gauge_t) (blk_reserved * blocksize));
+				df_submit_one (disk_name, "df_complex", "reserved",
+					(gauge_t) (blk_reserved * blocksize));
 			if (report_used)
-			    df_submit_one (disk_name, "df_complex", "used",
-				    (gauge_t) (blk_used * blocksize));
+				df_submit_one (disk_name, "df_complex", "used",
+					(gauge_t) (blk_used * blocksize));
 		}
 
 		if (values_percentage)
 		{
 			if (statbuf.f_blocks > 0)
-            {
-			    if (report_free) 
-				    df_submit_one (disk_name, "percent_bytes", "free",
-					    (gauge_t) ((float_t)(blk_free) / statbuf.f_blocks * 100));
-                if (report_reserved)
-                    df_submit_one (disk_name, "percent_bytes", "reserved",
-                        (gauge_t) ((float_t)(blk_reserved) / statbuf.f_blocks * 100));
-                if (report_used)
-                    df_submit_one (disk_name, "percent_bytes", "used",
-                        (gauge_t) ((float_t)(blk_used) / statbuf.f_blocks * 100));
-            }
+			{
+				if (report_free) 
+					df_submit_one (disk_name, "percent_bytes", "free",
+						(gauge_t) ((float_t)(blk_free) / statbuf.f_blocks * 100));
+				if (report_reserved)
+					df_submit_one (disk_name, "percent_bytes", "reserved",
+						(gauge_t) ((float_t)(blk_reserved) / statbuf.f_blocks * 100));
+				if (report_used)
+					df_submit_one (disk_name, "percent_bytes", "used",
+						(gauge_t) ((float_t)(blk_used) / statbuf.f_blocks * 100));
+			}
 			else return (-1);
 		}
 
@@ -399,28 +399,28 @@ static int df_read (void)
 				if (statbuf.f_files > 0)
 				{
 					if (report_free)
-                        df_submit_one (disk_name, "percent_inodes", "free",
-                            (gauge_t) ((float_t)(inode_free) / statbuf.f_files * 100));
+						df_submit_one (disk_name, "percent_inodes", "free",
+							(gauge_t) ((float_t)(inode_free) / statbuf.f_files * 100));
 					if (report_reserved)
-                        df_submit_one (disk_name, "percent_inodes", "reserved",
-                            (gauge_t) ((float_t)(inode_reserved) / statbuf.f_files * 100));
+						df_submit_one (disk_name, "percent_inodes", "reserved",
+							(gauge_t) ((float_t)(inode_reserved) / statbuf.f_files * 100));
 					if (report_used)
-                        df_submit_one (disk_name, "percent_inodes", "used",
-                            (gauge_t) ((float_t)(inode_used) / statbuf.f_files * 100));
+						df_submit_one (disk_name, "percent_inodes", "used",
+							(gauge_t) ((float_t)(inode_used) / statbuf.f_files * 100));
 				}
 				else return (-1);
 			}
 			if (values_absolute)
 			{
 				if (report_free)
-                    df_submit_one (disk_name, "df_inodes", "free",
-                        (gauge_t) inode_free);
+					df_submit_one (disk_name, "df_inodes", "free",
+						(gauge_t) inode_free);
 				if (report_reserved)
-                    df_submit_one (disk_name, "df_inodes", "reserved",
-                        (gauge_t) inode_reserved);
+					df_submit_one (disk_name, "df_inodes", "reserved",
+						(gauge_t) inode_reserved);
 				if (report_used)
-                    df_submit_one (disk_name, "df_inodes", "used",
-                        (gauge_t) inode_used);
+					df_submit_one (disk_name, "df_inodes", "used",
+						(gauge_t) inode_used);
 			}
 		}
 	}


### PR DESCRIPTION
I've added three new configuration flags to the DF plugin, which allows users to disable undesired metrics if they want to. Default behavior is to send all metrics, for backwards compatibility.

