### PR TITLE
generic-jmx: add AtomicLong and AtomicInteger

### DIFF
--- a/bindings/java-tests/README
+++ b/bindings/java-tests/README
@@ -1,0 +1,3 @@
+These dependencies are necessary to run tests:
+* junit (e.g. http://search.maven.org/remotecontent?filepath=junit/junit/4.12/junit-4.12.jar)
+* hamcrest-core (e.g. http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar)

--- a/bindings/java-tests/org/collectd/java/GenericJMXConfValueTest.java
+++ b/bindings/java-tests/org/collectd/java/GenericJMXConfValueTest.java
@@ -1,0 +1,47 @@
+package org.collectd.java;
+
+import org.collectd.api.OConfigItem;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.collectd.api.DataSource.TYPE_DERIVE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GenericJMXConfValueTest {
+
+    private GenericJMXConfValue confValue;
+
+    @Before
+    public void setUp() throws Exception {
+        final OConfigItem config = new OConfigItem("");
+        final OConfigItem type = new OConfigItem("Type");
+        type.addValue("DERIVE");
+        config.addChild(type);
+        final OConfigItem attribute = new OConfigItem("Attribute");
+        attribute.addValue("test");
+        config.addChild(attribute);
+        confValue = new GenericJMXConfValue(config);
+    }
+
+    @Test
+    public void genericObjectToNumber_should_copy_value_from_AtomicLong() {
+        final AtomicLong originalAtomicLong = new AtomicLong(2L);
+        final Number result = confValue.genericObjectToNumber(originalAtomicLong, TYPE_DERIVE);
+        originalAtomicLong.set(3L);
+
+        assertThat((Long) result, is(2L));
+    }
+
+    @Test
+    public void genericObjectToNumber_should_copy_value_from_AtomicInteger() {
+        final AtomicInteger originalAtomicInteger = new AtomicInteger(4);
+        final Number result = confValue.genericObjectToNumber(originalAtomicInteger, TYPE_DERIVE);
+        originalAtomicInteger.set(5);
+
+        assertThat((Integer) result, is(4));
+    }
+}

--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -26,7 +26,6 @@
 
 package org.collectd.java;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Collection;
 import java.util.Set;
@@ -35,6 +34,8 @@ import java.util.ArrayList;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -78,7 +79,7 @@ class GenericJMXConfValue
    *
    * Returns null if a conversion is not possible or not implemented.
    */
-  private Number genericObjectToNumber (Object obj, int ds_type) /* {{{ */
+  Number genericObjectToNumber (Object obj, int ds_type) /* {{{ */
   {
     if (obj instanceof String)
     {
@@ -108,9 +109,17 @@ class GenericJMXConfValue
     {
       return (new Integer ((Integer) obj));
     }
+    else if (obj instanceof AtomicInteger)
+    {
+      return ((AtomicInteger) obj).get();
+    }
     else if (obj instanceof Long)
     {
       return (new Long ((Long) obj));
+    }
+    else if (obj instanceof AtomicLong)
+    {
+      return ((AtomicLong) obj).get();
     }
     else if (obj instanceof Float)
     {


### PR DESCRIPTION
Some programs expose numbers of AtomicLong or
AtomicInteger types (e.g. Eureka from Netflix).