### PR TITLE
Nginx vhost

### DIFF
--- a/src/nginx.c
+++ b/src/nginx.c
@@ -130,7 +130,6 @@ static int init (void)
     ERROR ("nginx plugin: curl_easy_init failed.");
     return (-1);
   }
-  curl_easy_setopt (curl, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt (curl, CURLOPT_NOSIGNAL, 1L);
   curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, nginx_curl_callback);
   curl_easy_setopt (curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
@@ -168,7 +167,6 @@ static int init (void)
 
     curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
   }
-
 
   curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt (curl, CURLOPT_MAXREDIRS, 50L);

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -164,8 +164,8 @@ static int init (void)
     char header[256];
     snprintf(header, sizeof(header)-1, "Host: %s", vhost);
     headers = curl_slist_append (headers, header);
-
-    curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
+	if (headers != NULL)
+		curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers);
   }
 
   curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 1L);


### PR DESCRIPTION
Add Vhost config option to allow for requesting the servers status from specific vhost. This is needed in case nginx exposes the server status only for specific vhost/s.
