### PR TITLE
Nginx plugin: Incorrect metric provided

### DIFF
--- a/src/nginx.c
+++ b/src/nginx.c
@@ -256,7 +256,7 @@ static int nginx_read (void)
   /*
    * Active connections: 291
    * server accepts handled requests
-   *  16630948 16630948 31070465
+   *  101059015 100422216 347910649
    * Reading: 6 Writing: 179 Waiting: 106
    */
   for (int i = 0; i < lines_num; i++)
@@ -277,6 +277,7 @@ static int nginx_read (void)
       {
 	submit ("connections", "accepted", atoll (fields[0]));
 	submit ("connections", "handled", atoll (fields[1]));
+	submit ("connections", "failed", (atoll(fields[0]) - atoll (fields[1])));
 	submit ("nginx_requests", NULL, atoll (fields[2]));
       }
     }


### PR DESCRIPTION
As documented in http://nginx.org/en/docs/http/ngx_http_stub_status_module.html , nginx provides following status information:

 accepts -   The total number of accepted client connections. 
 handled -   The total number of handled connections. 

The 'handled', as noticed, is the same as 'accepts' unless some resource limits have been reached (for example, the worker_connections limit). 

In normal state, these values are equal. When an error occurs, the difference between these values appear, but rate of this difference is too small (compared with the number of accepted connections) to see it on graphs.  So, it does not useful to provide pure 'handled' metric, but 'failed' (failed=accepts-handled) should be provided instead. Such 'failed' metric also allows to configure notifications, based on it, which is impossible in current state.