### PR TITLE
Add capabilities checking to plugins needing privileges

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1584,7 +1584,7 @@ static int ceph_init(void)
       WARNING ("ceph plugin: Running collectd as root, but the "
           "CAP_DAC_OVERRIDE capability is missing. The plugin's read "
           "function will probably fail. Is your init system dropping "
-          "capabilities ?");
+          "capabilities?");
     else
       WARNING ("ceph plugin: collectd doesn't have the CAP_DAC_OVERRIDE "
           "capability. If you don't want to run collectd as root, try running "

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1577,7 +1577,7 @@ static int ceph_init(void)
 {
     int ret;
 
-#ifdef HAVE_SYS_CAPABILITY_H
+#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_DAC_OVERRIDE)
   if (check_capability (CAP_DAC_OVERRIDE) != 0)
   {
     if (getuid () == 0)

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -38,6 +38,9 @@
 #if HAVE_YAJL_YAJL_VERSION_H
 #include <yajl/yajl_version.h>
 #endif
+#ifdef HAVE_SYS_CAPABILITY_H
+# include <sys/capability.h>
+#endif
 
 #include <limits.h>
 #include <poll.h>
@@ -1573,6 +1576,22 @@ static int ceph_read(void)
 static int ceph_init(void)
 {
     int ret;
+
+#ifdef HAVE_SYS_CAPABILITY_H
+  if (check_capability (CAP_DAC_OVERRIDE) != 0)
+  {
+    if (getuid () == 0)
+      WARNING ("ceph plugin: Running collectd as root, but the "
+          "CAP_DAC_OVERRIDE capability is missing. The plugin's read "
+          "function will probably fail. Is your init system dropping "
+          "capabilities ?");
+    else
+      WARNING ("ceph plugin: collectd doesn't have the CAP_DAC_OVERRIDE "
+          "capability. If you don't want to run collectd as root, try running "
+          "\"setcap cap_dac_override=ep\" on the collectd binary.");
+  }
+#endif
+
     ceph_daemons_print();
 
     ret = cconn_main_loop(ASOK_REQ_VERSION);

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1677,23 +1677,42 @@ void strarray_free (char **array, size_t array_len) /* {{{ */
 int check_capability (int capability) /* {{{ */
 {
 #ifdef _LINUX_CAPABILITY_VERSION_3
-	struct __user_cap_header_struct cap_header_data;
-	cap_user_header_t cap_header = &cap_header_data;
-	struct __user_cap_data_struct cap_data_data;
-	cap_user_data_t cap_data = &cap_data_data;
+	cap_user_header_t cap_header = calloc(sizeof (*cap_header), 1);
+	if (cap_header == NULL)
+	{
+		ERROR("check_capability: calloc failed");
+		return (-1);
+	}
+
+	cap_user_data_t cap_data = calloc(sizeof (*cap_data), 1);
+	if (cap_data == NULL)
+	{
+		ERROR("check_capability: calloc failed");
+		return (-1);
+	}
 
 	cap_header->pid = getpid();
 	cap_header->version = _LINUX_CAPABILITY_VERSION;
 	if (capget(cap_header, cap_data) < 0)
 	{
 		ERROR("check_capability: capget failed");
+		sfree(cap_header);
+		sfree(cap_data);
 		return (-1);
 	}
 
 	if ((cap_data->effective & (1 << capability)) == 0)
+	{
+		sfree(cap_header);
+		sfree(cap_data);
 		return (-1);
+	}
 	else
+	{
+		sfree(cap_header);
+		sfree(cap_data);
 		return (0);
+	}
 #else
 	WARNING ("check_capability: unsupported capability implementation. "
 	    "Some plugin(s) may require elevated privileges to work properly.");

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1676,6 +1676,7 @@ void strarray_free (char **array, size_t array_len) /* {{{ */
 #ifdef HAVE_SYS_CAPABILITY_H
 int check_capability (int capability) /* {{{ */
 {
+#ifdef _LINUX_CAPABILITY_VERSION_3
 	struct __user_cap_header_struct cap_header_data;
 	cap_user_header_t cap_header = &cap_header_data;
 	struct __user_cap_data_struct cap_data_data;
@@ -1693,5 +1694,10 @@ int check_capability (int capability) /* {{{ */
 		return (-1);
 	else
 		return (0);
+#else
+	WARNING ("check_capability: unsupported capability implementation. "
+	    "Some plugin(s) may require elevated privileges to work properly.");
+	return (0);
+#endif /* _LINUX_CAPABILITY_VERSION_3 */
 } /* }}} int check_capability */
-#endif
+#endif /* HAVE_SYS_CAPABILITY_H */

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -60,6 +60,10 @@
 # include <arpa/inet.h>
 #endif
 
+#ifdef HAVE_SYS_CAPABILITY_H
+# include <sys/capability.h>
+#endif
+
 #ifdef HAVE_LIBKSTAT
 extern kstat_ctl_t *kc;
 #endif
@@ -1668,3 +1672,26 @@ void strarray_free (char **array, size_t array_len) /* {{{ */
 		sfree (array[i]);
 	sfree (array);
 } /* }}} void strarray_free */
+
+#ifdef HAVE_SYS_CAPABILITY_H
+int check_capability (int capability) /* {{{ */
+{
+	struct __user_cap_header_struct cap_header_data;
+	cap_user_header_t cap_header = &cap_header_data;
+	struct __user_cap_data_struct cap_data_data;
+	cap_user_data_t cap_data = &cap_data_data;
+
+	cap_header->pid = getpid();
+	cap_header->version = _LINUX_CAPABILITY_VERSION;
+	if (capget(cap_header, cap_data) < 0)
+	{
+		ERROR("check_capability: capget failed");
+		return (-1);
+	}
+
+	if ((cap_data->effective & (1 << capability)) == 0)
+		return (-1);
+	else
+		return (0);
+} /* }}} int check_capability */
+#endif

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1688,6 +1688,7 @@ int check_capability (int capability) /* {{{ */
 	if (cap_data == NULL)
 	{
 		ERROR("check_capability: calloc failed");
+		sfree(cap_header);
 		return (-1);
 	}
 

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -375,4 +375,12 @@ int strtogauge (const char *string, gauge_t *ret_value);
 int strarray_add (char ***ret_array, size_t *ret_array_len, char const *str);
 void strarray_free (char **array, size_t array_len);
 
+#ifdef HAVE_SYS_CAPABILITY_H
+/** Check if the current process benefits from the capability passed in
+ * argument. Returns zero if it does, less than zero if it doesn't or on error.
+ * See capabilities(7) for the list of possible capabilities.
+ * */
+int check_capability (int capability);
+#endif /* HAVE_SYS_CAPABILITY_H */
+
 #endif /* COMMON_H */

--- a/src/dns.c
+++ b/src/dns.c
@@ -35,6 +35,10 @@
 
 #include <pcap.h>
 
+#ifdef HAVE_SYS_CAPABILITY_H
+# include <sys/capability.h>
+#endif
+
 /*
  * Private data types
  */
@@ -346,6 +350,20 @@ static int dns_init (void)
 	}
 
 	listen_thread_init = 1;
+
+#ifdef HAVE_SYS_CAPABILITY_H
+	if (check_capability (CAP_NET_RAW) != 0)
+	{
+		if (getuid () == 0)
+			WARNING ("dns plugin: Running collectd as root, but the CAP_NET_RAW "
+					"capability is missing. The plugin's read function will probably "
+					"fail. Is your init system dropping capabilities ?");
+		else
+			WARNING ("dns plugin: collectd doesn't have the CAP_NET_RAW capability. "
+					"If you don't want to run collectd as root, try running \"setcap "
+					"cap_net_raw=ep\" on the collectd binary.");
+	}
+#endif
 
 	return (0);
 } /* int dns_init */

--- a/src/dns.c
+++ b/src/dns.c
@@ -357,7 +357,7 @@ static int dns_init (void)
 		if (getuid () == 0)
 			WARNING ("dns plugin: Running collectd as root, but the CAP_NET_RAW "
 					"capability is missing. The plugin's read function will probably "
-					"fail. Is your init system dropping capabilities ?");
+					"fail. Is your init system dropping capabilities?");
 		else
 			WARNING ("dns plugin: collectd doesn't have the CAP_NET_RAW capability. "
 					"If you don't want to run collectd as root, try running \"setcap "

--- a/src/dns.c
+++ b/src/dns.c
@@ -351,7 +351,7 @@ static int dns_init (void)
 
 	listen_thread_init = 1;
 
-#ifdef HAVE_SYS_CAPABILITY_H
+#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_NET_RAW)
 	if (check_capability (CAP_NET_RAW) != 0)
 	{
 		if (getuid () == 0)

--- a/src/exec.c
+++ b/src/exec.c
@@ -817,7 +817,7 @@ static int exec_init (void) /* {{{ */
     if (getuid () == 0)
       WARNING ("exec plugin: Running collectd as root, but the CAP_SETUID "
           "or CAP_SETGID capabilities are missing. The plugin's read function "
-          "will probably fail. Is your init system dropping capabilities ?");
+          "will probably fail. Is your init system dropping capabilities?");
     else
       WARNING ("exec plugin: collectd doesn't have the CAP_SETUID or "
           "CAP_SETGID capabilities. If you don't want to run collectd as root, "

--- a/src/exec.c
+++ b/src/exec.c
@@ -810,7 +810,7 @@ static int exec_init (void) /* {{{ */
 
   sigaction (SIGCHLD, &sa, NULL);
 
-#ifdef HAVE_SYS_CAPABILITY_H
+#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_SETUID) && defined(CAP_SETGID)
   if ((check_capability (CAP_SETUID) != 0) ||
       (check_capability (CAP_SETGID) != 0))
   {

--- a/src/exec.c
+++ b/src/exec.c
@@ -39,6 +39,10 @@
 #include <grp.h>
 #include <signal.h>
 
+#ifdef HAVE_SYS_CAPABILITY_H
+# include <sys/capability.h>
+#endif
+
 #define PL_NORMAL        0x01
 #define PL_NOTIF_ACTION  0x02
 
@@ -805,6 +809,22 @@ static int exec_init (void) /* {{{ */
   };
 
   sigaction (SIGCHLD, &sa, NULL);
+
+#ifdef HAVE_SYS_CAPABILITY_H
+  if ((check_capability (CAP_SETUID) != 0) ||
+      (check_capability (CAP_SETGID) != 0))
+  {
+    if (getuid () == 0)
+      WARNING ("exec plugin: Running collectd as root, but the CAP_SETUID "
+          "or CAP_SETGID capabilities are missing. The plugin's read function "
+          "will probably fail. Is your init system dropping capabilities ?");
+    else
+      WARNING ("exec plugin: collectd doesn't have the CAP_SETUID or "
+          "CAP_SETGID capabilities. If you don't want to run collectd as root, "
+          "try running \"setcap 'cap_setuid=ep cap_setgid=ep'\" on the "
+          "collectd binary.");
+  }
+#endif
 
   return (0);
 } /* int exec_init }}} */

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -512,7 +512,7 @@ static int iptables_init (void)
             WARNING ("iptables plugin: Running collectd as root, but the "
                   "CAP_NET_ADMIN capability is missing. The plugin's read "
                   "function will probably fail. Is your init system dropping "
-                  "capabilities ?");
+                  "capabilities?");
         else
             WARNING ("iptables plugin: collectd doesn't have the CAP_NET_ADMIN "
                   "capability. If you don't want to run collectd as root, try "

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -30,12 +30,12 @@
 #include "plugin.h"
 #include "configfile.h"
 
+#include <libiptc/libiptc.h>
+#include <libiptc/libip6tc.h>
+
 #ifdef HAVE_SYS_CAPABILITY_H
 # include <sys/capability.h>
 #endif
-
-#include <libiptc/libiptc.h>
-#include <libiptc/libip6tc.h>
 
 /*
  * iptc_handle_t was available before libiptc was officially available as a

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -505,7 +505,7 @@ static int iptables_shutdown (void)
 
 static int iptables_init (void)
 {
-#ifdef HAVE_SYS_CAPABILITY_H
+#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_NET_ADMIN)
     if (check_capability (CAP_NET_ADMIN) != 0)
     {
         if (getuid () == 0)

--- a/src/ping.c
+++ b/src/ping.c
@@ -458,7 +458,7 @@ static int ping_init (void) /* {{{ */
     if (getuid () == 0)
       WARNING ("ping plugin: Running collectd as root, but the CAP_NET_RAW "
           "capability is missing. The plugin's read function will probably "
-          "fail. Is your init system dropping capabilities ?");
+          "fail. Is your init system dropping capabilities?");
     else
       WARNING ("ping plugin: collectd doesn't have the CAP_NET_RAW capability. "
           "If you don't want to run collectd as root, try running \"setcap "

--- a/src/ping.c
+++ b/src/ping.c
@@ -36,6 +36,10 @@
 # include <netdb.h> /* NI_MAXHOST */
 #endif
 
+#ifdef HAVE_SYS_CAPABILITY_H
+# include <sys/capability.h>
+#endif
+
 #include <oping.h>
 
 #ifndef NI_MAXHOST
@@ -447,6 +451,20 @@ static int ping_init (void) /* {{{ */
     WARNING ("ping plugin: Timeout is greater than interval. "
         "Will use a timeout of %gs.", ping_timeout);
   }
+
+#ifdef HAVE_SYS_CAPABILITY_H
+  if (check_capability (CAP_NET_RAW) != 0)
+  {
+    if (getuid () == 0)
+      WARNING ("ping plugin: Running collectd as root, but the CAP_NET_RAW "
+          "capability is missing. The plugin's read function will probably "
+          "fail. Is your init system dropping capabilities ?");
+    else
+      WARNING ("ping plugin: collectd doesn't have the CAP_NET_RAW capability. "
+          "If you don't want to run collectd as root, try running \"setcap "
+          "cap_net_raw=ep\" on the collectd binary.");
+  }
+#endif
 
   return (start_thread ());
 } /* }}} int ping_init */

