### PR TITLE
new plugin: radio

### DIFF
--- a/README
+++ b/README
@@ -293,6 +293,11 @@ Features
       collectd without the need to start a heavy interpreter every interval.
       See collectd-python(5) for details.
 
+    - radio
+      The radio plugin records whether WiFi, Bluetooth and other radios are
+      switched on or off. For that, it uses rfkill interface exposed by Linux
+      kernel.
+
     - redis
       The redis plugin gathers information from a Redis server, including:
       uptime, used memory, total connections etc.

--- a/configure.ac
+++ b/configure.ac
@@ -5558,6 +5558,7 @@ plugin_numa="no"
 plugin_perl="no"
 plugin_processes="no"
 plugin_protocols="no"
+plugin_radio="no"
 plugin_serial="no"
 plugin_smart="no"
 plugin_swap="no"
@@ -5601,6 +5602,7 @@ then
 	plugin_numa="yes"
 	plugin_processes="yes"
 	plugin_protocols="yes"
+	plugin_radio="yes"
 	plugin_serial="yes"
 	plugin_swap="yes"
 	plugin_tcpconns="yes"
@@ -6024,6 +6026,7 @@ AC_PLUGIN([powerdns],            [yes],                     [PowerDNS statistics
 AC_PLUGIN([processes],           [$plugin_processes],       [Process statistics])
 AC_PLUGIN([protocols],           [$plugin_protocols],       [Protocol (IP, TCP, ...) statistics])
 AC_PLUGIN([python],              [$with_python],            [Embed a Python interpreter])
+AC_PLUGIN([radio],               [$plugin_radio],           [Radios enabled/disabled])
 AC_PLUGIN([redis],               [$with_libhiredis],        [Redis plugin])
 AC_PLUGIN([routeros],            [$with_librouteros],       [RouterOS plugin])
 AC_PLUGIN([rrdcached],           [$librrd_rrdc_update],     [RRDTool output plugin])
@@ -6435,6 +6438,7 @@ Configuration:
     processes . . . . . . $enable_processes
     protocols . . . . . . $enable_protocols
     python  . . . . . . . $enable_python
+    radio . . . . . . . . $enable_radio
     redis . . . . . . . . $enable_redis
     routeros  . . . . . . $enable_routeros
     rrdcached . . . . . . $enable_rrdcached

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -908,6 +908,12 @@ protocols_la_SOURCES = protocols.c
 protocols_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
+if BUILD_PLUGIN_RADIO
+pkglib_LTLIBRARIES += radio.la
+radio_la_SOURCES = radio.c
+radio_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+endif
+
 if BUILD_PLUGIN_REDIS
 pkglib_LTLIBRARIES += redis.la
 redis_la_SOURCES = redis.c

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -169,6 +169,7 @@
 #@BUILD_PLUGIN_PROCESSES_TRUE@LoadPlugin processes
 #@BUILD_PLUGIN_PROTOCOLS_TRUE@LoadPlugin protocols
 #@BUILD_PLUGIN_PYTHON_TRUE@LoadPlugin python
+#@BUILD_PLUGIN_RADIO_TRUE@LoadPlugin radio
 #@BUILD_PLUGIN_REDIS_TRUE@LoadPlugin redis
 #@BUILD_PLUGIN_ROUTEROS_TRUE@LoadPlugin routeros
 #@BUILD_PLUGIN_RRDCACHED_TRUE@LoadPlugin rrdcached

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6009,6 +6009,11 @@ Defaults to B<false>.
 
 =back
 
+=head2 Plugin C<radio>
+
+This plugin doesn't have any options. It determines whether radios in computer
+are switched on or off using rfkill interface.
+
 =head2 Plugin C<redis>
 
 The I<Redis plugin> connects to one or more Redis servers and gathers

--- a/src/radio.c
+++ b/src/radio.c
@@ -66,7 +66,7 @@ static int radio_init (void)
 	}
   
   INFO ("radio plugin: Found %d radio%s", num_rfkill,
-        (num_cpu == 1) ? "" : "s");
+        (num_rfkill == 1) ? "" : "s");
   
   if (num_rfkill == 0)
     plugin_unregister_read ("radio");
