### PR TITLE
Use AC_GNU_SOURCE macro to detect and propagate __GNU_SOURCE macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
+AC_GNU_SOURCE
 AC_CONFIG_SRCDIR(src/)
 AC_CONFIG_HEADERS(src/config.h)
 AC_CONFIG_AUX_DIR([libltdl/config])


### PR DESCRIPTION
*_GNU_SOURCE* is needed for *xfs/xqm.h* since xfsprogs-4.5.0 at least.

Using *AC_GNU_SOURCE* is the better way instead of patching individual files.

Fixes: https://github.com/collectd/collectd/issues/1637