### PR TITLE
Added 'operations_per_second' (redis) type

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -430,6 +430,7 @@ static int redis_read (void) /* {{{ */
     redis_handle_info (rn->name, rr->str, "volatile_changes", NULL, "changes_since_last_save", DS_TYPE_GAUGE);
     redis_handle_info (rn->name, rr->str, "total_connections", NULL, "total_connections_received", DS_TYPE_DERIVE);
     redis_handle_info (rn->name, rr->str, "total_operations", NULL, "total_commands_processed", DS_TYPE_DERIVE);
+    redis_handle_info (rn->name, rr->str, "operations_per_second", NULL, "instantaneous_ops_per_sec", DS_TYPE_GAUGE);
     redis_handle_info (rn->name, rr->str, "expired_keys", NULL, "expired_keys", DS_TYPE_DERIVE);
     redis_handle_info (rn->name, rr->str, "evicted_keys", NULL, "evicted_keys", DS_TYPE_DERIVE);
     redis_handle_info (rn->name, rr->str, "pubsub", "channels", "pubsub_channels", DS_TYPE_GAUGE);

--- a/src/types.db
+++ b/src/types.db
@@ -150,6 +150,7 @@ node_stat               value:DERIVE:0:U
 node_tx_rate            value:GAUGE:0:127
 objects                 value:GAUGE:0:U
 operations              value:DERIVE:0:U
+operations_per_second   value:GAUGE:0:U
 packets                 value:DERIVE:0:U
 pending_operations      value:GAUGE:0:U
 percent                 value:GAUGE:0:100.1


### PR DESCRIPTION
Added the following metric:

```
instantaneous_ops_per_sec: Number of commands processed per second
```

with key `operations_per_second`, type `gauge`.