### PR TITLE
exec plugin : kill correct pid on fdopen failure

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -742,8 +742,7 @@ static void *exec_notification_one (void *arg) /* {{{ */
     char errbuf[1024];
     ERROR ("exec plugin: fdopen (%i) failed: %s", fd,
         sstrerror (errno, errbuf, sizeof (errbuf)));
-    kill (pl->pid, SIGTERM);
-    pl->pid = 0;
+    kill (pid, SIGTERM);
     close (fd);
     sfree (arg);
     pthread_exit ((void *) 1);


### PR DESCRIPTION
Hi there,

hopefully I havn't misunderstood somthing here - but it looks like the wrong pid is been killed during error handling in the NotificationExec code.

Al far as I can see, pl->pid is always 0 at this line : https://github.com/collectd/collectd/blob/master/src/exec.c#L745

which means SIGTERM "is sent to every process in the process group of the calling process"  (man 2 kill)

Thanks.
