### PR TITLE
write_sensu: avoid calling strlen() on variable set to NULL

### DIFF
--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -456,7 +456,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
 	}
 
 	// incorporate sensu tags from config if any
-	if (strlen(sensu_tags) != 0) {
+	if ((sensu_tags != NULL) && (strlen(sensu_tags) != 0)) {
 		res = asprintf(&temp_str, "%s, %s", ret_str, sensu_tags);
 		free(ret_str);
 		if (res == -1) {
@@ -753,7 +753,7 @@ static char *sensu_notification_to_json(struct sensu_host *host, /* {{{ */
 	}
 
 	// incorporate sensu tags from config if any
-	if (strlen(sensu_tags) != 0) {
+	if ((sensu_tags != NULL) && (strlen(sensu_tags) != 0)) {
 		res = asprintf(&temp_str, "%s, %s", ret_str, sensu_tags);
 		free(ret_str);
 		if (res == -1) {


### PR DESCRIPTION
This fixes a segfault when no `Tag` option is set.