### PR TITLE
Tail plugin: DSType Latency

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,6 +31,9 @@ libmount_la_LIBADD = daemon/libcommon.la
 liblookup_la_SOURCES = utils_vl_lookup.c utils_vl_lookup.h
 liblookup_la_LIBADD = daemon/libavltree.la daemon/libcommon.la
 
+liblatency_la_SOURCES = utils_latency.c utils_latency.h
+liblatency_la_LIBADD = daemon/libcommon.la
+
 sbin_PROGRAMS = collectdmon
 bin_PROGRAMS = collectd-nagios collectdctl collectd-tg
 
@@ -985,6 +988,7 @@ if BUILD_PLUGIN_TAIL
 pkglib_LTLIBRARIES += tail.la
 tail_la_SOURCES = tail.c
 tail_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+tail_la_LIBADD = liblatency.la
 endif
 
 if BUILD_PLUGIN_TAIL_CSV

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1153,6 +1153,21 @@
 #      Instance "local_user"
 #    </Match>
 #  </File>
+#  <File "/var/log/nginx/apache-time.log">
+#    #Use the following log format in nginx:
+#    #log_format response_time '[$host] "$upstream_response_time" ...'
+#    Instance "apache"
+#    <Match>
+#      Regex "^\\S+ \"([0-9.]+)\""
+#      DSType "Latency"
+#      Type "response_time"
+#      LatencyPercentile 5
+#      LatencyPercentile 30
+#      LatencyPercentile 50
+#      LatencyPercentile 70
+#      LatencyPercentile 95
+#    </Match>
+#  </File>
 #</Plugin>
 
 #<Plugin tail_csv>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6383,6 +6383,14 @@ Increase the internal counter by one. These B<DSType> are the only ones that do
 not use the matched subexpression, but simply count the number of matched
 lines. Thus, you may use a regular expression without submatch in this case.
 
+=item B<Latency>
+
+Special type to handle latency values from logfiles and supported only 
+by L<tail> plugin. The matched value must be latency in seconds, floating point
+numbers are supported. Should be used with B<LatencyPercentile> option.
+
+The B<Instance> option cannot be used together with this option.
+
 =back
 
 As you'd expect the B<Gauge*> types interpret the submatch as a floating point
@@ -6400,6 +6408,14 @@ their configuration can be found in L<types.db(5)>.
 =item B<Instance> I<TypeInstance>
 
 This optional setting sets the type instance to use.
+
+=item B<LatencyPercentile> I<Percent>
+
+Calculate and dispatch the configured percentile, i.e. compute the latency, so
+that I<Percent> of all matched latency values are smaller than or equal to the
+computed latency.
+
+Different percentiles can be calculated by setting this option several times.
 
 =back
 

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -68,7 +68,7 @@ collectd_SOURCES = collectd.c collectd.h \
 		   utils_time.c utils_time.h \
 		   types_list.c types_list.h \
 		   utils_threshold.c utils_threshold.h \
-		   utils_latency.h ../utils_latency.c
+		   ../utils_latency.h ../utils_latency.c
 
 
 collectd_CPPFLAGS =  $(AM_CPPFLAGS) $(LTDLINCL)

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -67,7 +67,8 @@ collectd_SOURCES = collectd.c collectd.h \
 		   utils_tail.c utils_tail.h \
 		   utils_time.c utils_time.h \
 		   types_list.c types_list.h \
-		   utils_threshold.c utils_threshold.h
+		   utils_threshold.c utils_threshold.h \
+		   utils_latency.h ../utils_latency.c
 
 
 collectd_CPPFLAGS =  $(AM_CPPFLAGS) $(LTDLINCL)

--- a/src/daemon/utils_match.h
+++ b/src/daemon/utils_match.h
@@ -28,6 +28,7 @@
 #define UTILS_MATCH_H 1
 
 #include "plugin.h"
