### PR TITLE
statsd plugin: Fix deadlock on plugin shutdown (Issue #1703)

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -955,8 +955,6 @@ static int statsd_shutdown (void) /* {{{ */
   void *key;
   void *value;
 
-  pthread_mutex_lock (&metrics_lock);
-
   if (network_thread_running)
   {
     network_thread_shutdown = 1;
@@ -964,6 +962,8 @@ static int statsd_shutdown (void) /* {{{ */
     pthread_join (network_thread, /* retval = */ NULL);
   }
   network_thread_running = 0;
+
+  pthread_mutex_lock (&metrics_lock);
 
   while (c_avl_pick (metrics_tree, &key, &value) == 0)
   {


### PR DESCRIPTION
This is a patch for #1703. This is a bugfix and should be applied to all supported Collectd versions.

statsd_shutdown() holds metrics_lock before setting 'network_thread_shutdown' to 1.
So, statsd_network_thread() unable to finish work as it is awaiting same lock in
statsd_network_thread() -> statsd_network_read() -> statsd_parse_buffer() -> statsd_parse_line() -> statsd_handle_() -> statsd_metric_().

network_thread_shutdown must be set to 1 before aquiring metrics_lock in statsd_shutdown()
After that, pthread_join() will wait for statsd_network_thread() to finish. While this many 'lines' from may 'fd' buffers can be parsed by statsd_parse_line() and this can aquire 'metrics_lock' many times without lockup. After statsd_network_thread() finished statsd_shutdown() can aquire 'metrics_lock' and free 'metrics_tree'.