### PR TITLE
add ActiveInterfaceOnly option to interface plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -582,7 +582,7 @@
 #<Plugin interface>
 #	Interface "eth0"
 #	IgnoreSelected false
-#	ActiveInterfaceOnly false
+#	ReportInactive true
 #	UniqueName false
 #</Plugin>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -582,6 +582,7 @@
 #<Plugin interface>
 #	Interface "eth0"
 #	IgnoreSelected false
+#	ActiveInterfaceOnly false
 #	UniqueName false
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2735,6 +2735,18 @@ This will ignore the loopback interface, all interfaces with names starting
 with I<veth> and all interfaces with names starting with I<tun> followed by
 at least one digit.
 
+=item B<ActiveInterfaceOnly> I<true>|I<false>
+
+When set to I<true>, only interfaces with non-zero traffic will be
+reported. Note that the check is done by looking into whether a
+package was sent at any time from boot and the corresponding counter
+is non-zero. So, if the interface has been sending data in the past
+since boot, but not during the reported time-interval, it will still
+be reported.
+
+The default value is I<false> and results in collection of the data
+from all interfaces that are selected by B<Interface> and
+B<IgnoreSelected> options.
 
 =item B<UniqueName> I<true>|I<false>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2735,16 +2735,16 @@ This will ignore the loopback interface, all interfaces with names starting
 with I<veth> and all interfaces with names starting with I<tun> followed by
 at least one digit.
 
-=item B<ActiveInterfaceOnly> I<true>|I<false>
+=item B<ReportInactive> I<true>|I<false>
 
-When set to I<true>, only interfaces with non-zero traffic will be
+When set to I<false>, only interfaces with non-zero traffic will be
 reported. Note that the check is done by looking into whether a
 package was sent at any time from boot and the corresponding counter
 is non-zero. So, if the interface has been sending data in the past
 since boot, but not during the reported time-interval, it will still
 be reported.
 
-The default value is I<false> and results in collection of the data
+The default value is I<true> and results in collection of the data
 from all interfaces that are selected by B<Interface> and
 B<IgnoreSelected> options.
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -84,11 +84,14 @@ static const char *config_keys[] =
 {
 	"Interface",
 	"IgnoreSelected",
+	"ActiveInterfaceOnly",
 	NULL
 };
-static int config_keys_num = 2;
+static int config_keys_num = 3;
 
 static ignorelist_t *ignorelist = NULL;
+
+static _Bool active_interface_only = 0;
 
 #ifdef HAVE_LIBKSTAT
 #define MAX_NUMIF 256
@@ -113,6 +116,13 @@ static int interface_config (const char *key, const char *value)
 		if (IS_TRUE (value))
 			invert = 0;
 		ignorelist_set_invert (ignorelist, invert);
+	}
+	else if (strcasecmp (key, "ActiveInterfaceOnly") == 0)
+	{
+		if (IS_TRUE (value))
+			active_interface_only = 1;
+		else
+			active_interface_only = 0;
 	}
 	else if (strcasecmp (key, "UniqueName") == 0)
 	{
@@ -223,6 +233,9 @@ static int interface_read (void)
 		if (if_ptr->ifa_addr != NULL && if_ptr->ifa_addr->sa_family == AF_LINK) {
 			if_data = (struct IFA_DATA *) if_ptr->ifa_data;
 
+			if ( active_interface_only && if_data->IFA_RX_PACKT == 0 && if_data->IFA_TX_PACKT == 0 )
+				continue;
+
 			if_submit (if_ptr->ifa_name, "if_octets",
 				if_data->IFA_RX_BYTES,
 				if_data->IFA_TX_BYTES);
@@ -275,13 +288,16 @@ static int interface_read (void)
 		if (numfields < 11)
 			continue;
 
+		incoming = atoll (fields[1]);
+		outgoing = atoll (fields[9]);
+		if ( active_interface_only && incoming == 0 && outgoing == 0 )
+			continue;
+
+		if_submit (device, "if_packets", incoming, outgoing);
+
 		incoming = atoll (fields[0]);
 		outgoing = atoll (fields[8]);
 		if_submit (device, "if_octets", incoming, outgoing);
-
-		incoming = atoll (fields[1]);
-		outgoing = atoll (fields[9]);
-		if_submit (device, "if_packets", incoming, outgoing);
 
 		incoming = atoll (fields[2]);
 		outgoing = atoll (fields[10]);
@@ -315,6 +331,19 @@ static int interface_read (void)
 			sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));
 
 		/* try to get 64bit counters */
