### PR TITLE
network plugin: Fix heap overflow in parse_packet().

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1429,6 +1429,7 @@ static int parse_packet (sockent_t *se, /* {{{ */
 				printed_ignore_warning = 1;
 			}
 			buffer = ((char *) buffer) + pkg_length;
+			buffer_size -= (size_t) pkg_length;
 			continue;
 		}
 #endif /* HAVE_LIBGCRYPT */
@@ -1456,6 +1457,7 @@ static int parse_packet (sockent_t *se, /* {{{ */
 				printed_ignore_warning = 1;
 			}
 			buffer = ((char *) buffer) + pkg_length;
+			buffer_size -= (size_t) pkg_length;
 			continue;
 		}
 #endif /* HAVE_LIBGCRYPT */
@@ -1578,6 +1580,7 @@ static int parse_packet (sockent_t *se, /* {{{ */
 			DEBUG ("network plugin: parse_packet: Unknown part"
 					" type: 0x%04hx", pkg_type);
 			buffer = ((char *) buffer) + pkg_length;
+			buffer_size -= (size_t) pkg_length;
 		}
 	} /* while (buffer_size > sizeof (part_header_t)) */
 


### PR DESCRIPTION
Emilien Gaspar has identified a heap overflow in parse_packet(), the
function used by the network plugin to parse incoming network packets.

This is a vulnerability in collectd, though the scope is not clear at
this point. At the very least specially crafted network packets can be
used to crash the daemon. We can't rule out a potential remote code
execution though.

Fixes: CVE-2016-6254
(cherry picked from commit b589096f907052b3a4da2b9ccc9b0e2e888dfc18)