### PR TITLE
Tested building the RPM for collectd 5.5.1 released a couple of

### DIFF
--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -221,7 +221,7 @@
 
 Summary:	statistics collection and monitoring daemon
 Name:		collectd
-Version:	5.5.0
+Version:	5.5.1
 Release:	1%{?dist}
 URL:		http://collectd.org
 Source:		http://collectd.org/files/%{name}-%{version}.tar.bz2


### PR DESCRIPTION
weeks ago

Tested generating the RPM files with `mock -r centos-6-x86_64 ...`,
as in the comments at the beginning of './contrib/redhat/collectd.spec'

(As for the contents of the RPM history at the end of the file 
'./contrib/redhat/collectd.spec', there are no details specific for 
what is new in version 5.5.1 in respect to 5.5.0, as from

    https://collectd.org/wiki/index.php/Version_5.5

to:

    https://collectd.org/wiki/index.php/Version_5.5.1

which URL doesn't exist, as if it is not necessary because version
5.5.1 contains fixes over 5.5.0)
