### PR TITLE
Suppress spammy debug messages of #664

### DIFF
--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -217,7 +217,8 @@ int handle_putval (FILE *fh, char *buffer)
 	} /* while (*buffer != 0) */
 	/* Done parsing the options. */
 
-	print_to_socket (fh, "0 Success: %i %s been dispatched.\n",
+    if (fh!=stdout)
+	    print_to_socket (fh, "0 Success: %i %s been dispatched.\n",
 			values_submitted,
 			(values_submitted == 1) ? "value has" : "values have");
 


### PR DESCRIPTION
Suppress putval responses when output is STDOUT, which in the past had been expected to be /dev/null. Addresses debug messages of #664.

This appears to be working on my system for the past day---the only place fh is set to stdout is in exec.c, where we want this message suppressed. I admit I do not understand what is going on in amqp.c, but this patch will not affect the behavior there, since fh is set to STDERR instead.