### PR TITLE
network plugin: Improved error logging on decrypt error (wrong/missing username/password)

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1142,7 +1142,7 @@ static int parse_part_sign_sha256 (sockent_t *se, /* {{{ */
   if (memcmp (pss.hash, hash, sizeof (pss.hash)) != 0)
   {
     WARNING ("network plugin: Verifying HMAC-SHA-256 signature failed: "
-        "Hash mismatch.");
+        "Hash mismatch. Username: %s", pss.username);
   }
   else
   {
@@ -1226,8 +1226,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   /* Make sure at least the header if available. */
   if (buffer_len <= PART_ENCRYPTION_AES256_SIZE)
   {
-    ERROR ("network plugin: Decryption failed: "
-            "Discarding short packet.");
+    NOTICE ("network plugin: parse_part_encr_aes256: "
+        "Discarding short packet.");
     return (-1);
   }
 
@@ -1242,8 +1242,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   if ((part_size <= PART_ENCRYPTION_AES256_SIZE)
       || (part_size > buffer_len))
   {
-    ERROR ("network plugin: Decryption failed: "
-            "Discarding part with invalid size.");
+    NOTICE ("network plugin: parse_part_encr_aes256: "
+        "Discarding part with invalid size.");
     return (-1);
   }
 
@@ -1254,19 +1254,15 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   if ((username_len <= 0)
       || (username_len > (part_size - (PART_ENCRYPTION_AES256_SIZE + 1))))
   {
-    ERROR ("network plugin: Decryption failed: "
-            "Discarding part with invalid username length.");
+    NOTICE ("network plugin: parse_part_encr_aes256: "
+        "Discarding part with invalid username length.");
     return (-1);
   }
 
   assert (username_len > 0);
   pea.username = malloc (username_len + 1);
   if (pea.username == NULL)
-  {
-    ERROR ("network plugin: Decryption failed: "
-            "malloc() failed.");
     return (-ENOMEM);
-  }
   BUFFER_READ (pea.username, username_len);
   pea.username[username_len] = 0;
 
@@ -1281,8 +1277,7 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
       pea.username);
   if (cypher == NULL)
   {
-    ERROR ("network plugin: Decryption failed: "
-            "Failed to get cypher. Username: %s", pea.username);
+    ERROR ("network plugin: Failed to get cypher. Username: %s", pea.username);
     sfree (pea.username);
     return (-1);
   }
@@ -1316,8 +1311,7 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
       buffer + buffer_offset, payload_len);
   if (memcmp (hash, pea.hash, sizeof (hash)) != 0)
   {
-    ERROR ("network plugin: Decryption failed: "
-            "Checksum mismatch. Username: %s", pea.username);
+    ERROR ("network plugin: Checksum mismatch. Username: %s", pea.username);
     sfree (pea.username);
     return (-1);
   }
@@ -1433,7 +1427,12 @@ static int parse_packet (sockent_t *se, /* {{{ */
 			status = parse_part_encr_aes256 (se,
 					&buffer, &buffer_size, flags);
 			if (status != 0)
+			{
+				ERROR ("network plugin: Decrypting AES256 "
+						"part failed "
+						"with status %i.", status);
 				break;
+			}
 		}
 #if HAVE_LIBGCRYPT
 		else if ((se->data.server.security_level == SECURITY_LEVEL_ENCRYPT)

--- a/src/network.c
+++ b/src/network.c
@@ -1226,8 +1226,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   /* Make sure at least the header if available. */
   if (buffer_len <= PART_ENCRYPTION_AES256_SIZE)
   {
-    NOTICE ("network plugin: parse_part_encr_aes256: "
-        "Discarding short packet.");
+    ERROR ("network plugin: Decryption failed: "
+            "Discarding short packet.");
     return (-1);
   }
 
@@ -1242,8 +1242,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   if ((part_size <= PART_ENCRYPTION_AES256_SIZE)
       || (part_size > buffer_len))
   {
-    NOTICE ("network plugin: parse_part_encr_aes256: "
-        "Discarding part with invalid size.");
+    ERROR ("network plugin: Decryption failed: "
+            "Discarding part with invalid size.");
     return (-1);
   }
 
@@ -1254,15 +1254,19 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   if ((username_len <= 0)
       || (username_len > (part_size - (PART_ENCRYPTION_AES256_SIZE + 1))))
   {
-    NOTICE ("network plugin: parse_part_encr_aes256: "
-        "Discarding part with invalid username length.");
+    ERROR ("network plugin: Decryption failed: "
+            "Discarding part with invalid username length.");
     return (-1);
   }
 
   assert (username_len > 0);
   pea.username = malloc (username_len + 1);
   if (pea.username == NULL)
+  {
+    ERROR ("network plugin: Decryption failed: "
+            "malloc() failed.");
     return (-ENOMEM);
+  }
   BUFFER_READ (pea.username, username_len);
   pea.username[username_len] = 0;
 
@@ -1277,6 +1281,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
       pea.username);
   if (cypher == NULL)
   {
+    ERROR ("network plugin: Decryption failed: "
+            "Failed to get cypher. Username: %s", pea.username);
     sfree (pea.username);
     return (-1);
   }
