### PR TITLE
Enable TCP socket keepalive on write plugins

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -51,6 +51,10 @@
 # include <netinet/in.h>
 #endif
 
+#if HAVE_NETINET_TCP_H
+# include <netinet/tcp.h>
+#endif
+
 /* for ntohl and htonl */
 #if HAVE_ARPA_INET_H
 # include <arpa/inet.h>
@@ -1556,6 +1560,46 @@ int service_name_to_port_number (const char *service_name)
 		return (service_number);
 	return (-1);
 } /* int service_name_to_port_number */
+
+void set_sock_opts (int sockfd) /* {{{ */
+{
+	int status;
+	int socktype;
+
+	socklen_t socklen = sizeof (socklen_t);
+	int so_keepalive = 1;
+	int tcp_keepidle = ((CDTIME_T_TO_MS(plugin_get_interval()) - 1) / 100 + 1);
+	int tcp_keepintvl = ((CDTIME_T_TO_MS(plugin_get_interval()) - 1) / 1000 + 1);
+
+	status = getsockopt (sockfd, SOL_SOCKET, SO_TYPE, &socktype, &socklen);
+	if (status != 0)
+	{
+		WARNING ("set_sock_opts: failed to determine socket type");
+		return;
+	}
+
+	if (socktype == SOCK_STREAM)
+	{
+		status = setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE,
+				&so_keepalive, sizeof (so_keepalive));
+		if (status != 0)
+			WARNING ("set_sock_opts: failed to set socket keepalive flag");
+
+#ifdef TCP_KEEPIDLE
+		status = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
+				&tcp_keepidle, sizeof (tcp_keepidle));
+		if (status != 0)
+			WARNING ("set_sock_opts: failed to set socket tcp keepalive time");
+#endif
+
+#ifdef TCP_KEEPINTVL
+		status = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
+				&tcp_keepintvl, sizeof (tcp_keepintvl));
+		if (status != 0)
+			WARNING ("set_sock_opts: failed to set socket tcp keepalive interval");
+#endif
+	}
+} /* }}} void set_sock_opts */
 
 int strtoderive (const char *string, derive_t *ret_value) /* {{{ */
 {

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -361,6 +361,9 @@ int value_to_rate (gauge_t *ret_rate, value_t value, int ds_type, cdtime_t t,
  * (in the range [1-65535]). Returns less than zero on error. */
 int service_name_to_port_number (const char *service_name);
 
+/* Sets various, non-default, socket options */
+void set_sock_opts (int sockfd);
+
 /** Parse a string to a derive_t value. Returns zero on success or non-zero on
  * failure. If failure is returned, ret_value is not touched. */
 int strtoderive (const char *string, derive_t *ret_value);

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -240,6 +240,8 @@ static int wg_callback_init (struct wg_callback *cb)
             continue;
         }
 
+        set_sock_opts (cb->sock_fd);
+
         status = connect (cb->sock_fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
         if (status != 0)
         {

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -112,6 +112,8 @@ static int wrr_connect(struct riemann_host *host) /* {{{ */
     }
   }
 
+  set_sock_opts(riemann_client_get_fd(host->client));
+
   c_release(LOG_INFO, &host->init_complaint,
             "write_riemann plugin: Successfully connected to %s:%d", node,
             port);

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -196,6 +196,8 @@ static int sensu_connect(struct sensu_host *host) /* {{{ */
 		if (setsockopt(host->s, SOL_SOCKET, SO_LINGER, &so_linger, sizeof so_linger) != 0)
 			WARNING("write_sensu plugin: failed to set socket close() lingering");
 
+		set_sock_opts(host->s);
+
 		// connect the socket
 		if (connect(host->s, ai->ai_addr, ai->ai_addrlen) != 0) {
 			close(host->s);

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -187,6 +187,8 @@ static int wt_callback_init(struct wt_callback *cb)
         if (cb->sock_fd < 0)
             continue;
 
+        set_sock_opts(cb->sock_fd);
+
         status = connect(cb->sock_fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
         if (status != 0)
         {


### PR DESCRIPTION
Up to now, collectd fails to notice when a remote server dies without properly closing the network connection, leading to more and more memory getting allocated as the values pile up in the write queue. This patch serie aims to help collectd identify this scenario and let the error handling code paths kick in.

I split this up to be able to cherry-pick bits to the release branches (I do consider collectd triggering the OOM killer as a bug :wink:)

The function name has no explicit reference to keepalive because I'd also like to add a global configure option to enable & tweak the socket close lingering (giving control on if and how collectd drops unflushed data at shutdown time). This part would be targetted to the next feature release.

TODO: check if plugins which have their network socket setup handled by an external lib (amqp, mqtt, postgresql, write_kafka, write_mongodb, write_redis) are also prone to this problem.