+#include "utils_latency.h"
 
 /*
  * Each type may have 12 sub-types
@@ -46,6 +47,7 @@
 #define UTILS_MATCH_CF_GAUGE_LAST    0x08
 #define UTILS_MATCH_CF_GAUGE_INC     0x10
 #define UTILS_MATCH_CF_GAUGE_ADD     0x20
+#define UTILS_MATCH_CF_GAUGE_LATENCY 0x40
 
 #define UTILS_MATCH_CF_COUNTER_SET   0x01
 #define UTILS_MATCH_CF_COUNTER_ADD   0x02
@@ -70,6 +72,7 @@ struct cu_match_value_s
   int ds_type;
   value_t value;
   unsigned int values_num;
+  latency_counter_t *latency;
 };
 typedef struct cu_match_value_s cu_match_value_t;
 
@@ -93,11 +96,13 @@ typedef struct cu_match_value_s cu_match_value_t;
  *  callback.
  *  The optional `excluderegex' allows to exclude the line from the match, if
  *  the excluderegex matches.
+ *  When `match_destroy' is called the `user_data' pointer is freed using
+ *  the `free_user_data' callback - if it is not NULL.
  */
 cu_match_t *match_create_callback (const char *regex, const char *excluderegex,
 		int (*callback) (const char *str,
 		  char * const *matches, size_t matches_num, void *user_data),
-		void *user_data);
+		void *user_data, void (*free_user_data) (void *user_data));
 
 /*
  * NAME

--- a/src/daemon/utils_tail_match.h
+++ b/src/daemon/utils_tail_match.h
@@ -110,7 +110,9 @@ int tail_match_add_match (cu_tail_match_t *obj, cu_match_t *match,
 int tail_match_add_match_simple (cu_tail_match_t *obj,
     const char *regex, const char *excluderegex, int ds_type,
     const char *plugin, const char *plugin_instance,
-    const char *type, const char *type_instance, const cdtime_t interval);
+    const char *type, const char *type_instance,
+    const double *percentile, const size_t percentile_num,
+    const cdtime_t interval);
 
 /*
  * NAME

--- a/src/tail.c
+++ b/src/tail.c
@@ -53,6 +53,8 @@ struct ctail_config_match_s
   char *type;
   char *type_instance;
   cdtime_t interval;
+  double *percentile;
+  size_t percentile_num;
 };
 typedef struct ctail_config_match_s ctail_config_match_t;
 
@@ -84,6 +86,8 @@ static int ctail_config_add_match_dstype (ctail_config_match_t *cm,
       cm->flags |= UTILS_MATCH_CF_GAUGE_INC;
     else if (strcasecmp ("GaugeAdd", ci->values[0].value.string) == 0)
       cm->flags |= UTILS_MATCH_CF_GAUGE_ADD;
+    else if (strcasecmp ("Latency", ci->values[0].value.string) == 0)
+      cm->flags |= UTILS_MATCH_CF_GAUGE_LATENCY;
     else
       cm->flags = 0;
   }
@@ -133,6 +137,44 @@ static int ctail_config_add_match_dstype (ctail_config_match_t *cm,
 
   return (0);
 } /* int ctail_config_add_match_dstype */
+    
+static int ctail_config_add_match_latency_percentile (ctail_config_match_t *cm,
+    oconfig_item_t *ci)
+{
+  if (ci->values_num != 1)
+  {
+    WARNING ("tail plugin: `LatencyPercentile' needs exactly one argument.");
+    return (-1);
+  }
+  
+  double percent = NAN;
+  double *tmp;
+  int status;
+
+  status = cf_util_get_double (ci, &percent);
+  if (status != 0)
+    return (status);
+
+  if ((percent <= 0.0) || (percent >= 100))
+  {
+    ERROR ("tail plugin: The value for \"%s\" must be between 0 and 100, "
+        "exclusively.", ci->key);
+    return (ERANGE);
+  }
+  
+  tmp = realloc (cm->percentile,
+      sizeof (*cm->percentile) * (cm->percentile_num + 1));
+  if (tmp == NULL)
+  {
+    ERROR ("tail plugin: realloc failed.");
+    return (ENOMEM);
+  }
+  cm->percentile = tmp;
+  cm->percentile[cm->percentile_num] = percent;
+  cm->percentile_num++;
+
+  return (0);
+} /* int ctail_config_add_match_latency_percentile */
 
 static int ctail_config_add_match (cu_tail_match_t *tm,
     const char *plugin_instance, oconfig_item_t *ci, cdtime_t interval)