@@ -1292,8 +1298,8 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
   if (err != 0)
   {
     sfree (pea.username);
-    ERROR ("network plugin: gcry_cipher_decrypt returned: %s",
-        gcry_strerror (err));
+    ERROR ("network plugin: gcry_cipher_decrypt returned: %s. Username: %s",
+        gcry_strerror (err), pea.username);
     return (-1);
   }
 
@@ -1310,8 +1316,9 @@ static int parse_part_encr_aes256 (sockent_t *se, /* {{{ */
       buffer + buffer_offset, payload_len);
   if (memcmp (hash, pea.hash, sizeof (hash)) != 0)
   {
+    ERROR ("network plugin: Decryption failed: "
+            "Checksum mismatch. Username: %s", pea.username);
     sfree (pea.username);
-    ERROR ("network plugin: Decryption failed: Checksum mismatch.");
     return (-1);
   }
 
@@ -1390,7 +1397,7 @@ static int parse_packet (sockent_t *se, /* {{{ */
 
 #if HAVE_LIBGCRYPT
 	int packet_was_signed = (flags & PP_SIGNED);
-        int packet_was_encrypted = (flags & PP_ENCRYPTED);
+	int packet_was_encrypted = (flags & PP_ENCRYPTED);
 	int printed_ignore_warning = 0;
 #endif /* HAVE_LIBGCRYPT */
 
@@ -1426,12 +1433,7 @@ static int parse_packet (sockent_t *se, /* {{{ */
 			status = parse_part_encr_aes256 (se,
 					&buffer, &buffer_size, flags);
 			if (status != 0)
-			{
-				ERROR ("network plugin: Decrypting AES256 "
-						"part failed "
-						"with status %i.", status);
 				break;
-			}
 		}
 #if HAVE_LIBGCRYPT
 		else if ((se->data.server.security_level == SECURITY_LEVEL_ENCRYPT)


### PR DESCRIPTION
Hi!

Yesterday I found the following repeating in my collectd hub syslog:

```
May 30 19:59:16 SERVER collectd[31844]: network plugin: Decryption failed: Checksum mismatch.
May 30 19:59:16 SERVER collectd[31844]: network plugin: Decrypting AES256 part failed with status -1.
```

These messages are not informative enough. So, introduce to you the PR about logging improve.

Before:

When 'No such user':

`May 30 19:59:16 SERVER collectd[31844]: network plugin: Decrypting AES256 part failed with status -1.`

When 'Wrong password':

```
May 30 19:59:16 SERVER collectd[31844]: network plugin: Decryption failed: Checksum mismatch.
May 30 19:59:16 SERVER collectd[31844]: network plugin: Decrypting AES256 part failed with status -1.
```

After:

No such user:

`[2016-05-31 01:24:31] network plugin: Decryption failed: Failed to get cypher. Username: webserver03`

Wrong password:

`[2016-05-31 01:25:32] network plugin: Decryption failed: Checksum mismatch. Username: webserver03`

The message 'Decrypting AES256 part failed with status -1' is hidden in favour of new error messages in parse_part_encr_aes256().

This patch helps me to find which server has wrong username configured (using tcpdump + grep by found username).