### PR TITLE
Remove broken filter syntax from collectd.conf(5)

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -172,9 +172,7 @@ I<pattern> may be specified to filter which files to include. This may be used
 in combination with recursively including a directory to easily be able to
 arbitrarily mix configuration files and other documents (e.g. README files).
 The given example is similar to the first example above but includes all files
-matching C<*.conf> in any subdirectory of C</etc/collectd.d>:
-
-  Include "/etc/collectd.d" "*.conf"
+matching C<*.conf> in any subdirectory of C</etc/collectd.d>.
 
 =back
 


### PR DESCRIPTION
fb67910d documented the new syntax.
The old syntax does no longer work, remove it.