+		rx = get_kstat_value (ksp[i], "ipackets64");
+		tx = get_kstat_value (ksp[i], "opackets64");
+		/* or fallback to 32bit */
+		if (rx == -1LL)
+			rx = get_kstat_value (ksp[i], "ipackets");
+		if (tx == -1LL)
+			tx = get_kstat_value (ksp[i], "opackets");
+		if ( active_interface_only && rx == 0 && tx == 0 )
+			continue;
+		if ((rx != -1LL) || (tx != -1LL))
+			if_submit (iname, "if_packets", rx, tx);
+
+		/* try to get 64bit counters */
 		rx = get_kstat_value (ksp[i], "rbytes64");
 		tx = get_kstat_value (ksp[i], "obytes64");
 		/* or fallback to 32bit */
@@ -324,17 +353,6 @@ static int interface_read (void)
 			tx = get_kstat_value (ksp[i], "obytes");
 		if ((rx != -1LL) || (tx != -1LL))
 			if_submit (iname, "if_octets", rx, tx);
-
-		/* try to get 64bit counters */
-		rx = get_kstat_value (ksp[i], "ipackets64");
-		tx = get_kstat_value (ksp[i], "opackets64");
-		/* or fallback to 32bit */
-		if (rx == -1LL)
-			rx = get_kstat_value (ksp[i], "ipackets");
-		if (tx == -1LL)
-			tx = get_kstat_value (ksp[i], "opackets");
-		if ((rx != -1LL) || (tx != -1LL))
-			if_submit (iname, "if_packets", rx, tx);
 
 		/* no 64bit error counters yet */
 		rx = get_kstat_value (ksp[i], "ierrors");
@@ -350,8 +368,11 @@ static int interface_read (void)
 
 	ios = sg_get_network_io_stats (&num);
 
-	for (i = 0; i < num; i++)
+	for (i = 0; i < num; i++) {
+		if ( active_interface_only && ios[i].rx == 0 && ios[i].tx == 0 )
+			continue;
 		if_submit (ios[i].interface_name, "if_octets", ios[i].rx, ios[i].tx);
+	}
 /* #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT)
@@ -384,6 +405,9 @@ static int interface_read (void)
 
 	for (i = 0; i < ifs; i++)
 	{
+		if ( active_interface_only && ifstat[i].ipackets == 0 && ifstat[i].opackets == 0 )
+			continue;
+
 		if_submit (ifstat[i].name, "if_octets", ifstat[i].ibytes, ifstat[i].obytes);
 		if_submit (ifstat[i].name, "if_packets", ifstat[i].ipackets ,ifstat[i].opackets);
 		if_submit (ifstat[i].name, "if_errors", ifstat[i].ierrors, ifstat[i].oerrors );

--- a/src/interface.c
+++ b/src/interface.c
@@ -422,12 +422,3 @@ void module_register (void)
 	plugin_register_read ("interface", interface_read);
 } /* void module_register */
 
-/*
- * Local variables:
- *  c-file-style: "linux"
- *  indent-tabs-mode: t
- *  c-indent-level: 4
- *  c-basic-offset: 4
- *  tab-width: 4
- * End:
- */

--- a/src/interface.c
+++ b/src/interface.c
@@ -426,3 +426,13 @@ void module_register (void)
 #endif
 	plugin_register_read ("interface", interface_read);
 } /* void module_register */
+
+/*
+ * Local variables:
+ *  c-file-style: "linux"
+ *  indent-tabs-mode: t
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ *  tab-width: 4
+ * End:
+ */


### PR DESCRIPTION
This PR adds ActiveInterfaceOnly to interface plugin. 

Rationale: In Sailfish devices there are very many network interfaces (28 in Nexus 4) out of which only 3 are actually used: one for cellular data, one for WIFI, and lo. Unfortunately, active interfaces on different devices could be different leading to inability to enable only the active ones using Interface option for all devices in default configuration. So, users would have to find out which interface is active for them and enable these interfaces manually.

By adding ActiveInterfaceOnly option, only interfaces with packet count larger than 0 would be reported. The implementation has been tested on Linux (Sailfish), but I hope that it works on other platforms as well.