### PR TITLE
collectd-python(5): remove NOTES section

### DIFF
--- a/src/collectd-python.pod
+++ b/src/collectd-python.pod
@@ -679,22 +679,6 @@ To register those functions with collectd:
 See the section L<"CLASSES"> above for a complete documentation of the data
 types used by the read, write and match functions.
 
-=head1 NOTES
-
-=over 4
-
-=item *
-
-Please feel free to send in new plugins to collectd's mailing list at
-E<lt>collectdE<nbsp>atE<nbsp>collectd.orgE<gt> for review and, possibly,
-inclusion in the main distribution. In the latter case, we will take care of
-keeping the plugin up to date and adapting it to new versions of collectd.
-
-Before submitting your plugin, please take a look at
-L<http://collectd.org/dev-info.shtml>.
-
-=back
-
 =head1 CAVEATS
 
 =over 4


### PR DESCRIPTION
This man page just describes the python plugin so it shouldn't contain
generic information for developers.