### PR TITLE
zfs_arc: 'stolen' was removed after FreeBSD 10.2

### DIFF
--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -171,7 +171,10 @@ static int za_read (void)
 	za_read_derive (ksp, "deleted",  "cache_operation", "deleted");
 #if __FreeBSD__
 	za_read_derive (ksp, "allocated","cache_operation", "allocated");
+#if defined(__FreeBSD_version) && (__FreeBSD_version < 1002501)
+	/* stolen removed from sysctl kstat.zfs.misc.arcstats on FreeBSD 10.2+ */
 	za_read_derive (ksp, "stolen",   "cache_operation", "stolen");
+#endif
 #endif
 
 	/* Issue indicators */


### PR DESCRIPTION
Patch taken from FreeBSD port