### PR TITLE
Fix write_riemann plugin build on 32-bit Solaris

### DIFF
--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -28,16 +28,18 @@
  *   Gergely Nagy <algernon at madhouse-project.org>
  */
 
-#include <riemann/riemann-client.h>
-#include <errno.h>
-
 #include "collectd.h"
+
+
 #include "plugin.h"
 #include "common.h"
 #include "configfile.h"
 #include "utils_cache.h"
 #include "utils_complain.h"
 #include "write_riemann_threshold.h"
+
+#include <errno.h>
+#include <riemann/riemann-client.h>
 
 #define RIEMANN_HOST		"localhost"
 #define RIEMANN_PORT		5555

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -25,10 +25,6 @@
  *   Andrés J. Díaz <ajdiaz at connectical.com>
  **/
 
-#include <assert.h>
-#include <ltdl.h>
-#include <pthread.h>
-
 #include "collectd.h"
 #include "common.h"
 #include "plugin.h"
@@ -36,6 +32,10 @@
 #include "utils_cache.h"
 #include "utils_threshold.h"
 #include "write_riemann_threshold.h"
+
+#include <assert.h>
+#include <ltdl.h>
+#include <pthread.h>
 
 /*
  * Threshold management


### PR DESCRIPTION
Fixes #1782

CC       write_riemann_la-write_riemann.lo
In file included from ./daemon/collectd.h:31:0,
                 from write_riemann.c:34:
./config.h:1664:0: error: "_FILE_OFFSET_BITS" redefined [-Werror]
 #define _FILE_OFFSET_BITS 64
 ^
In file included from /usr/include/limits.h:17:0,
                 from
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/limits.h:168,
                 from
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/syslimits.h:7,
                 from
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/limits.h:34,
                 from /opt/csw/include/protobuf-c/protobuf-c.h:200,
                 from /opt/csw/include/riemann/proto/riemann.pb-c.h:7,
                 from /opt/csw/include/riemann/attribute.h:21,
                 from /opt/csw/include/riemann/riemann-client.h:23,
                 from write_riemann.c:31:
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/sys/feature_tests.h:196:0:
note: this is the location of the previous definition
 #define _FILE_OFFSET_BITS 32
 ^
cc1: all warnings being treated as errors
Makefile:4645: recipe for target 'write_riemann_la-write_riemann.lo'
failed
gmake[3]: *** [write_riemann_la-write_riemann.lo] Error 1
gmake[3]: Leaving directory
'/home/dam/mgar/pkg/collectd/trunk/work/solaris10-i386/build-isa-pentium_pro/collectd-5.5.1.1126.g37fe166/src'
Makefile:4879: recipe for target 'all-recursive' failed
gmake[2]: *** [all-recursive] Error 1
gmake[2]: Leaving directory
'/home/dam/mgar/pkg/collectd/trunk/work/solaris10-i386/build-isa-pentium_pro/collectd-5.5.1.1126.g37fe166/src'
Makefile:3209: recipe for target 'all' failed
gmake[1]: *** [all] Error 2
gmake[1]: Leaving directory
'/home/dam/mgar/pkg/collectd/trunk/work/solaris10-i386/build-isa-pentium_pro/collectd-5.5.1.1126.g37fe166/src'
Makefile:572: recipe for target 'all-recursive' failed
gmake: *** [all-recursive] Error 1
gmake: Leaving directory
'/home/dam/mgar/pkg/collectd/trunk/work/solaris10-i386/build-isa-pentium_pro/collectd-5.5.1.1126.g37fe166'
/home/dam/mgar/pkg/.buildsys/v2/gar//gar.lib.mk:874: die Regel für Ziel
„build-work/solaris10-i386/build-isa-pentium_pro/collectd-5.5.1.1126.g37fe166/Makefile“
scheiterte