### PR TITLE
python plugin: Fix conversion of value-lists from Python to C.

### DIFF
--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -551,19 +551,22 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 	for (i = 0; i < size; ++i) {
 		PyObject *item, *num;
 		item = PySequence_Fast_GET_ITEM(values, i); /* Borrowed reference. */
-		if (ds->ds->type == DS_TYPE_COUNTER) {
+		switch (ds->ds[i].type) {
+		case DS_TYPE_COUNTER:
 			num = PyNumber_Long(item); /* New reference. */
 			if (num != NULL) {
 				value[i].counter = PyLong_AsUnsignedLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_GAUGE) {
+			break;
+		case DS_TYPE_GAUGE:
 			num = PyNumber_Float(item); /* New reference. */
 			if (num != NULL) {
 				value[i].gauge = PyFloat_AsDouble(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_DERIVE) {
+			break;
+		case DS_TYPE_DERIVE:
 			/* This might overflow without raising an exception.
 			 * Not much we can do about it */
 			num = PyNumber_Long(item); /* New reference. */
@@ -571,7 +574,8 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 				value[i].derive = PyLong_AsLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_ABSOLUTE) {
+			break;
+		case DS_TYPE_ABSOLUTE:
 			/* This might overflow without raising an exception.
 			 * Not much we can do about it */
 			num = PyNumber_Long(item); /* New reference. */
@@ -579,9 +583,10 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
 				value[i].absolute = PyLong_AsUnsignedLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else {
+			break;
+		default:
 			free(value);
-			PyErr_Format(PyExc_RuntimeError, "unknown data type %d for %s", ds->ds->type, value_list.type);
+			PyErr_Format(PyExc_RuntimeError, "unknown data type %d for %s", ds->ds[i].type, value_list.type);
 			return NULL;
 		}
 		if (PyErr_Occurred() != NULL) {
@@ -655,19 +660,22 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
 	for (i = 0; i < size; ++i) {
 		PyObject *item, *num;
 		item = PySequence_Fast_GET_ITEM(values, i); /* Borrowed reference. */
-		if (ds->ds->type == DS_TYPE_COUNTER) {
+		switch (ds->ds[i].type) {
+		case DS_TYPE_COUNTER:
 			num = PyNumber_Long(item); /* New reference. */
 			if (num != NULL) {
 				value[i].counter = PyLong_AsUnsignedLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_GAUGE) {
+			break;
+		case DS_TYPE_GAUGE:
 			num = PyNumber_Float(item); /* New reference. */
 			if (num != NULL) {
 				value[i].gauge = PyFloat_AsDouble(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_DERIVE) {
+			break;
+		case DS_TYPE_DERIVE:
 			/* This might overflow without raising an exception.
 			 * Not much we can do about it */
 			num = PyNumber_Long(item); /* New reference. */
@@ -675,7 +683,8 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
 				value[i].derive = PyLong_AsLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else if (ds->ds->type == DS_TYPE_ABSOLUTE) {
+			break;
+		case DS_TYPE_ABSOLUTE:
 			/* This might overflow without raising an exception.
 			 * Not much we can do about it */
 			num = PyNumber_Long(item); /* New reference. */
@@ -683,9 +692,10 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
 				value[i].absolute = PyLong_AsUnsignedLongLong(num);
 				Py_XDECREF(num);
 			}
-		} else {
+			break;
+		default:
 			free(value);
-			PyErr_Format(PyExc_RuntimeError, "unknown data type %d for %s", ds->ds->type, value_list.type);
+			PyErr_Format(PyExc_RuntimeError, "unknown data type %d for %s", ds->ds[i].type, value_list.type);
 			return NULL;
 		}
 		if (PyErr_Occurred() != NULL) {


### PR DESCRIPTION
This affects data-sets with more than one data-source of different types.
Previously, the type of the first data-source would have been used to convert
all values.