### PR TITLE
snmp : don't send values for empty type_instance

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1360,8 +1360,12 @@ static int csnmp_dispatch_table (host_definition_t *host, data_definition_t *dat
     for (i = 0; i < data->values_len; i++)
       vl.values[i] = value_table_ptr[i]->value;
 
-    /* If we get here `vl.type_instance' and all `vl.values' have been set */
-    plugin_dispatch_values (&vl);
+    /* If we get here `vl.type_instance' and all `vl.values' have been set
+     * vl.type_instance can be empty, i.e. a blank port description on a
+     * switch if you're using IF-MIB::ifDescr as Instance.
+     */
+    if (vl.type_instance[0] != '\0')
+      plugin_dispatch_values (&vl);
 
     if (instance_list != NULL)
       instance_list_ptr = instance_list_ptr->next;


### PR DESCRIPTION
If you have multiple Instance values that are empty string,
they all end up in the same rrd file, resulting in:
rrdc_update (/collectd/rrd/vc3/snmp/if_errors.rrd, [1352632188:0:0], 1) failed with status -1

Fixes #176