### PR TITLE
Valgrind: Suppress a bogus invalid read on FreeBSD.

### DIFF
--- a/src/valgrind.FreeBSD.suppress
+++ b/src/valgrind.FreeBSD.suppress
@@ -1,0 +1,8 @@
+{
+   strlen_bogus_invalid_read_after_strdup
+   Memcheck:Addr4
+   fun:parse_value
+   fun:parse_values
+   fun:test_parse_values
+   fun:main
+}

--- a/testwrapper.sh
+++ b/testwrapper.sh
@@ -14,6 +14,14 @@ if test -n "$VALGRIND"; then
 	MEMCHECK="$MEMCHECK --trace-children=yes"
 	MEMCHECK="$MEMCHECK --leak-check=full"
 	MEMCHECK="$MEMCHECK --gen-suppressions=all"
+
+	for f in "valgrind.$( uname -s ).suppress" "valgrind.suppress"; do
+		filename="$( dirname "$0" )/src/$f"
+		if test -e "$filename"; then
+			# Valgrind supports up to 100 suppression files.
+			MEMCHECK="$MEMCHECK --suppressions=$filename"
+		fi
+	done
 fi
 
 exec $MEMCHECK "$@"


### PR DESCRIPTION
Valgrind reports an invalid read in common.c:parse_value. The error is
supposed to happen in strlen() on a just previously strdup()ed string.

Possibly, this is some sort of alignment issue. The read size is reported to
be 4 on a buffer of size 3.

https://bugzilla.redhat.com/show_bug.cgi?id=678518 may also be related.