### PR TITLE
Allow custom plugin name for 'curl', 'memcachec', 'tail' and 'tail_csv' plugins.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3542,6 +3542,7 @@ Synopsis of the configuration:
    <Page "plugin_instance">
      Server "localhost"
      Key "page_key"
+     PluginName "plugin_name"
      <Match>
        Regex "(\\d+) bytes sent"
        DSType CounterAdd
@@ -3568,6 +3569,11 @@ B<Page> block.
 =item B<Key> I<Key>
 
 When connected to the memcached server, asks for the page I<Key>.
+
+=item B<PluginName> I<PluginName>
+
+Use I<PluginName> as the plugin name when submitting values.
+Defaults to 'memcachec'.
 
 =item E<lt>B<Match>E<gt>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1611,6 +1611,7 @@ finance page and dispatch the value to collectd.
 
   <Plugin curl>
     <Page "stock_quotes">
+      PluginName "quotes"
       URL "http://finance.google.com/finance?q=NYSE%3AAMD"
       User "foo"
       Password "bar"
@@ -1641,6 +1642,11 @@ string argument to the B<Page> block is used as plugin instance.
 The following options are valid within B<Page> blocks:
 
 =over 4
+
+=item B<PluginName> I<PluginName>
+
+Use I<PluginName> as the plugin name when submitting values.
+Defaults to 'curl'.
 
 =item B<URL> I<URL>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1611,7 +1611,7 @@ finance page and dispatch the value to collectd.
 
   <Plugin curl>
     <Page "stock_quotes">
-      PluginName "quotes"
+      Plugin "quotes"
       URL "http://finance.google.com/finance?q=NYSE%3AAMD"
       User "foo"
       Password "bar"
@@ -1643,9 +1643,9 @@ The following options are valid within B<Page> blocks:
 
 =over 4
 
-=item B<PluginName> I<PluginName>
+=item B<Plugin> I<Plugin>
 
-Use I<PluginName> as the plugin name when submitting values.
+Use I<Plugin> as the plugin name when submitting values.
 Defaults to 'curl'.
 
 =item B<URL> I<URL>
@@ -3542,7 +3542,7 @@ Synopsis of the configuration:
    <Page "plugin_instance">
      Server "localhost"
      Key "page_key"
-     PluginName "plugin_name"
+     Plugin "plugin_name"
      <Match>
        Regex "(\\d+) bytes sent"
        DSType CounterAdd
@@ -3570,9 +3570,9 @@ B<Page> block.
 
 When connected to the memcached server, asks for the page I<Key>.
 
-=item B<PluginName> I<PluginName>
+=item B<Plugin> I<Plugin>
 
-Use I<PluginName> as the plugin name when submitting values.
+Use I<Plugin> as the plugin name when submitting values.
 Defaults to 'memcachec'.
 
 =item E<lt>B<Match>E<gt>
@@ -7531,7 +7531,7 @@ user using (extended) regular expressions, as described in L<regex(7)>.
 
   <Plugin "tail">
     <File "/var/log/exim4/mainlog">
-      PluginName "mail"
+      Plugin "mail"
       Instance "exim"
       Interval 60
       <Match>
@@ -7563,12 +7563,12 @@ The config consists of one or more B<File> blocks, each of which configures one
 logfile to parse. Within each B<File> block, there are one or more B<Match>
 blocks, which configure a regular expression to search for.
 
-The B<PluginName> and B<Instance> options in the B<File> block may be used to set
+The B<Plugin> and B<Instance> options in the B<File> block may be used to set
 the plugin name and instance respectively. So in the above example the plugin name
 C<mail-exim> would be used.
 
 These options are applied for all B<Match> blocks that B<follow> it, until the
-next B<PluginName> or B<Instance> option. This way you can extract several plugin
+next B<Plugin> or B<Instance> option. This way you can extract several plugin
 instances from one logfile, handy when parsing syslog and the like.
 
 The B<Interval> option allows you to define the length of time between reads. If
@@ -7750,7 +7750,7 @@ B<Synopsis:>
        Index 1
    </Metric>
    <File "/var/log/snort/snort.stats">
-       PluginName "snortstats"
+       Plugin "snortstats"
        Instance "eth0"
        Interval 600
        Collect "snort-dropped"
@@ -7803,9 +7803,9 @@ I<File> block but there can be multiple if you have multiple CSV files.
 
 =over 4
 
