### PR TITLE
'df' plugin: warn about unrecognized config keys.

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -152,7 +152,7 @@ static int df_config (const char *key, const char *value)
 
 		return (0);
 	}
-
+	WARNING ("df plugin: Ignoring config key '%s'", key);
 	return (-1);
 }
 


### PR DESCRIPTION
Change 'df' so that instead of silently ignoring keys, it writes a message to the log.

Note: it might at first seem that 'df' is returning an error code on an unrecognized key,
but as far as I can tell, that error is ignored by collectd. Evidence: the following code inside
```cf_read()``` of ```configfile.c``` ignores the result code that bubbled up to ```dispatch_value``` or ```dispatch_block```.

```
for (i = 0; i < conf->children_num; i++)
{
    if (conf->children[i].children == NULL)
        dispatch_value (conf->children + i);
    else
        dispatch_block (conf->children + i);
}
```

I intend to address this in my next PR.