### PR TITLE
Now cpufreq is able to get CPU frequency on CentOS 7.2

### DIFF
--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -31,7 +31,7 @@
 static int num_cpu = 0;
 
 static char const * freq_fname_def = "/sys/devices/system/cpu/cpu%d/cpufreq/"
-                                     "scaling_cur_freq";
+									 "scaling_cur_freq";
 /**
  * Linux kernel exposes current CPU frequency via
  * "/sys/devices/system/cpu/cpuX/cpufreq/scaling_cur_freq" file.
@@ -45,10 +45,10 @@ static char const * freq_fname_def = "/sys/devices/system/cpu/cpu%d/cpufreq/"
  * This file exposes not exactly the same thing as "scaling_cur_freq" does, but close by nature.
  *
  * Thus it's better to have a workaround to monitor some CPU frequency on even "broken" kernels.
- * So, the optional paramer "Path" was introduced to specify alternative CPU frequency path.
+ * So, the optional parameter "Path" was introduced to specify alternative CPU frequency path.
  * Example:
- * <Plugin cpufreq>/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_cur_freq
- *     Path ""
+ * <Plugin cpufreq>
+ *     Path "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_cur_freq"
  * </Plugin>
  *
  * Note, "%d" has to be used only once as CPU index placeholder.
@@ -58,173 +58,173 @@ static char freq_fname[MAX_STR_L] = {0};
 
 static const char *config_keys[] =
 {
-    "Path"
+	"Path"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
 int check_format (char const * src)
 {
-    int pc = -2;
-    int d = -2;
+	int pc = -2;
+	int d = -2;
 
-    for (char const * p=src; *p; ++p) {
-        switch (*p)
-        {
-            case '%':
-                if (-2 == pc) pc=p-src;
-                else return 0;
-                break;
+	for (char const * p=src; *p; ++p) {
+		switch (*p)
+		{
+			case '%':
+				if (-2 == pc) pc=p-src;
+				else return 0;
+				break;
 
-            case 'd':
-                if (pc+1 == p-src) d=p-src;
-                break;
-        }
-    }
+			case 'd':
+				if (pc+1 == p-src) d=p-src;
+				break;
+		}
+	}
 
-    return pc+1==d;
+	return pc+1==d;
 } /* check_format */
 
 static int cpufreq_config (char const * key, char const * value)
 {
-    if (strcasecmp ("Path", key) == 0) {
-        if (check_format (value)) {
-            sstrncpy(freq_fname, value, sizeof(freq_fname));
-        }
-        else {
-            WARNING ("cpufreq: Path parameter is wrong: %s", value);
-            return -1;
-        }
-    }
+	if (strcasecmp ("Path", key) == 0) {
+		if (check_format (value)) {
+			sstrncpy(freq_fname, value, sizeof(freq_fname));
+		}
+		else {
+			WARNING ("cpufreq: Path parameter is wrong: %s", value);
+			return -1;
+		}
+	}
 
-    return 0;
+	return 0;
 } /* cpufreq_config */
 
 static int setup_freq_fname ()
 {
-    int status;
-    char filename[MAX_STR_L];
+	int status;
+	char filename[MAX_STR_L];
 
-    if (!freq_fname[0]) {
-        sstrncpy (freq_fname, freq_fname_def, sizeof (freq_fname));
-    }
+	if (!freq_fname[0]) {
+		sstrncpy (freq_fname, freq_fname_def, sizeof (freq_fname));
+	}
 
-    status = ssnprintf (filename, sizeof (filename), freq_fname, 0);
-    if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-        return 0;
+	status = ssnprintf (filename, sizeof (filename), freq_fname, 0);
+	if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+		return 0;
 
-    if (!access (filename, R_OK)) {
-        return 1;
-    }
+	if (!access (filename, R_OK)) {
+		return 1;
+	}
 
-    return 0;
+	return 0;
 } /* setup_freq_fname */
 
 static int cpufreq_init (void)
 {
-    int status;
-    char filename[MAX_STR_L];
+	int status;
+	char filename[MAX_STR_L];
 
-    if (!setup_freq_fname ()) {
-        return -1;
-    }
+	if (!setup_freq_fname ()) {
+		return -1;
+	}
 
-    num_cpu = 0;
+	num_cpu = 0;
 
-    while (1)
-    {
-        status = ssnprintf (filename, sizeof (filename), freq_fname, num_cpu);
-        if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-            break;
+	while (1)
+	{
+		status = ssnprintf (filename, sizeof (filename), freq_fname, num_cpu);
+		if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+			break;
 
-        if (access (filename, R_OK))
-            break;
+		if (access (filename, R_OK))
+			break;
 
-        num_cpu++;
-    }
+		num_cpu++;
+	}
 
-    INFO ("cpufreq plugin: Found %d CPU%s", num_cpu,
-            (num_cpu == 1) ? "" : "s");
+	INFO ("cpufreq plugin: Found %d CPU%s", num_cpu,
+			(num_cpu == 1) ? "" : "s");
 
-    if (num_cpu == 0)
-        return -1;
+	if (num_cpu == 0)
+		return -1;
 
-    return 0;
+	return 0;
 } /* int cpufreq_init */
 
 static void cpufreq_submit (int cpu_num, double value)
 {
-    value_t values[1];
-    value_list_t vl = VALUE_LIST_INIT;
+	value_t values[1];
+	value_list_t vl = VALUE_LIST_INIT;
 
-    values[0].gauge = value;
+	values[0].gauge = value;
 
-    vl.values = values;
-    vl.values_len = 1;
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-    sstrncpy (vl.plugin, "cpufreq", sizeof (vl.plugin));
-    sstrncpy (vl.type, "cpufreq", sizeof (vl.type));
-    ssnprintf (vl.type_instance, sizeof (vl.type_instance),
-            "%i", cpu_num);
+	vl.values = values;
+	vl.values_len = 1;
+	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+	sstrncpy (vl.plugin, "cpufreq", sizeof (vl.plugin));
+	sstrncpy (vl.type, "cpufreq", sizeof (vl.type));
+	ssnprintf (vl.type_instance, sizeof (vl.type_instance),
+			"%i", cpu_num);
 
-    plugin_dispatch_values (&vl);
+	plugin_dispatch_values (&vl);
 }
 
 static int cpufreq_read (void)
 {
-    int status;
-    unsigned long long val;
-    int i = 0;
-    FILE *fp;
-    char filename[MAX_STR_L];
-    char buffer[16];
+	int status;
+	unsigned long long val;
+	int i = 0;
+	FILE *fp;
+	char filename[MAX_STR_L];
+	char buffer[16];
 
-    for (i = 0; i < num_cpu; i++)
-    {
-        status = ssnprintf (filename, sizeof (filename), freq_fname, i);
-        if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-            return (-1);
+	for (i = 0; i < num_cpu; i++)
+	{
+		status = ssnprintf (filename, sizeof (filename), freq_fname, i);
+		if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+			return (-1);
 
-        if ((fp = fopen (filename, "r")) == NULL)
-        {
-            char errbuf[1024];
-            WARNING ("cpufreq: fopen (%s): %s", filename,
-                    sstrerror (errno, errbuf,
-                        sizeof (errbuf)));
-            return (-1);
-        }
+		if ((fp = fopen (filename, "r")) == NULL)
+		{
+			char errbuf[1024];
+			WARNING ("cpufreq: fopen (%s): %s", filename,
+					sstrerror (errno, errbuf,
+						sizeof (errbuf)));
+			return (-1);
+		}
 
-        if (fgets (buffer, 16, fp) == NULL)
-        {
-            char errbuf[1024];
-            WARNING ("cpufreq: fgets: %s",
-                    sstrerror (errno, errbuf,
-                        sizeof (errbuf)));
-            fclose (fp);
-            return (-1);
-        }
+		if (fgets (buffer, 16, fp) == NULL)
+		{
+			char errbuf[1024];
+			WARNING ("cpufreq: fgets: %s",
+					sstrerror (errno, errbuf,
+						sizeof (errbuf)));
+			fclose (fp);
+			return (-1);
+		}
 
-        if (fclose (fp))
-        {
-            char errbuf[1024];
-            WARNING ("cpufreq: fclose: %s",
-                    sstrerror (errno, errbuf,
-                        sizeof (errbuf)));
-        }
+		if (fclose (fp))
+		{
+			char errbuf[1024];
+			WARNING ("cpufreq: fclose: %s",
+					sstrerror (errno, errbuf,
+						sizeof (errbuf)));
+		}
 
 
-        /* You're seeing correctly: The file is reporting kHz values.. */
-        val = atoll (buffer) * 1000;
+		/* You're seeing correctly: The file is reporting kHz values.. */
+		val = atoll (buffer) * 1000;
 
-        cpufreq_submit (i, val);
-    }
+		cpufreq_submit (i, val);
+	}
 
-    return (0);
+	return (0);
 } /* int cpufreq_read */
 
 void module_register (void)
 {
-    plugin_register_config ("cpufreq", cpufreq_config,
-                            config_keys, config_keys_num);
-    plugin_register_init ("cpufreq", cpufreq_init);
-    plugin_register_read ("cpufreq", cpufreq_read);
+	plugin_register_config ("cpufreq", cpufreq_config,
+							config_keys, config_keys_num);
+	plugin_register_init ("cpufreq", cpufreq_init);
+	plugin_register_read ("cpufreq", cpufreq_read);
 }

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -33,19 +33,23 @@ static int num_cpu = 0;
 static char const * freq_fname_def = "/sys/devices/system/cpu/cpu%d/cpufreq/"
 									 "scaling_cur_freq";
 /**
- * Linux kernel exposes current CPU frequency via
+ * For quite a while, Linux kernel exposes the current CPU frequency via
  * "/sys/devices/system/cpu/cpuX/cpufreq/scaling_cur_freq" file.
  *
- * In CentOS 7.1 it was observed that kernel doesn't provide "scaling_cur_freq" file.
- * Such behaviour observed with intel_pstate CPU frequency driver.
- * It was fixed in https://github.com/torvalds/linux/commit/c034b02e213d271b98c45c4a7b54af8f69aaac1e .
- * But at this moment in CentOS 7.2 the fix isn't ported yet.
+ * Nevertheless, in CentOS 7.1 it was observed that kernel doesn't provide the file anymore, with
+ * the employed intel_pstate CPU frequency driver.
  *
- * There is another "cpuinfo_cur_freq" file under "/sys/devices/system/cpu/cpuX/cpufreq/" directory.
+ * The issue above has been fixed in https://github.com/torvalds/linux/commit/c034b02e213d271b98c45c4a7b54af8f69aaac1e .
+ * But up to now with for example, CentOS 7.2, the fix has not been back-ported yet.
+ *
+ * Note that there is another "cpuinfo_cur_freq" file under "/sys/devices/system/cpu/cpuX/cpufreq/" directory.
  * This file exposes not exactly the same thing as "scaling_cur_freq" does, but close by nature.
+ * More details: http://www.pantz.org/software/cpufreq/usingcpufreqonlinux.html
  *
- * Thus it's better to have a workaround to monitor some CPU frequency on even "broken" kernels.
- * So, the optional parameter "Path" was introduced to specify alternative CPU frequency path.
+ * Overall it is better to have a workaround for monitoring some CPU frequency on even with kernels that lack
+ * the aforementioned fix.
+ *
+ * Also, an optional parameter "Path" is introduced to specify alternative CPU frequency path.
  * Example:
  * <Plugin cpufreq>
  *     Path "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_cur_freq"

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -31,202 +31,200 @@
 static int num_cpu = 0;
 
 static char const * freq_fname_def = "/sys/devices/system/cpu/cpu%d/cpufreq/"
-									 "scaling_cur_freq";
-
-/* The path "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq"
- * was seen first in CentOS 7.1 and old one has 400 access rights.
- * The cpuinfo_cur_freq just disappeared.
- * It's rather a bug and fix was made in
- * https://github.com/torvalds/linux/commit/c034b02e213d271b98c45c4a7b54af8f69aaac1e .
- * But such issue at this moments is still present in CentOS 7.2.
- * Thus the workaround was created to have a possibility to monitor CPU frequency
- * even in "broken" kernels.
- * Note that scaling_cur_freq and cpuinfo_cur_freq aren't exactly the same,
- * but by nature they are very close.
+                                     "scaling_cur_freq";
+/**
+ * Linux kernel exposes current CPU frequency via
+ * "/sys/devices/system/cpu/cpuX/cpufreq/scaling_cur_freq" file.
  *
+ * In CentOS 7.1 it was observed that kernel doesn't provide "scaling_cur_freq" file.
+ * Such behaviour observed with intel_pstate CPU frequency driver.
+ * It was fixed in https://github.com/torvalds/linux/commit/c034b02e213d271b98c45c4a7b54af8f69aaac1e .
+ * But at this moment in CentOS 7.2 the fix isn't ported yet.
+ *
+ * There is another "cpuinfo_cur_freq" file under "/sys/devices/system/cpu/cpuX/cpufreq/" directory.
+ * This file exposes not exactly the same thing as "scaling_cur_freq" does, but close by nature.
+ *
+ * Thus it's better to have a workaround to monitor some CPU frequency on even "broken" kernels.
+ * So, the optional paramer "Path" was introduced to specify alternative CPU frequency path.
  * Example:
- * <Plugin cpufreq>
- *      Path "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq"
+ * <Plugin cpufreq>/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_cur_freq
+ *     Path ""
  * </Plugin>
  *
- */
+ * Note, "%d" has to be used only once as CPU index placeholder.
+**/
 
 static char freq_fname[MAX_STR_L] = {0};
 
 static const char *config_keys[] =
 {
-	"Path"
+    "Path"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
-static char const * str_replace (char const *src, char const *what, char const * by)
+int check_format (char const * src)
 {
-	static char buf[MAX_STR_L];
-	char const * p = strstr (src, what);
+    int pc = -2;
+    int d = -2;
 
-	if (!p)
-		return NULL;
+    for (char const * p=src; *p; ++p) {
+        switch (*p)
+        {
+            case '%':
+                if (-2 == pc) pc=p-src;
+                else return 0;
+                break;
 
-	size_t n = p-src;
-	size_t n_by = strlen (by);
-	size_t n_what = strlen (what);
-	size_t n_buf = sizeof (buf);
+            case 'd':
+                if (pc+1 == p-src) d=p-src;
+                break;
+        }
+    }
 
-	if (MAX_STR_L <= n+n_by)
-		return NULL; /* too long input strings */
-
-	sstrncpy (buf, src, n);
-	sstrncpy (buf+n, by, n_buf-n);
-	sstrncpy (buf+n+n_by, src+n+n_what, n_buf-n-n_by);
-
-	return buf;
-}
+    return pc+1==d;
+} /* check_format */
 
 static int cpufreq_config (char const * key, char const * value)
 {
-	if (strcasecmp ("Path", key) == 0) {
-		char const * custom_path = str_replace (value, "cpu0", "cpu%d");
-		if (custom_path) {
-			sstrncpy(freq_fname, custom_path, sizeof(freq_fname));
-		}
-		else {
-			WARNING ("cpufreq: Path parameter is wrong: %s", value);
-			return -1;
-		}
-	}
+    if (strcasecmp ("Path", key) == 0) {
+        if (check_format (value)) {
+            sstrncpy(freq_fname, value, sizeof(freq_fname));
+        }
+        else {
+            WARNING ("cpufreq: Path parameter is wrong: %s", value);
+            return -1;
+        }
+    }
 
-	return 0;
-}
+    return 0;
+} /* cpufreq_config */
 
 static int setup_freq_fname ()
 {
-	int status;
-	char filename[MAX_STR_L];
+    int status;
+    char filename[MAX_STR_L];
 
-	if (!freq_fname[0]) {
-		sstrncpy (freq_fname, freq_fname_def, sizeof (freq_fname));
-	}
+    if (!freq_fname[0]) {
+        sstrncpy (freq_fname, freq_fname_def, sizeof (freq_fname));
+    }
 
-	status = ssnprintf (filename, sizeof (filename),
-						freq_fname, 0);
-	if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-		return 0;
+    status = ssnprintf (filename, sizeof (filename), freq_fname, 0);
+    if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        return 0;
 
-	if (!access (filename, R_OK)) {
-		return 1;
-	}
+    if (!access (filename, R_OK)) {
+        return 1;
+    }
 
-	return 0;
-}
+    return 0;
+} /* setup_freq_fname */
 
 static int cpufreq_init (void)
 {
-	int status;
-	char filename[MAX_STR_L];
+    int status;
+    char filename[MAX_STR_L];
 
-	if (!setup_freq_fname ()) {
-		/* The plugin is being unregistered by daemon itself if negative
-		 * value is returned. */
-		return -1;
-	}
+    if (!setup_freq_fname ()) {
+        return -1;
+    }
 
-	num_cpu = 0;
+    num_cpu = 0;
 
-	while (1)
-	{
-		status = ssnprintf (filename, sizeof (filename), freq_fname, num_cpu);
-		if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-			break;
+    while (1)
+    {
+        status = ssnprintf (filename, sizeof (filename), freq_fname, num_cpu);
+        if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+            break;
 
-		if (access (filename, R_OK))
-			break;
+        if (access (filename, R_OK))
+            break;
 
-		num_cpu++;
-	}
+        num_cpu++;
+    }
 
-	INFO ("cpufreq plugin: Found %d CPU%s", num_cpu,
-			(num_cpu == 1) ? "" : "s");
+    INFO ("cpufreq plugin: Found %d CPU%s", num_cpu,
+            (num_cpu == 1) ? "" : "s");
 
-	if (num_cpu == 0)
-		return -1;
+    if (num_cpu == 0)
+        return -1;
 
-	return 0;
+    return 0;
 } /* int cpufreq_init */
 
 static void cpufreq_submit (int cpu_num, double value)
 {
-	value_t values[1];
-	value_list_t vl = VALUE_LIST_INIT;
+    value_t values[1];
+    value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
+    values[0].gauge = value;
 
-	vl.values = values;
-	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-	sstrncpy (vl.plugin, "cpufreq", sizeof (vl.plugin));
-	sstrncpy (vl.type, "cpufreq", sizeof (vl.type));
-	ssnprintf (vl.type_instance, sizeof (vl.type_instance),
-			"%i", cpu_num);
+    vl.values = values;
+    vl.values_len = 1;
+    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy (vl.plugin, "cpufreq", sizeof (vl.plugin));
+    sstrncpy (vl.type, "cpufreq", sizeof (vl.type));
+    ssnprintf (vl.type_instance, sizeof (vl.type_instance),
+            "%i", cpu_num);
 
-	plugin_dispatch_values (&vl);
+    plugin_dispatch_values (&vl);
 }
 
 static int cpufreq_read (void)
 {
-	int status;
-	unsigned long long val;
-	int i = 0;
-	FILE *fp;
-	char filename[MAX_STR_L];
-	char buffer[16];
+    int status;
+    unsigned long long val;
+    int i = 0;
+    FILE *fp;
+    char filename[MAX_STR_L];
+    char buffer[16];
 
-	for (i = 0; i < num_cpu; i++)
-	{
-		status = ssnprintf (filename, sizeof (filename), freq_fname, i);
-		if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
-			return (-1);
+    for (i = 0; i < num_cpu; i++)
+    {
+        status = ssnprintf (filename, sizeof (filename), freq_fname, i);
+        if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+            return (-1);
 
-		if ((fp = fopen (filename, "r")) == NULL)
-		{
-			char errbuf[1024];
-			WARNING ("cpufreq: fopen (%s): %s", filename,
-					sstrerror (errno, errbuf,
-						sizeof (errbuf)));
-			return (-1);
-		}
+        if ((fp = fopen (filename, "r")) == NULL)
+        {
+            char errbuf[1024];
+            WARNING ("cpufreq: fopen (%s): %s", filename,
+                    sstrerror (errno, errbuf,
+                        sizeof (errbuf)));
+            return (-1);
+        }
 
-		if (fgets (buffer, 16, fp) == NULL)
-		{
-			char errbuf[1024];
-			WARNING ("cpufreq: fgets: %s",
-					sstrerror (errno, errbuf,
-						sizeof (errbuf)));
-			fclose (fp);
-			return (-1);
-		}
+        if (fgets (buffer, 16, fp) == NULL)
+        {
+            char errbuf[1024];
+            WARNING ("cpufreq: fgets: %s",
+                    sstrerror (errno, errbuf,
+                        sizeof (errbuf)));
+            fclose (fp);
+            return (-1);
+        }
 
-		if (fclose (fp))
-		{
-			char errbuf[1024];
-			WARNING ("cpufreq: fclose: %s",
-					sstrerror (errno, errbuf,
-						sizeof (errbuf)));
-		}
+        if (fclose (fp))
+        {
+            char errbuf[1024];
+            WARNING ("cpufreq: fclose: %s",
+                    sstrerror (errno, errbuf,
+                        sizeof (errbuf)));
+        }
 
 
-		/* You're seeing correctly: The file is reporting kHz values.. */
-		val = atoll (buffer) * 1000;
+        /* You're seeing correctly: The file is reporting kHz values.. */
+        val = atoll (buffer) * 1000;
 
-		cpufreq_submit (i, val);
-	}
+        cpufreq_submit (i, val);
+    }
 
-	return (0);
+    return (0);
 } /* int cpufreq_read */
 
 void module_register (void)
 {
-	plugin_register_config ("cpufreq", cpufreq_config,
-							config_keys, config_keys_num);
-	plugin_register_init ("cpufreq", cpufreq_init);
-	plugin_register_read ("cpufreq", cpufreq_read);
+    plugin_register_config ("cpufreq", cpufreq_config,
+                            config_keys, config_keys_num);
+    plugin_register_init ("cpufreq", cpufreq_init);
+    plugin_register_read ("cpufreq", cpufreq_read);
 }


### PR DESCRIPTION
On the latest CentOS 7.2 there is no "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq" file anymore on certain OS configurations.

The proposed changes make cpufreq plugin functional on CentOS 7.2.