-=item B<PluginName> I<PluginName>
+=item B<Plugin> I<Plugin>
 
-Use I<PluginName> as the plugin name when submitting values.
+Use I<Plugin> as the plugin name when submitting values.
 Defaults to 'tail_csv'.
 
 =item B<Instance> I<PluginInstance>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7735,7 +7735,8 @@ B<Synopsis:>
        Index 1
    </Metric>
    <File "/var/log/snort/snort.stats">
-       Instance "snort-eth0"
+       PluginName "snortstats"
+       Instance "eth0"
        Interval 600
        Collect "snort-dropped"
    </File>
@@ -7786,6 +7787,11 @@ Each B<File> block represents one CSV file to read. There must be at least one
 I<File> block but there can be multiple if you have multiple CSV files.
 
 =over 4
+
+=item B<PluginName> I<PluginName>
+
+Use I<PluginName> as the plugin name when submitting values.
+Defaults to 'tail_csv'.
 
 =item B<Instance> I<PluginInstance>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7519,6 +7519,7 @@ user using (extended) regular expressions, as described in L<regex(7)>.
 
   <Plugin "tail">
     <File "/var/log/exim4/mainlog">
+      PluginName "mail"
       Instance "exim"
       Interval 60
       <Match>
@@ -7550,11 +7551,13 @@ The config consists of one or more B<File> blocks, each of which configures one
 logfile to parse. Within each B<File> block, there are one or more B<Match>
 blocks, which configure a regular expression to search for.
 
-The B<Instance> option in the B<File> block may be used to set the plugin
-instance. So in the above example the plugin name C<tail-foo> would be used.
-This plugin instance is for all B<Match> blocks that B<follow> it, until the
-next B<Instance> option. This way you can extract several plugin instances from
-one logfile, handy when parsing syslog and the like.
+The B<PluginName> and B<Instance> options in the B<File> block may be used to set
+the plugin name and instance respectively. So in the above example the plugin name
+C<mail-exim> would be used.
+
+These options are applied for all B<Match> blocks that B<follow> it, until the
+next B<PluginName> or B<Instance> option. This way you can extract several plugin
+instances from one logfile, handy when parsing syslog and the like.
 
 The B<Interval> option allows you to define the length of time between reads. If
 this is not set, the default Interval will be used.

--- a/src/curl.c
+++ b/src/curl.c
@@ -53,6 +53,7 @@ struct web_page_s;
 typedef struct web_page_s web_page_t;
 struct web_page_s /* {{{ */
 {
+  char *plugin_name;
   char *instance;
 
   char *url;
@@ -146,6 +147,7 @@ static void cc_web_page_free(web_page_t *wp) /* {{{ */
     curl_easy_cleanup(wp->curl);
   wp->curl = NULL;
 
+  sfree(wp->plugin_name);
   sfree(wp->instance);
 
   sfree(wp->url);
@@ -412,6 +414,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
     ERROR("curl plugin: calloc failed.");
     return -1;
   }
+  page->plugin_name = NULL;
   page->url = NULL;
   page->user = NULL;
   page->pass = NULL;
@@ -435,7 +438,9 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
 
-    if (strcasecmp("URL", child->key) == 0)
+    if (strcasecmp("PluginName", child->key) == 0)
+      status = cf_util_get_string(child, &page->plugin_name);
+    else if (strcasecmp("URL", child->key) == 0)
       status = cf_util_get_string(child, &page->url);
     else if (strcasecmp("User", child->key) == 0)
       status = cf_util_get_string(child, &page->user);
