### PR TITLE
write_kafka: reliability when no key provided

### DIFF
--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -202,6 +202,8 @@ static int kafka_write(const data_set_t *ds, /* {{{ */
     key = ctx->key;
     if (key != NULL)
         keylen = strlen (key);
+    else
+        keylen = 0;
 
     rd_kafka_produce(ctx->topic, RD_KAFKA_PARTITION_UA,
                      RD_KAFKA_MSG_F_COPY, buffer, blen,
@@ -252,6 +254,7 @@ static void kafka_config_topic(rd_kafka_conf_t *conf, oconfig_item_t *ci) /* {{{
     tctx->escape_char = '.';
     tctx->store_rates = 1;
     tctx->format = KAFKA_FORMAT_JSON;
+    tctx->key = NULL;
 
     if ((tctx->kafka_conf = rd_kafka_conf_dup(conf)) == NULL) {
         sfree(tctx);
@@ -315,6 +318,7 @@ static void kafka_config_topic(rd_kafka_conf_t *conf, oconfig_item_t *ci) /* {{{
 
         } else if (strcasecmp ("Key", child->key) == 0)  {
             cf_util_get_string (child, &tctx->key);
+            assert (tctx->key != NULL);
         } else if (strcasecmp ("Format", child->key) == 0) {
             status = cf_util_get_string(child, &key);
             if (status != 0)


### PR DESCRIPTION
Ensure that we don't break when no key is provided.