@@ -163,6 +205,8 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
       status = cf_util_get_string (option, &cm.type);
     else if (strcasecmp ("Instance", option->key) == 0)
       status = cf_util_get_string (option, &cm.type_instance);
+    else if (strcasecmp ("LatencyPercentile", option->key) == 0)
+      status = ctail_config_add_match_latency_percentile (&cm, option);
     else
     {
       WARNING ("tail plugin: Option `%s' not allowed here.", option->key);
@@ -196,13 +240,26 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
       break;
     }
 
+    if ((cm.flags & UTILS_MATCH_CF_GAUGE_LATENCY) && (cm.type_instance != NULL))
+    {
+      WARNING ("tail plugin: `DSType Latency' and 'Instance %s' in `Match' block could not be used together.",cm.type_instance);
+      status = -1;
+      break;
+    }
+    
+    if ((cm.flags & UTILS_MATCH_CF_GAUGE_LATENCY) && (cm.percentile_num == 0))
+    {
+      WARNING ("tail plugin: `DSType Latency' has no 'LatencyPercentile' options.");
+      status = -1;
+      break;
+    }
     break;
   } /* while (status == 0) */
 
   if (status == 0)
   {
     status = tail_match_add_match_simple (tm, cm.regex, cm.excluderegex,
-	cm.flags, "tail", plugin_instance, cm.type, cm.type_instance, interval);
+	cm.flags, "tail", plugin_instance, cm.type, cm.type_instance, cm.percentile, cm.percentile_num, interval);
 
     if (status != 0)
     {
@@ -214,6 +271,7 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
   sfree (cm.excluderegex);
   sfree (cm.type);
   sfree (cm.type_instance);
+  sfree (cm.percentile);
 
   return (status);
 } /* int ctail_config_add_match */

--- a/src/tail.c
+++ b/src/tail.c
@@ -86,10 +86,13 @@ static int ctail_config_add_match_dstype (ctail_config_match_t *cm,
       cm->flags |= UTILS_MATCH_CF_GAUGE_INC;
     else if (strcasecmp ("GaugeAdd", ci->values[0].value.string) == 0)
       cm->flags |= UTILS_MATCH_CF_GAUGE_ADD;
-    else if (strcasecmp ("Latency", ci->values[0].value.string) == 0)
-      cm->flags |= UTILS_MATCH_CF_GAUGE_LATENCY;
     else
       cm->flags = 0;
+  }
+  else if (strcasecmp ("Latency", ci->values[0].value.string) == 0)
+  {
+    cm->flags = UTILS_MATCH_DS_TYPE_GAUGE;
+    cm->flags |= UTILS_MATCH_CF_GAUGE_LATENCY;
   }
   else if (strncasecmp ("Counter", ci->values[0].value.string, strlen ("Counter")) == 0)
   {

--- a/src/tail.c
+++ b/src/tail.c
@@ -252,7 +252,7 @@ static int ctail_config_add_match (cu_tail_match_t *tm,
     
     if ((cm.flags & UTILS_MATCH_CF_GAUGE_LATENCY) && (cm.percentile_num == 0))
     {
-      WARNING ("tail plugin: `DSType Latency' has no 'LatencyPercentile' options.");
+      WARNING ("tail plugin: `Match' with `DSType Latency' has no 'LatencyPercentile' options.");
       status = -1;
       break;
     }


### PR DESCRIPTION
This PR proposes new DSType "Latency" in 'tail' plugin and allows to calculate percentiles. 
Useful for webserver response time monitoring.

There is a plan to add 'request rate by range' reporting based on this DSType.