### PR TITLE
Add alias to Ping Host config

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -930,6 +930,7 @@
 
 #<Plugin ping>
 #	Host "host.foo.bar"
+#	Host "host-with-alias.foo.bar" "alias"
 #	Interval 1.0
 #	Timeout 0.9
 #	TTL 255

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -22,7 +22,7 @@ collectd.conf - Configuration for the system statistics collection daemon B<coll
 
   LoadPlugin ping
   <Plugin ping>
-    Host "example.org"
+    Host "example" "example.org"
     Host "provider.net"
   </Plugin>
 
@@ -4987,10 +4987,11 @@ Available configuration options:
 
 =over 4
 
-=item B<Host> I<IP-address>
+=item B<Host> I<IP-address> [I<Alias>]
 
 Host to ping periodically. This option may be repeated several times to ping
-multiple hosts.
+multiple hosts. If an alias is specified, it will be used as the type
+instance, rather than the IP-address.
 
 =item B<Interval> I<Seconds>
 


### PR DESCRIPTION
This pull request adds an "alias" option to the ping plugin's Host configuration statement. The alias is used in all the external output of the host, i.e. in the logs, and more importantly, in stats that are written to anywhere.

In this way, we can have long term stats for something, even if its IP address changes time. Of course, collectd configuration is required to track the new IP address, but if the alias stays consistent then we will write the stats to the same place.
