### PR TITLE
write_http: in cleanup handler free http headers

### DIFF
--- a/src/write_http.c
+++ b/src/write_http.c
@@ -56,6 +56,7 @@ struct wh_callback_s
         int format;
 
         CURL *curl;
+	struct curl_slist *headers;
         char curl_errbuf[CURL_ERROR_SIZE];
 
         char   send_buffer[4096];
@@ -99,8 +100,6 @@ static int wh_send_buffer (wh_callback_t *cb) /* {{{ */
 
 static int wh_callback_init (wh_callback_t *cb) /* {{{ */
 {
-        struct curl_slist *headers;
-
         if (cb->curl != NULL)
                 return (0);
 
@@ -114,14 +113,14 @@ static int wh_callback_init (wh_callback_t *cb) /* {{{ */
         curl_easy_setopt (cb->curl, CURLOPT_NOSIGNAL, 1L);
         curl_easy_setopt (cb->curl, CURLOPT_USERAGENT, PACKAGE_NAME"/"PACKAGE_VERSION);
 
-        headers = NULL;
-        headers = curl_slist_append (headers, "Accept:  */*");
+	cb->headers = NULL;
+        cb->headers = curl_slist_append (cb->headers, "Accept:  */*");
         if (cb->format == WH_FORMAT_JSON)
-                headers = curl_slist_append (headers, "Content-Type: application/json");
+                cb->headers = curl_slist_append (cb->headers, "Content-Type: application/json");
         else
-                headers = curl_slist_append (headers, "Content-Type: text/plain");
-        headers = curl_slist_append (headers, "Expect:");
-        curl_easy_setopt (cb->curl, CURLOPT_HTTPHEADER, headers);
+                cb->headers = curl_slist_append (cb->headers, "Content-Type: text/plain");
+        cb->headers = curl_slist_append (cb->headers, "Expect:");
+        curl_easy_setopt (cb->curl, CURLOPT_HTTPHEADER, cb->headers);
 
         curl_easy_setopt (cb->curl, CURLOPT_ERRORBUFFER, cb->curl_errbuf);
         curl_easy_setopt (cb->curl, CURLOPT_URL, cb->location);
@@ -264,6 +263,13 @@ static void wh_callback_free (void *data) /* {{{ */
         wh_flush_nolock (/* timeout = */ 0, cb);
 
         curl_easy_cleanup (cb->curl);
+
+	if (cb->headers != NULL)
+	{
+		curl_slist_free_all (cb->headers);
+		cb->headers = NULL;
+	}
+
         sfree (cb->location);
         sfree (cb->user);
         sfree (cb->pass);
@@ -525,6 +531,7 @@ static int wh_config_url (oconfig_item_t *ci) /* {{{ */
         cb->cacert = NULL;
         cb->format = WH_FORMAT_COMMAND;
         cb->curl = NULL;
+	cb->headers = NULL;
 
         pthread_mutex_init (&cb->send_lock, /* attr = */ NULL);
 


### PR DESCRIPTION
slist of http headers require cleanup to avoid
memory leak. See libcurl example:

https://curl.haxx.se/libcurl/c/httpcustomheader.html