### PR TITLE
pf plugin: collect per-label statistics as well

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -108,6 +108,14 @@ io_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
 ipt_bytes               value:DERIVE:0:U
 ipt_packets             value:DERIVE:0:U
 irq                     value:DERIVE:0:U
+label_evaluations       value:DERIVE:0:U
+label_packets_total     value:DERIVE:0:U
+label_packets_in        value:DERIVE:0:U
+label_packets_out       value:DERIVE:0:U
+label_bytes_total       value:DERIVE:0:U
+label_bytes_in          value:DERIVE:0:U
+label_bytes_out         value:DERIVE:0:U
+label_state_creations   value:DERIVE:0:U
 latency                 value:GAUGE:0:U
 links                   value:GAUGE:0:U
 load                    shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000


### PR DESCRIPTION
This has worked swimmingly for me on FreeBSD 10.0 - 10.3.

I haven't had the opportunity to test it on the other BSDs though.