@@ -566,7 +571,8 @@ static void cc_submit(const web_page_t *wp, const web_match_t *wm, /* {{{ */
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy(vl.plugin, "curl", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (wp->plugin_name != NULL) ? wp->plugin_name : "curl",
+           sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, wp->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, wm->type, sizeof(vl.type));
   if (wm->instance != NULL)
@@ -581,7 +587,8 @@ static void cc_submit_response_code(const web_page_t *wp, long code) /* {{{ */
 
   vl.values = &(value_t){.gauge = (gauge_t)code};
   vl.values_len = 1;
-  sstrncpy(vl.plugin, "curl", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (wp->plugin_name != NULL) ? wp->plugin_name : "curl",
+           sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, wp->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, "response_code", sizeof(vl.type));
 
@@ -594,7 +601,8 @@ static void cc_submit_response_time(const web_page_t *wp, /* {{{ */
 
   vl.values = &(value_t){.gauge = response_time};
   vl.values_len = 1;
-  sstrncpy(vl.plugin, "curl", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (wp->plugin_name != NULL) ? wp->plugin_name : "curl",
+           sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, wp->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, "response_time", sizeof(vl.type));
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -438,7 +438,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
 
-    if (strcasecmp("PluginName", child->key) == 0)
+    if (strcasecmp("Plugin", child->key) == 0)
       status = cf_util_get_string(child, &page->plugin_name);
     else if (strcasecmp("URL", child->key) == 0)
       status = cf_util_get_string(child, &page->url);

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -304,8 +304,8 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
       status = cmc_config_add_string("Server", &page->server, child);
     else if (strcasecmp("Key", child->key) == 0)
       status = cmc_config_add_string("Key", &page->key, child);
-    else if (strcasecmp("PluginName", child->key) == 0)
-      status = cmc_config_add_string("PluginName", &page->plugin_name, child);
+    else if (strcasecmp("Plugin", child->key) == 0)
+      status = cmc_config_add_string("Plugin", &page->plugin_name, child);
     else if (strcasecmp("Match", child->key) == 0)
       /* Be liberal with failing matches => don't set `status'. */
       cmc_config_add_match(page, child);

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -51,6 +51,7 @@ struct web_page_s;
 typedef struct web_page_s web_page_t;
 struct web_page_s /* {{{ */
 {
+  char *plugin_name;
   char *instance;
 
   char *server;
@@ -94,6 +95,7 @@ static void cmc_web_page_free(web_page_t *wp) /* {{{ */
     memcached_free(wp->memc);
   wp->memc = NULL;
 
+  sfree(wp->plugin_name);
   sfree(wp->instance);
   sfree(wp->server);
   sfree(wp->key);
@@ -302,6 +304,8 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
       status = cmc_config_add_string("Server", &page->server, child);
     else if (strcasecmp("Key", child->key) == 0)
       status = cmc_config_add_string("Key", &page->key, child);
+    else if (strcasecmp("PluginName", child->key) == 0)
+      status = cmc_config_add_string("PluginName", &page->plugin_name, child);
     else if (strcasecmp("Match", child->key) == 0)
       /* Be liberal with failing matches => don't set `status'. */
       cmc_config_add_match(page, child);
@@ -407,7 +411,8 @@ static void cmc_submit(const web_page_t *wp, const web_match_t *wm, /* {{{ */
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy(vl.plugin, "memcachec", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (wp->plugin_name != NULL) ? wp->plugin_name : "memcachec",
+           sizeof (vl.plugin));
   sstrncpy(vl.plugin_instance, wp->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, wm->type, sizeof(vl.type));
   sstrncpy(vl.type_instance, wm->instance, sizeof(vl.type_instance));

--- a/src/tail.c
+++ b/src/tail.c
@@ -34,7 +34,8 @@
 /*
  *  <Plugin tail>
  *    <File "/var/log/exim4/mainlog">
- *	Instance "exim"
+ *      PluginName "mail"
+ *      Instance "exim"
  *      Interval 60
  *	<Match>
  *	  Regex "S=([1-9][0-9]*)"
@@ -134,6 +135,7 @@ static int ctail_config_add_match_dstype(ctail_config_match_t *cm,
 } /* int ctail_config_add_match_dstype */
 
 static int ctail_config_add_match(cu_tail_match_t *tm,
+                                  const char *plugin_name,
                                   const char *plugin_instance,
                                   oconfig_item_t *ci, cdtime_t interval) {
   ctail_config_match_t cm = {0};
@@ -191,7 +193,8 @@ static int ctail_config_add_match(cu_tail_match_t *tm,
   if (status == 0) {
     // TODO(octo): there's nothing "simple" about the latency stuff …
     status = tail_match_add_match_simple(
-        tm, cm.regex, cm.excluderegex, cm.flags, "tail", plugin_instance,
+        tm, cm.regex, cm.excluderegex, cm.flags,
+        (plugin_name != NULL) ? plugin_name : "tail", plugin_instance,
         cm.type, cm.type_instance, cm.latency, interval);
 
     if (status != 0)
@@ -210,6 +213,7 @@ static int ctail_config_add_match(cu_tail_match_t *tm,
 static int ctail_config_add_file(oconfig_item_t *ci) {
   cu_tail_match_t *tm;
   cdtime_t interval = 0;
+  char *plugin_name = NULL;
   char *plugin_instance = NULL;
   int num_matches = 0;
 
@@ -229,12 +233,15 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
     oconfig_item_t *option = ci->children + i;
     int status = 0;
 
-    if (strcasecmp("Instance", option->key) == 0)
+    if (strcasecmp("PluginName", option->key) == 0)
+      status = cf_util_get_string (option, &plugin_name);
+    else if (strcasecmp("Instance", option->key) == 0)
       status = cf_util_get_string(option, &plugin_instance);
     else if (strcasecmp("Interval", option->key) == 0)
       cf_util_get_cdtime(option, &interval);
     else if (strcasecmp("Match", option->key) == 0) {
-      status = ctail_config_add_match(tm, plugin_instance, option, interval);
+      status = ctail_config_add_match(tm, plugin_name, plugin_instance, option,
+                                      interval);
       if (status == 0)
         num_matches++;
       /* Be mild with failed matches.. */
@@ -247,6 +254,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
       break;
   } /* for (i = 0; i < ci->children_num; i++) */
 
+  sfree(plugin_name);
   sfree(plugin_instance);
 
   if (num_matches == 0) {

--- a/src/tail.c
+++ b/src/tail.c
@@ -34,7 +34,7 @@
 /*
  *  <Plugin tail>
  *    <File "/var/log/exim4/mainlog">
- *      PluginName "mail"
+ *      Plugin "mail"
  *      Instance "exim"
  *      Interval 60
  *	<Match>
@@ -233,7 +233,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
     oconfig_item_t *option = ci->children + i;
     int status = 0;
 
-    if (strcasecmp("PluginName", option->key) == 0)
+    if (strcasecmp("Plugin", option->key) == 0)
       status = cf_util_get_string (option, &plugin_name);
     else if (strcasecmp("Instance", option->key) == 0)
       status = cf_util_get_string(option, &plugin_instance);

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -451,7 +451,7 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
       cf_util_get_cdtime(option, &id->interval);
     else if (strcasecmp("TimeFrom", option->key) == 0)
       status = tcsv_config_get_index(option, &id->time_from);
-    else if (strcasecmp("PluginName", option->key) == 0)
+    else if (strcasecmp("Plugin", option->key) == 0)
       status = cf_util_get_string(option, &id->plugin_name);
     else {
       WARNING("tail_csv plugin: Option `%s' not allowed here.", option->key);

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -44,6 +44,7 @@ struct metric_definition_s {
 typedef struct metric_definition_s metric_definition_t;
 
 struct instance_definition_s {
+  char *plugin_name;
   char *instance;
   char *path;
   cu_tail_t *tail;
@@ -67,7 +68,8 @@ static int tcsv_submit(instance_definition_t *id, metric_definition_t *md,
   vl.values_len = 1;
   vl.values = &v;
 
-  sstrncpy(vl.plugin, "tail_csv", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, (id->plugin_name != NULL) ? id->plugin_name : "tail_csv",
+           sizeof(vl.plugin));
   if (id->instance != NULL)
     sstrncpy(vl.plugin_instance, id->instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, md->type, sizeof(vl.type));
@@ -358,6 +360,7 @@ static void tcsv_instance_definition_destroy(void *arg) {
     cu_tail_destroy(id->tail);
   id->tail = NULL;
 
+  sfree(id->plugin_name);
   sfree(id->instance);
   sfree(id->path);
   sfree(id->metric_list);
@@ -420,6 +423,7 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
   id = calloc(1, sizeof(*id));
   if (id == NULL)
     return -1;
+  id->plugin_name = NULL;
   id->instance = NULL;
   id->path = NULL;
   id->metric_list = NULL;
@@ -447,6 +451,8 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
       cf_util_get_cdtime(option, &id->interval);
     else if (strcasecmp("TimeFrom", option->key) == 0)
       status = tcsv_config_get_index(option, &id->time_from);
+    else if (strcasecmp("PluginName", option->key) == 0)
+      status = cf_util_get_string(option, &id->plugin_name);
     else {
       WARNING("tail_csv plugin: Option `%s' not allowed here.", option->key);
       status = -1;


### PR DESCRIPTION
Like added in  #1558 and #1563 , added option 'PluginName' to other Collectd plugins:

tail plugin: Allow custom plugin name for file instances
tail_csv: Allow custom plugin name for file instances
curl plugin: Allow custom plugin name for each Page block
memcachec: Allow custom plugin name for each Page block
