### PR TITLE
Postgresql plugin: set plugin instance from query results.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5191,6 +5191,12 @@ specific or global B<Interval> options).
 Please note that parameters are only supported by PostgreSQL's protocol
 version 3 and above which was introduced in version 7.4 of PostgreSQL.
 
+=item B<PluginInstanceFrom> I<column>
+
+Specify how to create the "PluginInstance" for reporting this query results.
+Only one column is supported. You may concatenate fields and string values in
+the query statement to get the required results.
+
 =item B<MinVersion> I<version>
 
 =item B<MaxVersion> I<version>
@@ -5425,6 +5431,8 @@ Specify the plugin instance name that should be used instead of the database
 name (which is the default, if this option has not been specified). This
 allows to query multiple databases of the same name on the same host (e.g.
 when running multiple database server versions in parallel).
+The plugin instance name can also be set from the query result using
+the B<PluginInstanceFrom> option in B<Query> block.
 
 =item B<Host> I<hostname>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5131,13 +5131,12 @@ The B<Query> block defines one database query which may later be used by a
 database definition. It accepts a single mandatory argument which specifies
 the name of the query. The names of all queries have to be unique (see the
 B<MinVersion> and B<MaxVersion> options below for an exception to this
-rule). The following configuration options are available to define the query:
+rule).
 
-In each B<Query> block, there is one or more B<Result> blocks. B<Result>
-blocks define how to handle the values returned from the query. They define
-which column holds which value and how to dispatch that value to the daemon.
-Multiple B<Result> blocks may be used to extract multiple values from a single
-query.
+In each B<Query> block, there is one or more B<Result> blocks. Multiple
+B<Result> blocks may be used to extract multiple values from a single query.
+
+The following configuration options are available to define the query:
 
 =over 4
 
@@ -5155,7 +5154,7 @@ allowed as long as a single non-empty command has been specified only.
 
 The returned lines will be handled separately one after another.
 
-=item B<Param> I<hostname>|I<database>|I<username>|I<interval>
+=item B<Param> I<hostname>|I<database>|I<instance>|I<username>|I<interval>
 
 Specify the parameters which should be passed to the SQL query. The parameters
 are referred to in the SQL query as B<$1>, B<$2>, etc. in the same order as
@@ -5192,6 +5191,28 @@ specific or global B<Interval> options).
 Please note that parameters are only supported by PostgreSQL's protocol
 version 3 and above which was introduced in version 7.4 of PostgreSQL.
 
+=item B<MinVersion> I<version>
+
+=item B<MaxVersion> I<version>
+
+Specify the minimum or maximum version of PostgreSQL that this query should be
+used with. Some statistics might only be available with certain versions of
+PostgreSQL. This allows you to specify multiple queries with the same name but
+which apply to different versions, thus allowing you to use the same
+configuration in a heterogeneous environment.
+
+The I<version> has to be specified as the concatenation of the major, minor
+and patch-level versions, each represented as two-decimal-digit numbers. For
+example, version 8.2.3 will become 80203.
+
+=back
+
+The B<Result> block defines how to handle the values returned from the query.
+It defines which column holds which value and how to dispatch that value to
+the daemon.
+
+=over 4
+
 =item B<Type> I<type>
 
 The I<type> name to be used when dispatching the values. The type describes
@@ -5199,7 +5220,7 @@ how to handle the data and where to store it. See L<types.db(5)> for more
 details on types and their configuration. The number and type of values (as
 selected by the B<ValuesFrom> option) has to match the type of the given name.
 
-This option is required inside a B<Result> block.
+This option is mandatory.
 
 =item B<InstancePrefix> I<prefix>
 
@@ -5234,20 +5255,6 @@ by the plugin as well.
 This option is required inside a B<Result> block and may be specified multiple
 times. If multiple B<ValuesFrom> options are specified, the columns are read
 in the given order.
