### PR TITLE
Collection3: Graphing speed improvements with many hosts

### DIFF
--- a/contrib/collection3/lib/Collectd/Graph/Common.pm
+++ b/contrib/collection3/lib/Collectd/Graph/Common.pm
@@ -487,6 +487,8 @@ sub get_files_by_ident
   my $ident = shift;
   my $all_files;
   my @ret = ();
+  my $temp;
+  my $hosts;
 
   my $cache_key = ident_to_string ($ident);
   if (defined ($Cache->{'get_files_by_ident'}{$cache_key}))
@@ -496,7 +498,20 @@ sub get_files_by_ident
     return ($ret)
   }
 
-  $all_files = _get_all_files ();
+  if ($ident->{'hostname'})
+  {
+    $all_files = [];
+    $hosts = $ident->{'hostname'};
+    foreach (@$hosts)
+    {
+      $temp = get_files_for_host ($_);
+      push (@$all_files, @$temp);
+    }
+  }
+  else
+  {
+    $all_files = _get_all_files ();
+  }
 
   @ret = grep { _filter_ident ($ident, $_) == 0 } (@$all_files);
 


### PR DESCRIPTION
At present graph.cgi is extremely slowly on servers with large numbers of
RRD files.  This is because it issues an unnecessary stat() call to _every_
RRD file on the local system before loading and rendering graph data.

Patch originally from:
http://mailman.verplant.org/pipermail/collectd/2011-May/004519.html

The patch was improved so that it correctly handles multiple hostnames.

I'm seeing a 5x improvement in speed, the original patch creator
had a 24x speedup.