### PR TITLE
uc_get_iterator: use ansi function declaration

### DIFF
--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -879,7 +879,7 @@ int uc_inc_hits (const data_set_t *ds, const value_list_t *vl, int step)
 /*
  * Iterator interface
  */
-uc_iter_t *uc_get_iterator ()
+uc_iter_t *uc_get_iterator (void)
 {
   uc_iter_t *iter;
 

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -73,7 +73,7 @@ typedef struct uc_iter_s uc_iter_t;
  * RETURN VALUE
  *   An iterator object on success or NULL else.
  */
-uc_iter_t *uc_get_iterator ();
+uc_iter_t *uc_get_iterator (void);
 
 /*
  * NAME


### PR DESCRIPTION
In file included from common.c:37:0:
utils_cache.h:76:1: warning: function declaration isn’t a prototype
[-Wstrict-prototypes]
 uc_iter_t *uc_get_iterator ();
 ^