### PR TITLE
Curl_xml: Custom names for plugin/plugin instances

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -466,6 +466,7 @@
 #<Plugin curl_xml>
 #  <URL "http://localhost/stats.xml">
 #    Host "my_host"
+#    #Plugin "stats"
 #    Instance "some_instance"
 #    User "collectd"
 #    Password "thaiNg0I"
@@ -480,6 +481,7 @@
 #      Type "magic_level"
 #      #InstancePrefix "prefix-"
 #      InstanceFrom "td[1]"
+#      #PluginInstanceFrom "td[1]"
 #      ValuesFrom "td[2]/span[@class=\"level\"]"
 #    </XPath>
 #  </URL>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1902,6 +1902,7 @@ The B<curl_xml plugin> uses B<libcurl> (L<http://curl.haxx.se/>) and B<libxml2>
        Type "magic_level"
        #InstancePrefix "prefix-"
        InstanceFrom "td[1]"
+       #PluginInstanceFrom "td[1]"
        ValuesFrom "td[2]/span[@class=\"level\"]"
      </XPath>
    </URL>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1927,16 +1927,16 @@ Within the B<URL> block the following options are accepted:
 Use I<Name> as the host name when submitting values. Defaults to the global
 host name setting.
 
+=item B<Plugin> I<Plugin>
+
+Use I<Plugin> as the plugin name when submitting values.
+Defaults to 'curl_xml'.
+
 =item B<Instance> I<Instance>
 
 Use I<Instance> as the plugin instance when submitting values.
 May be overridden by B<PluginInstanceFrom> option inside B<XPath> blocks.
 Defaults to an empty string (no plugin instance).
-
-=item B<Plugin> I<Plugin>
-
-Use I<Plugin> as the plugin name when submitting values.
-Defaults to 'curl_xml'.
 
 =item B<Namespace> I<Prefix> I<URL>
 
@@ -2028,6 +2028,7 @@ number of XPath expressions must match the number of data sources in the
 I<type> specified with B<Type> (see above). Each XPath expression must return
 exactly one element. The element's value is then parsed as a number and used as
 value for the appropriate value in the value list dispatched to the daemon.
+This option is required.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1931,6 +1931,11 @@ host name setting.
 Use I<Instance> as the plugin instance when submitting values. Defaults to an
 empty string (no plugin instance).
 
+=item B<PluginName> I<PluginName>
+
+Use I<PluginName> as the plugin name when submitting values.
+Defaults to 'curl_xml'.
+
 =item B<Namespace> I<Prefix> I<URL>
 
 If an XPath expression references namespaces, they must be specified
@@ -2000,9 +2005,19 @@ Specifies a XPath expression to use for determining the I<type instance>. The
 XPath expression must return exactly one element. The element's value is then
 used as I<type instance>, possibly prefixed with I<InstancePrefix> (see above).
 
-This value is required. As a special exception, if the "base XPath expression"
-(the argument to the B<XPath> block) returns exactly one argument, then this
-option may be omitted.
+=item B<PluginInstanceFrom> I<PluginInstanceFrom>
+
+Specifies a XPath expression to use for determining the I<plugin instance>. The
+XPath expression must return exactly one element. The element's value is then
+used as I<plugin instance>.
+
+=back
+
+If the "base XPath expression" (the argument to the B<XPath> block) returns
+exactly one argument, then I<InstanceFrom> and I<PluginInstanceFrom> may be omitted.
+Otherwise, at least one of I<InstanceFrom> or I<PluginInstanceFrom> is required.
+
+=over 4
 
 =item B<ValuesFrom> I<ValuesFrom> [I<ValuesFrom> ...]
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1888,6 +1888,7 @@ The B<curl_xml plugin> uses B<libcurl> (L<http://curl.haxx.se/>) and B<libxml2>
  <Plugin "curl_xml">
    <URL "http://localhost/stats.xml">
      Host "my_host"
+     #Plugin "curl_xml"
      Instance "some_instance"
      User "collectd"
      Password "thaiNg0I"
@@ -1928,12 +1929,13 @@ host name setting.
 
 =item B<Instance> I<Instance>
 
-Use I<Instance> as the plugin instance when submitting values. Defaults to an
-empty string (no plugin instance).
+Use I<Instance> as the plugin instance when submitting values.
+May be overridden by B<PluginInstanceFrom> option inside B<XPath> blocks.
+Defaults to an empty string (no plugin instance).
 
-=item B<PluginName> I<PluginName>
+=item B<Plugin> I<Plugin>
 
-Use I<PluginName> as the plugin name when submitting values.
+Use I<Plugin> as the plugin name when submitting values.
 Defaults to 'curl_xml'.
 
 =item B<Namespace> I<Prefix> I<URL>

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -276,6 +276,9 @@ static int cx_if_not_text_node(xmlNodePtr node) /* {{{ */
   return -1;
 } /* }}} cx_if_not_text_node */
 
