### PR TITLE
Add metadata support for write_riemann

### DIFF
--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -746,3 +746,41 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
 
   return (0);
 } /* }}} int meta_data_as_string */
+
+int meta_data_list_keys (meta_data_t *md, meta_data_keys_t **keys) /* {{{ */
+{
+  meta_entry_t *e;
+  meta_data_keys_t *tmp;
+
+  if (md == NULL)
+    return (-EINVAL);
+
+  pthread_mutex_lock (&md->lock);
+
+  for (e = md->head; e != NULL; e = e->next)
+  {
+      tmp = malloc(sizeof(meta_data_keys_t *));
+      tmp->val = md_strdup(e->key);
+      tmp->next = *keys;
+      *keys = tmp;
+  }
+
+  pthread_mutex_unlock (&md->lock);
+  return (0);
+} /* }}} int meta_data_list_keys */
+
+
+void meta_data_free_list_keys (meta_data_keys_t **keys) /* {{{ */
+{
+    meta_data_keys_t *tmp = NULL;
+
+    while (*keys)
+    {
+	tmp = *keys;
+	*keys = (*keys)->next;
+	free(tmp->val);
+	free(tmp);
+    }
+} /* }}} void meta_data_free_list_keys */
+  
+/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/meta_data.h
+++ b/src/daemon/meta_data.h
@@ -46,6 +46,14 @@ meta_data_t *meta_data_clone(meta_data_t *orig);
 int meta_data_clone_merge(meta_data_t **dest, meta_data_t *orig);
 void meta_data_destroy(meta_data_t *md);
 
+struct meta_data_keys_s;
+typedef struct meta_data_keys_s meta_data_keys_t;
+struct meta_data_keys_s
+{
+    char		*val;
+    meta_data_keys_t	*next;
+};
+
 int meta_data_exists(meta_data_t *md, const char *key);
 int meta_data_type(meta_data_t *md, const char *key);
 int meta_data_toc(meta_data_t *md, char ***toc);
@@ -58,6 +66,8 @@ int meta_data_add_unsigned_int(meta_data_t *md, const char *key,
 int meta_data_add_double(meta_data_t *md, const char *key, double value);
 int meta_data_add_boolean(meta_data_t *md, const char *key, _Bool value);
 
+int meta_data_list_keys(meta_data_t *md, meta_data_keys_t **keys);
+void meta_data_free_list_keys(meta_data_keys_t **keys);
 int meta_data_get_string(meta_data_t *md, const char *key, char **value);
 int meta_data_get_signed_int(meta_data_t *md, const char *key, int64_t *value);
 int meta_data_get_unsigned_int(meta_data_t *md, const char *key,


### PR DESCRIPTION
Hi there,

@pyr @mfournier  following up our conversation from last time on irc here is a pull request to support MetaData in write_riemann plugin.

First time in a while I am writing C so it is probably far from perfect and not sure if what I propose to access all the metadata keys will suit you. I am ready for any feedback :)

I have added the function `meta_data_list_keys()` for the meta_data access. It is because I did not want to break what is currently done and expose `meta_entry_s`. So it basically give us a list of all the meta data keys so we can then use the already existing method without breaking the thread protection around it.
It sounds a bit redundant but I could not think on a better way to do it.

I have tested it and it works fine with riemann as I can see my extra attributes, in order to activate it here is a snippet of my config:

```
<Chain "PostCache">
        <Rule "cpu-send">
               <Match "regex">
                Plugin "^cpu$"

               </Match>
               <Target "set">
                 MetaDataSet "KEY1" "VAL1"
                 MetaDataSet "janus" "pralorantus"
               </Target>
               Target "write"
        </Rule>
       Target "stop"
</Chain>
```

Let me know what you think.