-
-=item B<MinVersion> I<version>
-
-=item B<MaxVersion> I<version>
-
-Specify the minimum or maximum version of PostgreSQL that this query should be
-used with. Some statistics might only be available with certain versions of
-PostgreSQL. This allows you to specify multiple queries with the same name but
-which apply to different versions, thus allowing you to use the same
-configuration in a heterogeneous environment.
-
-The I<version> has to be specified as the concatenation of the major, minor
-and patch-level versions, each represented as two-decimal-digit numbers. For
-example, version 8.2.3 will become 80203.
 
 =back
 


### PR DESCRIPTION
Hi!

Proposed patches adds ability to set plugin instance from query.
This feature is useful for generic plugins.

Example:

````
<Query instance_summary>
        Statement "SELECT 'summary' as instance,\
        sum(numbackends) as numbackends, \
        sum(xact_commit) as xact_commit, \
        sum(xact_rollback) as xact_rollback, \
        sum(blks_read) as blks_read, \
        sum(blks_hit) as blks_hit, \
        sum(tup_returned) as tup_returned, \
        sum(tup_fetched) as tup_fetched, \
        sum(tup_inserted) as tup_inserted, \
        sum(tup_updated) as tup_updated, \
        sum(tup_deleted) as tup_deleted \
        FROM pg_stat_database"

        PluginInstanceFrom "instance"

        #TODO: types should have '_summary' suffix
        <Result>
                Type "pg_numbackends"
                ValuesFrom "numbackends"
        </Result>
        #
        <Result>
                Type "pg_xact"
                InstancePrefix "commit"
                ValuesFrom "xact_commit"
        </Result>
        <Result>
                Type "pg_xact"
                InstancePrefix "rollback"
                ValuesFrom "xact_rollback"
        </Result>
        #
        <Result>
                Type "pg_blks"
                InstancePrefix "blks_read"
                ValuesFrom "blks_read"
        </Result>
        <Result>
                Type "pg_blks"
                InstancePrefix "blks_hit"
                ValuesFrom "blks_hit"
        </Result>
        #
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_returned"
                ValuesFrom "tup_returned"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_fetched"
                ValuesFrom "tup_fetched"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_inserted"
                ValuesFrom "tup_inserted"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_updated"
                ValuesFrom "tup_updated"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_deleted"
                ValuesFrom "tup_deleted"
        </Result>
</Query>
<Query instance_bydb>
        Statement "SELECT datname, \
        numbackends, \
        xact_commit, xact_rollback, \
        blks_read, blks_hit, \
        tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted \
        FROM pg_stat_database WHERE datname <> 'template0'"

        PluginInstanceFrom "datname"

        #TODO: types should have '_summary' suffix
        <Result>
                Type "pg_numbackends"
                ValuesFrom "numbackends"
        </Result>
        #
        <Result>
                Type "pg_xact"
                InstancePrefix "commit"
                ValuesFrom "xact_commit"
        </Result>
        <Result>
                Type "pg_xact"
                InstancePrefix "rollback"
                ValuesFrom "xact_rollback"
        </Result>
        #
        <Result>
                Type "pg_blks"
                InstancePrefix "blks_read"
                ValuesFrom "blks_read"
        </Result>
        <Result>
                Type "pg_blks"
                InstancePrefix "blks_hit"
                ValuesFrom "blks_hit"
        </Result>
        #
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_returned"
                ValuesFrom "tup_returned"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_fetched"
               ValuesFrom "tup_fetched"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_inserted"
                ValuesFrom "tup_inserted"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_updated"
                ValuesFrom "tup_updated"
        </Result>
        <Result>
                Type "pg_scan"
                InstancePrefix "tup_deleted"
                ValuesFrom "tup_deleted"
        </Result>
</Query>
        <Database template1>
                Host "localhost"
                Port 5432
                User "postgres"
                Password "CHANGEME"
                Query instance_summary
                Query instance_bydb
        </Database>
</Plugin>
````