### PR TITLE
rdkafka is called librdkafka

### DIFF
--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -781,7 +781,7 @@ using HTTP POST requests.
 Summary:       Write-kafka plugin for collectd
 Group:         System Environment/Daemons
 Requires:      %{name}%{?_isa} = %{version}-%{release}
-BuildRequires: rdkafka-devel
+BuildRequires: librdkafka-devel
 %description write_kafka
 The write_kafka plugin sends values to kafka, a distributed messaging system.
 %endif


### PR DESCRIPTION
The [spec file for
librdkafka](https://github.com/edenhill/librdkafka/blob/master/packaging/rpm/librdkafka.spec)
calls its package 'librdkafka-devel', not 'rdkafka-devel'. Searching the
web for 'rdkafka-devel RPM' turns up nothing, all the RPMs are named
'librdkafka-devel'.