### PR TITLE
Modify the -T command line option so it watches for more errors.

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -332,9 +332,7 @@ static int do_init (void)
 	}
 #endif
 
-	plugin_init_all ();
-
-	return (0);
+	return plugin_init_all ();
 } /* int do_init () */
 
 
@@ -388,8 +386,7 @@ static int do_loop (void)
 
 static int do_shutdown (void)
 {
-	plugin_shutdown_all ();
-	return (0);
+	return plugin_shutdown_all ();
 } /* int do_shutdown */
 
 #if COLLECT_DAEMON
@@ -729,12 +726,19 @@ int main (int argc, char **argv)
 	/*
 	 * run the actual loops
 	 */
-	do_init ();
+	if (do_init () != 0)
+	{
+		ERROR ("Error: one or more plugin init callbacks failed.");
+		exit_status = 1;
+	}
 
 	if (test_readall)
 	{
 		if (plugin_read_all_once () != 0)
+		{
+			ERROR ("Error: one or more plugin read callbacks failed.");
 			exit_status = 1;
+		}
 	}
 	else
 	{
@@ -745,7 +749,11 @@ int main (int argc, char **argv)
 	/* close syslog */
 	INFO ("Exiting normally.");
 
-	do_shutdown ();
+	if (do_shutdown () != 0)
+	{
+		ERROR ("Error: one or more plugin shutdown callbacks failed.");
+		exit_status = 1;
+	}
 
 #if COLLECT_DAEMON
 	if (daemonize)

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -240,10 +240,10 @@ void plugin_set_dir (const char *dir);
  */
 int plugin_load (const char *name, uint32_t flags);
 
-void plugin_init_all (void);
+int plugin_init_all (void);
 void plugin_read_all (void);
 int plugin_read_all_once (void);
-void plugin_shutdown_all (void);
+int plugin_shutdown_all (void);
 
 /*
  * NAME


### PR DESCRIPTION
I have really come to appreciate the -T command line option for testing to see if my collectd is working as configured. However, I noticed that, as written, the only errors that get propagated to the exit status of collectd are errors from the ```read``` callback of the configured plugins. In my opinion it would be more valuable if it reported errors that happened in other stages as well. In this way it would be a more faithful end-to-end test.

After this change, the following kinds of errors will cause ```collectd -T``` to exit with an abnormal status:
1. errors reading the config file
2. errors reading ```types.db```
3. errors on ```plugin_init```
4. errors on ```plugin_read``` (as now)
5. errors on ```plugin_shutdown```

**Note:** this PR causes collectd to do more error checking than it did previously. Specifically it bubbles up errors from each plugin's config callback rather than ignoring those errors. It's hypothetically possible that this change could break some existing configurations. Suggestions are welcome on the question of (a) whether it is desirable for collectd to be more strict like this, and (b) if so, how to test the existing plugins to make sure they don't break.

Edit: this paragraph mooted by https://github.com/collectd/collectd/commit/a8700539e4131ae20af1462d1e6c6ec38a266577
~~One thing I found myself was that the ```df``` plugin will return an error in ```df_config()``` if the deprecated option ```ReportReserved``` is in your config, but the rest of collectd will ignore that error. (see https://github.com/collectd/collectd/pull/1641 for an explanation of why this is so). After this change, such a keyword will cause collectd to report an error. Of course it's possible that the correct fix there is to fix ```df``` so that unrecognized keywords in the config file are just warnings and not errors (in other words, maybe ```df_config``` should return 0 and not -1).~~
