### PR TITLE
statsd: Document collectd behaviour when receiving the 0.000 timer value

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6326,6 +6326,8 @@ Calculate and dispatch various values out of I<Timer> metrics received during
 an interval. If set to B<False>, the default, these values aren't calculated /
 dispatched.
 
+Please note what reported timer values less than 0.001 are ignored in all B<Timer*> reports.
+
 =back
 
 =head2 Plugin C<swap>


### PR DESCRIPTION
As documented on https://github.com/b/statsd_spec , valid timer values are in the range [0, 2^64^).
But in https://github.com/collectd/collectd/blob/master/src/utils_latency.c#L139 we have 'return' if latency is equal to zero.

Do we need fix for this by allowing 0.000 value (possible by additional option, as this highly affects results) or we need to document this? Excluding 0.000 might be invisible in calculation results when rate of such values is small (which happens in most cases, I think).

Currently I'm working on new version of #1612, implementing something like 'TimerRate MIN MAX' option (in 'statsd' plugin terms) which would report rate of timers in selected range.
When 0.000 values are ignored by utils_latency.c, minimal supported value for MIN will be 0.001 also.
