### PR TITLE
Add current values from libsensors.

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -132,10 +132,10 @@ static sensors_labeltypes_t known_features[] =
 	{ "2.5V", SENSOR_TYPE_VOLTAGE },
 	{ "2.0V", SENSOR_TYPE_VOLTAGE },
 	{ "12V", SENSOR_TYPE_VOLTAGE },
-	{ "power1", SENSOR_TYPE_POWER }
-	{ "curr1", SENSOR_TYPE_CURRENT }
-	{ "curr2", SENSOR_TYPE_CURRENT }
-	{ "curr3", SENSOR_TYPE_CURRENT }
+	{ "power1", SENSOR_TYPE_POWER },
+	{ "curr1", SENSOR_TYPE_CURRENT },
+	{ "curr2", SENSOR_TYPE_CURRENT },
+	{ "curr3", SENSOR_TYPE_CURRENT },
 	{ "curr4", SENSOR_TYPE_CURRENT }
 };
 static int known_features_num = STATIC_ARRAY_SIZE (known_features);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -421,6 +421,7 @@ static int sensors_load_conf (void)
 					&& (feature->type != SENSORS_FEATURE_FAN)
 					&& (feature->type != SENSORS_FEATURE_TEMP)
 					&& (feature->type != SENSORS_FEATURE_POWER)
+					&& (feature->type != SENSORS_FEATURE_ENERGY)
 					&& (feature->type != SENSORS_FEATURE_CURR))
 			{
 				DEBUG ("sensors plugin: sensors_load_conf: "
@@ -439,6 +440,7 @@ static int sensors_load_conf (void)
 						&& (subfeature->type != SENSORS_SUBFEATURE_FAN_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_TEMP_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_POWER_INPUT)
+						&& (subfeature->type != SENSORS_SUBFEATURE_ENERGY_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_CURR_INPUT))
 					continue;
 
@@ -587,6 +589,9 @@ static int sensors_read (void)
 		else if (fl->feature->type
 				== SENSORS_FEATURE_POWER)
 			type = "power";
+		else if (fl->feature->type
+				== SENSORS_FEATURE_ENERGY)
+			type = "energy";
 		else if (fl->feature->type
 				== SENSORS_FEATURE_CURR)
 			type = "current";

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -419,8 +419,10 @@ static int sensors_load_conf (void)
 					&& (feature->type != SENSORS_FEATURE_FAN)
 					&& (feature->type != SENSORS_FEATURE_TEMP)
 					&& (feature->type != SENSORS_FEATURE_POWER)
+#if (SENSORS_API_VERSION >= 0x402)
 					&& (feature->type != SENSORS_FEATURE_ENERGY)
 					&& (feature->type != SENSORS_FEATURE_CURR))
+#endif
 			{
 				DEBUG ("sensors plugin: sensors_load_conf: "
 						"Ignoring feature `%s', "
@@ -438,8 +440,10 @@ static int sensors_load_conf (void)
 						&& (subfeature->type != SENSORS_SUBFEATURE_FAN_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_TEMP_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_POWER_INPUT)
+#if (SENSORS_API_VERSION >= 0x402)
 						&& (subfeature->type != SENSORS_SUBFEATURE_ENERGY_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_CURR_INPUT))
+#endif
 					continue;
 
 				fl = calloc (1, sizeof (*fl));

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -64,7 +64,9 @@ static char *sensor_type_name_map[] =
 	"temperature",
 # define SENSOR_TYPE_POWER       3
 	"power",
-# define SENSOR_TYPE_UNKNOWN     4
+# define SENSOR_TYPE_CURRENT     4
+	"current",
+# define SENSOR_TYPE_UNKNOWN     5
 	NULL
 };
 
@@ -131,6 +133,10 @@ static sensors_labeltypes_t known_features[] =
 	{ "2.0V", SENSOR_TYPE_VOLTAGE },
 	{ "12V", SENSOR_TYPE_VOLTAGE },
 	{ "power1", SENSOR_TYPE_POWER }
+	{ "curr1", SENSOR_TYPE_CURRENT }
+	{ "curr2", SENSOR_TYPE_CURRENT }
+	{ "curr3", SENSOR_TYPE_CURRENT }
+	{ "curr4", SENSOR_TYPE_CURRENT }
 };
 static int known_features_num = STATIC_ARRAY_SIZE (known_features);
 /* end new naming */
@@ -414,7 +420,8 @@ static int sensors_load_conf (void)
 			if ((feature->type != SENSORS_FEATURE_IN)
 					&& (feature->type != SENSORS_FEATURE_FAN)
 					&& (feature->type != SENSORS_FEATURE_TEMP)
-					&& (feature->type != SENSORS_FEATURE_POWER))
+					&& (feature->type != SENSORS_FEATURE_POWER)
+					&& (feature->type != SENSORS_FEATURE_CURR))
 			{
 				DEBUG ("sensors plugin: sensors_load_conf: "
 						"Ignoring feature `%s', "
@@ -431,7 +438,8 @@ static int sensors_load_conf (void)
 				if ((subfeature->type != SENSORS_SUBFEATURE_IN_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_FAN_INPUT)
 						&& (subfeature->type != SENSORS_SUBFEATURE_TEMP_INPUT)
-						&& (subfeature->type != SENSORS_SUBFEATURE_POWER_INPUT))
+						&& (subfeature->type != SENSORS_SUBFEATURE_POWER_INPUT)
+						&& (subfeature->type != SENSORS_SUBFEATURE_CURR_INPUT))
 					continue;
 
 				fl = calloc (1, sizeof (*fl));
@@ -579,6 +587,9 @@ static int sensors_read (void)
 		else if (fl->feature->type
 				== SENSORS_FEATURE_POWER)
 			type = "power";
+		else if (fl->feature->type
+				== SENSORS_FEATURE_CURR)
+			type = "current";
 		else
 			continue;
 

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -131,10 +131,6 @@ static sensors_labeltypes_t known_features[] =
 	{ "2.0V", SENSOR_TYPE_VOLTAGE },
 	{ "12V", SENSOR_TYPE_VOLTAGE },
 	{ "power1", SENSOR_TYPE_POWER },
-	{ "curr1", SENSOR_TYPE_CURRENT },
-	{ "curr2", SENSOR_TYPE_CURRENT },
-	{ "curr3", SENSOR_TYPE_CURRENT },
-	{ "curr4", SENSOR_TYPE_CURRENT }
 };
 static int known_features_num = STATIC_ARRAY_SIZE (known_features);
 /* end new naming */

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -64,9 +64,7 @@ static char *sensor_type_name_map[] =
 	"temperature",
 # define SENSOR_TYPE_POWER       3
 	"power",
-# define SENSOR_TYPE_CURRENT     4
-	"current",
-# define SENSOR_TYPE_UNKNOWN     5
+# define SENSOR_TYPE_UNKNOWN     4
 	NULL
 };
 

--- a/src/types.db
+++ b/src/types.db
@@ -66,6 +66,7 @@ duration                seconds:GAUGE:0:U
 email_check             value:GAUGE:0:U
 email_count             value:GAUGE:0:U
 email_size              value:GAUGE:0:U
+energy			value:GAUGE:0:U
 entropy                 value:GAUGE:0:4294967295
 evicted_keys            value:DERIVE:0:U
 expired_keys            value:DERIVE:0:U


### PR DESCRIPTION
Four sensors are available with this patch.
Tested with axp209-isa-0000 on BananaPi-R1.
