### PR TITLE
Fix for #1688 The SMART plugin does not build/load, v.5.5.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5318,6 +5318,7 @@ plugin_perl="no"
 plugin_processes="no"
 plugin_protocols="no"
 plugin_serial="no"
+plugin_smart="no"
 plugin_swap="no"
 plugin_tape="no"
 plugin_tcpconns="no"
@@ -5615,6 +5616,11 @@ then
 	plugin_processes="yes"
 fi
 
+if test "x$with_libatasmart" = "xyes" && test "x$with_libudev" = "xyes"
+then
+	plugin_smart="yes"
+fi
+
 if test "x$with_kvm_getswapinfo" = "xyes"
 then
 	plugin_swap="yes"
@@ -5758,7 +5764,7 @@ AC_PLUGIN([rrdtool],     [$with_librrd],       [RRDTool output plugin])
 AC_PLUGIN([sensors],     [$with_libsensors],   [lm_sensors statistics])
 AC_PLUGIN([serial],      [$plugin_serial],     [serial port traffic])
 AC_PLUGIN([sigrok],      [$with_libsigrok],    [sigrok acquisition sources])
-AC_PLUGIN([smart],       [$with_libatasmart],  [SMART statistics])
+AC_PLUGIN([smart],       [$plugin_smart],      [SMART statistics])
 AC_PLUGIN([snmp],        [$with_libnetsnmp],   [SNMP querying plugin])
 AC_PLUGIN([statsd],      [yes],                [StatsD plugin])
 AC_PLUGIN([swap],        [$plugin_swap],       [Swap usage statistics])


### PR DESCRIPTION
With libatasmart  but w/o libudev:

```
./configure
...
smart . . . . . . . . no 
...

./configure --enable-smart
...
smart . . . . . . . . no (dependency error)
...
```