@@ -141,6 +141,11 @@ static void sanitize(char *buffer, size_t buffer_size)
     {
       char c = buffer[i];
       if (c == '\0') return;
+      if (c == '\n')
+        {
+          buffer[i] = '\0';
+          return;
+        }
       
       if (i == buffer_size-1)
         {
@@ -159,7 +164,7 @@ static int radio_read (void)
   char filename[BFSZ];
   char type[BFSZ];
   char name[BFSZ];
-  gauge_t value = NAN;
+  int status;
   int hard;
   int soft;
   int i;
@@ -196,7 +201,7 @@ static int radio_read (void)
           return (-1);
         }
 
-      sanitize(type, sizeof(type));
+      sanitize(name, sizeof(name));
 
       // hardware switch
       status = ssnprintf (filename, sizeof (filename),

--- a/src/radio.c
+++ b/src/radio.c
@@ -1,0 +1,256 @@
+/**
+ * collectd - src/radio.c
+ * Copyright (C) 2016 rinigus
+ *
+ *
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+ * Authors:
+ *   rinigus <http://github.com/rinigus>
+
+ Radio switches are monitored, as exposed by rfkill interface in Linux
+ 
+ Sysfs description: https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-rfkill
+ 
+ 
+ **/
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+
+#define SYSFS_ROOT "/sys/class/rfkill/"
+#define BFSZ 512
+
+static int num_rfkill = 0;
+
+static int radio_init (void)
+{
+  int status;
+  char filename[256];
+
+  num_rfkill = 0;
+  
+  while (1)
+	{
+      status = ssnprintf (filename, sizeof (filename),
+                          SYSFS_ROOT "rfkill%d/"
+                          "hard", num_rfkill);
+      
+      if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        break;
+      
+      if (access (filename, R_OK))
+        break;
+      
+      num_rfkill++;
+	}
+  
+  INFO ("radio plugin: Found %d radio%s", num_rfkill,
+        (num_cpu == 1) ? "" : "s");
+  
+  if (num_rfkill == 0)
+    plugin_unregister_read ("radio");
+  
+  return (0);
+}
+
+
+static void radio_submit (const char *type, const char *plugin_instance, const char *type_instance, gauge_t value)
+{
+  value_t values[1];
+  value_list_t vl = VALUE_LIST_INIT;
+  
+  values[0].gauge = value;
+  
+  vl.values = values;
+  vl.values_len = 1;
+  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+  sstrncpy (vl.plugin, "radio", sizeof (vl.plugin));
+  sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
+  sstrncpy (vl.type, type, sizeof (vl.type));
+  sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
+  
+  plugin_dispatch_values (&vl);
+}
+
+
+static _Bool get_value(const char *fname, int *value)
+{
+  FILE *fh;
+  char buffer[BFSZ];
+
+  if ((fh = fopen(fname, "r")) == NULL)
+    return (0);
+
+  if ( fgets(buffer, sizeof(buffer), fh) == NULL )
+    {
+      fclose(fh);
+      return (0); // empty file
+    }
+
+  (*value) = atoi( buffer );
+
+  fclose(fh);
+
+  return (1);
+}
+
+
+static _Bool get_string(const char *fname, char *buffer, size_t buffer_size)
+{
+  FILE *fh;
+  if ((fh = fopen(fname, "r")) == NULL)
+    return (0);
+
+  if ( fgets(buffer, buffer_size, fh) == NULL )
+    {
+      fclose(fh);
+      return (0); // empty file
+    }
+
+  fclose(fh);
+
+  return (1);
+}
+
+
+static void sanitize(char *buffer, size_t buffer_size)
+{
+  size_t i;
+  for (i=0; i<buffer_size; ++i)
+    {
+      char c = buffer[i];
+      if (c == '\0') return;
+      
+      if (i == buffer_size-1)
+        {
+          buffer[i] = '\0';
+          return;
+        }
+      
+      if (c == ' ' || c == '-' || c == '/')
+        buffer[i] = '_';
+    }
+}
+
+
+static int radio_read (void)
+{
+  char filename[BFSZ];
+  char type[BFSZ];
+  char name[BFSZ];
+  gauge_t value = NAN;
+  int hard;
+  int soft;
+  int i;
+
+  for (i=0; i < num_rfkill; ++i)
+    {
+      // type
+      status = ssnprintf (filename, sizeof (filename),
+                          SYSFS_ROOT "rfkill%d/"
+                          "type", i);
+      
+      if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        return (-1);
+
+      if ( !get_string(filename, type, sizeof(type)) )
+        {
+          ERROR("radio: cannot read value from %s", filename);
+          return (-1);
+        }
+
+      sanitize(type, sizeof(type));
+
+      // name
+      status = ssnprintf (filename, sizeof (filename),
+                          SYSFS_ROOT "rfkill%d/"
+                          "name", i);
+      
+      if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        return (-1);
+
+      if ( !get_string(filename, name, sizeof(name)) )
+        {
+          ERROR("radio: cannot read value from %s", filename);
+          return (-1);
+        }
+
+      sanitize(type, sizeof(type));
+
+      // hardware switch
+      status = ssnprintf (filename, sizeof (filename),
+                          SYSFS_ROOT "rfkill%d/"
+                          "hard", i);
+      
+      if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        return (-1);
+
+      if ( !get_value(filename, &hard) )
+        {
+          ERROR("radio: cannot read value from %s", filename);
+          return (-1);
+        }
+
+      if (hard) // radio is killed by hardware switch
+        {
+          radio_submit ("active", type, name, 0);
+          continue; // no need to read soft switch
+        }
+
+      // software switch
+      status = ssnprintf (filename, sizeof (filename),
+                          SYSFS_ROOT "rfkill%d/"
+                          "soft", i);
+      
+      if ((status < 1) || ((unsigned int)status >= sizeof (filename)))
+        return (-1);
+
+      if ( !get_value(filename, &soft) )
+        {
+          ERROR("radio: cannot read value from %s", filename);
+          return (-1);
+        }
+
+      radio_submit ("active", type, name, (hard==0 && soft==0));
+    }
+  
+  return (0);
+}
+
+void module_register (void)
+{
+  plugin_register_init ("radio", radio_init);
+  plugin_register_read ("radio", radio_read);
+} /* void module_register */
+
+
+/*
+ * Local variables:
+ *  c-file-style: "gnu"
+ *  indent-tabs-mode: nil
+ *  c-indent-level: 4
+ *  c-basic-offset: 2
+ *  tab-width: 4
+ * End:
+ */

--- a/src/types.db
+++ b/src/types.db
@@ -1,4 +1,5 @@
 absolute                value:ABSOLUTE:0:U
+active			value:GAUGE:0:1
 apache_bytes            value:DERIVE:0:U
 apache_connections      value:GAUGE:0:65535
 apache_idle_workers     value:GAUGE:0:65535


### PR DESCRIPTION
Radio plugin monitors the state of the hardware and software switches for WiFi, Bluetooth, and other radios controlled by rfkill in Linux. At present, plugin is used to monitor radios in Sailfish mobile devices and on Linux laptops