--- a/src/ping.c
+++ b/src/ping.c
@@ -452,7 +452,7 @@ static int ping_init (void) /* {{{ */
         "Will use a timeout of %gs.", ping_timeout);
   }
 
-#ifdef HAVE_SYS_CAPABILITY_H
+#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_NET_RAW)
   if (check_capability (CAP_NET_RAW) != 0)
   {
     if (getuid () == 0)

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1475,8 +1475,6 @@ static int
 check_permissions(void)
 {
 
-	int ret = 0;
-
 	if (getuid() == 0) {
 		/* We have everything we need */
 		return 0;
@@ -1488,6 +1486,8 @@ check_permissions(void)
 	}
 #else /* HAVE_SYS_CAPABILITY_H && CAP_SYS_RAWIO */
 	}
+
+	int ret = 0;
 
 	if (check_capability(CAP_SYS_RAWIO) != 0) {
 		WARNING("turbostat plugin: Collectd doesn't have the "

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1480,13 +1480,13 @@ check_permissions(void)
 	if (getuid() == 0) {
 		/* We have everything we need */
 		return 0;
-#ifndef HAVE_SYS_CAPABILITY_H
+#if !defined(HAVE_SYS_CAPABILITY_H) && !defined(CAP_SYS_RAWIO)
 	} else {
 		ERROR("turbostat plugin: Initialization failed: this plugin "
 		      "requires collectd to run as root");
 		return -1;
 	}
-#else /* HAVE_SYS_CAPABILITY_H */
+#else /* HAVE_SYS_CAPABILITY_H && CAP_SYS_RAWIO */
 	}
 
 	if (check_capability(CAP_SYS_RAWIO) != 0) {
@@ -1511,7 +1511,7 @@ check_permissions(void)
 		      "collectd a special capability (CAP_SYS_RAWIO) and read "
                       "access to /dev/cpu/*/msr (see previous warnings)");
 	return ret;
-#endif /* HAVE_SYS_CAPABILITY_H */
+#endif /* HAVE_SYS_CAPABILITY_H && CAP_SYS_RAWIO */
 }
 
 static int

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1474,13 +1474,8 @@ out:
 static int
 check_permissions(void)
 {
-#ifdef HAVE_SYS_CAPABILITY_H
-	struct __user_cap_header_struct cap_header_data;
-	cap_user_header_t cap_header = &cap_header_data;
-	struct __user_cap_data_struct cap_data_data;
-	cap_user_data_t cap_data = &cap_data_data;
+
 	int ret = 0;
-#endif /* HAVE_SYS_CAPABILITY_H */
 
 	if (getuid() == 0) {
 		/* We have everything we need */
@@ -1494,15 +1489,7 @@ check_permissions(void)
 #else /* HAVE_SYS_CAPABILITY_H */
 	}
 
-	/* check for CAP_SYS_RAWIO */
-	cap_header->pid = getpid();
-	cap_header->version = _LINUX_CAPABILITY_VERSION;
-	if (capget(cap_header, cap_data) < 0) {
-		ERROR("turbostat plugin: capget failed");
-		return -1;
-	}
-
-	if ((cap_data->effective & (1 << CAP_SYS_RAWIO)) == 0) {
+	if (check_capability(CAP_SYS_RAWIO) != 0) {
 		WARNING("turbostat plugin: Collectd doesn't have the "
 			"CAP_SYS_RAWIO capability. If you don't want to run "
 			"collectd as root, try running \"setcap "


### PR DESCRIPTION
A few plugins historically required collectd to be run as root. Capabilities offer a way to control more precisely the privileges given to the collectd process, depending on which plugins are loaded.

My goal to start with, is simply to help the user configure his system to run collectd with reduced privileges. Once we've got a bit more experience with this, it would be nice to have collectd drop the unneeded capabilities itself, depending on which plugins are loaded.

So this hasn't been thoroughly tested yet, I just wanted to pass it through jenkins, and get some feedback about the idea.

Also, I'm sure more plugins than just these 6 require privileges.