### PR TITLE
apcups plugin: Change "PersistentConnection" option default value depending on poll Interval.

### DIFF
--- a/src/apcups.c
+++ b/src/apcups.c
@@ -378,6 +378,7 @@ static int apc_query_server (char const *node, char const *service,
 static int apcups_config (oconfig_item_t *ci)
 {
 	int i;
+	_Bool persistent_conn_set = 0;
 
 	for (i = 0; i < ci->children_num; i++)
 	{
@@ -389,10 +390,23 @@ static int apcups_config (oconfig_item_t *ci)
 			cf_util_get_service (child, &conf_service);
 		else if (strcasecmp (child->key, "ReportSeconds") == 0)
 			cf_util_get_boolean (child, &conf_report_seconds);
-		else if (strcasecmp (child->key, "PersistentConnection") == 0)
+		else if (strcasecmp (child->key, "PersistentConnection") == 0) {
 			cf_util_get_boolean (child, &conf_persistent_conn);
+			persistent_conn_set = 1;
+		}
 		else
 			ERROR ("apcups plugin: Unknown config option \"%s\".", child->key);
+	}
+
+	if (!persistent_conn_set) {
+		double interval = CDTIME_T_TO_DOUBLE(plugin_get_interval());
+		if (interval > 15.0) {
+			NOTICE ("apcups plugin: Plugin poll interval set to %.3f seconds. "
+				"Apcupsd NIS socket timeout is 15 seconds, "
+				"PersistentConnection disabled by default.",
+				interval);
+			conf_persistent_conn = 0;
+		}
 	}
 
 	return (0);

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -322,9 +322,6 @@ static int apc_query_server (char const *node, char const *service,
 		printf ("net_recv = `%s';\n", recvline);
 #endif /* if APCMAIN */
 
-		if (strncmp ("END APC", recvline, strlen ("END APC")) == 0)
-			break;
-
 		toksaveptr = NULL;
 		tokptr = strtok_r (recvline, " :\t", &toksaveptr);
 		while (tokptr != NULL)

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -834,13 +834,15 @@ default for backwards compatibility, the time will be reported in minutes.
 
 =item B<PersistentConnection> B<true>|B<false>
 
-By default, the plugin will try to keep the connection to UPS open between
-reads. Since this appears to be somewhat brittle (I<apcupsd> appears to close
-the connection due to inactivity quite quickly), the plugin will try to detect
-this problem and switch to an open-read-close mode in such cases.
+The plugin is designed to keep the connection to I<apcupsd> open between reads.
+If plugin poll interval is greater than 15 seconds (hardcoded socket close
+timeout in I<apcupsd> NIS), then this option is B<false> by default.
 
 You can instruct the plugin to close the connection after each read by setting
-this option to B<false>.
+this option to B<false> or force keeping the connection by setting it to B<true>.
+
+If I<apcupsd> appears to close the connection due to inactivity quite quickly,
+the plugin will try to detect this problem and switch to an open-read-close mode.
 
 =back
 


### PR DESCRIPTION
This PR fixes core problem of #617 and reverts fb075e15e3400afdb691b88f1e1a4a38578aaba9 which causes problem, described in #1607.