### PR TITLE
processes: MAXCOMLEN is not exposed on Solaris

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -130,6 +130,10 @@
 
 # include <sys/user.h>
 # include <dirent.h>
+#ifndef MAXCOMLEN
+#define MAXCOMLEN 16
+#endif
+
 /* #endif KERNEL_SOLARIS */
 
 #else


### PR DESCRIPTION
MAXCOMLEN in <sys/user.h> is only exposed to kernel
code. I think it's safe to assume that it isn't going
to change, so just hardcode it.