### PR TITLE
add PersistFrequency option to the threshold plugin

### DIFF
--- a/src/collectd-threshold.pod
+++ b/src/collectd-threshold.pod
@@ -76,6 +76,9 @@ information.
      <Type "cpu">
        Instance "idle"
        FailureMin 10
+       Persist true
+       PersistOK true
+       PersistFrequency 30
      </Type>
    
      <Plugin "memory">
@@ -162,6 +165,20 @@ Sets how OKAY notifications act. If set to B<true> one notification will be
 generated for each value that is in the acceptable range. If set to B<false>
 (the default) then a notification is only generated if a value is in range but
 the previous value was not.
+
+=item B<PersistFrequency> I<Value>
+
+Sets how often notifications are generated if B<Persist> or B<PersistOK> is set
+to B<true>. This defaults to B<0>, which means every time a value comes in, a 
+notification is dispatched.
+If set to a positive integer, persistent notifications are suppressed that number
+of B<Interval>s before dispatching the next notification.
+This can be seen as a way to rate limmit dispached persistent notifications while
+still alert on state changes immediately.
+Be aware, that due to the fact that most of your metrics are within the OK range
+most of the time, the B<PersistOK> setting combined with the B<PersistFrequency>
+feature will lead to bursts of notifications every B<PersistFrequency> times the
+B<Interval> after collectd startup.
 
 =item B<Percentage> B<true>|B<false>
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -690,7 +690,7 @@ int uc_set_state (const data_set_t *ds, const value_list_t *vl, int state)
 
   if (FORMAT_VL (name, sizeof (name), vl) != 0)
   {
-    ERROR ("uc_get_state: FORMAT_VL failed.");
+    ERROR ("uc_set_state: FORMAT_VL failed.");
     return (STATE_ERROR);
   }
 
@@ -798,7 +798,7 @@ int uc_get_hits (const data_set_t *ds, const value_list_t *vl)
 
   if (FORMAT_VL (name, sizeof (name), vl) != 0)
   {
-    ERROR ("uc_get_state: FORMAT_VL failed.");
+    ERROR ("uc_get_hits: FORMAT_VL failed.");
     return (STATE_ERROR);
   }
 
@@ -823,7 +823,7 @@ int uc_set_hits (const data_set_t *ds, const value_list_t *vl, int hits)
 
   if (FORMAT_VL (name, sizeof (name), vl) != 0)
   {
-    ERROR ("uc_get_state: FORMAT_VL failed.");
+    ERROR ("uc_set_hits: FORMAT_VL failed.");
     return (STATE_ERROR);
   }
 
@@ -849,7 +849,7 @@ int uc_inc_hits (const data_set_t *ds, const value_list_t *vl, int step)
 
   if (FORMAT_VL (name, sizeof (name), vl) != 0)
   {
-    ERROR ("uc_get_state: FORMAT_VL failed.");
+    ERROR ("uc_inc_hits: FORMAT_VL failed.");
     return (STATE_ERROR);
   }
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -51,6 +51,7 @@ typedef struct cache_entry_s
 	cdtime_t interval;
 	int state;
 	int hits;
+	int persist_frequency;
 
 	/*
 	 * +-----+-----+-----+-----+-----+-----+-----+-----+-----+----
@@ -866,6 +867,83 @@ int uc_inc_hits (const data_set_t *ds, const value_list_t *vl, int step)
 
   return (ret);
 } /* int uc_inc_hits */
