### PR TITLE
mysql plugin: Split 'mysql_sort' type into several types.

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -900,8 +900,15 @@ static int mysql_read (user_data_t *ud)
 		}
 		else if (strncmp (key, "Sort_", strlen ("Sort_")) == 0)
 		{
-			counter_submit ("mysql_sort", key + strlen ("Sort_"),
-					val, db);
+			if (strcmp (key, "Sort_merge_passes") == 0)
+				counter_submit ("mysql_sort_merge_passes", NULL, val, db);
+			else if (strcmp (key, "Sort_rows") == 0)
+				counter_submit ("mysql_sort_rows", NULL, val, db);
+			else if (strcmp (key, "Sort_range") == 0)
+				counter_submit ("mysql_sort", "range", val, db);
+			else if (strcmp (key, "Sort_scan") == 0)
+				counter_submit ("mysql_sort", "scan", val, db);
+			
 		}
 	}
 	mysql_free_result (res); res = NULL;

--- a/src/types.db
+++ b/src/types.db
@@ -128,6 +128,8 @@ mysql_innodb_row_lock	value:DERIVE:0:U
 mysql_innodb_rows	value:DERIVE:0:U
 mysql_select		value:DERIVE:0:U
 mysql_sort		value:DERIVE:0:U
+mysql_sort_merge_passes	value:DERIVE:0:U
+mysql_sort_rows		value:DERIVE:0:U
 nfs_procedure		value:DERIVE:0:U
 nginx_connections	value:GAUGE:0:U
 nginx_requests		value:DERIVE:0:U


### PR DESCRIPTION
The 'mysql_sort' type needs to be splitted.

As documented in http://dev.mysql.com/doc/refman/5.6/en/server-status-variables.html#statvar_Sort_range , 'Sort_*' keys are:

 * The number of sorts:    Sort_range, Sort_scan
 * The number of sorted rows: Sort_rows
 * The number of merge passes: Sort_merge_passes

These are cannot be mixed together into one type 'mysql_sort'. 
Proposed patch solves this problem.

https://github.com/collectd/collectd/commit/7d1ee33e6e2250ab6c52be935c897ad8141fdea4