### PR TITLE
Fix process plugin memory leak [solaris]

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1369,6 +1369,10 @@ static int ps_read_process(long pid, procstat_t *ps, char *state)
 		ps->num_proc = 0;
 		ps->num_lwp = 0;
 		*state = (char) 'Z';
+
+		sfree(myStatus);
+		sfree(myInfo);
+		sfree(myUsage);
 		return (0);
 	} else {
 		ps->num_proc = 1;


### PR DESCRIPTION
On solaris, if a process is flagged as zombie, the 'myStatus', 'myInfo', and 'myUsage' structures are leaked. I've added the required frees to release the resources before the method returns.