### PR TITLE
src/plugin.c: Stop write threads before calling shutdown callbacks.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -2893,6 +2893,11 @@ static int network_write (const data_set_t *ds, const value_list_t *vl,
 {
 	int status;
 
+	/* listen_loop is set to non-zero in the shutdown callback, which is
+	 * guaranteed to be called *after* all the write threads have been shut
+	 * down. */
+	assert (listen_loop == 0);
+
 	if (!check_send_okay (vl))
 	{
 #if COLLECT_DEBUG

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -1731,9 +1731,9 @@ void plugin_shutdown_all (void)
 {
 	llentry_t *le;
 
-	stop_read_threads ();
-
 	destroy_all_callbacks (&list_init);
+
+	stop_read_threads ();
 
 	pthread_mutex_lock (&read_lock);
 	llist_destroy (read_list);
@@ -1742,6 +1742,10 @@ void plugin_shutdown_all (void)
 
 	destroy_read_heap ();
 
+	/* blocks until all write threads have shut down. */
+	stop_write_threads ();
+
+	/* ask all plugins to write out the state they kept. */
 	plugin_flush (/* plugin = */ NULL,
 			/* timeout = */ 0,
 			/* identifier = */ NULL);
@@ -1770,8 +1774,6 @@ void plugin_shutdown_all (void)
 
 		plugin_set_ctx (old_ctx);
 	}
-
-	stop_write_threads ();
 
 	/* Write plugins which use the `user_data' pointer usually need the
 	 * same data available to the flush callback. If this is the case, set


### PR DESCRIPTION
I have hopes that this fixes #1110, but I'd welcome some testers because I'm not sure how reliably this can be reproduced.