### PR TITLE
utils_avltree.c: fix compiler warning

### DIFF
--- a/src/utils_avltree.c
+++ b/src/utils_avltree.c
@@ -241,7 +241,7 @@ static void rebalance (c_avl_tree_t *t, c_avl_node_t *n)
 		{
 			assert (n->right != NULL);
 			b_bottom = BALANCE (n->right);
-			assert ((b_bottom >= -1) || (b_bottom <= 1));
+			assert ((b_bottom >= -1) && (b_bottom <= 1));
 			if (b_bottom == 1)
 				n = rotate_right_left (t, n);
 			else
@@ -251,7 +251,7 @@ static void rebalance (c_avl_tree_t *t, c_avl_node_t *n)
 		{
 			assert (n->left != NULL);
 			b_bottom = BALANCE (n->left);
-			assert ((b_bottom >= -1) || (b_bottom <= 1));
+			assert ((b_bottom >= -1) && (b_bottom <= 1));
 			if (b_bottom == -1)
 				n = rotate_left_right (t, n);
 			else


### PR DESCRIPTION
make[3]: Entering directory '/home/ruben/src/collectd/src/daemon'
  CC       utils_avltree.lo
utils_avltree.c: In function ‘rebalance’:
utils_avltree.c:248:20: warning: logical ‘or’ of collectively exhaustive
tests is always true [-Wlogical-op]
    assert ((b_bottom >= -1) || (b_bottom <= 1));
                    ^~
utils_avltree.c:258:20: warning: logical ‘or’ of collectively exhaustive
tests is always true [-Wlogical-op]
    assert ((b_bottom >= -1) || (b_bottom <= 1));
                    ^~