+/*
+ * Returned value should be freed with xmlFree().
+ */
 static char *cx_get_text_node_value(xmlXPathContextPtr xpath_ctx, /* {{{ */
                                     char *expr, const char *from_option) {
   xmlXPathObjectPtr values_node_obj = cx_evaluate_xpath(xpath_ctx, expr);
@@ -353,7 +356,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
                                               /* endptr = */ NULL);
   }
 
-  sfree(node_value);
+  xmlFree(node_value);
 
   /* We have reached here which means that
    * we have got something to work */
@@ -397,7 +400,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
     else
       sstrncpy(vl->type_instance, node_value, sizeof(vl->type_instance));
 
-    sfree(node_value);
+    xmlFree(node_value);
   } else if (xpath->instance_prefix != NULL)
     sstrncpy(vl->type_instance, xpath->instance_prefix,
              sizeof(vl->type_instance));
@@ -411,7 +414,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
       return -1;
 
     sstrncpy(vl->plugin_instance, node_value, sizeof(vl->plugin_instance));
-    sfree(node_value);
+    xmlFree(node_value);
   }
 
   return 0;

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -383,8 +383,6 @@ static int cx_handle_all_value_xpaths(xmlXPathContextPtr xpath_ctx, /* {{{ */
 static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
                                     cx_xpath_t *xpath, value_list_t *vl) {
 
-  memset(vl->type_instance, 0, sizeof(vl->type_instance));
-
   /* Handle type instance */
   if (xpath->instance != NULL) {
     char *node_value = cx_get_text_node_value(xpath_ctx, xpath->instance,

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -959,7 +959,7 @@ static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Instance", child->key) == 0)
       status = cf_util_get_string(child, &db->instance);
-    else if (strcasecmp("PluginName", child->key) == 0)
+    else if (strcasecmp("Plugin", child->key) == 0)
       status = cf_util_get_string(child, &db->plugin_name);
     else if (strcasecmp("Host", child->key) == 0)
       status = cf_util_get_string(child, &db->host);


### PR DESCRIPTION
Hi!

Proposed patches adds ability to set custom plugin name and set plugin instance from XML data.
curl_xml is a generic plugin and we found such feature very useful.

In our case, we have XML-response like this:

```
<?xml version="1.0"?>
<statistic>
  <source id="total">
    <errors>4</errors>
    <avg-duration>900</avg-duration>
    <max-duration>1500</max-duration>
  </source>
  <source id="pool1">
    <errors>1</errors>
    <avg-duration>1000</avg-duration>
    <max-duration>1500</max-duration>
  </source>
  <source id="pool2">
    <errors>3</errors>
    <avg-duration>850</avg-duration>
    <max-duration>1000</max-duration>
  </source>
</statistic>
```

From this response and with proposed patches, our collectd produces RRDs:

service-total/service_errors.rrd
service-total/service_avgduration.rrd
service-total/service_maxduration.rrd

service-pool1/service_errors.rrd
service-pool1/service_avgduration.rrd
service-pool1/service_maxduration.rrd

service-pool2/service_errors.rrd
service-pool2/service_avgduration.rrd
service-pool2/service_maxduration.rrd

The config example for this case:

```
<Plugin "curl_xml">
<URL "http://service.example.com/xml/stat">
    Host "service.example.com"
    PluginName "service"
    Instance "all"

    <xpath "/statistic/source">
      Type "service_errors"
      PluginInstanceFrom "@id"
      ValuesFrom "errors/text()"
    </xpath>

    <xpath "/statistic/source">
      Type "service_avgduration"
      PluginInstanceFrom "@id"
      ValuesFrom "avg-duration/text()"
    </xpath>

    <xpath "/statistic/source">
      Type "service_maxduration"
      PluginInstanceFrom "@id"
      ValuesFrom "max-duration/text()"
    </xpath>
</URL>
</Plugin>
```
