### PR TITLE
write_graphite: only flush data if socket is open

### DIFF
--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -297,10 +297,9 @@ static void wg_callback_free (void *data)
 
     pthread_mutex_lock (&cb->send_lock);
 
-    wg_flush_nolock (/* timeout = */ 0, cb);
-
     if (cb->sock_fd >= 0)
     {
+        wg_flush_nolock (/* timeout = */ 0, cb);
         close (cb->sock_fd);
         cb->sock_fd = -1;
     }


### PR DESCRIPTION
wg_callback_free can be called with a negative fd,
in which case we try to flush data on a closed socket.

CID 116310