### PR TITLE
Curl_JSON: Custom plugin name; PHP-FPM configuration example

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -459,7 +459,7 @@
 #  </URL>
 ## PHP-FPM status metrics
 #<URL "http://nginx-status/php-fpm-status?json">
-#  PluginName 'phpfpm'
+#  Plugin 'phpfpm'
 #  Instance 'main'
 #  <Key "accepted conn">
 #      Type "phpfpm_requests"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -457,6 +457,31 @@
 #      Type "bytes"
 #    </Key>
 #  </URL>
+## PHP-FPM status metrics
+#<URL "http://nginx-status/php-fpm-status?json">
+#  PluginName 'phpfpm'
+#  Instance 'main'
+#  <Key "accepted conn">
+#      Type "phpfpm_requests"
+#      Instance ""
+#  </Key>
+#  <Key "slow requests">
+#      Type "phpfpm_slow_requests"
+#      Instance ""
+#  </Key>
+#  <Key "listen queue">
+#      Type "phpfpm_listen_queue"
+#      Instance ""
+#  </Key>
+#  <Key "active processes">
+#      Type "phpfpm_processes"
+#      Instance "active"
+#  </Key>
+#  <Key "total processes">
+#      Type "phpfpm_processes"
+#      Instance "total"
+#  </Key>
+#</URL>
 #</Plugin>
 
 #<Plugin curl_xml>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1802,6 +1802,11 @@ The following options are valid within B<URL> blocks:
 Use I<Name> as the host name when submitting values. Defaults to the global
 host name setting.
 
+=item B<PluginName> I<PluginName>
+
+Use I<PluginName> as the plugin name when submitting values.
+Defaults to 'curl_json'.
+
 =item B<Instance> I<Instance>
 
 Sets the plugin instance to I<Instance>.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1802,9 +1802,9 @@ The following options are valid within B<URL> blocks:
 Use I<Name> as the host name when submitting values. Defaults to the global
 host name setting.
 
-=item B<PluginName> I<PluginName>
+=item B<Plugin> I<Plugin>
 
-Use I<PluginName> as the plugin name when submitting values.
+Use I<Plugin> as the plugin name when submitting values.
 Defaults to 'curl_json'.
 
 =item B<Instance> I<Instance>

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -82,6 +82,7 @@ typedef struct {
 struct cj_s /* {{{ */
 {
   char *instance;
+  char *plugin_name;
   char *host;
 
   char *sock;
@@ -396,6 +397,7 @@ static void cj_free(void *arg) /* {{{ */
   db->tree = NULL;
 
   sfree(db->instance);
+  sfree(db->plugin_name);
   sfree(db->host);
 
   sfree(db->sock);
@@ -672,6 +674,8 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Instance", child->key) == 0)
       status = cf_util_get_string(child, &db->instance);
+    else if (strcasecmp("PluginName", child->key) == 0)
+      status = cf_util_get_string(child, &db->plugin_name);
     else if (strcasecmp("Host", child->key) == 0)
       status = cf_util_get_string(child, &db->host);
     else if (db->url && strcasecmp("User", child->key) == 0)
@@ -805,7 +809,8 @@ static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
     sstrncpy(vl.type_instance, key->instance, sizeof(vl.type_instance));
 
   sstrncpy(vl.host, cj_host(db), sizeof(vl.host));
-  sstrncpy(vl.plugin, "curl_json", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (db->plugin_name != NULL) ? db->plugin_name : "curl_json",
+           sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, db->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, key->type, sizeof(vl.type));
 

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -674,7 +674,7 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Instance", child->key) == 0)
       status = cf_util_get_string(child, &db->instance);
-    else if (strcasecmp("PluginName", child->key) == 0)
+    else if (strcasecmp("Plugin", child->key) == 0)
       status = cf_util_get_string(child, &db->plugin_name);
     else if (strcasecmp("Host", child->key) == 0)
       status = cf_util_get_string(child, &db->host);

--- a/src/types.db
+++ b/src/types.db
@@ -185,6 +185,10 @@ pg_n_tup_g              value:GAUGE:0:U
 pg_numbackends          value:GAUGE:0:U
 pg_scan                 value:DERIVE:0:U
 pg_xact                 value:DERIVE:0:U
+phpfpm_listen_queue     value:GAUGE:0:65535
+phpfpm_processes        value:GAUGE:0:65535
+phpfpm_requests         value:DERIVE:0:U
+phpfpm_slow_requests    value:DERIVE:0:U
 ping                    value:GAUGE:0:65535
 ping_droprate           value:GAUGE:0:100
 ping_stddev             value:GAUGE:0:65535


### PR DESCRIPTION
Hi!

Proposed patch adds ability to set custom plugin name instead of 'curl_json'.
curl_json is a generic plugin and we found such feature very useful. I add configuration example of php-fpm status monitoring as example of custom plugin name usage.
