### PR TITLE
network plugin: Don't abort() if gcrypt initialization failed.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -496,7 +496,7 @@ static int network_dispatch_notification (notification_t *n) /* {{{ */
 } /* }}} int network_dispatch_notification */
 
 #if HAVE_LIBGCRYPT
-static void network_init_gcrypt (void) /* {{{ */
+static int network_init_gcrypt (void) /* {{{ */
 {
   gcry_error_t err;
 
@@ -504,7 +504,7 @@ static void network_init_gcrypt (void) /* {{{ */
    * Because you can't know in a library whether another library has
    * already initialized the library */
   if (gcry_control (GCRYCTL_ANY_INITIALIZATION_P))
-    return;
+    return (0);
 
  /* http://www.gnupg.org/documentation/manuals/gcrypt/Multi_002dThreading.html
   * To ensure thread-safety, it's important to set GCRYCTL_SET_THREAD_CBS
@@ -518,7 +518,7 @@ static void network_init_gcrypt (void) /* {{{ */
   if (err)
   {
     ERROR ("network plugin: gcry_control (GCRYCTL_SET_THREAD_CBS) failed: %s", gcry_strerror (err));
-    abort ();
+    return (-1);
   }
 # endif
 
@@ -528,11 +528,12 @@ static void network_init_gcrypt (void) /* {{{ */
   if (err)
   {
     ERROR ("network plugin: gcry_control (GCRYCTL_INIT_SECMEM) failed: %s", gcry_strerror (err));
-    abort ();
+    return (-1);
   }
 
   gcry_control (GCRYCTL_INITIALIZATION_FINISHED);
-} /* }}} void network_init_gcrypt */
+  return (0);
+} /* }}} int network_init_gcrypt */
 
 static gcry_cipher_hd_t network_get_aes256_cypher (sockent_t *se, /* {{{ */
     const void *iv, size_t iv_size, const char *username)
@@ -2066,7 +2067,12 @@ static int sockent_init_crypto (sockent_t *se) /* {{{ */
 	{
 		if (se->data.client.security_level > SECURITY_LEVEL_NONE)
 		{
-			network_init_gcrypt ();
+			if (network_init_gcrypt () < 0)
+			{
+				ERROR ("network plugin: Cannot configure client socket with "
+						"security: Failed to initialize crypto library.");
+				return (-1);
+			}
 
 			if ((se->data.client.username == NULL)
 					|| (se->data.client.password == NULL))
@@ -2086,7 +2092,12 @@ static int sockent_init_crypto (sockent_t *se) /* {{{ */
 	{
 		if (se->data.server.security_level > SECURITY_LEVEL_NONE)
 		{
-			network_init_gcrypt ();
+			if (network_init_gcrypt () < 0)
+			{
+				ERROR ("network plugin: Cannot configure server socket with "
+						"security: Failed to initialize crypto library.");
+				return (-1);
+			}
 
 			if (se->data.server.auth_file == NULL)
 			{
@@ -3519,7 +3530,11 @@ static int network_init (void)
 	have_init = 1;
 
 #if HAVE_LIBGCRYPT
-	network_init_gcrypt ();
+	if (network_init_gcrypt () < 0)
+	{
+		ERROR ("network plugin: Failed to initialize crypto library.");
+		return (-1);
+	}
 #endif
 
 	if (network_config_stats != 0)


### PR DESCRIPTION
Instead, report an error and let plugin initialization fail.