### PR TITLE
Perl plugin fixes for #1706

### DIFF
--- a/src/perl.c
+++ b/src/perl.c
@@ -2168,11 +2168,6 @@ static int perl_shutdown (void)
 			nanosleep (&ts_wait, NULL);
 		}
 		if (thr->running) {
-			/* This will crash collectd process later due to PERL_SYS_TERM() */
-			//ERROR ("perl shutdown: thread hangs inside perl. "
-			//       "Skipped perl interpreter destroy.");
-			//continue;
-			
 			ERROR ("perl shutdown: thread hangs inside perl. Thread killed.");
 			pthread_kill (thr->pthread, SIGTERM);
 		}


### PR DESCRIPTION
* lock base thread interpreter in perl_init() too, to avoid race conditions with c_ithread_create() called from threads of already-initialized plugins. (with deadlock when perl_log() called from perl_init() detection)
* Fix coredump due to destroying interpreter on thread running perl.

See #1706 for comments.