### PR TITLE
Require a compiler that understands C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,9 @@ AC_SYS_LARGEFILE
 #
 # Checks for programs.
 #
-AC_PROG_CC
+AC_PROG_CC_C99([],
+  [AC_MSG_ERROR([No compiler found that supports C99])]
+)
 AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_EGREP


### PR DESCRIPTION
Upcoming changes will requires C99 support.

For newer compilers this is the default, but older
compilers needs a flag like -std=gnu99 or -std=c99.