### PR TITLE
disk plugin: release udev-based name. Fixes #1781

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -896,7 +896,7 @@ static int disk_read (void)
 		{
 #if HAVE_LIBUDEV
 			/* release udev-based alternate name, if allocated */
-			sfree (output_name);
+			sfree (alt_name);
 #endif
 			continue;
 		}


### PR DESCRIPTION
Fixes a core dump induced by freeing a wrong pointer when UDEV alt_name was not allocated (for some reason) earlier