### PR TITLE
processes: warn about process names above OS limit

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -4796,6 +4796,9 @@ collected for these selected processes are size of the resident segment size
 (RSS), user- and system-time used, number of processes and number of threads,
 io data (where available) and minor and major pagefaults.
 
+Some platforms have a limit on the length of process names. I<Name> must stay
+below this limit.
+
 =item B<ProcessMatch> I<name> I<regex>
 
 Similar to the B<Process> option this allows to select more detailed

--- a/src/processes.c
+++ b/src/processes.c
@@ -128,6 +128,7 @@
 #  undef SAVE_FOB_64
 #endif
 
+# include <sys/user.h>
 # include <dirent.h>
 /* #endif KERNEL_SOLARIS */
 
@@ -548,6 +549,8 @@ static int ps_config (oconfig_item_t *ci)
 
 #if KERNEL_LINUX
 	const size_t max_procname_len = 15;
+#elif KERNEL_SOLARIS
+	const size_t max_procname_len = MAXCOMLEN -1;
 #endif
 
 	for (i = 0; i < ci->children_num; ++i) {
@@ -570,7 +573,7 @@ static int ps_config (oconfig_item_t *ci)
 						c->children_num, c->values[0].value.string);
 			}
 
-#if KERNEL_LINUX
+#if KERNEL_LINUX || KERNEL_SOLARIS
 			if (strlen (c->values[0].value.string) > max_procname_len) {
 				WARNING ("processes plugin: this platform has a %zu character limit "
 						"to process names. The `Process \"%s\"' option will "

--- a/src/processes.c
+++ b/src/processes.c
@@ -549,7 +549,7 @@ static int ps_config (oconfig_item_t *ci)
 
 #if KERNEL_LINUX
 	const size_t max_procname_len = 15;
-#elif KERNEL_SOLARIS
+#elif KERNEL_SOLARIS || KERNEL_FREEBSD
 	const size_t max_procname_len = MAXCOMLEN -1;
 #endif
 
@@ -573,7 +573,7 @@ static int ps_config (oconfig_item_t *ci)
 						c->children_num, c->values[0].value.string);
 			}
 
-#if KERNEL_LINUX || KERNEL_SOLARIS
+#if KERNEL_LINUX || KERNEL_SOLARIS || KERNEL_FREEBSD
 			if (strlen (c->values[0].value.string) > max_procname_len) {
 				WARNING ("processes plugin: this platform has a %zu character limit "
 						"to process names. The `Process \"%s\"' option will "

--- a/src/processes.c
+++ b/src/processes.c
@@ -546,6 +546,10 @@ static int ps_config (oconfig_item_t *ci)
 {
 	int i;
 
+#if KERNEL_LINUX
+	const size_t max_procname_len = 15;
+#endif
+
 	for (i = 0; i < ci->children_num; ++i) {
 		oconfig_item_t *c = ci->children + i;
 
@@ -565,6 +569,15 @@ static int ps_config (oconfig_item_t *ci)
 						"content (%i elements) of the <Process '%s'> block.",
 						c->children_num, c->values[0].value.string);
 			}
+
+#if KERNEL_LINUX
+			if (strlen (c->values[0].value.string) > max_procname_len) {
+				WARNING ("processes plugin: this platform has a %lu character limit "
+						"to process names. The `Process \"%s\"' option will "
+						"not work as expected.",
+						max_procname_len, c->values[0].value.string);
+			}
+#endif
 
 			ps_list_register (c->values[0].value.string, NULL);
 		}

--- a/src/processes.c
+++ b/src/processes.c
@@ -572,7 +572,7 @@ static int ps_config (oconfig_item_t *ci)
 
 #if KERNEL_LINUX
 			if (strlen (c->values[0].value.string) > max_procname_len) {
-				WARNING ("processes plugin: this platform has a %lu character limit "
+				WARNING ("processes plugin: this platform has a %zu character limit "
 						"to process names. The `Process \"%s\"' option will "
 						"not work as expected.",
 						max_procname_len, c->values[0].value.string);


### PR DESCRIPTION
Fixes #1284. Rebased version of #1508.

This emits this warning once at startup time:

```
[2016-01-12 22:25:10] [warning] processes plugin: this platform has a 15 character limit to process names. The `Process "a very very long process name"' option will not work as expected.
```