### PR TITLE
ntpd: Check STA_NANO in the server status

### DIFF
--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -51,6 +51,10 @@
 # include <poll.h>
 #endif
 
+#ifndef STA_NANO
+# define STA_NANO 0x2000
+#endif
+
 static const char *config_keys[] =
 {
 	"Host",
@@ -910,8 +914,7 @@ static int ntpd_read (void)
 	int i;
 
 	/* On Linux, if the STA_NANO bit is set in ik->status, then ik->offset
-	 * is is nanoseconds, otherwise it's microseconds.
-	 * TODO(octo): STA_NANO is defined in the Linux specific <sys/timex.h> header. */
+	 * is is nanoseconds, otherwise it's microseconds. */
 	double scale_loop  = 1e-6;
 	double scale_error = 1e-6;
 
@@ -934,6 +937,11 @@ static int ntpd_read (void)
 				"(ik = %p; ik_num = %i; ik_size = %i)",
 				(void *) ik, ik_num, ik_size);
 		return (-1);
+	}
+
+	if (ntohs(ik->status) & STA_NANO) {
+		scale_loop  = 1e-9;
+		scale_error = 1e-9;
 	}
 
 	/* kerninfo -> estimated error */


### PR DESCRIPTION
When STA_NANO is set in ik->status, then results are
expressed in nanoseconds (instead of microseconds by default).

Signed-off-by: Matwey V. Kornilov <matwey.kornilov@gmail.com>