+
+int uc_get_persist_frequency (const data_set_t *ds, const value_list_t *vl)
+{
+  char name[6 * DATA_MAX_NAME_LEN];
+  cache_entry_t *ce = NULL;
+  int ret = STATE_ERROR;
+
+  if (FORMAT_VL (name, sizeof (name), vl) != 0)
+  {
+    ERROR ("uc_get_persist_frequency: FORMAT_VL failed.");
+    return (STATE_ERROR);
+  }
+
+  pthread_mutex_lock (&cache_lock);
+
+  if (c_avl_get (cache_tree, name, (void *) &ce) == 0)
+  {
+    assert (ce != NULL);
+    ret = ce->persist_frequency;
+  }
+
+  pthread_mutex_unlock (&cache_lock);
+
+  return (ret);
+} /* int uc_get_persist_frequency */
+
+int uc_set_persist_frequency (const data_set_t *ds, const value_list_t *vl, int persist_frequency)
+{
+  char name[6 * DATA_MAX_NAME_LEN];
+  cache_entry_t *ce = NULL;
+  int ret = -1;
+
+  if (FORMAT_VL (name, sizeof (name), vl) != 0)
+  {
+    ERROR ("uc_set_persist_frequency: FORMAT_VL failed.");
+    return (STATE_ERROR);
+  }
+
+  pthread_mutex_lock (&cache_lock);
+
+  if (c_avl_get (cache_tree, name, (void *) &ce) == 0)
+  {
+    assert (ce != NULL);
+    ret = ce->persist_frequency;
+    ce->persist_frequency = persist_frequency;
+  }
+
+  pthread_mutex_unlock (&cache_lock);
+
+  return (ret);
+} /* int uc_set_persist_frequency */
+
+int uc_inc_persist_frequency (const data_set_t *ds, const value_list_t *vl, int step)
+{
+  char name[6 * DATA_MAX_NAME_LEN];
+  cache_entry_t *ce = NULL;
+  int ret = -1;
+
+  if (FORMAT_VL (name, sizeof (name), vl) != 0)
+  {
+    ERROR ("uc_inc_persist_frequency: FORMAT_VL failed.");
+    return (STATE_ERROR);
+  }
+
+  pthread_mutex_lock (&cache_lock);
+
+  if (c_avl_get (cache_tree, name, (void *) &ce) == 0)
+  {
+    assert (ce != NULL);
+    ret = ce->persist_frequency;
+    ce->persist_frequency = ret + step;
+  }
+
+  pthread_mutex_unlock (&cache_lock);
+
+  return (ret);
+} /* int uc_inc_persist_frequency */
 
 /*
  * Meta data interface

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -48,6 +48,9 @@ int uc_set_state (const data_set_t *ds, const value_list_t *vl, int state);
 int uc_get_hits (const data_set_t *ds, const value_list_t *vl);
 int uc_set_hits (const data_set_t *ds, const value_list_t *vl, int hits);
 int uc_inc_hits (const data_set_t *ds, const value_list_t *vl, int step);
+int uc_get_persist_frequency (const data_set_t *ds, const value_list_t *vl);
+int uc_set_persist_frequency (const data_set_t *ds, const value_list_t *vl, int persist_frequency);
+int uc_inc_persist_frequency (const data_set_t *ds, const value_list_t *vl, int step);
 
 int uc_get_history (const data_set_t *ds, const value_list_t *vl,
     gauge_t *ret_history, size_t num_steps, size_t num_ds);

--- a/src/daemon/utils_threshold.h
+++ b/src/daemon/utils_threshold.h
@@ -47,6 +47,7 @@ typedef struct threshold_s
   gauge_t hysteresis;
   unsigned int flags;
   int hits;
+  int persist_frequency;
   struct threshold_s *next;
 } threshold_t;
 

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -201,6 +201,23 @@ static int ut_config_type_hits (threshold_t *th, oconfig_item_t *ci)
   return (0);
 } /* int ut_config_type_hits */
 
