### PR TITLE
Adding mysql Open Table stats. Fixes #979

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -904,6 +904,20 @@ static int mysql_read (user_data_t *ud)
 				counter_submit ("mysql_sort", "scan", val, db);
 
 		}
+        else if (strncmp (key, "Open_", strlen ("Open_")) == 0)
+        {
+            if (strcmp (key, "Open_table_definitions") == 0)
+                gauge_submit ("mysql_open_table_definitions", "open", val, db);
+            else if (strcmp (key, "Open_tables") == 0)
+                gauge_submit ("mysql_open_tables", "open", val, db);
+        }
+        else if (strncmp (key, "Opened_", strlen ("Opened_")) == 0)
+        {
+            if (strcmp (key, "Opened_table_definitions") == 0)
+                counter_submit ("mysql_opened_table_definitions", "opened", val, db);
+            else if (strcmp (key, "Opened_tables") == 0)
+                counter_submit ("mysql_opened_tables", "opened", val, db);
+        }
 	}
 	mysql_free_result (res); res = NULL;
 

--- a/src/types.db
+++ b/src/types.db
@@ -126,6 +126,10 @@ mysql_innodb_row_lock   value:DERIVE:0:U
 mysql_innodb_rows       value:DERIVE:0:U
 mysql_locks             value:DERIVE:0:U
 mysql_log_position      value:DERIVE:0:U
+mysql_open_table_definitions        value:GAUGE:0:U
+mysql_open_tables                   value:GAUGE:0:U
+mysql_opened_table_definitions      value:DERIVE:0:U
+mysql_opened_tables                 value:DERIVE:0:U
 mysql_octets            rx:DERIVE:0:U, tx:DERIVE:0:U
 mysql_select            value:DERIVE:0:U
 mysql_sort              value:DERIVE:0:U


### PR DESCRIPTION
This pull request adds support for [open_tables](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Open_tables), [open_table_definitions](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Open_table_definitions), [opened_tables](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Opened_tables), and [opened_table_definitions](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Opened_table_definitions)

I have tested locally with mysql:5.7.12

Example output:
```
{"values":[105],"dstypes":["gauge"],"dsnames":["value"],"time":1462236936.270,"interval":10.000,"host":"192.168.99.100","plugin":"mysql","plugin_instance":"foo","type":"mysql_open_table_definitions","type_instance":"open"},{"values":[114],"dstypes":["gauge"],"dsnames":["value"],"time":1462236936.270,"interval":10.000,"host":"192.168.99.100","plugin":"mysql","plugin_instance":"foo","type":"mysql_open_tables","type_instance":"open"},{"values":[105],"dstypes":["derive"],"dsnames":["value"],"time":1462236936.270,"interval":10.000,"host":"192.168.99.100","plugin":"mysql","plugin_instance":"foo","type":"mysql_opened_table_definitions","type_instance":"opened"},{"values":[121],"dstypes":["derive"],"dsnames":["value"],"time":1462236936.270,"interval":10.000,"host":"192.168.99.100","plugin":"mysql","plugin_instance":"foo","type":"mysql_opened_tables","type_instance":"opened"}
```