+static int ut_config_type_persist_frequency (threshold_t *th, oconfig_item_t *ci)
+{
+  if ((ci->values_num != 1)
+      || (ci->values[0].type != OCONFIG_TYPE_NUMBER))
+  {
+    WARNING ("threshold values: The `%s' option needs exactly one "
+      "number argument.", ci->key);
+    return (-1);
+  }
+
+  th->persist_frequency = ci->values[0].value.number;
+  DEBUG("ut_config_type_persist_frequency: th->persist_frequency = %d",
+      th->persist_frequency);
+
+  return (0);
+} /* int ut_config_type_persist_frequency */
+
 static int ut_config_type_hysteresis (threshold_t *th, oconfig_item_t *ci)
 {
   if ((ci->values_num != 1)
@@ -245,6 +262,7 @@ static int ut_config_type (const threshold_t *th_orig, oconfig_item_t *ci)
   th.failure_max = NAN;
   th.hits = 0;
   th.hysteresis = 0;
+  th.persist_frequency = 0;
   th.flags = UT_FLAG_INTERESTING; /* interesting by default */
 
   for (i = 0; i < ci->children_num; i++)
@@ -269,6 +287,8 @@ static int ut_config_type (const threshold_t *th_orig, oconfig_item_t *ci)
       status = cf_util_get_flag (option, &th.flags, UT_FLAG_PERSIST);
     else if (strcasecmp ("PersistOK", option->key) == 0)
       status = cf_util_get_flag (option, &th.flags, UT_FLAG_PERSIST_OK);
+    else if (strcasecmp ("PersistFrequency", option->key) == 0)
+      status = ut_config_type_persist_frequency (&th, option);
     else if (strcasecmp ("Percentage", option->key) == 0)
       status = cf_util_get_flag (option, &th.flags, UT_FLAG_PERCENTAGE);
     else if (strcasecmp ("Hits", option->key) == 0)
@@ -447,14 +467,27 @@ static int ut_report_state (const data_set_t *ds,
 
   state_old = uc_get_state (ds, vl);
 
-  /* If the state didn't change, report if `persistent' is specified. If the
-   * state is `okay', then only report if `persist_ok` flag is set. */
+  DEBUG("ut_report_state: th->persist_frequency = %d, uc_get_persist_frequency = %d",
+      th->persist_frequency, uc_get_persist_frequency(ds,vl));
+
+  /* If the state didn't change, report if `persistent' is specified. 
+   * But only if persist_frequency threshold is reached.
+   * If the state is `okay', then only report if `persist_ok` flag is set
+   * and persist_frequency threshold is reached. */
   if (state == state_old)
   {
-    if ((th->flags & UT_FLAG_PERSIST) == 0)
+    if ( (th->flags & UT_FLAG_PERSIST) == 0 )
       return (0);
     else if ( (state == STATE_OKAY) && ((th->flags & UT_FLAG_PERSIST_OK) == 0) )
       return (0);
+    else if ( th->persist_frequency == 0 )
+      ; /* persist_frequency is 'always', therefore notify */
+    else if ( uc_get_persist_frequency(ds,vl) > th->persist_frequency )
+      uc_set_persist_frequency(ds,vl,0); /* reset persist_frequency counter and notify */
+    else {
+      (void) uc_inc_persist_frequency(ds,vl,1); /* increase persist_frequency counter */
+      return (0);
+    }
   }
 
   if (state != state_old)
@@ -893,6 +926,9 @@ static int ut_config (oconfig_item_t *ci)
 
   th.hits = 0;
   th.hysteresis = 0;
+  th.persist_frequency = 0;
+  DEBUG("ut_config: th.persist_frequency = %d",
+      th.persist_frequency);
   th.flags = UT_FLAG_INTERESTING; /* interesting by default */
 
   for (i = 0; i < ci->children_num; i++)


### PR DESCRIPTION
Hello,
I've implemented a feature to limit the amount of notifications that the threshold plugin generates when the persist(ok) option is set.
The feature is documented and implemented similar to the hits feature.
From my point of view the feature has the flaw of being bursty, but that's documented and still better than not having the feature at all.

The flaw described: I set the PersistFrequency option to whatever value and get notifications every "frequency" in bursts for all the OK threshold checks after collectd start.

I'd like to spread out those bursts via starting with a random(frequency) initial, but I would need some help to find the right place in the code to do that and maybe even the right way to access the configured frequency there.
I'm happy to implement that as well if someone is up to point me into the right direction.

By the way, this is part of adding a direct link from collectd into Flapjack for alerting.

Cheers,
Birger