### PR TITLE
More autoconf work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
-AM_CONDITIONAL(COMPILER_IS_GCC, test "x$GCC" = "xyes")
+AM_CONDITIONAL([COMPILER_IS_GCC], [test "x$GCC" = "xyes"])
 
 AC_PROG_LEX
 AC_PROG_YACC
@@ -46,16 +46,18 @@ m4_pattern_forbid([^_?PKG_[A-Z_]+$],[*** pkg.m4 missing, please install pkg-conf
 
 PKG_PROG_PKG_CONFIG
 
-AC_CACHE_CHECK([if bison is the parser generator],
-	[collectd_cv_prog_bison],
-	[AS_IF([$YACC --version 2>/dev/null | $EGREP -q '^bison '],
-		[collectd_cv_prog_bison=yes], [collectd_cv_prog_bison=no]
-	)]
+AC_CACHE_CHECK([if Bison is the parser generator],
+  [collectd_cv_prog_bison],
+  [
+    AS_IF([$YACC --version 2>/dev/null | $EGREP -q '^bison '],
+      [collectd_cv_prog_bison=yes],
+      [collectd_cv_prog_bison=no]
+    )
+  ]
 )
 
-if test "x$collectd_cv_prog_bison" = "xno" && test ! -f "${srcdir}/src/liboconfig/parser.c"
-then
-	AC_MSG_ERROR([bison is missing and you do not have ${srcdir}/src/liboconfig/parser.c. Please install bison])
+if test "x$collectd_cv_prog_bison" = "xno" && test ! -f "${srcdir}/src/liboconfig/parser.c"; then
+  AC_MSG_ERROR([bison is missing and you do not have ${srcdir}/src/liboconfig/parser.c. Please install bison])
 fi
 
 AS_IF([test "x$lt_cv_dlopen" = "xno"],
@@ -64,66 +66,40 @@ AS_IF([test "x$lt_cv_dlopen" = "xno"],
 
 AC_SUBST([DLOPEN_LIBS], [$lt_cv_dlopen_libs])
 
-AC_ARG_VAR([PROTOC], [path to the protoc binary])
-AC_PATH_PROG([PROTOC], [protoc])
-have_protoc3="no"
-if test "x$PROTOC" != "x"; then
-	AC_MSG_CHECKING([for protoc 3.0.0+])
-	if $PROTOC --version | $EGREP libprotoc.3 >/dev/null; then
-		protoc3="yes (`$PROTOC --version`)"
-		have_protoc3="yes"
-	else
-		protoc3="no (`$PROTOC --version`)"
-	fi
-	AC_MSG_RESULT([$protoc3])
-fi
-AM_CONDITIONAL(HAVE_PROTOC3, test "x$have_protoc3" = "xyes")
-
-AC_ARG_VAR([GRPC_CPP_PLUGIN], [path to the grpc_cpp_plugin binary])
-AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
-AM_CONDITIONAL(HAVE_GRPC_CPP, test "x$GRPC_CPP_PLUGIN" != "x")
-
-AC_ARG_VAR([PROTOC_C], [path to the protoc-c binary])
-AC_PATH_PROG([PROTOC_C], [protoc-c])
-if test "x$PROTOC_C" = "x"
-then
-  have_protoc_c="no (protoc-c compiler not found)"
-else
-  have_protoc_c="yes"
-fi
 
 AC_MSG_CHECKING([for kernel type ($host_os)])
 case $host_os in
-	*linux*)
-	AC_DEFINE([KERNEL_LINUX], 1, [True if program is to be compiled for a Linux kernel])
-	ac_system="Linux"
-	;;
-	*solaris*)
-	AC_DEFINE([KERNEL_SOLARIS], 1, [True if program is to be compiled for a Solaris kernel])
-	ac_system="Solaris"
-	;;
-	*darwin*)
-	AC_DEFINE([KERNEL_DARWIN], 1, [True if program is to be compiled for a Darwin kernel])
-	ac_system="Darwin"
-	;;
-	*openbsd*)
-	AC_DEFINE([KERNEL_OPENBSD], 1, [True if program is to be compiled for an OpenBSD kernel])
-	ac_system="OpenBSD"
-	;;
-	*netbsd*)
-	AC_DEFINE([KERNEL_NETBSD], 1, [True if program is to be compiled for a NetBSD kernel])
-	ac_system="NetBSD"
-	;;
-	*aix*)
-	AC_DEFINE([KERNEL_AIX], 1, [True if program is to be compiled for a AIX kernel])
-	ac_system="AIX"
-	;;
-	*freebsd*)
-	AC_DEFINE([KERNEL_FREEBSD], 1, [True if program is to be compiled for a FreeBSD kernel])
-	ac_system="FreeBSD"
-	;;
-	*)
-	ac_system="unknown"
+  *aix*)
+    AC_DEFINE([KERNEL_AIX], [1], [True if program is to be compiled for a AIX kernel])
+    ac_system="AIX"
+    ;;
+  *darwin*)
+    AC_DEFINE([KERNEL_DARWIN], [1], [True if program is to be compiled for a Darwin kernel])
+    ac_system="Darwin"
+    ;;
+  *freebsd*)
+    AC_DEFINE([KERNEL_FREEBSD], [1], [True if program is to be compiled for a FreeBSD kernel])
+    ac_system="FreeBSD"
+    ;;
+  *linux*)
+    AC_DEFINE([KERNEL_LINUX], [1], [True if program is to be compiled for a Linux kernel])
+    ac_system="Linux"
+    ;;
+  *netbsd*)
+    AC_DEFINE([KERNEL_NETBSD], [1], [True if program is to be compiled for a NetBSD kernel])
+    ac_system="NetBSD"
+    ;;
+  *openbsd*)
+    AC_DEFINE([KERNEL_OPENBSD], [1], [True if program is to be compiled for an OpenBSD kernel])
+    ac_system="OpenBSD"
+    ;;
+  *solaris*)
+    AC_DEFINE([KERNEL_SOLARIS], [1], [True if program is to be compiled for a Solaris kernel])
+    ac_system="Solaris"
+    ;;
+  *)
+    ac_system="unknown"
+    ;;
 esac
 AC_MSG_RESULT([$ac_system])
 
@@ -134,77 +110,55 @@ AM_CONDITIONAL([BUILD_LINUX], [test "x$ac_system" = "xLinux"])
 AM_CONDITIONAL([BUILD_OPENBSD], [test "x$ac_system" = "xOpenBSD"])
 AM_CONDITIONAL([BUILD_SOLARIS], [test "x$ac_system" = "xSolaris"])
 
-if test "x$ac_system" = "xLinux"
-then
-	AC_ARG_VAR([KERNEL_DIR], [path to Linux kernel sources])
-	if test -z "$KERNEL_DIR"
-	then
-		KERNEL_DIR="/lib/modules/`uname -r`/source"
-	fi
-
-	KERNEL_CFLAGS="-I$KERNEL_DIR/include"
-	AC_SUBST(KERNEL_CFLAGS)
+if test "x$ac_system" = "xLinux"; then
+  AC_ARG_VAR([KERNEL_DIR], [path to Linux kernel sources])
+  if test "x$KERNEL_DIR" = "x"; then
+    KERNEL_DIR="/lib/modules/`uname -r`/source"
+  fi
+  KERNEL_CFLAGS="-I$KERNEL_DIR/include"
+  AC_SUBST([KERNEL_CFLAGS])
 fi
 
-if test "x$ac_system" = "xSolaris"
-then
-	AC_DEFINE(_POSIX_PTHREAD_SEMANTICS, 1, [Define to enforce POSIX thread semantics under Solaris.])
-	AC_DEFINE(_REENTRANT,               1, [Define to enable reentrancy interfaces.])
+if test "x$ac_system" = "xSolaris"; then
+  AC_DEFINE([_POSIX_PTHREAD_SEMANTICS], [1], [Define to enforce POSIX thread semantics under Solaris.])
+  AC_DEFINE([_REENTRANT], [1], [Define to enable reentrancy interfaces.])
 
-	AC_MSG_CHECKING([whether compiler builds 64bit binaries])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-			   #ifndef _LP64
-			   # error "Compiler not in 64bit mode."
-			   #endif
-			   ])],
-			   [AC_MSG_RESULT([yes])],
-			   [
-			    AC_MSG_RESULT([no])
-			    AC_MSG_NOTICE([Solaris detected. Please consider building a 64-bit binary.])
-			   ])
+  AC_MSG_CHECKING([whether compiler builds 64bit binaries])
+  AC_COMPILE_IFELSE(
+    [
+      AC_LANG_PROGRAM(
+        [
+          #ifndef _LP64
+          # error "Compiler not in 64bit mode."
+          #endif
+        ]
+      )
+    ],
+    [AC_MSG_RESULT([yes])],
+    [
+      AC_MSG_RESULT([no])
+      AC_MSG_NOTICE([Solaris detected. Please consider building a 64-bit binary.])
+    ]
+  )
 fi
 
-if test "x$ac_system" = "xAIX"
-then
-	AC_DEFINE(_THREAD_SAFE_ERRNO, 1, [Define to use the thread-safe version of errno under AIX.])
+if test "x$ac_system" = "xAIX"; then
+  AC_DEFINE([_THREAD_SAFE_ERRNO], [1], [Define to use the thread-safe version of errno under AIX.])
 fi
 
 # Where to install .pc files.
 pkgconfigdir="${libdir}/pkgconfig"
-AC_SUBST(pkgconfigdir)
-
-# Check for standards compliance mode
-AC_ARG_ENABLE(standards,
-	      AS_HELP_STRING([--enable-standards], [Enable standards compliance mode]),
-	      [enable_standards="$enableval"],
-	      [enable_standards="no"])
-if test "x$enable_standards" = "xyes"
-then
-	AC_DEFINE(_ISOC99_SOURCE,        1, [Define to enforce ISO C99 compliance.])
-	AC_DEFINE(_POSIX_C_SOURCE, 200809L, [Define to enforce POSIX.1-2008 compliance.])
-	AC_DEFINE(_XOPEN_SOURCE,       700, [Define to enforce X/Open 7 (XSI) compliance.])
-	AC_DEFINE(_REENTRANT,            1, [Define to enable reentrancy interfaces.])
-	if test "x$GCC" = "xyes"
-	then
-		CFLAGS="$CFLAGS -std=c99"
-	fi
-fi
-AM_CONDITIONAL(BUILD_FEATURE_STANDARDS, test "x$enable_standards" = "xyes")
+AC_SUBST([pkgconfigdir])
 
 #
 # Checks for header files.
 #
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_HEADER_DIRENT
-AC_HEADER_STDBOOL
 
-AC_CHECK_HEADERS([ \
+AC_CHECK_HEADERS_ONCE([ \
   arpa/inet.h \
-  assert.h \
-  ctype.h \
   endian.h \
-  errno.h \
   fcntl.h \
   fnmatch.h \
   fs_info.h \
@@ -213,9 +167,6 @@ AC_CHECK_HEADERS([ \
   kstat.h \
   kvm.h \
   libgen.h \
-  limits.h \
-  locale.h \
-  math.h \
   mntent.h \
   mnttab.h \
   netdb.h \
@@ -224,9 +175,6 @@ AC_CHECK_HEADERS([ \
   pthread_np.h \
   pwd.h \
   regex.h \
-  signal.h \
-  stdarg.h \
-  stdio.h \
   sys/fs_types.h \
   sys/fstyp.h \
   sys/ioctl.h \
@@ -245,450 +193,463 @@ AC_CHECK_HEADERS([ \
   sys/vfstab.h \
   sys/vmmeter.h \
   syslog.h \
-  wordexp.h \
+  wordexp.h
 ])
 
-# For entropy plugin on newer NetBSD
-AC_CHECK_HEADERS(sys/rndio.h, [], [],
-[#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_SYS_IOCTL_H
-# include <sys/ioctl.h>
-#endif
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-])
+if test "x$ac_system" = "xNetBSD"; then
+  # For entropy plugin on newer NetBSD
+  AC_CHECK_HEADERS([sys/rndio.h], [], [],
+    [[
+      #if HAVE_SYS_TYPES_H
+      # include <sys/types.h>
+      #endif
+      #if HAVE_SYS_IOCTL_H
+      # include <sys/ioctl.h>
+      #endif
+      #if HAVE_SYS_PARAM_H
+      # include <sys/param.h>
+      #endif
+    ]]
+  )
+fi
 
 # For ping library
-AC_CHECK_HEADERS(netinet/in_systm.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/in.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/ip.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/ip_icmp.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/ip_var.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/ip6.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/icmp6.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP6_H
-# include <netinet/ip6.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/tcp.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/udp.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-])
+AC_CHECK_HEADERS([netinet/in_systm.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+  ]]
+)
 
-have_ip6_ext="no"
-AC_CHECK_TYPES([struct ip6_ext], [have_ip6_ext="yes"], [have_ip6_ext="no"],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP6_H
-# include <netinet/ip6.h>
-#endif
-])
+AC_CHECK_HEADERS([netinet/in.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+  ]]
+)
 
-if test "x$have_ip6_ext" = "xno"; then
-	SAVE_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS -DSOLARIS2=8"
+AC_CHECK_HEADERS([netinet/ip.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+  ]]
+)
 
-	AC_CHECK_TYPES([struct ip6_ext],
-		       [have_ip6_ext="yes, with -DSOLARIS2=8"],
-		       [have_ip6_ext="no"],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP6_H
-# include <netinet/ip6.h>
-#endif
-])
+AC_CHECK_HEADERS([netinet/ip_icmp.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+  ]]
+)
 
-	if test "x$have_ip6_ext" = "xno"; then
-		CFLAGS="$SAVE_CFLAGS"
-	fi
-fi
+AC_CHECK_HEADERS([netinet/ip_var.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([netinet/ip6.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([netinet/icmp6.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP6_H
+    # include <netinet/ip6.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([netinet/tcp.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([netinet/udp.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+  ]]
+)
 
 # For cpu modules
-AC_CHECK_HEADERS(sys/dkstat.h)
+AC_CHECK_HEADERS([sys/dkstat.h])
 if test "x$ac_system" = "xDarwin"
 then
-	AC_CHECK_HEADERS(mach/mach_init.h mach/host_priv.h mach/mach_error.h mach/mach_host.h mach/mach_port.h mach/mach_types.h mach/message.h mach/processor_set.h mach/processor.h mach/processor_info.h mach/task.h mach/thread_act.h mach/vm_region.h mach/vm_map.h mach/vm_prot.h mach/vm_statistics.h mach/kern_return.h)
-	AC_CHECK_HEADERS(CoreFoundation/CoreFoundation.h IOKit/IOKitLib.h IOKit/IOTypes.h IOKit/ps/IOPSKeys.h IOKit/IOBSD.h IOKit/storage/IOBlockStorageDriver.h)
-	# For the battery plugin
-	AC_CHECK_HEADERS(IOKit/ps/IOPowerSources.h, [], [],
-[
-#if HAVE_IOKIT_IOKITLIB_H
-#  include <IOKit/IOKitLib.h>
-#endif
-#if HAVE_IOKIT_IOTYPES_H
-#  include <IOKit/IOTypes.h>
-#endif
-])
+  AC_CHECK_HEADERS(
+    [[ \
+      mach/mach_init.h \
+      mach/host_priv.h \
+      mach/mach_error.h \
+      mach/mach_host.h \
+      mach/mach_port.h \
+      mach/mach_types.h \
+      mach/message.h \
+      mach/processor_set.h \
+      mach/processor.h \
+      mach/processor_info.h \
+      mach/task.h \
+      mach/thread_act.h \
+      mach/vm_region.h \
+      mach/vm_map.h \
+      mach/vm_prot.h \
+      mach/vm_statistics.h \
+      mach/kern_return.h \
+      CoreFoundation/CoreFoundation.h \
+      IOKit/IOKitLib.h \
+      IOKit/IOTypes.h \
+      IOKit/ps/IOPSKeys.h \
+      IOKit/IOBSD.h \
+      IOKit/storage/IOBlockStorageDriver.h
+    ]]
+  )
 
+  # For the battery plugin
+  AC_CHECK_HEADERS([IOKit/ps/IOPowerSources.h], [], [],
+    [[
+      #if HAVE_IOKIT_IOKITLIB_H
+      #  include <IOKit/IOKitLib.h>
+      #endif
+      #if HAVE_IOKIT_IOTYPES_H
+      #  include <IOKit/IOTypes.h>
+      #endif
+    ]]
+  )
 fi
 
-AC_CHECK_HEADERS(sys/sysctl.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-])
+AC_CHECK_HEADERS([sys/sysctl.h], [], [],
+  [[
+    #if HAVE_SYS_TYPES_H
+    #  include <sys/types.h>
+    #endif
+    #if HAVE_SYS_PARAM_H
+    # include <sys/param.h>
+    #endif
+  ]]
+)
 
-AC_MSG_CHECKING([for sysctl kern.cp_times])
-if test -x /sbin/sysctl
-then
-	/sbin/sysctl kern.cp_times >/dev/null 2>&1
-	if test $? -eq 0
-	then
-		AC_MSG_RESULT([yes])
-		AC_DEFINE(HAVE_SYSCTL_KERN_CP_TIMES, 1,
-		[Define if sysctl supports kern.cp_times])
-	else
-		AC_MSG_RESULT([no])
-	fi
-else
-	AC_MSG_RESULT([no])
-fi
+# For interface plugin
+AC_CHECK_HEADERS([ifaddrs.h])
+AC_CHECK_HEADERS([net/if.h], [], [],
+  [[
+    #if HAVE_SYS_TYPES_H
+    #  include <sys/types.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    #  include <sys/socket.h>
+    #endif
+  ]]
+)
 
-AC_MSG_CHECKING([for sysctl kern.cp_time])
-if test -x /sbin/sysctl
-then
-	/sbin/sysctl kern.cp_time >/dev/null 2>&1
-	if test $? -eq 0
-	then
-		AC_MSG_RESULT([yes])
-		AC_DEFINE(HAVE_SYSCTL_KERN_CP_TIME, 1,
-			[Define if sysctl supports kern.cp_time])
-	else
-		AC_MSG_RESULT([no])
-	fi
-else
-	AC_MSG_RESULT([no])
-fi
-
-# For hddtemp module
-AC_CHECK_HEADERS(linux/major.h)
-
-# For md module (Linux only)
 if test "x$ac_system" = "xLinux"
 then
-	AC_CHECK_HEADERS(linux/raid/md_u.h,
-			 [have_linux_raid_md_u_h="yes"],
-			 [have_linux_raid_md_u_h="no"],
-[
-#include <sys/ioctl.h>
-#include <linux/major.h>
-#include <linux/types.h>
-])
-	AC_CHECK_HEADERS([sys/sysmacros.h])
+  # For hddtemp module
+  AC_CHECK_HEADERS([linux/major.h])
+
+  # For md module (Linux only)
+  AC_CHECK_HEADERS([linux/raid/md_u.h],
+    [have_linux_raid_md_u_h="yes"],
+    [have_linux_raid_md_u_h="no"],
+    [[
+      #include <sys/ioctl.h>
+      #include <linux/major.h>
+      #include <linux/types.h>
+    ]]
+  )
+  AC_CHECK_HEADERS([sys/sysmacros.h])
+
+  AC_CHECK_HEADERS([linux/wireless.h],
+    [have_linux_wireless_h="yes"],
+    [have_linux_wireless_h="no"],
+    [[
+      #include <dirent.h>
+      #include <sys/ioctl.h>
+      #include <sys/socket.h>
+    ]]
+  )
+
+  AC_CHECK_HEADERS([linux/if.h], [], [],
+    [[
+      #if HAVE_SYS_TYPES_H
+      #  include <sys/types.h>
+      #endif
+      #if HAVE_SYS_SOCKET_H
+      #  include <sys/socket.h>
+      #endif
+    ]]
+  )
+  
+  AC_CHECK_HEADERS([linux/inet_diag.h], [], [],
+    [[
+      #if HAVE_SYS_TYPES_H
+      #  include <sys/types.h>
+      #endif
+      #if HAVE_SYS_SOCKET_H
+      #  include <sys/socket.h>
+      #endif
+    ]]
+  )
+  
+  AC_CHECK_HEADERS([linux/netdevice.h], [], [],
+    [[
+      #if HAVE_SYS_TYPES_H
+      #  include <sys/types.h>
+      #endif
+      #if HAVE_SYS_SOCKET_H
+      #  include <sys/socket.h>
+      #endif
+      #if HAVE_LINUX_IF_H
+      # include <linux/if.h>
+      #endif
+    ]]
+  )
+  
+  # For ethstat module
+  AC_CHECK_HEADERS([linux/sockios.h],
+    [have_linux_sockios_h="yes"],
+    [have_linux_sockios_h="no"],
+    [[
+      #if HAVE_SYS_IOCTL_H
+      # include <sys/ioctl.h>
+      #endif
+      #if HAVE_NET_IF_H
+      # include <net/if.h>
+      #endif
+    ]]
+  )
+  
+  AC_CHECK_HEADERS([linux/ethtool.h],
+    [have_linux_ethtool_h="yes"],
+    [have_linux_ethtool_h="no"],
+    [[
+      #if HAVE_SYS_IOCTL_H
+      # include <sys/ioctl.h>
+      #endif
+      #if HAVE_NET_IF_H
+      # include <net/if.h>
+      #endif
+      #if HAVE_LINUX_SOCKIOS_H
+      # include <linux/sockios.h>
+      #endif
+    ]]
+  )
+
+  # For ipvs module
+  AC_CHECK_HEADERS([linux/ip_vs.h], [have_linux_ip_vs_h="yes"], [have_linux_ip_vs="no"])
+  AC_CHECK_HEADERS([net/ip_vs.h], [have_net_ip_vs_h="yes"], [have_net_ip_vs_h="no"])
+  AC_CHECK_HEADERS([ip_vs.h], [have_ip_vs_h="yes"], [have_ip_vs_h="no"])
+
+  ip_vs_h_needs_kernel_cflags="no"
+  
+  if test "x$have_linux_ip_vs_h$have_net_ip_vs_h$have_ip_vs_h" = "xnonono" && test -d "$KERNEL_DIR"; then
+    SAVE_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $KERNEL_CFLAGS"
+    
+    AC_MSG_NOTICE([Did not find ip_vs.h. Trying again using headers from $KERNEL_DIR.])
+    
+    AC_CHECK_HEADERS([linux/ip_vs.h], [have_linux_ip_vs_h="yes"])
+    AC_CHECK_HEADERS([net/ip_vs.h], [have_net_ip_vs_h="yes"])
+    AC_CHECK_HEADERS([ip_vs.h], [have_ip_vs_h="yes"])
+    
+    if test "x$have_linux_ip_vs_h" = "xyes" || test "x$have_net_ip_vs_h" = "xyes" || test "x$have_ip_vs_h" = "xyes"; then
+      ip_vs_h_needs_kernel_cflags="yes"
+    fi
+    
+    CFLAGS="$SAVE_CFLAGS"
+  fi
+
+  # For the email plugin
+  AC_CHECK_HEADERS([linux/un.h], [], [],
+    [[
+      #if HAVE_SYS_SOCKET_H
+      #  include <sys/socket.h>
+      #endif
+    ]]
+  )
+  # For the turbostat plugin
+  AC_CHECK_HEADERS([asm/msr-index.h],
+    [have_asm_msrindex_h="yes"],
+    [have_asm_msrindex_h="no"]
+  )
+  
+  if test "x$have_asm_msrindex_h" = "xyes"; then
+    AC_CACHE_CHECK([whether asm/msr-index.h has MSR_PKG_C10_RESIDENCY],
+      [c_cv_have_usable_asm_msrindex_h],
+      [
+        AC_COMPILE_IFELSE(
+          [
+            AC_LANG_PROGRAM(
+              [[#include<asm/msr-index.h>]],
+              [[
+                int y = MSR_PKG_C10_RESIDENCY;
+                return(y);
+              ]]
+            )
+          ],
+          [c_cv_have_usable_asm_msrindex_h="yes"],
+          [c_cv_have_usable_asm_msrindex_h="no"],
+        )
+      ]
+    )
+  fi
+  
+  AC_CHECK_HEADERS([cpuid.h],
+    [have_cpuid_h="yes"],
+    [have_cpuid_h="no (cpuid.h not found)"]
+  )
+  
+  AC_CHECK_HEADERS([sys/capability.h],
+    [have_capability="yes"],
+    [have_capability="no (<sys/capability.h> not found)"]
+  )
+
+  if test "x$have_capability" = "xyes"; then
+    AC_CHECK_LIB([cap], [cap_get_bound],
+      [have_capability="yes"],
+      [have_capability="no (cap_get_bound() not found)"]
+    )
+  fi
+
+  if test "x$have_capability" = "xyes"; then
+    AC_DEFINE([HAVE_CAPABILITY], [1], [Define to 1 if you have cap_get_bound() (-lcap).])
+  fi
+
 else
-	have_linux_raid_md_u_h="no"
+  have_linux_raid_md_u_h="no"
+  have_linux_wireless_h="no"
 fi
 
-# For the wireless module
-have_linux_wireless_h="no"
-if test "x$ac_system" = "xLinux"
-then
-  AC_CHECK_HEADERS(linux/wireless.h,
-		   [have_linux_wireless_h="yes"],
-		   [have_linux_wireless_h="no"],
-[
-#include <dirent.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-])
-fi
+AM_CONDITIONAL([IP_VS_H_NEEDS_KERNEL_CFLAGS], [test "x$ip_vs_h_needs_kernel_cflags" = "xyes"])
+AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
 
 # For the swap module
 have_sys_swap_h="yes"
-AC_CHECK_HEADERS(sys/swap.h vm/anon.h, [], [have_sys_swap_h="no"],
-[
-#undef _FILE_OFFSET_BITS
-#undef _LARGEFILE64_SOURCE
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-])
+AC_CHECK_HEADERS([sys/swap.h vm/anon.h],
+  [],
+  [have_sys_swap_h="no"],
+  [[
+    #undef _FILE_OFFSET_BITS
+    #undef _LARGEFILE64_SOURCE
+    #if HAVE_SYS_TYPES_H
+    #  include <sys/types.h>
+    #endif
+    #if HAVE_SYS_PARAM_H
+    # include <sys/param.h>
+    #endif
+  ]]
+)
 
 # For load module
 # For the processes plugin
 # For users module
-AC_CHECK_HEADERS(sys/loadavg.h linux/config.h utmp.h utmpx.h)
-
-# For interface plugin
-AC_CHECK_HEADERS(ifaddrs.h)
-AC_CHECK_HEADERS(net/if.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif
-])
-AC_CHECK_HEADERS(linux/if.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif
-])
-AC_CHECK_HEADERS(linux/inet_diag.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif
-#if HAVE_LINUX_INET_DIAG_H
-# include <linux/inet_diag.h>
-#endif
-])
-AC_CHECK_HEADERS(linux/netdevice.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif
-#if HAVE_LINUX_IF_H
-# include <linux/if.h>
-#endif
-])
-
-# For ethstat module
-AC_CHECK_HEADERS(linux/sockios.h,
-    [have_linux_sockios_h="yes"],
-    [have_linux_sockios_h="no"],
-    [
-#if HAVE_SYS_IOCTL_H
-# include <sys/ioctl.h>
-#endif
-#if HAVE_NET_IF_H
-# include <net/if.h>
-#endif
-    ])
-AC_CHECK_HEADERS(linux/ethtool.h,
-    [have_linux_ethtool_h="yes"],
-    [have_linux_ethtool_h="no"],
-    [
-#if HAVE_SYS_IOCTL_H
-# include <sys/ioctl.h>
-#endif
-#if HAVE_NET_IF_H
-# include <net/if.h>
-#endif
-#if HAVE_LINUX_SOCKIOS_H
-# include <linux/sockios.h>
-#endif
-    ])
-
-# For ipvs module
-have_linux_ip_vs_h="no"
-have_net_ip_vs_h="no"
-have_ip_vs_h="no"
-ip_vs_h_needs_kernel_cflags="no"
-if test "x$ac_system" = "xLinux"
-then
-	AC_CHECK_HEADERS(linux/ip_vs.h, [have_linux_ip_vs_h="yes"])
-	AC_CHECK_HEADERS(net/ip_vs.h, [have_net_ip_vs_h="yes"])
-	AC_CHECK_HEADERS(ip_vs.h, [have_ip_vs_h="yes"])
-
-	if test "x$have_linux_ip_vs_h$have_net_ip_vs_h$have_ip_vs_h" = "xnonono" && test -d "$KERNEL_DIR"
-	then
-		SAVE_CFLAGS="$CFLAGS"
-		CFLAGS="$CFLAGS $KERNEL_CFLAGS"
-
-		AC_MSG_NOTICE([Did not find ip_vs.h. Trying again using headers from $KERNEL_DIR.])
-
-		AC_CHECK_HEADERS(linux/ip_vs.h, [have_linux_ip_vs_h="yes"])
-		AC_CHECK_HEADERS(net/ip_vs.h, [have_net_ip_vs_h="yes"])
-		AC_CHECK_HEADERS(ip_vs.h, [have_ip_vs_h="yes"])
-
-		if test "x$have_linux_ip_vs_h" = "xyes" || test "x$have_net_ip_vs_h" = "xyes" || test "x$have_ip_vs_h" = "xyes"
-		then
-			ip_vs_h_needs_kernel_cflags="yes"
-		fi
-
-		CFLAGS="$SAVE_CFLAGS"
-	fi
-fi
-AM_CONDITIONAL(IP_VS_H_NEEDS_KERNEL_CFLAGS, test "x$ip_vs_h_needs_kernel_cflags" = "xyes")
+AC_CHECK_HEADERS([sys/loadavg.h linux/config.h utmp.h utmpx.h])
 
 # For quota module
-AC_CHECK_HEADERS(sys/ucred.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-])
+AC_CHECK_HEADERS([sys/ucred.h], [], [],
+  [[
+    #if HAVE_SYS_TYPES_H
+    #  include <sys/types.h>
+    #endif
+    #if HAVE_SYS_PARAM_H
+    # include <sys/param.h>
+    #endif
+  ]]
+)
 
 # For mount interface
-AC_CHECK_HEADERS(sys/mount.h, [], [],
-[
-#if HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-])
-
-# For the email plugin
-AC_CHECK_HEADERS(linux/un.h, [], [],
-[
-#if HAVE_SYS_SOCKET_H
-#	include <sys/socket.h>
-#endif
-])
+AC_CHECK_HEADERS([sys/mount.h], [], [],
+  [[
+    #if HAVE_SYS_TYPES_H
+    #  include <sys/types.h>
+    #endif
+    #if HAVE_SYS_PARAM_H
+    # include <sys/param.h>
+    #endif
+  ]]
+)
 
 # --enable-xfs {{{
 AC_ARG_ENABLE([xfs],
@@ -712,122 +673,95 @@ fi
 # }}}
 
 # For the dns plugin
-AC_CHECK_HEADERS(arpa/nameser.h)
-AC_CHECK_HEADERS(arpa/nameser_compat.h, [], [],
-[
-#if HAVE_ARPA_NAMESER_H
-# include <arpa/nameser.h>
-#endif
-])
+AC_CHECK_HEADERS([arpa/nameser.h])
+AC_CHECK_HEADERS([arpa/nameser_compat.h], [], [],
+  [[
+    #if HAVE_ARPA_NAMESER_H
+    # include <arpa/nameser.h>
+    #endif
+  ]]
+)
 
-AC_CHECK_HEADERS(net/if_arp.h, [], [],
-[#if HAVE_SYS_SOCKET_H
-# include <sys/socket.h>
-#endif
-])
-AC_CHECK_HEADERS(net/ppp_defs.h)
-AC_CHECK_HEADERS(net/if_ppp.h, [], [],
-[#if HAVE_NET_PPP_DEFS_H
-# include <net/ppp_defs.h>
-#endif
-])
-AC_CHECK_HEADERS(netinet/if_ether.h, [], [],
-[#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-# include <sys/socket.h>
-#endif
-#if HAVE_NET_IF_H
-# include <net/if.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-])
+AC_CHECK_HEADERS([net/if_arp.h], [], [],
+  [[
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+  ]]
+)
 
-have_net_pfvar_h="no"
-AC_CHECK_HEADERS(net/pfvar.h,
-               [have_net_pfvar_h="yes"],
-               [have_net_pfvar_h="no"],
-[
-#if HAVE_SYS_IOCTL_H
-# include <sys/ioctl.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-# include <sys/socket.h>
-#endif
-#if HAVE_NET_IF_H
-# include <net/if.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-])
+AC_CHECK_HEADERS([net/ppp_defs.h])
+AC_CHECK_HEADERS([net/if_ppp.h], [], [],
+  [[
+    #if HAVE_NET_PPP_DEFS_H
+    # include <net/ppp_defs.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([netinet/if_ether.h], [], [],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    #if HAVE_NET_IF_H
+    # include <net/if.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+  ]]
+)
+
+AC_CHECK_HEADERS([net/pfvar.h],
+  [have_net_pfvar_h="yes"],
+  [have_net_pfvar_h="no"],
+  [[
+    #if HAVE_SYS_IOCTL_H
+    # include <sys/ioctl.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    #if HAVE_NET_IF_H
+    # include <net/if.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+  ]]
+)
 
 # For the multimeter plugin
-have_termios_h="no"
-AC_CHECK_HEADERS(termios.h, [have_termios_h="yes"])
+AC_CHECK_HEADERS([termios.h],
+  [have_termios_h="yes"],
+  [have_termios_h="no"]
+)
 
 # For cpusleep plugin
 AC_CACHE_CHECK([whether clock_boottime and clock_monotonic are supported],
-		       [c_cv_have_clock_boottime_monotonic],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[
-#include <time.h>
-]],
-[[
- struct timespec b, m;
- clock_gettime(CLOCK_BOOTTIME, &b );
- clock_gettime(CLOCK_MONOTONIC, &m );
-]]
-		       )],
-		       [c_cv_have_clock_boottime_monotonic="yes"],
-		       [c_cv_have_clock_boottime_monotonic="no"]))
+  [c_cv_have_clock_boottime_monotonic],
+  [
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+        [[#include <time.h>]],
+        [[
+          struct timespec b, m;
+          clock_gettime(CLOCK_BOOTTIME, &b );
+          clock_gettime(CLOCK_MONOTONIC, &m );
+        ]]
+      )
+      ],
+      [c_cv_have_clock_boottime_monotonic="yes"],
+      [c_cv_have_clock_boottime_monotonic="no"]
+    )
+  ]
+)
 
-
-# For the turbostat plugin
-have_asm_msrindex_h="no"
-AC_CHECK_HEADERS(asm/msr-index.h, [have_asm_msrindex_h="yes"])
-
-if test "x$have_asm_msrindex_h" = "xyes"
-then
-  AC_CACHE_CHECK([whether asm/msr-index.h has MSR_PKG_C10_RESIDENCY],
-                 [c_cv_have_usable_asm_msrindex_h],
-                 AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include<asm/msr-index.h>
-]]],
-[[[
-int y = MSR_PKG_C10_RESIDENCY;
-return(y);
-]]]
-  )],
-                 [c_cv_have_usable_asm_msrindex_h="yes"],
-                 [c_cv_have_usable_asm_msrindex_h="no"],
-                                  )
-                 )
-fi
-
-have_cpuid_h="no"
-AC_CHECK_HEADERS(cpuid.h, [have_cpuid_h="yes"])
-
-have_capability="yes"
-AC_CHECK_HEADERS(sys/capability.h,
-                 [have_capability="yes"],
-                 [have_capability="no (<sys/capability.h> not found)"])
-if test "x$have_capability" = "xyes"; then
-AC_CHECK_LIB(cap, cap_get_bound,
-                 [have_capability="yes"],
-                 [have_capability="no (cap_get_bound() not found)"])
-fi
-if test "x$have_capability" = "xyes"; then
-  AC_DEFINE(HAVE_CAPABILITY, 1, [Define to 1 if you have cap_get_bound() (-lcap).])
-fi
-AM_CONDITIONAL(BUILD_WITH_CAPABILITY, test "x$have_capability" = "xyes")
 
 #
 # Checks for typedefs, structures, and compiler characteristics.
@@ -838,836 +772,990 @@ AC_TYPE_SIZE_T
 AC_TYPE_UID_T
 AC_HEADER_TIME
 
+test_cxx_flags() {
+  AC_LANG_PUSH([C++])
+  AC_LANG_CONFTEST(
+    [AC_LANG_SOURCE([[int main(void){}]]) ]
+  )
+  $CXX -c conftest.cpp $CXXFLAGS $@ > /dev/null 2> /dev/null
+  ret=$?
+  rm -f conftest.o
+  AC_LANG_POP([C++])
+  return $ret
+}
+
 #
 # Checks for library functions.
 #
-AC_CHECK_FUNCS(gettimeofday select strdup strtol getaddrinfo getnameinfo strchr memcpy strstr strcmp strncmp strncpy strlen strncasecmp strcasecmp openlog closelog sysconf setenv if_indextoname setlocale asprintf)
+AC_CHECK_FUNCS_ONCE([ \
+    asprintf \
+    closelog \
+    getaddrinfo \
+    getgrnam_r \
+    getnameinfo \
+    getpwnam_r \
+    gettimeofday \
+    if_indextoname \
+    openlog \
+    regcomp \
+    regerror \
+    regexec \
+    regfree \
+    select \
+    setenv \
+    setgroups \
+    strcasecmp \
+    strdup \
+    strncasecmp \
+    sysconf
+  ]
+)
 
 AC_FUNC_STRERROR_R
 
-test_cxx_flags() {
-	AC_LANG_PUSH([C++])
-	AC_LANG_CONFTEST([
-		AC_LANG_SOURCE([[int main(void){}]])
-	])
-	$CXX -c conftest.cpp $CXXFLAGS $@ > /dev/null 2> /dev/null
-	ret=$?
-	rm -f conftest.o
-	AC_LANG_POP([C++])
-	return $ret
-}
-
 SAVE_CFLAGS="$CFLAGS"
 # Emulate behavior of src/Makefile.am
-if test "x$GCC" = "xyes"
-then
-	CFLAGS="$CFLAGS -Wall -Werror"
+if test "x$GCC" = "xyes"; then
+  CFLAGS="$CFLAGS -Wall -Werror"
 fi
 
 AC_CACHE_CHECK([for strtok_r],
   [c_cv_have_strtok_r_default],
-  AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-]]],
-[[[
-      char buffer[] = "foo,bar,baz";
-      char *token;
-      char *dummy;
-      char *saveptr;
+  [
+    AC_LINK_IFELSE(
+      [
+        AC_LANG_PROGRAM(
+          [[
+            #include <stdlib.h>
+            #include <stdio.h>
+            #include <string.h>
+          ]],
+          [[
+            char buffer[] = "foo,bar,baz";
+            char *token;
+            char *dummy;
+            char *saveptr;
 
-      dummy = buffer;
-      saveptr = NULL;
-      while ((token = strtok_r (dummy, ",", &saveptr)) != NULL)
-      {
-        dummy = NULL;
-        printf ("token = %s;\n", token);
-      }
-]]]
-    )],
-    [c_cv_have_strtok_r_default="yes"],
-    [c_cv_have_strtok_r_default="no"]
-  )
+            dummy = buffer;
+            saveptr = NULL;
+            while ((token = strtok_r (dummy, ",", &saveptr)) != NULL)
+            {
+              dummy = NULL;
+              printf ("token = %s;\n", token);
+            }
+          ]]
+        )
+      ],
+      [c_cv_have_strtok_r_default="yes"],
+      [c_cv_have_strtok_r_default="no"]
+    )
+  ]
 )
 
-if test "x$c_cv_have_strtok_r_default" = "xno"
-then
+if test "x$c_cv_have_strtok_r_default" = "xno"; then
   CFLAGS="$CFLAGS -D_REENTRANT=1"
 
   AC_CACHE_CHECK([if strtok_r needs _REENTRANT],
     [c_cv_have_strtok_r_reentrant],
-    AC_LINK_IFELSE(
-      [AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-]]],
-[[[
-        char buffer[] = "foo,bar,baz";
-        char *token;
-        char *dummy;
-        char *saveptr;
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #include <stdio.h>
+              #include <string.h>
+            ]],
+            [[
+              char buffer[] = "foo,bar,baz";
+              char *token;
+              char *dummy;
+              char *saveptr;
 
-        dummy = buffer;
-        saveptr = NULL;
-        while ((token = strtok_r (dummy, ",", &saveptr)) != NULL)
-        {
-          dummy = NULL;
-          printf ("token = %s;\n", token);
-        }
-]]]
-      )],
-      [c_cv_have_strtok_r_reentrant="yes"],
-      [AC_MSG_FAILURE([strtok_r isn't available. Please file a bugreport!])]
-    )
+              dummy = buffer;
+              saveptr = NULL;
+              while ((token = strtok_r (dummy, ",", &saveptr)) != NULL)
+              {
+                dummy = NULL;
+                printf ("token = %s;\n", token);
+              }
+            ]]
+          )
+        ],
+        [c_cv_have_strtok_r_reentrant="yes"],
+        [AC_MSG_FAILURE([strtok_r is not available. Please file a bugreport!])]
+      )
+    ]
   )
 fi
 
 CFLAGS="$SAVE_CFLAGS"
-if test "x$c_cv_have_strtok_r_reentrant" = "xyes"
-then
-	CFLAGS="$CFLAGS -D_REENTRANT=1"
+if test "x$c_cv_have_strtok_r_reentrant" = "xyes"; then
+  CFLAGS="$CFLAGS -D_REENTRANT=1"
 fi
 
-AC_CHECK_FUNCS(getpwnam_r getgrnam_r setgroups regcomp regerror regexec regfree)
+AC_CHECK_FUNCS([socket],
+  [],
+  [
+    AC_CHECK_LIB([socket], [socket],
+      [socket_needs_socket="yes"],
+      [AC_MSG_ERROR([cannot find socket() in libsocket])]
+    )
+  ]
+)
+AM_CONDITIONAL([BUILD_WITH_LIBSOCKET], [test "x$socket_needs_socket" = "xyes"])
 
-socket_needs_socket="no"
-AC_CHECK_FUNCS(socket, [], AC_CHECK_LIB(socket, socket, [socket_needs_socket="yes"], AC_MSG_ERROR(cannot find socket)))
-AM_CONDITIONAL(BUILD_WITH_LIBSOCKET, test "x$socket_needs_socket" = "xyes")
-
-clock_gettime_needs_rt="no"
 clock_gettime_needs_posix4="no"
-have_clock_gettime="no"
-AC_CHECK_FUNCS(clock_gettime, [have_clock_gettime="yes"])
+AC_CHECK_FUNCS([clock_gettime],
+  [have_clock_gettime="yes"],
+  [have_clock_gettime="no"]
+)
+
 if test "x$have_clock_gettime" = "xno"
 then
-	AC_CHECK_LIB(rt, clock_gettime, [clock_gettime_needs_rt="yes"
-					 have_clock_gettime="yes"])
+  AC_CHECK_LIB([rt], [clock_gettime],
+    [
+      clock_gettime_needs_rt="yes"
+      have_clock_gettime="yes"
+    ]
+  )
 fi
+
 if test "x$have_clock_gettime" = "xno"
 then
-	AC_CHECK_LIB(posix4, clock_gettime, [clock_gettime_needs_posix4="yes"
-					     have_clock_gettime="yes"])
+  AC_CHECK_LIB([posix4], [clock_gettime],
+    [
+      clock_gettime_needs_posix4="yes"
+      have_clock_gettime="yes"
+    ]
+  )
 fi
+
 if test "x$have_clock_gettime" = "xyes"
 then
-	AC_DEFINE(HAVE_CLOCK_GETTIME, 1, [Define if the clock_gettime(2) function is available.])
+  AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define if the clock_gettime(2) function is available.])
 fi
 
-nanosleep_needs_rt="no"
-nanosleep_needs_posix4="no"
-AC_CHECK_FUNCS(nanosleep,
-    [],
-    AC_CHECK_LIB(rt, nanosleep,
-        [nanosleep_needs_rt="yes"],
-        AC_CHECK_LIB(posix4, nanosleep,
-            [nanosleep_needs_posix4="yes"],
-            AC_MSG_ERROR(cannot find nanosleep))))
+AC_CHECK_FUNCS([nanosleep], [],
+  AC_CHECK_LIB([rt], [nanosleep],
+    [nanosleep_needs_rt="yes"],
+    [
+      AC_CHECK_LIB([posix4], [nanosleep],
+        [nanosleep_needs_posix4="yes"],
+        [AC_MSG_ERROR([cannot find nanosleep])]
+      )
+    ]
+  )
+)
 
-AM_CONDITIONAL(BUILD_WITH_LIBRT, test "x$clock_gettime_needs_rt" = "xyes" || test "x$nanosleep_needs_rt" = "xyes")
-AM_CONDITIONAL(BUILD_WITH_LIBPOSIX4, test "x$clock_gettime_needs_posix4" = "xyes" || test "x$nanosleep_needs_posix4" = "xyes")
+AM_CONDITIONAL([BUILD_WITH_LIBRT], [test "x$clock_gettime_needs_rt" = "xyes" || test "x$nanosleep_needs_rt" = "xyes"])
+AM_CONDITIONAL([BUILD_WITH_LIBPOSIX4], [test "x$clock_gettime_needs_posix4" = "xyes" || test "x$nanosleep_needs_posix4" = "xyes"])
 
-AC_CHECK_FUNCS(sysctl, [have_sysctl="yes"], [have_sysctl="no"])
-AC_CHECK_FUNCS(sysctlbyname, [have_sysctlbyname="yes"], [have_sysctlbyname="no"])
-AC_CHECK_FUNCS(host_statistics, [have_host_statistics="yes"], [have_host_statistics="no"])
-AC_CHECK_FUNCS(processor_info, [have_processor_info="yes"], [have_processor_info="no"])
-AC_CHECK_FUNCS(thread_info, [have_thread_info="yes"], [have_thread_info="no"])
-AC_CHECK_FUNCS(statfs, [have_statfs="yes"], [have_statfs="no"])
-AC_CHECK_FUNCS(statvfs, [have_statvfs="yes"], [have_statvfs="no"])
-AC_CHECK_FUNCS(getifaddrs, [have_getifaddrs="yes"], [have_getifaddrs="no"])
-AC_CHECK_FUNCS(getloadavg, [have_getloadavg="yes"], [have_getloadavg="no"])
-AC_CHECK_FUNCS(syslog, [have_syslog="yes"], [have_syslog="no"])
-AC_CHECK_FUNCS(getutent, [have_getutent="yes"], [have_getutent="no"])
-AC_CHECK_FUNCS(getutxent, [have_getutxent="yes"], [have_getutxent="no"])
+AC_CHECK_FUNCS([getifaddrs], [have_getifaddrs="yes"], [have_getifaddrs="no"])
+AC_CHECK_FUNCS([getloadavg], [have_getloadavg="yes"], [have_getloadavg="no"])
+AC_CHECK_FUNCS([getutent], [have_getutent="yes"], [have_getutent="no"])
+AC_CHECK_FUNCS([getutxent], [have_getutxent="yes"], [have_getutxent="no"])
+AC_CHECK_FUNCS([host_statistics], [have_host_statistics="yes"], [have_host_statistics="no"])
+AC_CHECK_FUNCS([processor_info], [have_processor_info="yes"], [have_processor_info="no"])
+AC_CHECK_FUNCS([statfs], [have_statfs="yes"], [have_statfs="no"])
+AC_CHECK_FUNCS([statvfs], [have_statvfs="yes"], [have_statvfs="no"])
+AC_CHECK_FUNCS([sysctl], [have_sysctl="yes"], [have_sysctl="no"])
+AC_CHECK_FUNCS([sysctlbyname], [have_sysctlbyname="yes"], [have_sysctlbyname="no"])
+AC_CHECK_FUNCS([syslog], [have_syslog="yes"], [have_syslog="no"])
+AC_CHECK_FUNCS([thread_info], [have_thread_info="yes"], [have_thread_info="no"])
 
 # Check for strptime {{{
 if test "x$GCC" = "xyes"
 then
-	SAVE_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS -Wall -Wextra -Werror"
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS -Wall -Wextra -Werror"
 fi
 
-AC_CHECK_FUNCS(strptime, [have_strptime="yes"], [have_strptime="no"])
+AC_CHECK_FUNCS([strptime], [have_strptime="yes"], [have_strptime="no"])
 if test "x$have_strptime" = "xyes"
 then
-	AC_CACHE_CHECK([whether strptime is exported by default],
-		       [c_cv_have_strptime_default],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <time.h>
-]]],
-[[[
- struct tm stm;
- (void) strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
-]]]
-		       )],
-		       [c_cv_have_strptime_default="yes"],
-		       [c_cv_have_strptime_default="no"]))
+  AC_CACHE_CHECK([whether strptime is exported by default],
+    [c_cv_have_strptime_default],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[#include <time.h>]],
+            [[
+              struct tm stm;
+              (void)strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
+            ]]
+          )
+        ],
+        [c_cv_have_strptime_default="yes"],
+        [c_cv_have_strptime_default="no"])
+    ]
+  )
 fi
+
 if test "x$have_strptime" = "xyes" && test "x$c_cv_have_strptime_default" = "xno"
 then
-	AC_CACHE_CHECK([whether strptime needs standards mode],
-		       [c_cv_have_strptime_standards],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#ifndef _ISOC99_SOURCE
-# define _ISOC99_SOURCE 1
-#endif
-#ifndef _POSIX_C_SOURCE
-# define _POSIX_C_SOURCE 200112L
-#endif
-#ifndef _XOPEN_SOURCE
-# define _XOPEN_SOURCE 500
-#endif
-#include <time.h>
-]]],
-[[[
- struct tm stm;
- (void) strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
-]]]
-		       )],
-		       [c_cv_have_strptime_standards="yes"],
-		       [c_cv_have_strptime_standards="no"]))
+  AC_CACHE_CHECK([whether strptime needs standards mode],
+    [c_cv_have_strptime_standards],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #ifndef _ISOC99_SOURCE
+              # define _ISOC99_SOURCE 1
+              #endif
+              #ifndef _POSIX_C_SOURCE
+              # define _POSIX_C_SOURCE 200112L
+              #endif
+              #ifndef _XOPEN_SOURCE
+              # define _XOPEN_SOURCE 500
+              #endif
+              #include <time.h>
+            ]],
+            [[
+              struct tm stm;
+              (void)strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
+            ]]
+          )
+        ],
+        [c_cv_have_strptime_standards="yes"],
+        [c_cv_have_strptime_standards="no"]
+      )
+    ]
+  )
 
-	if test "x$c_cv_have_strptime_standards" = "xyes"
-	then
-		AC_DEFINE([STRPTIME_NEEDS_STANDARDS], 1, [Set to true if strptime is only exported in X/Open mode (GNU libc).])
-	else
-		have_strptime="no"
-	fi
+  if test "x$c_cv_have_strptime_standards" = "xyes"; then
+    AC_DEFINE([STRPTIME_NEEDS_STANDARDS], [1],
+      [Set to true if strptime is only exported in X/Open mode (GNU libc).]
+    )
+  else
+    have_strptime="no"
+  fi
 fi
 
 if test "x$GCC" = "xyes"
 then
-	CFLAGS="$SAVE_CFLAGS"
+  CFLAGS="$SAVE_CFLAGS"
 fi
 # }}} Check for strptime
 
-AC_CHECK_FUNCS(swapctl, [have_swapctl="yes"], [have_swapctl="no"])
-if test "x$have_swapctl" = "xyes"; then
-        AC_CACHE_CHECK([whether swapctl takes two arguments],
-                [c_cv_have_swapctl_two_args],
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#if HAVE_SYS_SWAP_H && !defined(_LP64) && _FILE_OFFSET_BITS == 64
-#  undef _FILE_OFFSET_BITS
-#  undef _LARGEFILE64_SOURCE
-#endif
-#include <sys/stat.h>
-#include <sys/param.h>
-#include <sys/swap.h>
-#include <unistd.h>
-]]],
-[[[
-int num = swapctl(0, NULL);
-]]]
-                        )],
-                        [c_cv_have_swapctl_two_args="yes"],
-                        [c_cv_have_swapctl_two_args="no"]
-                )
-        )
-        AC_CACHE_CHECK([whether swapctl takes three arguments],
-                [c_cv_have_swapctl_three_args],
-                AC_COMPILE_IFELSE(
-                        [AC_LANG_PROGRAM(
-[[[
-#if HAVE_SYS_SWAP_H && !defined(_LP64) && _FILE_OFFSET_BITS == 64
-#  undef _FILE_OFFSET_BITS
-#  undef _LARGEFILE64_SOURCE
-#endif
-#include <sys/stat.h>
-#include <sys/param.h>
-#include <sys/swap.h>
-#include <unistd.h>
-]]],
-[[[
-int num = swapctl(0, NULL, 0);
-]]]
-                        )],
-                        [c_cv_have_swapctl_three_args="yes"],
-                        [c_cv_have_swapctl_three_args="no"]
-                )
-        )
+AC_MSG_CHECKING([for sysctl kern.cp_times])
+if test -x /sbin/sysctl
+then
+  /sbin/sysctl kern.cp_times >/dev/null 2>&1
+  if test $? -eq 0; then
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_SYSCTL_KERN_CP_TIMES], [1], [Define if sysctl supports kern.cp_times])
+  else
+    AC_MSG_RESULT([no])
+  fi
+else
+  AC_MSG_RESULT([no])
 fi
+
+AC_MSG_CHECKING([for sysctl kern.cp_time])
+if test -x /sbin/sysctl
+then
+  /sbin/sysctl kern.cp_time >/dev/null 2>&1
+  if test $? -eq 0
+  then
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_SYSCTL_KERN_CP_TIME], [1], [Define if sysctl supports kern.cp_time])
+  else
+    AC_MSG_RESULT([no])
+  fi
+else
+  AC_MSG_RESULT([no])
+fi
+
+AC_CHECK_FUNCS([swapctl], [have_swapctl="yes"], [have_swapctl="no"])
+if test "x$have_swapctl" = "xyes"; then
+  AC_CACHE_CHECK([whether swapctl takes two arguments],
+    [c_cv_have_swapctl_two_args],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #if HAVE_SYS_SWAP_H && !defined(_LP64) && _FILE_OFFSET_BITS == 64
+              #  undef _FILE_OFFSET_BITS
+              #  undef _LARGEFILE64_SOURCE
+              #endif
+              #include <sys/stat.h>
+              #include <sys/param.h>
+              #include <sys/swap.h>
+              #include <unistd.h>
+            ]],
+            [[int num = swapctl(0, NULL);]]
+          )
+        ],
+        [c_cv_have_swapctl_two_args="yes"],
+        [c_cv_have_swapctl_two_args="no"]
+      )
+    ]
+  )
+
+  AC_CACHE_CHECK([whether swapctl takes three arguments],
+    [c_cv_have_swapctl_three_args],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #if HAVE_SYS_SWAP_H && !defined(_LP64) && _FILE_OFFSET_BITS == 64
+              #  undef _FILE_OFFSET_BITS
+              #  undef _LARGEFILE64_SOURCE
+              #endif
+              #include <sys/stat.h>
+              #include <sys/param.h>
+              #include <sys/swap.h>
+              #include <unistd.h>
+            ]],
+            [[int num = swapctl(0, NULL, 0);]]
+          )
+        ],
+        [c_cv_have_swapctl_three_args="yes"],
+        [c_cv_have_swapctl_three_args="no"]
+      )
+    ]
+  )
+fi
+
 # Check for different versions of `swapctl' here..
 if test "x$have_swapctl" = "xyes"; then
-        if test "x$c_cv_have_swapctl_two_args" = "xyes"; then
-                AC_DEFINE(HAVE_SWAPCTL_TWO_ARGS, 1,
-                          [Define if the function swapctl exists and takes two arguments.])
-        fi
-        if test "x$c_cv_have_swapctl_three_args" = "xyes"; then
-                AC_DEFINE(HAVE_SWAPCTL_THREE_ARGS, 1,
-                          [Define if the function swapctl exists and takes three arguments.])
-        fi
+  if test "x$c_cv_have_swapctl_two_args" = "xyes"; then
+    AC_DEFINE([HAVE_SWAPCTL_TWO_ARGS], [1], [Define if the function swapctl exists and takes two arguments.])
+  fi
+
+  if test "x$c_cv_have_swapctl_three_args" = "xyes"; then
+    AC_DEFINE([HAVE_SWAPCTL_THREE_ARGS], [1], [Define if the function swapctl exists and takes three arguments.])
+  fi
 fi
 
 # Check for NAN
-AC_ARG_WITH(nan-emulation, [AS_HELP_STRING([--with-nan-emulation], [use emulated NAN. For crosscompiling only.])],
-[
- if test "x$withval" = "xno"; then
-	 nan_type="none"
- else if test "x$withval" = "xyes"; then
-	 nan_type="zero"
- else
-	 nan_type="$withval"
- fi; fi
-],
-[nan_type="none"])
+AC_ARG_WITH([nan-emulation],
+  [AS_HELP_STRING([--with-nan-emulation], [use emulated NAN. For crosscompiling only.])],
+  [
+    if test "x$withval" = "xno"; then
+      nan_type="none"
+    else if test "x$withval" = "xyes"; then
+      nan_type="zero"
+    else
+      nan_type="$withval"
+    fi; fi
+  ],
+  [nan_type="none"]
+)
+
 if test "x$nan_type" = "xnone"; then
   AC_CACHE_CHECK([whether NAN is defined by default],
     [c_cv_have_nan_default],
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <math.h>
-static double foo = NAN;
-]]],
-[[[
-       if (isnan (foo))
-        return 0;
-       else
-	return 1;
-]]]
-      )],
-      [c_cv_have_nan_default="yes"],
-      [c_cv_have_nan_default="no"]
-    )
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #include <math.h>
+              static double foo = NAN;
+            ]],
+            [[
+              if (isnan (foo))
+                return 0;
+              return 1;
+            ]]
+          )
+        ],
+        [c_cv_have_nan_default="yes"],
+        [c_cv_have_nan_default="no"]
+      )
+    ]
   )
-  if test "x$c_cv_have_nan_default" = "xyes"
-  then
-    nan_type="default"
-  fi
 fi
+
+if test "x$c_cv_have_nan_default" = "xyes"; then
+  nan_type="default"
+fi
+
 if test "x$nan_type" = "xnone"; then
   AC_CACHE_CHECK([whether NAN is defined by __USE_ISOC99],
     [c_cv_have_nan_isoc],
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#define __USE_ISOC99 1
-#include <math.h>
-static double foo = NAN;
-]]],
-[[[
-       if (isnan (foo))
-        return 0;
-       else
-	return 1;
-]]]
-      )],
-      [c_cv_have_nan_isoc="yes"],
-      [c_cv_have_nan_isoc="no"]
-    )
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #define __USE_ISOC99 1
+              #include <math.h>
+              static double foo = NAN;
+            ]],
+            [[
+              if (isnan (foo))
+                return 0;
+              return 1;
+            ]]
+          )
+        ],
+        [c_cv_have_nan_isoc="yes"],
+        [c_cv_have_nan_isoc="no"]
+      )
+    ]
   )
-  if test "x$c_cv_have_nan_isoc" = "xyes"
-  then
-    nan_type="isoc99"
-  fi
 fi
+
+if test "x$c_cv_have_nan_isoc" = "xyes"; then
+  nan_type="isoc99"
+fi
+
 if test "x$nan_type" = "xnone"; then
-  SAVE_LDFLAGS=$LDFLAGS
+  SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS -lm"
   AC_CACHE_CHECK([whether NAN can be defined by 0/0],
     [c_cv_have_nan_zero],
-    AC_RUN_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <math.h>
-#ifdef NAN
-# undef NAN
-#endif
-#define NAN (0.0 / 0.0)
-#ifndef isnan
-# define isnan(f) ((f) != (f))
-#endif
-static double foo = NAN;
-]]],
-[[[
-       if (isnan (foo))
-        return 0;
-       else
-	return 1;
-]]]
-      )],
-      [c_cv_have_nan_zero="yes"],
-      [c_cv_have_nan_zero="no"]
-    )
+    [
+      AC_RUN_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #include <math.h>
+              #ifdef NAN
+              # undef NAN
+              #endif
+              #define NAN (0.0 / 0.0)
+              #ifndef isnan
+              # define isnan(f) ((f) != (f))
+              #endif
+              static double foo = NAN;
+            ]],
+            [[
+              if (isnan (foo))
+                return 0;
+              return 1;
+            ]]
+          )
+        ],
+        [c_cv_have_nan_zero="yes"],
+        [c_cv_have_nan_zero="no"]
+      )
+    ]
   )
   LDFLAGS=$SAVE_LDFLAGS
-  if test "x$c_cv_have_nan_zero" = "xyes"
-  then
-    nan_type="zero"
-  fi
+fi
+
+if test "x$c_cv_have_nan_zero" = "xyes"; then
+  nan_type="zero"
 fi
 
 if test "x$nan_type" = "xdefault"; then
-  AC_DEFINE(NAN_STATIC_DEFAULT, 1,
-    [Define if NAN is defined by default and can initialize static variables.])
+  AC_DEFINE([NAN_STATIC_DEFAULT], [1],
+    [Define if NAN is defined by default and can initialize static variables.]
+  )
 else if test "x$nan_type" = "xisoc99"; then
-  AC_DEFINE(NAN_STATIC_ISOC, 1,
-    [Define if NAN is defined by __USE_ISOC99 and can initialize static variables.])
+  AC_DEFINE([NAN_STATIC_ISOC], [1],
+    [Define if NAN is defined by __USE_ISOC99 and can initialize static variables.]
+  )
 else if test "x$nan_type" = "xzero"; then
-  AC_DEFINE(NAN_ZERO_ZERO, 1,
-    [Define if NAN can be defined as (0.0 / 0.0)])
+  AC_DEFINE([NAN_ZERO_ZERO], [1],
+    [Define if NAN can be defined as (0.0 / 0.0)]
+  )
 else
   AC_MSG_ERROR([Didn't find out how to statically initialize variables to NAN. Sorry.])
 fi; fi; fi
 
-AC_ARG_WITH(fp-layout, [AS_HELP_STRING([--with-fp-layout], [set the memory layout of doubles. For crosscompiling only.])],
-[
- if test "x$withval" = "xnothing"; then
- 	fp_layout_type="nothing"
- else if test "x$withval" = "xendianflip"; then
- 	fp_layout_type="endianflip"
- else if test "x$withval" = "xintswap"; then
- 	fp_layout_type="intswap"
- else
- 	AC_MSG_ERROR([Invalid argument for --with-fp-layout. Valid arguments are: nothing, endianflip, intswap]);
-fi; fi; fi
-],
-[fp_layout_type="unknown"])
+AC_ARG_WITH([fp-layout],
+  [
+    AS_HELP_STRING([--with-fp-layout],
+      [set the memory layout of doubles. For crosscompiling only.]
+    )
+  ],
+  [
+    if test "x$withval" = "xnothing"; then
+      fp_layout_type="nothing"
+    else if test "x$withval" = "xendianflip"; then
+      fp_layout_type="endianflip"
+    else if test "x$withval" = "xintswap"; then
+      fp_layout_type="intswap"
+    else
+      AC_MSG_ERROR([Invalid argument for --with-fp-layout. Valid arguments are: nothing, endianflip, intswap]);
+    fi; fi; fi
+  ],
+  [fp_layout_type="unknown"]
+)
 
 if test "x$fp_layout_type" = "xunknown"; then
-  AC_CACHE_CHECK([if doubles are stored in x86 representation],
-    [c_cv_fp_layout_need_nothing],
-    AC_RUN_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_INTTYPES_H
-# include <inttypes.h>
-#endif
-#if HAVE_STDBOOL_H
-# include <stdbool.h>
-#endif
-]]],
-[[[
-	uint64_t i0;
-	uint64_t i1;
-	uint8_t c[8];
-	double d;
+AC_CACHE_CHECK([if doubles are stored in x86 representation],
+  [c_cv_fp_layout_need_nothing],
+  [
+    AC_RUN_IFELSE(
+      [
+        AC_LANG_PROGRAM(
+          [[
+            #include <stdlib.h>
+            #include <stdio.h>
+            #include <string.h>
+            #include <stdint.h>
+            #include <inttypes.h>
+            #include <stdbool.h>
+          ]],
+          [[
+            uint64_t i0;
+            uint64_t i1;
+            uint8_t c[8];
+            double d;
 
-	d = 8.642135e130;
-	memcpy ((void *) &i0, (void *) &d, 8);
+            d = 8.642135e130;
+            memcpy ((void *) &i0, (void *) &d, 8);
 
-	i1 = i0;
-	memcpy ((void *) c, (void *) &i1, 8);
+            i1 = i0;
+            memcpy ((void *) c, (void *) &i1, 8);
 
-	if ((c[0] == 0x2f) && (c[1] == 0x25)
-			&& (c[2] == 0xc0) && (c[3] == 0xc7)
-			&& (c[4] == 0x43) && (c[5] == 0x2b)
-			&& (c[6] == 0x1f) && (c[7] == 0x5b))
-		return (0);
-	else
-		return (1);
-]]]
-      )],
+            if ((c[0] == 0x2f) && (c[1] == 0x25)
+                && (c[2] == 0xc0) && (c[3] == 0xc7)
+                && (c[4] == 0x43) && (c[5] == 0x2b)
+                && (c[6] == 0x1f) && (c[7] == 0x5b))
+              return (0);
+            return (1);
+          ]]
+        )
+      ],
       [c_cv_fp_layout_need_nothing="yes"],
       [c_cv_fp_layout_need_nothing="no"]
     )
-  )
-  if test "x$c_cv_fp_layout_need_nothing" = "xyes"; then
-    fp_layout_type="nothing"
-  fi
+  ]
+)
 fi
+
+if test "x$c_cv_fp_layout_need_nothing" = "xyes"; then
+  fp_layout_type="nothing"
+fi
+
 if test "x$fp_layout_type" = "xunknown"; then
   AC_CACHE_CHECK([if endianflip converts to x86 representation],
     [c_cv_fp_layout_need_endianflip],
-    AC_RUN_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_INTTYPES_H
-# include <inttypes.h>
-#endif
-#if HAVE_STDBOOL_H
-# include <stdbool.h>
-#endif
-#define endianflip(A) ((((uint64_t)(A) & 0xff00000000000000LL) >> 56) | \
-                       (((uint64_t)(A) & 0x00ff000000000000LL) >> 40) | \
-                       (((uint64_t)(A) & 0x0000ff0000000000LL) >> 24) | \
-                       (((uint64_t)(A) & 0x000000ff00000000LL) >> 8)  | \
-                       (((uint64_t)(A) & 0x00000000ff000000LL) << 8)  | \
-                       (((uint64_t)(A) & 0x0000000000ff0000LL) << 24) | \
-                       (((uint64_t)(A) & 0x000000000000ff00LL) << 40) | \
-                       (((uint64_t)(A) & 0x00000000000000ffLL) << 56))
-]]],
-[[[
-	uint64_t i0;
-	uint64_t i1;
-	uint8_t c[8];
-	double d;
-
-	d = 8.642135e130;
-	memcpy ((void *) &i0, (void *) &d, 8);
-
-	i1 = endianflip (i0);
-	memcpy ((void *) c, (void *) &i1, 8);
-
-	if ((c[0] == 0x2f) && (c[1] == 0x25)
-			&& (c[2] == 0xc0) && (c[3] == 0xc7)
-			&& (c[4] == 0x43) && (c[5] == 0x2b)
-			&& (c[6] == 0x1f) && (c[7] == 0x5b))
-		return (0);
-	else
-		return (1);
-]]]
-      )],
-      [c_cv_fp_layout_need_endianflip="yes"],
-      [c_cv_fp_layout_need_endianflip="no"]
+    [
+      AC_RUN_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #include <stdio.h>
+              #include <string.h>
+              #include <stdint.h>
+              #include <inttypes.h>
+              #include <stdbool.h>
+              #define endianflip(A) ((((uint64_t)(A) & 0xff00000000000000LL) >> 56) | \
+                                     (((uint64_t)(A) & 0x00ff000000000000LL) >> 40) | \
+                                     (((uint64_t)(A) & 0x0000ff0000000000LL) >> 24) | \
+                                     (((uint64_t)(A) & 0x000000ff00000000LL) >> 8)  | \
+                                     (((uint64_t)(A) & 0x00000000ff000000LL) << 8)  | \
+                                     (((uint64_t)(A) & 0x0000000000ff0000LL) << 24) | \
+                                     (((uint64_t)(A) & 0x000000000000ff00LL) << 40) | \
+                                     (((uint64_t)(A) & 0x00000000000000ffLL) << 56))
+            ]],
+            [[
+              uint64_t i0;
+              uint64_t i1;
+              uint8_t c[8];
+              double d;
+              
+              d = 8.642135e130;
+              memcpy ((void *) &i0, (void *) &d, 8);
+              
+              i1 = endianflip (i0);
+              memcpy ((void *) c, (void *) &i1, 8);
+              
+              if ((c[0] == 0x2f) && (c[1] == 0x25)
+                  && (c[2] == 0xc0) && (c[3] == 0xc7)
+                  && (c[4] == 0x43) && (c[5] == 0x2b)
+                  && (c[6] == 0x1f) && (c[7] == 0x5b))
+                return (0);
+              return (1);
+            ]]
+          )
+        ],
+        [c_cv_fp_layout_need_endianflip="yes"],
+        [c_cv_fp_layout_need_endianflip="no"]
+      ]
     )
   )
-  if test "x$c_cv_fp_layout_need_endianflip" = "xyes"; then
-    fp_layout_type="endianflip"
-  fi
 fi
+
+if test "x$c_cv_fp_layout_need_endianflip" = "xyes"; then
+  fp_layout_type="endianflip"
+fi
+
 if test "x$fp_layout_type" = "xunknown"; then
   AC_CACHE_CHECK([if intswap converts to x86 representation],
     [c_cv_fp_layout_need_intswap],
-    AC_RUN_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_INTTYPES_H
-# include <inttypes.h>
-#endif
-#if HAVE_STDBOOL_H
-# include <stdbool.h>
-#endif
-#define intswap(A)    ((((uint64_t)(A) & 0xffffffff00000000LL) >> 32) | \
-                       (((uint64_t)(A) & 0x00000000ffffffffLL) << 32))
-]]],
-[[[
-	uint64_t i0;
-	uint64_t i1;
-	uint8_t c[8];
-	double d;
-
-	d = 8.642135e130;
-	memcpy ((void *) &i0, (void *) &d, 8);
-
-	i1 = intswap (i0);
-	memcpy ((void *) c, (void *) &i1, 8);
-
-	if ((c[0] == 0x2f) && (c[1] == 0x25)
-			&& (c[2] == 0xc0) && (c[3] == 0xc7)
-			&& (c[4] == 0x43) && (c[5] == 0x2b)
-			&& (c[6] == 0x1f) && (c[7] == 0x5b))
-		return (0);
-	else
-		return (1);
-]]]
-      )],
-      [c_cv_fp_layout_need_intswap="yes"],
-      [c_cv_fp_layout_need_intswap="no"]
-    )
+    [
+      AC_RUN_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdlib.h>
+              #include <stdio.h>
+              #include <string.h>
+              #include <stdint.h>
+              #include <inttypes.h>
+              #include <stdbool.h>
+              #define intswap(A)    ((((uint64_t)(A) & 0xffffffff00000000LL) >> 32) | \
+                                     (((uint64_t)(A) & 0x00000000ffffffffLL) << 32))
+            ]],
+            [[
+              uint64_t i0;
+              uint64_t i1;
+              uint8_t c[8];
+              double d;
+              
+              d = 8.642135e130;
+              memcpy ((void *) &i0, (void *) &d, 8);
+              
+              i1 = intswap (i0);
+              memcpy ((void *) c, (void *) &i1, 8);
+              
+              if ((c[0] == 0x2f) && (c[1] == 0x25)
+                  && (c[2] == 0xc0) && (c[3] == 0xc7)
+                  && (c[4] == 0x43) && (c[5] == 0x2b)
+                  && (c[6] == 0x1f) && (c[7] == 0x5b))
+                return (0);
+              return (1);
+            ]]
+          )
+        ],
+        [c_cv_fp_layout_need_intswap="yes"],
+        [c_cv_fp_layout_need_intswap="no"]
+      )
+    ]
   )
-  if test "x$c_cv_fp_layout_need_intswap" = "xyes"; then
-    fp_layout_type="intswap"
-  fi
+fi
+
+if test "x$c_cv_fp_layout_need_intswap" = "xyes"; then
+  fp_layout_type="intswap"
 fi
 
 if test "x$fp_layout_type" = "xnothing"; then
-  AC_DEFINE(FP_LAYOUT_NEED_NOTHING, 1,
-  [Define if doubles are stored in x86 representation.])
+  AC_DEFINE([FP_LAYOUT_NEED_NOTHING], [1],
+    [Define if doubles are stored in x86 representation.]
+  )
 else if test "x$fp_layout_type" = "xendianflip"; then
-  AC_DEFINE(FP_LAYOUT_NEED_ENDIANFLIP, 1,
-  [Define if endianflip is needed to convert to x86 representation.])
+  AC_DEFINE([FP_LAYOUT_NEED_ENDIANFLIP], [1],
+    [Define if endianflip is needed to convert to x86 representation.]
+  )
 else if test "x$fp_layout_type" = "xintswap"; then
-  AC_DEFINE(FP_LAYOUT_NEED_INTSWAP, 1,
-  [Define if intswap is needed to convert to x86 representation.])
+  AC_DEFINE([FP_LAYOUT_NEED_INTSWAP], [1],
+    [Define if intswap is needed to convert to x86 representation.]
+  )
 else
   AC_MSG_ERROR([Didn't find out how doubles are stored in memory. Sorry.])
 fi; fi; fi
 
+# For cpusleep plugin
+AC_CACHE_CHECK([whether clock_boottime and clock_monotonic are supported],
+  [c_cv_have_clock_boottime_monotonic],
+  [
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+        [[#include <time.h>]],
+        [[
+          struct timespec b, m;
+          clock_gettime(CLOCK_BOOTTIME, &b );
+          clock_gettime(CLOCK_MONOTONIC, &m );
+        ]]
+      )
+      ],
+      [c_cv_have_clock_boottime_monotonic="yes"],
+      [c_cv_have_clock_boottime_monotonic="no"]
+    )
+  ]
+)
+
 # --with-useragent {{{
-AC_ARG_WITH(useragent, [AS_HELP_STRING([--with-useragent@<:@=AGENT@:>@], [User agent to use on http requests])],
-[
-    if test "x$withval" != "xno" && test "x$withval" != "xyes"
-    then
-        AC_DEFINE_UNQUOTED(COLLECTD_USERAGENT, ["$withval"], [User agent for http requests])
+AC_ARG_WITH([useragent],
+  [AS_HELP_STRING([--with-useragent@<:@=AGENT@:>@], [User agent to use on http requests])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      AC_DEFINE_UNQUOTED([COLLECTD_USERAGENT], ["$withval"], [User agent for http requests])
     fi
-])
+  ]
+)
 
 # }}}
 
 # --with-data-max-name-len {{{
-AC_ARG_WITH(data-max-name-len, [AS_HELP_STRING([--with-data-max-name-len@<:@=VALUE@:>@], [Maximum length of data buffers])],
-[
-    if test "x$withval" != "x" && test $withval -gt 0
-    then
-        AC_DEFINE_UNQUOTED(DATA_MAX_NAME_LEN, [$withval], [Maximum length of data buffers])
+AC_ARG_WITH([data-max-name-len],
+  [AS_HELP_STRING([--with-data-max-name-len@<:@=VALUE@:>@], [Maximum length of data buffers])],
+  [
+    if test "x$withval" != "x" && test $withval -gt 0; then
+      AC_DEFINE_UNQUOTED([DATA_MAX_NAME_LEN], [$withval], [Maximum length of data buffers])
     else
-        AC_MSG_ERROR([DATA_MAX_NAME_LEN must be a positive integer -- $withval given])
+      AC_MSG_ERROR([DATA_MAX_NAME_LEN must be a positive integer -- $withval given])
     fi
-],
-[   AC_DEFINE(DATA_MAX_NAME_LEN, 128, [Maximum length of data buffers])]
+  ],
+  [AC_DEFINE([DATA_MAX_NAME_LEN], [128], [Maximum length of data buffers])]
 )
 # }}}
 
-have_getfsstat="no"
-AC_CHECK_FUNCS(getfsstat, [have_getfsstat="yes"])
-have_getvfsstat="no"
-AC_CHECK_FUNCS(getvfsstat, [have_getvfsstat="yes"])
-have_listmntent="no"
-AC_CHECK_FUNCS(listmntent, [have_listmntent="yes"])
-have_getmntent_r="no"
-AC_CHECK_FUNCS(getmntent_r, [have_getmntent_r="yes"])
+AC_CHECK_FUNCS([getfsstat], [have_getfsstat="yes"], [have_getfsstat="no"])
+AC_CHECK_FUNCS(getvfsstat, [have_getvfsstat="yes"], [have_getvfsstat="no"])
+AC_CHECK_FUNCS(listmntent, [have_listmntent="yes"], [have_listmntent="no"])
+AC_CHECK_FUNCS(getmntent_r, [have_getmntent_r="yes"], [have_getmntent_r="no"])
 
-have_getmntent="no"
-AC_CHECK_FUNCS(getmntent, [have_getmntent="c"])
+AC_CHECK_FUNCS(getmntent, [have_getmntent="libc"], [have_getmntent="no"])
 if test "x$have_getmntent" = "xno"; then
-	AC_CHECK_LIB(sun, getmntent, [have_getmntent="sun"])
-fi
-if test "x$have_getmntent" = "xno"; then
-	AC_CHECK_LIB(seq, getmntent, [have_getmntent="seq"])
-fi
-if test "x$have_getmntent" = "xno"; then
-	AC_CHECK_LIB(gen, getmntent, [have_getmntent="gen"])
+  AC_CHECK_LIB([sun], [getmntent],
+    [have_getmntent="sun"],
+    [have_gemntent="no"]
+  )
 fi
 
-if test "x$have_getmntent" = "xc"; then
-	AC_CACHE_CHECK([whether getmntent takes one argument],
-		[c_cv_have_one_getmntent],
-		AC_COMPILE_IFELSE(
-			[AC_LANG_PROGRAM(
-[[[
-#include "$srcdir/src/utils_mount.h"
-]]],
-[[[
-FILE *fh;
-struct mntent *me;
-fh = setmntent ("/etc/mtab", "r");
-me = getmntent (fh);
-return(me->mnt_passno);
-]]]
-			)],
-			[c_cv_have_one_getmntent="yes"],
-			[c_cv_have_one_getmntent="no"]
-		)
-	)
-	AC_CACHE_CHECK([whether getmntent takes two arguments],
-		[c_cv_have_two_getmntent],
-		AC_COMPILE_IFELSE(
-			[AC_LANG_PROGRAM(
-[[[
-#include "$srcdir/src/utils_mount.h"
-]]],
-[[[
-				 FILE *fh;
-				 struct mnttab mt;
-				 int status;
-				 fh = fopen ("/etc/mnttab", "r");
-				 status = getmntent (fh, &mt);
-				 return(status);
-]]]
-			)],
-			[c_cv_have_two_getmntent="yes"],
-			[c_cv_have_two_getmntent="no"]
-		)
-	)
+if test "x$have_getmntent" = "xno"; then
+  AC_CHECK_LIB([seq], [getmntent],
+    [have_getmntent="seq"],
+    [have_getmntent="no"]
+  )
+fi
+
+if test "x$have_getmntent" = "xno"; then
+  AC_CHECK_LIB([gen], [getmntent],
+    [have_getmntent="gen"],
+    [have_getmntent="no"]
+  )
+fi
+
+if test "x$have_getmntent" = "xlibc"; then
+  AC_CACHE_CHECK([whether getmntent takes one argument],
+    [c_cv_have_one_getmntent],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[#include "$srcdir/src/utils_mount.h"]],
+            [[
+              FILE *fh;
+              struct mntent *me;
+              fh = setmntent ("/etc/mtab", "r");
+              me = getmntent (fh);
+              return(me->mnt_passno);
+            ]]
+          )
+        ],
+        [c_cv_have_one_getmntent="yes"],
+        [c_cv_have_one_getmntent="no"]
+      )
+    ]
+  )
+
+  AC_CACHE_CHECK([whether getmntent takes two arguments],
+    [c_cv_have_two_getmntent],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[#include "$srcdir/src/utils_mount.h"]],
+            [[
+              FILE *fh;
+              struct mnttab mt;
+              int status;
+              fh = fopen ("/etc/mnttab", "r");
+              status = getmntent (fh, &mt);
+              return(status);
+            ]]
+          )
+        ],
+        [c_cv_have_two_getmntent="yes"],
+        [c_cv_have_two_getmntent="no"]
+      )
+    ]
+  )
 fi
 
 # Check for different versions of `getmntent' here..
 
-if test "x$have_getmntent" = "xc"; then
-	if test "x$c_cv_have_one_getmntent" = "xyes"; then
-		AC_DEFINE(HAVE_ONE_GETMNTENT, 1,
-			  [Define if the function getmntent exists and takes one argument.])
-	fi
-	if test "x$c_cv_have_two_getmntent" = "xyes"; then
-		AC_DEFINE(HAVE_TWO_GETMNTENT, 1,
-			  [Define if the function getmntent exists and takes two arguments.])
-	fi
+if test "x$have_getmntent" = "xlibc"; then
+  if test "x$c_cv_have_one_getmntent" = "xyes"; then
+    AC_DEFINE([HAVE_ONE_GETMNTENT], [1],
+      [Define if the function getmntent exists and takes one argument.]
+    )
+  fi
+
+  if test "x$c_cv_have_two_getmntent" = "xyes"; then
+    AC_DEFINE([HAVE_TWO_GETMNTENT], [1],
+      [Define if the function getmntent exists and takes two arguments.]
+    )
+  fi
 fi
+
 if test "x$have_getmntent" = "xsun"; then
-	AC_DEFINE(HAVE_SUN_GETMNTENT, 1,
-		  [Define if the function getmntent exists. It is the version from libsun.])
+  AC_DEFINE([HAVE_SUN_GETMNTENT], [1],
+    [Define if the function getmntent exists. It is the version from libsun.]
+  )
 fi
-if test "x$have_getmntent" = "xseq"; then
-	AC_DEFINE(HAVE_SEQ_GETMNTENT, 1,
-		  [Define if the function getmntent exists. It is the version from libseq.])
-fi
+
 if test "x$have_getmntent" = "xgen"; then
-	AC_DEFINE(HAVE_GEN_GETMNTENT, 1,
-		  [Define if the function getmntent exists. It is the version from libgen.])
+  AC_DEFINE([HAVE_GEN_GETMNTENT], [1],
+    [Define if the function getmntent exists. It is the version from libgen.]
+  )
 fi
 
 # Check for htonll
-AC_CACHE_CHECK([if have htonll defined],
-                  [c_cv_have_htonll],
-                  AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <sys/types.h>
-#include <netinet/in.h>
-#if HAVE_INTTYPES_H
-# include <inttypes.h>
-#endif
-]]],
-[[[
-          return htonll(0);
-]]]
-    )],
-    [c_cv_have_htonll="yes"],
-    [c_cv_have_htonll="no"]
-  )
+AC_CACHE_CHECK([whether htonll is defined],
+  [c_cv_have_htonll],
+  [
+    AC_LINK_IFELSE(
+      [
+        AC_LANG_PROGRAM(
+          [[
+            #include <inttypes.h>
+            #include <sys/types.h>
+            #include <netinet/in.h>
+          ]],
+          [[return htonll(0);]]
+        )
+      ],
+      [c_cv_have_htonll="yes"],
+      [c_cv_have_htonll="no"]
+    )
+  ]
 )
-if test "x$c_cv_have_htonll" = "xyes"
-then
-    AC_DEFINE(HAVE_HTONLL, 1, [Define if the function htonll exists.])
+
+if test "x$c_cv_have_htonll" = "xyes"; then
+  AC_DEFINE([HAVE_HTONLL], [1], [Define if the function htonll exists.])
 fi
 
 # Check for structures
 AC_CHECK_MEMBERS([struct if_data.ifi_ibytes, struct if_data.ifi_opackets, struct if_data.ifi_ierrors],
-	[AC_DEFINE(HAVE_STRUCT_IF_DATA, 1, [Define if struct if_data exists and is usable.])],
-	[],
-	[
-	#include <sys/types.h>
-	#include <sys/socket.h>
-	#include <net/if.h>
-	])
-AC_CHECK_MEMBERS([struct net_device_stats.rx_bytes, struct net_device_stats.tx_packets, struct net_device_stats.rx_errors],
-	[AC_DEFINE(HAVE_STRUCT_NET_DEVICE_STATS, 1, [Define if struct net_device_stats exists and is usable.])],
-	[],
-	[
-	#include <sys/types.h>
-	#include <sys/socket.h>
-	#include <linux/if.h>
-	#include <linux/netdevice.h>
-	])
-AC_CHECK_MEMBERS([struct inet_diag_req.id, struct inet_diag_req.idiag_states],
-	[AC_DEFINE(HAVE_STRUCT_LINUX_INET_DIAG_REQ, 1, [Define if struct inet_diag_req exists and is usable.])],
-	[],
-	[
-	#include <linux/inet_diag.h>
-	])
+  [AC_DEFINE([HAVE_STRUCT_IF_DATA], [1], [Define if struct if_data exists and is usable.])],
+  [],
+  [[
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <net/if.h>
+  ]]
+)
 
+AC_CHECK_MEMBERS([struct net_device_stats.rx_bytes, struct net_device_stats.tx_packets, struct net_device_stats.rx_errors],
+  [AC_DEFINE([HAVE_STRUCT_NET_DEVICE_STATS], [1], [Define if struct net_device_stats exists and is usable.])],
+  [],
+  [[
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <linux/if.h>
+    #include <linux/netdevice.h>
+  ]]
+)
+
+AC_CHECK_MEMBERS([struct inet_diag_req.id, struct inet_diag_req.idiag_states],
+  [AC_DEFINE([HAVE_STRUCT_LINUX_INET_DIAG_REQ], [1], [Define if struct inet_diag_req exists and is usable.])],
+  [],
+  [[#include <linux/inet_diag.h>]]
+)
 
 AC_CHECK_MEMBERS([struct ip_mreqn.imr_ifindex], [],
-	[],
-	[
-	#include <netinet/in.h>
-	#include <net/if.h>
-	])
+  [],
+  [[
+    #include <netinet/in.h>
+    #include <net/if.h>
+  ]]
+)
 
 AC_CHECK_MEMBERS([struct kinfo_proc.ki_pid, struct kinfo_proc.ki_rssize, struct kinfo_proc.ki_rusage],
-	[
-		AC_DEFINE(HAVE_STRUCT_KINFO_PROC_FREEBSD, 1,
-			[Define if struct kinfo_proc exists in the FreeBSD variant.])
-		have_struct_kinfo_proc_freebsd="yes"
-	],
-	[
-		have_struct_kinfo_proc_freebsd="no"
-	],
-	[
-#include <kvm.h>
-#include <sys/param.h>
-#include <sys/sysctl.h>
-#include <sys/user.h>
-	])
+  [
+    AC_DEFINE([HAVE_STRUCT_KINFO_PROC_FREEBSD], [1], [Define if struct kinfo_proc exists in the FreeBSD variant.])
+    have_struct_kinfo_proc_freebsd="yes"
+  ],
+  [],
+  [[
+    #include <kvm.h>
+    #include <sys/param.h>
+    #include <sys/sysctl.h>
+    #include <sys/user.h>
+  ]]
+)
 
 AC_CHECK_MEMBERS([struct kinfo_proc.p_pid, struct kinfo_proc.p_vm_rssize],
-	[
-		AC_DEFINE(HAVE_STRUCT_KINFO_PROC_OPENBSD, 1,
-			[Define if struct kinfo_proc exists in the OpenBSD variant.])
-		have_struct_kinfo_proc_openbsd="yes"
-	],
-	[
-		have_struct_kinfo_proc_openbsd="no"
-	],
-	[
-#include <sys/param.h>
-#include <sys/sysctl.h>
-#include <kvm.h>
-	])
-
+  [
+    AC_DEFINE([HAVE_STRUCT_KINFO_PROC_OPENBSD], [1], [Define if struct kinfo_proc exists in the OpenBSD variant.])
+    have_struct_kinfo_proc_openbsd="yes"
+  ],
+  [],
+  [[
+    #include <sys/param.h>
+    #include <sys/sysctl.h>
+    #include <kvm.h>
+  ]]
+)
 
 AC_CHECK_MEMBERS([struct kinfo_proc2.p_pid, struct kinfo_proc2.p_uru_maxrss],
-	[
-		AC_DEFINE(HAVE_STRUCT_KINFO_PROC2_NETBSD, 1,
-			[Define if struct kinfo_proc2 exists in the NetBSD variant.])
-		have_struct_kinfo_proc2_netbsd="yes"
-	],
-	[
-		have_struct_kinfo_proc2_netbsd="no"
-	],
-	[
-#include <sys/param.h>
-#include <sys/sysctl.h>
-#include <kvm.h>
-	])
+  [
+    AC_DEFINE([HAVE_STRUCT_KINFO_PROC2_NETBSD], [1], [Define if struct kinfo_proc2 exists in the NetBSD variant.])
+    have_struct_kinfo_proc2_netbsd="yes"
+  ],
+  [],
+  [[
+    #include <sys/param.h>
+    #include <sys/sysctl.h>
+    #include <kvm.h>
+  ]]
+)
 
+AC_CHECK_MEMBERS([struct udphdr.uh_dport, struct udphdr.uh_sport],
+  [],
+  [],
+  [[
+    #define _BSD_SOURCE
+    #define _DEFAULT_SOURCE
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+    #if HAVE_NETINET_UDP_H
+    # include <netinet/udp.h>
+    #endif
+  ]]
+)
 
-
-AC_CHECK_MEMBERS([struct udphdr.uh_dport, struct udphdr.uh_sport], [], [],
-[#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-#if HAVE_NETINET_UDP_H
-# include <netinet/udp.h>
-#endif
-])
-AC_CHECK_MEMBERS([struct udphdr.dest, struct udphdr.source], [], [],
-[#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_SYSTM_H
-# include <netinet/in_systm.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_IP_H
-# include <netinet/ip.h>
-#endif
-#if HAVE_NETINET_UDP_H
-# include <netinet/udp.h>
-#endif
-])
+AC_CHECK_MEMBERS([struct udphdr.dest, struct udphdr.source],
+  [],
+  [],
+  [[
+    #define _BSD_SOURCE
+    #define _DEFAULT_SOURCE
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP_H
+    # include <netinet/ip.h>
+    #endif
+    #if HAVE_NETINET_UDP_H
+    # include <netinet/udp.h>
+    #endif
+  ]]
+)
 
 AC_CHECK_MEMBERS([kstat_io_t.nwritten, kstat_io_t.writes, kstat_io_t.nwrites, kstat_io_t.wtime],
-	[],
-	[],
-	[
-#if HAVE_KSTAT_H
-# include <kstat.h>
-#endif
-	])
+  [],
+  [],
+  [[# include <kstat.h>]]
+)
 
 # check for pthread_setname_np
 SAVE_LDFLAGS="$LDFLAGS"
@@ -1708,20 +1796,72 @@ AC_MSG_RESULT([$have_pthread_set_name_np])
 
 LDFLAGS="$SAVE_LDFLAGS"
 
+AC_CHECK_TYPES([struct ip6_ext],
+  [have_ip6_ext="yes"],
+  [have_ip6_ext="no"],
+  [[
+    #include <stdint.h>
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_NETINET_IN_SYSTM_H
+    # include <netinet/in_systm.h>
+    #endif
+    #if HAVE_NETINET_IN_H
+    # include <netinet/in.h>
+    #endif
+    #if HAVE_NETINET_IP6_H
+    # include <netinet/ip6.h>
+    #endif
+  ]]
+)
+
+if test "x$have_ip6_ext" = "xno"; then
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS -DSOLARIS2=8"
+  AC_CHECK_TYPES([struct ip6_ext],
+    [have_ip6_ext="yes, with -DSOLARIS2=8"],
+    [have_ip6_ext="no"],
+    [[
+      #include <stdint.h>
+      #if HAVE_SYS_TYPES_H
+      # include <sys/types.h>
+      #endif
+      #if HAVE_NETINET_IN_SYSTM_H
+      # include <netinet/in_systm.h>
+      #endif
+      #if HAVE_NETINET_IN_H
+      # include <netinet/in.h>
+      #endif
+      #if HAVE_NETINET_IP6_H
+      # include <netinet/ip6.h>
+      #endif
+    ]]
+  )
+  if test "x$have_ip6_ext" = "xno"; then
+    CFLAGS="$SAVE_CFLAGS"
+  fi
+fi
+
+# libi2c-dev
+if test "x$ac_system" = "xLinux"; then
+  AC_CHECK_DECL([i2c_smbus_read_i2c_block_data],
+    [with_libi2c="yes"],
+    [with_libi2c="no (symbol i2c_smbus_read_i2c_block_data not found - have you installed libi2c-dev ?)"],
+    [[
+      #include <stdlib.h>
+      #include <linux/i2c-dev.h>
+    ]]
+  )
+else
+  with_libi2c="no (Linux only)"
+fi
+
 #
 # Checks for libraries begin here
 #
 
-with_libresolv="yes"
-AC_CHECK_LIB(resolv, res_search,
-[
-	AC_DEFINE(HAVE_LIBRESOLV, 1, [Define to 1 if you have the 'resolv' library (-lresolv).])
-],
-[with_libresolv="no"])
-AM_CONDITIONAL(BUILD_WITH_LIBRESOLV, test "x$with_libresolv" = "xyes")
-
-dnl Check for HAL (hardware abstraction library)
-with_libhal="no"
+# Check for HAL (hardware abstraction library)
 PKG_CHECK_MODULES([HAL], [hal],
   [
     SAVE_LIBS="$LIBS"
@@ -1738,512 +1878,528 @@ PKG_CHECK_MODULES([HAL], [hal],
         ])
         CPPFLAGS="$SAVE_CPPFLAGS"
       ],
-      [ : ]
+      [with_libhal="no"]
     )
     LIBS="$SAVE_LIBS"
   ],
-  [ : ]
+  [with_libhal="no"]
 )
 AC_SUBST(BUILD_WITH_LIBHAL_CFLAGS)
 AC_SUBST(BUILD_WITH_LIBHAL_LIBS)
 
 
+# Check for libpthread
 SAVE_LIBS="$LIBS"
 AC_CHECK_LIB([pthread],
   [pthread_create],
   [],
-  [AC_MSG_ERROR([Symbol 'pthread_create' not found in libpthread"])],
+  [AC_MSG_ERROR([Symbol 'pthread_create' not found in libpthread])],
   []
 )
 PTHREAD_LIBS="$LIBS"
 LIBS="$SAVE_LIBS"
+AC_SUBST([PTHREAD_LIBS])
 
 AC_CHECK_HEADERS([pthread.h],
   [],
   [AC_MSG_ERROR([pthread.h not found])]
 )
-AC_SUBST([PTHREAD_LIBS])
 
 m4_divert_once([HELP_WITH], [
-collectd additional packages:])
+Collectd additional packages:])
 
-if test "x$ac_system" = "xAIX"
-then
-	with_perfstat="yes"
-	with_procinfo="yes"
+if test "x$ac_system" = "xAIX"; then
+  with_perfstat="yes"
+  with_procinfo="yes"
 else
-	with_perfstat="no (AIX only)"
-	with_procinfo="no (AIX only)"
+  with_perfstat="no (AIX only)"
+  with_procinfo="no (AIX only)"
 fi
 
-if test "x$with_perfstat" = "xyes"
-then
-	AC_CHECK_LIB(perfstat, perfstat_reset, [with_perfstat="yes"], [with_perfstat="no (perfstat not found)"], [])
-#	AC_CHECK_HEADERS(sys/protosw.h libperfstat.h,, [with_perfstat="no (perfstat not found)"])
+if test "x$with_perfstat" = "xyes"; then
+  AC_CHECK_LIB([perfstat], [perfstat_reset],
+    [with_perfstat="yes"],
+    [with_perfstat="no (perfstat not found)"]
+  )
 fi
-if test "x$with_perfstat" = "xyes"
-then
-	 AC_DEFINE(HAVE_PERFSTAT, 1, [Define to 1 if you have the 'perfstat' library (-lperfstat)])
-	 # struct members pertaining to donation have been added to libperfstat somewhere between AIX5.3ML5 and AIX5.3ML9
-	 AC_CHECK_MEMBER([perfstat_partition_type_t.b.donate_enabled], [], [], [[#include <libperfstat.h]])
-	 if test "x$av_cv_member_perfstat_partition_type_t_b_donate_enabled" = "xyes"
-	 then
-		AC_DEFINE(PERFSTAT_SUPPORTS_DONATION, 1, [Define to 1 if your version of the 'perfstat' library supports donation])
-	 fi
+
+if test "x$with_perfstat" = "xyes"; then
+  AC_DEFINE([HAVE_PERFSTAT], [1], [Define to 1 if you have the 'perfstat' library (-lperfstat)])
+  # struct members pertaining to donation have been added to libperfstat somewhere between AIX5.3ML5 and AIX5.3ML9
+  AC_CHECK_MEMBER([perfstat_partition_type_t.b.donate_enabled],
+    [],
+    [],
+    [[#include <libperfstat.h]]
+  )
+  if test "x$av_cv_member_perfstat_partition_type_t_b_donate_enabled" = "xyes"; then
+    AC_DEFINE([PERFSTAT_SUPPORTS_DONATION], [1], [Define to 1 if your version of the 'perfstat' library supports donation])
+  fi
 fi
-AM_CONDITIONAL(BUILD_WITH_PERFSTAT, test "x$with_perfstat" = "xyes")
+AM_CONDITIONAL([BUILD_WITH_PERFSTAT], [test "x$with_perfstat" = "xyes"])
 
 # Processes plugin under AIX.
-if test "x$with_procinfo" = "xyes"
-then
-	AC_CHECK_HEADERS(procinfo.h,, [with_procinfo="no (procinfo.h not found)"])
-fi
-if test "x$with_procinfo" = "xyes"
-then
-	 AC_DEFINE(HAVE_PROCINFO_H, 1, [Define to 1 if you have the procinfo.h])
+if test "x$with_procinfo" = "xyes"; then
+  AC_CHECK_HEADERS([procinfo.h],
+    [AC_DEFINE([HAVE_PROCINFO_H], [1], [Define to 1 if you have the procinfo.h])],
+    [with_procinfo="no (procinfo.h not found)"]
+  )
 fi
 
-if test "x$ac_system" = "xSolaris"
-then
-	with_kstat="yes"
-	with_devinfo="yes"
+if test "x$ac_system" = "xSolaris"; then
+  with_kstat="yes"
+  with_devinfo="yes"
 else
-	with_kstat="no (Solaris only)"
-	with_devinfo="no (Solaris only)"
+  with_kstat="no (Solaris only)"
+  with_devinfo="no (Solaris only)"
 fi
 
-if test "x$with_kstat" = "xyes"
-then
-	AC_CHECK_LIB(kstat, kstat_open, [with_kstat="yes"], [with_kstat="no (libkstat not found)"], [])
+if test "x$with_kstat" = "xyes"; then
+  AC_CHECK_LIB([kstat], [kstat_open],
+    [with_kstat="yes"],
+    [with_kstat="no (libkstat not found)"]
+  )
 fi
-if test "x$with_kstat" = "xyes"
-then
-	AC_CHECK_LIB(devinfo, di_init, [with_devinfo="yes"], [with_devinfo="no (not found)"], [])
-	AC_CHECK_HEADERS(kstat.h,, [with_kstat="no (kstat.h not found)"])
-fi
-if test "x$with_kstat" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBKSTAT, 1,
-		  [Define to 1 if you have the 'kstat' library (-lkstat)])
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBKSTAT, test "x$with_kstat" = "xyes")
-AM_CONDITIONAL(BUILD_WITH_LIBDEVINFO, test "x$with_devinfo" = "xyes")
 
-with_libiokit="no"
-if test "x$ac_system" = "xDarwin"
-then
-	with_libiokit="yes"
+if test "x$with_kstat" = "xyes"; then
+  AC_CHECK_LIB([devinfo], [di_init],
+    [with_devinfo="yes"],
+    [with_devinfo="no (not found)"]
+  )
+  AC_CHECK_HEADERS([kstat.h],
+    [AC_DEFINE(HAVE_LIBKSTAT, [1], [Define to 1 if you have the 'kstat' library (-lkstat)])],
+    [with_kstat="no (kstat.h not found)"]
+  )
+fi
+
+AM_CONDITIONAL([BUILD_WITH_LIBDEVINFO], [test "x$with_devinfo" = "xyes"])
+AM_CONDITIONAL([BUILD_WITH_LIBKSTAT], [test "x$with_kstat" = "xyes"])
+
+if test "x$ac_system" = "xDarwin"; then
+  with_libiokit="yes"
 else
-	with_libiokit="no"
+  with_libiokit="no"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBIOKIT, test "x$with_libiokit" = "xyes")
+AM_CONDITIONAL([BUILD_WITH_LIBIOKIT], [test "x$with_libiokit" = "xyes"])
 
 with_libkvm="no"
-AC_CHECK_LIB(kvm, kvm_getprocs, [with_kvm_getprocs="yes"], [with_kvm_getprocs="no"])
-if test "x$with_kvm_getprocs" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBKVM_GETPROCS, 1,
-		  [Define to 1 if you have the 'kvm' library with the 'kvm_getprocs' symbol (-lkvm)])
-	with_libkvm="yes"
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBKVM_GETPROCS, test "x$with_kvm_getprocs" = "xyes")
+AC_CHECK_LIB([kvm], [kvm_getprocs],
+  [with_kvm_getprocs="yes"],
+  []
+)
 
-AC_CHECK_LIB(kvm, kvm_getswapinfo, [with_kvm_getswapinfo="yes"], [with_kvm_getswapinfo="no"])
-if test "x$with_kvm_getswapinfo" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBKVM_GETSWAPINFO, 1,
-		  [Define to 1 if you have the 'kvm' library with the 'kvm_getswapinfo' symbol (-lkvm)])
-	with_libkvm="yes"
+if test "x$with_kvm_getprocs" = "xyes"; then
+  AC_DEFINE([HAVE_LIBKVM_GETPROCS], [1],
+    [Define to 1 if you have the 'kvm' library with the 'kvm_getprocs' symbol (-lkvm)]
+  )
+  with_libkvm="yes"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBKVM_GETSWAPINFO, test "x$with_kvm_getswapinfo" = "xyes")
 
-AC_CHECK_LIB(kvm, kvm_nlist, [with_kvm_nlist="yes"], [with_kvm_nlist="no"])
-if test "x$with_kvm_nlist" = "xyes"
-then
-	AC_CHECK_HEADERS(bsd/nlist.h nlist.h)
-	AC_DEFINE(HAVE_LIBKVM_NLIST, 1,
-		  [Define to 1 if you have the 'kvm' library with the 'kvm_nlist' symbol (-lkvm)])
-	with_libkvm="yes"
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBKVM_NLIST, test "x$with_kvm_nlist" = "xyes")
+AM_CONDITIONAL([BUILD_WITH_LIBKVM_GETPROCS], [test "x$with_kvm_getprocs" = "xyes"])
 
-AC_CHECK_LIB(kvm, kvm_openfiles, [with_kvm_openfiles="yes"], [with_kvm_openfiles="no"])
-if test "x$with_kvm_openfiles" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBKVM_NLIST, 1,
-		  [Define to 1 if you have the 'kvm' library with the 'kvm_openfiles' symbol (-lkvm)])
-	with_libkvm="yes"
+AC_CHECK_LIB([kvm], [kvm_getswapinfo],
+  [with_kvm_getswapinfo="yes"],
+  []
+)
+
+if test "x$with_kvm_getswapinfo" = "xyes"; then
+  AC_DEFINE([HAVE_LIBKVM_GETSWAPINFO], [1],
+    [Define to 1 if you have the 'kvm' library with the 'kvm_getswapinfo' symbol (-lkvm)]
+  )
+  with_libkvm="yes"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBKVM_OPENFILES, test "x$with_kvm_openfiles" = "xyes")
+
+AM_CONDITIONAL([BUILD_WITH_LIBKVM_GETSWAPINFO], [test "x$with_kvm_getswapinfo" = "xyes"])
+
+AC_CHECK_LIB([kvm], [kvm_nlist],
+  [with_kvm_nlist="yes"],
+  []
+)
+
+if test "x$with_kvm_nlist" = "xyes"; then
+  AC_CHECK_HEADERS([bsd/nlist.h nlist.h])
+  AC_DEFINE([HAVE_LIBKVM_NLIST], [1],
+    [Define to 1 if you have the 'kvm' library with the 'kvm_nlist' symbol (-lkvm)]
+  )
+  with_libkvm="yes"
+fi
+
+AM_CONDITIONAL([BUILD_WITH_LIBKVM_NLIST], [test "x$with_kvm_nlist" = "xyes"])
+
+AC_CHECK_LIB([kvm], [kvm_openfiles],
+  [with_kvm_openfiles="yes"],
+  []
+)
+
+if test "x$with_kvm_openfiles" = "xyes"; then
+  AC_DEFINE([HAVE_LIBKVM_NLIST], [1],
+    [Define to 1 if you have the 'kvm' library with the 'kvm_openfiles' symbol (-lkvm)]
+  )
+  with_libkvm="yes"
+fi
 
 # --with-libaquaero5 {{{
-AC_ARG_WITH(libaquaero5, [AS_HELP_STRING([--with-libaquaero5@<:@=PREFIX@:>@], [Path to aquatools-ng source code.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_libaquaero5="yes"
- else if test "x$withval" = "xno"
- then
-	 with_libaquaero5="no"
- else
-	 with_libaquaero5="yes"
-	 LIBAQUAERO5_CFLAGS="$LIBAQUAERO5_CFLAGS -I$withval/src"
-	 LIBAQUAERO5_LDFLAGS="$LIBAQUAERO5_LDFLAGS -L$withval/obj"
- fi; fi
-],
-[with_libaquaero5="yes"])
+AC_ARG_WITH([libaquaero5],
+  [AS_HELP_STRING([--with-libaquaero5@<:@=PREFIX@:>@], [Path to aquatools-ng source code.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libaquaero5="yes"
+    else if test "x$withval" = "xno"; then
+      with_libaquaero5="no"
+    else
+      with_libaquaero5="yes"
+      LIBAQUAERO5_CFLAGS="$LIBAQUAERO5_CFLAGS -I$withval/src"
+      LIBAQUAERO5_LDFLAGS="$LIBAQUAERO5_LDFLAGS -L$withval/obj"
+    fi; fi
+  ],
+  [with_libaquaero5="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
-
 CPPFLAGS="$CPPFLAGS $LIBAQUAERO5_CFLAGS"
 LDFLAGS="$LDFLAGS $LIBAQUAERO5_LDFLAGS"
 
-if test "x$with_libaquaero5" = "xyes"
-then
-	if test "x$LIBAQUAERO5_CFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libaquaero5 CPPFLAGS: $LIBAQUAERO5_CFLAGS])
-	fi
-	AC_CHECK_HEADERS(libaquaero5.h,
-	[with_libaquaero5="yes"],
-	[with_libaquaero5="no (libaquaero5.h not found)"])
+if test "x$with_libaquaero5" = "xyes"; then
+  if test "x$LIBAQUAERO5_CFLAGS" != "x"; then
+    AC_MSG_NOTICE([libaquaero5 CPPFLAGS: $LIBAQUAERO5_CFLAGS])
+  fi
+  AC_CHECK_HEADERS([libaquaero5.h],
+    [with_libaquaero5="yes"],
+    [with_libaquaero5="no (libaquaero5.h not found)"]
+  )
 fi
-if test "x$with_libaquaero5" = "xyes"
-then
-	if test "x$LIBAQUAERO5_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libaquaero5 LDFLAGS: $LIBAQUAERO5_LDFLAGS])
-	fi
-	AC_CHECK_LIB(aquaero5, libaquaero5_poll,
-	[with_libaquaero5="yes"],
-	[with_libaquaero5="no (symbol 'libaquaero5_poll' not found)"])
+
+if test "x$with_libaquaero5" = "xyes"; then
+  if test "x$LIBAQUAERO5_LDFLAGS" != "x"; then
+    AC_MSG_NOTICE([libaquaero5 LDFLAGS: $LIBAQUAERO5_LDFLAGS])
+  fi
+  AC_CHECK_LIB([aquaero5], libaquaero5_poll,
+    [with_libaquaero5="yes"],
+    [with_libaquaero5="no (symbol 'libaquaero5_poll' not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 
-if test "x$with_libaquaero5" = "xyes"
-then
-	BUILD_WITH_LIBAQUAERO5_CFLAGS="$LIBAQUAERO5_CFLAGS"
-	BUILD_WITH_LIBAQUAERO5_LDFLAGS="$LIBAQUAERO5_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBAQUAERO5_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBAQUAERO5_LDFLAGS)
+if test "x$with_libaquaero5" = "xyes"; then
+  BUILD_WITH_LIBAQUAERO5_CFLAGS="$LIBAQUAERO5_CFLAGS"
+  BUILD_WITH_LIBAQUAERO5_LDFLAGS="$LIBAQUAERO5_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBAQUAERO5, test "x$with_libaquaero5" = "xyes")
+AC_SUBST([BUILD_WITH_LIBAQUAERO5_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBAQUAERO5_LDFLAGS])
 # }}}
 
 # --with-libhiredis {{{
-AC_ARG_WITH(libhiredis, [AS_HELP_STRING([--with-libhiredis@<:@=PREFIX@:>@],
-      [Path to libhiredis.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_libhiredis="yes"
- else if test "x$withval" = "xno"
- then
-	 with_libhiredis="no"
- else
-	 with_libhiredis="yes"
-	 LIBHIREDIS_CPPFLAGS="$LIBHIREDIS_CPPFLAGS -I$withval/include"
-	 LIBHIREDIS_LDFLAGS="$LIBHIREDIS_LDFLAGS -L$withval/lib"
- fi; fi
-],
-[with_libhiredis="yes"])
+AC_ARG_WITH([libhiredis],
+  [AS_HELP_STRING([--with-libhiredis@<:@=PREFIX@:>@], [Path to libhiredis.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libhiredis="yes"
+    else if test "x$withval" = "xno"; then
+      with_libhiredis="no"
+    else
+      with_libhiredis="yes"
+      LIBHIREDIS_CPPFLAGS="$LIBHIREDIS_CPPFLAGS -I$withval/include"
+      LIBHIREDIS_LDFLAGS="$LIBHIREDIS_LDFLAGS -L$withval/lib"
+    fi; fi
+  ],
+  [with_libhiredis="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
-
 CPPFLAGS="$CPPFLAGS $LIBHIREDIS_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBHIREDIS_LDFLAGS"
 
-if test "x$with_libhiredis" = "xyes"
-then
-	if test "x$LIBHIREDIS_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libhiredis CPPFLAGS: $LIBHIREDIS_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(hiredis/hiredis.h,
-	[with_libhiredis="yes"],
-	[with_libhiredis="no (hiredis.h not found)"])
+if test "x$with_libhiredis" = "xyes"; then
+  if test "x$LIBHIREDIS_CPPFLAGS" != "x"; then
+    AC_MSG_NOTICE([libhiredis CPPFLAGS: $LIBHIREDIS_CPPFLAGS])
+  fi
+  AC_CHECK_HEADERS([hiredis/hiredis.h],
+    [with_libhiredis="yes"],
+    [with_libhiredis="no (hiredis.h not found)"]
+  )
 fi
-if test "x$with_libhiredis" = "xyes"
-then
-	if test "x$LIBHIREDIS_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libhiredis LDFLAGS: $LIBHIREDIS_LDFLAGS])
-	fi
-	AC_CHECK_LIB(hiredis, redisCommand,
-	[with_libhiredis="yes"],
-	[with_libhiredis="no (symbol 'redisCommand' not found)"])
 
+if test "x$with_libhiredis" = "xyes"; then
+  if test "x$LIBHIREDIS_LDFLAGS" != "x"; then
+    AC_MSG_NOTICE([libhiredis LDFLAGS: $LIBHIREDIS_LDFLAGS])
+  fi
+  AC_CHECK_LIB([hiredis], [redisCommand],
+    [with_libhiredis="yes"],
+    [with_libhiredis="no (symbol 'redisCommand' not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 
-if test "x$with_libhiredis" = "xyes"
-then
-	BUILD_WITH_LIBHIREDIS_CPPFLAGS="$LIBHIREDIS_CPPFLAGS"
-	BUILD_WITH_LIBHIREDIS_LDFLAGS="$LIBHIREDIS_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBHIREDIS_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBHIREDIS_LDFLAGS)
+if test "x$with_libhiredis" = "xyes"; then
+  BUILD_WITH_LIBHIREDIS_CPPFLAGS="$LIBHIREDIS_CPPFLAGS"
+  BUILD_WITH_LIBHIREDIS_LDFLAGS="$LIBHIREDIS_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBHIREDIS, test "x$with_libhiredis" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBHIREDIS_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBHIREDIS_LDFLAGS])
 # }}}
 
 # --with-libcurl {{{
 with_curl_config="curl-config"
 with_curl_cflags=""
 with_curl_libs=""
-AC_ARG_WITH(libcurl, [AS_HELP_STRING([--with-libcurl@<:@=PREFIX@:>@], [Path to libcurl.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libcurl="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libcurl="yes"
-	else
-		if test -f "$withval" && test -x "$withval"
-		then
-			with_curl_config="$withval"
-			with_libcurl="yes"
-		else if test -x "$withval/bin/curl-config"
-		then
-			with_curl_config="$withval/bin/curl-config"
-			with_libcurl="yes"
-		fi; fi
-		with_libcurl="yes"
-	fi; fi
-],
-[
-	with_libcurl="yes"
-])
-if test "x$with_libcurl" = "xyes"
-then
-	with_curl_cflags=`$with_curl_config --cflags 2>/dev/null`
-	curl_config_status=$?
+AC_ARG_WITH(libcurl,
+  [AS_HELP_STRING([--with-libcurl@<:@=PREFIX@:>@], [Path to libcurl.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_libcurl="no"
+    else if test "x$withval" = "xyes"; then
+      with_libcurl="yes"
+    else
+      if test -f "$withval" && test -x "$withval"; then
+        with_curl_config="$withval"
+        with_libcurl="yes"
+      else if test -x "$withval/bin/curl-config"; then
+        with_curl_config="$withval/bin/curl-config"
+        with_libcurl="yes"
+      fi; fi
+      with_libcurl="yes"
+    fi; fi
+  ],
+  [with_libcurl="yes"]
+)
 
-	if test $curl_config_status -ne 0
-	then
-		with_libcurl="no ($with_curl_config failed)"
-	else
-		SAVE_CPPFLAGS="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $with_curl_cflags"
+if test "x$with_libcurl" = "xyes"; then
+  with_curl_cflags=`$with_curl_config --cflags 2>/dev/null`
+  curl_config_status=$?
 
-		AC_CHECK_HEADERS(curl/curl.h, [], [with_libcurl="no (curl/curl.h not found)"], [])
+  if test $curl_config_status -ne 0; then
+    with_libcurl="no ($with_curl_config failed)"
+  else
+    SAVE_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $with_curl_cflags"
 
-		CPPFLAGS="$SAVE_CPPFLAGS"
-	fi
-fi
-if test "x$with_libcurl" = "xyes"
-then
-	with_curl_libs=`$with_curl_config --libs 2>/dev/null`
-	curl_config_status=$?
+    AC_CHECK_HEADERS([curl/curl.h],
+      [with_libcurl="yes"],
+      [with_libcurl="no (curl/curl.h not found)"]
+    )
 
-	if test $curl_config_status -ne 0
-	then
-		with_libcurl="no ($with_curl_config failed)"
-	else
-		AC_CHECK_LIB(curl, curl_easy_init,
-		 [with_libcurl="yes"],
-		 [with_libcurl="no (symbol 'curl_easy_init' not found)"],
-		 [$with_curl_libs])
-		AC_CHECK_DECL(CURLOPT_USERNAME,
-		 [have_curlopt_username="yes"],
-		 [have_curlopt_username="no"],
-		 [[#include <curl/curl.h>]])
-		AC_CHECK_DECL(CURLOPT_TIMEOUT_MS,
-		 [have_curlopt_timeout="yes"],
-		 [have_curlopt_timeout="no"],
-		 [[#include <curl/curl.h>]])
-	fi
-fi
-if test "x$with_libcurl" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_curl_cflags"
-	LDFLAGS="$LDFLAGS $with_curl_libs"
-	AC_CACHE_CHECK([for CURLINFO_APPCONNECT_TIME],
-		[c_cv_have_curlinfo_appconnect_time],
-		AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[
-#include <curl/curl.h>
-]],
-[[
-int val = CURLINFO_APPCONNECT_TIME;
-return val;
-]]
-			)],
-			[c_cv_have_curlinfo_appconnect_time="yes"],
-			[c_cv_have_curlinfo_appconnect_time="no"]
-		)
-	)
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBCURL, test "x$with_libcurl" = "xyes")
-if test "x$c_cv_have_curlinfo_appconnect_time" = "xyes"
-then
-	AC_DEFINE(HAVE_CURLINFO_APPCONNECT_TIME, 1, [Define if curl.h defines CURLINFO_APPCONNECT_TIME.])
+    CPPFLAGS="$SAVE_CPPFLAGS"
+  fi
 fi
 
-if test "x$with_libcurl" = "xyes"
-then
-	BUILD_WITH_LIBCURL_CFLAGS="$with_curl_cflags"
-	BUILD_WITH_LIBCURL_LIBS="$with_curl_libs"
-	AC_SUBST(BUILD_WITH_LIBCURL_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBCURL_LIBS)
+if test "x$with_libcurl" = "xyes"; then
+  with_curl_libs=`$with_curl_config --libs 2>/dev/null`
+  curl_config_status=$?
 
-	if test "x$have_curlopt_username" = "xyes"
-	then
-		AC_DEFINE(HAVE_CURLOPT_USERNAME, 1, [Define if libcurl supports CURLOPT_USERNAME option.])
-	fi
+  if test $curl_config_status -ne 0; then
+    with_libcurl="no ($with_curl_config failed)"
+  else
+    AC_CHECK_LIB([curl], [curl_easy_init],
+      [with_libcurl="yes"],
+      [with_libcurl="no (symbol 'curl_easy_init' not found)"],
+      [$with_curl_libs]
+    )
 
-	if test "x$have_curlopt_timeout" = "xyes"
-	then
-		AC_DEFINE(HAVE_CURLOPT_TIMEOUT_MS, 1, [Define if libcurl supports CURLOPT_TIMEOUT_MS option.])
-	fi
+    AC_CHECK_DECL([CURLOPT_USERNAME],
+      [have_curlopt_username="yes"],
+      [have_curlopt_username="no"],
+      [[#include <curl/curl.h>]]
+    )
+
+    AC_CHECK_DECL(CURLOPT_TIMEOUT_MS,
+      [have_curlopt_timeout="yes"],
+      [have_curlopt_timeout="no"],
+      [[#include <curl/curl.h>]]
+    )
+  fi
 fi
+
+if test "x$with_libcurl" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LDFLAGS="$LDFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_curl_cflags"
+  LDFLAGS="$LDFLAGS $with_curl_libs"
+  AC_CACHE_CHECK([for CURLINFO_APPCONNECT_TIME],
+    [c_cv_have_curlinfo_appconnect_time],
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[#include <curl/curl.h>]],
+            [[
+              int val = CURLINFO_APPCONNECT_TIME;
+              return val;
+            ]]
+          )
+        ],
+        [c_cv_have_curlinfo_appconnect_time="yes"],
+        [c_cv_have_curlinfo_appconnect_time="no"]
+      )
+    ]
+  )
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$c_cv_have_curlinfo_appconnect_time" = "xyes"; then
+  AC_DEFINE([HAVE_CURLINFO_APPCONNECT_TIME], [1],
+    [Define if curl.h defines CURLINFO_APPCONNECT_TIME.]
+  )
+fi
+
+if test "x$with_libcurl" = "xyes"; then
+  BUILD_WITH_LIBCURL_CFLAGS="$with_curl_cflags"
+  BUILD_WITH_LIBCURL_LIBS="$with_curl_libs"
+
+  if test "x$have_curlopt_username" = "xyes"; then
+    AC_DEFINE([HAVE_CURLOPT_USERNAME], [1],
+      [Define if libcurl supports CURLOPT_USERNAME option.]
+    )
+  fi
+
+  if test "x$have_curlopt_timeout" = "xyes"; then
+    AC_DEFINE([HAVE_CURLOPT_TIMEOUT_MS], [1],
+      [Define if libcurl supports CURLOPT_TIMEOUT_MS option.]
+    )
+  fi
+fi
+
+AC_SUBST(BUILD_WITH_LIBCURL_CFLAGS)
+AC_SUBST(BUILD_WITH_LIBCURL_LIBS)
 # }}}
 
 # --with-libdbi {{{
-with_libdbi_cppflags=""
-with_libdbi_ldflags=""
-AC_ARG_WITH(libdbi, [AS_HELP_STRING([--with-libdbi@<:@=PREFIX@:>@], [Path to libdbi.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libdbi_cppflags="-I$withval/include"
-		with_libdbi_ldflags="-L$withval/lib"
-		with_libdbi="yes"
-	else
-		with_libdbi="$withval"
-	fi
-],
-[
-	with_libdbi="yes"
-])
-if test "x$with_libdbi" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libdbi_cppflags"
+AC_ARG_WITH([libdbi],
+  [AS_HELP_STRING([--with-libdbi@<:@=PREFIX@:>@], [Path to libdbi.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libdbi_cppflags="-I$withval/include"
+      with_libdbi_ldflags="-L$withval/lib"
+      with_libdbi="yes"
+    else
+      with_libdbi="$withval"
+    fi
+  ],
+  [with_libdbi="yes"]
+)
 
-	AC_CHECK_HEADERS(dbi/dbi.h, [with_libdbi="yes"], [with_libdbi="no (dbi/dbi.h not found)"])
+if test "x$with_libdbi" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libdbi_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([dbi/dbi.h],
+    [with_libdbi="yes"],
+    [with_libdbi="no (dbi/dbi.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libdbi" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libdbi_cppflags"
-	LDFLAGS="$LDFLAGS $with_libdbi_ldflags"
 
-	AC_CHECK_LIB(dbi, dbi_initialize, [with_libdbi="yes"], [with_libdbi="no (Symbol 'dbi_initialize' not found)"])
+if test "x$with_libdbi" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libdbi_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([dbi], [dbi_initialize],
+    [with_libdbi="yes"],
+    [with_libdbi="no (Symbol 'dbi_initialize' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libdbi" = "xyes"
-then
-	BUILD_WITH_LIBDBI_CPPFLAGS="$with_libdbi_cppflags"
-	BUILD_WITH_LIBDBI_LDFLAGS="$with_libdbi_ldflags"
-	BUILD_WITH_LIBDBI_LIBS="-ldbi"
-	AC_SUBST(BUILD_WITH_LIBDBI_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBDBI_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBDBI_LIBS)
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBDBI, test "x$with_libdbi" = "xyes")
+
+BUILD_WITH_LIBDBI_CPPFLAGS="$with_libdbi_cppflags"
+BUILD_WITH_LIBDBI_LDFLAGS="$with_libdbi_ldflags"
+BUILD_WITH_LIBDBI_LIBS="-ldbi"
+AC_SUBST(BUILD_WITH_LIBDBI_CPPFLAGS)
+AC_SUBST(BUILD_WITH_LIBDBI_LDFLAGS)
+AC_SUBST(BUILD_WITH_LIBDBI_LIBS)
 # }}}
 
 # --with-libesmtp {{{
-AC_ARG_WITH(libesmtp, [AS_HELP_STRING([--with-libesmtp@<:@=PREFIX@:>@], [Path to libesmtp.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		LDFLAGS="$LDFLAGS -L$withval/lib"
-		CPPFLAGS="$CPPFLAGS -I$withval/include -D_THREAD_SAFE"
-		with_libesmtp="yes"
-	else
-		with_libesmtp="$withval"
-	fi
-],
-[
-	with_libesmtp="yes"
-])
-if test "x$with_libesmtp" = "xyes"
-then
-	AC_CHECK_LIB(esmtp, smtp_create_session,
-	[
-		AC_DEFINE(HAVE_LIBESMTP, 1, [Define to 1 if you have the esmtp library (-lesmtp).])
-	], [with_libesmtp="no (libesmtp not found)"])
+AC_ARG_WITH([libesmtp],
+  [AS_HELP_STRING([--with-libesmtp@<:@=PREFIX@:>@], [Path to libesmtp.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libesmtp_cppflags="-I$withval/include"
+      with_libesmtp_ldflags="-L$withval/lib"
+      with_libesmtp="yes"
+    else
+      with_libesmtp="$withval"
+    fi
+  ],
+  [with_libesmtp="yes"]
+)
+
+if test "x$with_libesmtp" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libesmtp_cppflags"
+
+  AC_CHECK_HEADERS([libesmtp.h],
+    [with_libesmtp="yes"],
+    [with_libesmtp="no (libesmtp.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libesmtp" = "xyes"
-then
-	AC_CHECK_HEADERS(libesmtp.h,
-	[
-		AC_DEFINE(HAVE_LIBESMTP_H, 1, [Define to 1 if you have the <libesmtp.h> header file.])
-	], [with_libesmtp="no (libesmtp.h not found)"])
+
+if test "x$with_libesmtp" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_esmtp_ldflags"
+
+  AC_CHECK_LIB([esmtp], [smtp_create_session],
+    [with_libesmtp="yes"],
+    [with_libesmtp="no (Symbol 'smtp_create_session' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libesmtp" = "xyes"
-then
-	collect_libesmtp=1
-else
-	collect_libesmtp=0
-fi
-AC_DEFINE_UNQUOTED(COLLECT_LIBESMTP, [$collect_libesmtp],
-	[Wether or not to use the esmtp library])
-AM_CONDITIONAL(BUILD_WITH_LIBESMTP, test "x$with_libesmtp" = "xyes")
+
+BUILD_WITH_LIBESMTP_CPPFLAGS="$with_libesmtp_cppflags"
+BUILD_WITH_LIBESMTP_LDFLAGS="$with_libesmtp_ldflags"
+BUILD_WITH_LIBESMTP_LIBS="-lesmtp"
+AC_SUBST(BUILD_WITH_LIBESMTP_CPPFLAGS)
+AC_SUBST(BUILD_WITH_LIBESMTP_LDFLAGS)
+AC_SUBST(BUILD_WITH_LIBESMTP_LIBS)
 # }}}
 
 # --with-libganglia {{{
-AC_ARG_WITH(libganglia, [AS_HELP_STRING([--with-libganglia@<:@=PREFIX@:>@], [Path to libganglia.])],
-[
- if test -f "$withval" && test -x "$withval"
- then
-	 with_libganglia_config="$withval"
-	 with_libganglia="yes"
- else if test -f "$withval/bin/ganglia-config" && test -x "$withval/bin/ganglia-config"
- then
-	 with_libganglia_config="$withval/bin/ganglia-config"
-	 with_libganglia="yes"
- else if test -d "$withval"
- then
-	 GANGLIA_CPPFLAGS="-I$withval/include"
-	 GANGLIA_LDFLAGS="-L$withval/lib"
-	 with_libganglia="yes"
- else
-	 with_libganglia="$withval"
- fi; fi; fi
-],
-[
- with_libganglia="yes"
-])
+AC_ARG_WITH([libganglia],
+  [AS_HELP_STRING([--with-libganglia@<:@=PREFIX@:>@], [Path to libganglia.])],
+  [
+    if test -f "$withval" && test -x "$withval"; then
+      with_libganglia_config="$withval"
+      with_libganglia="yes"
+    else if test -f "$withval/bin/ganglia-config" && test -x "$withval/bin/ganglia-config"; then
+      with_libganglia_config="$withval/bin/ganglia-config"
+      with_libganglia="yes"
+    else if test -d "$withval"; then
+      GANGLIA_CPPFLAGS="-I$withval/include"
+      GANGLIA_LDFLAGS="-L$withval/lib"
+      with_libganglia="yes"
+    else
+      with_libganglia="$withval"
+    fi; fi; fi
+  ],
+  [with_libganglia="yes"]
+)
 
-if test "x$with_libganglia" = "xyes"
-then
-	if test "x$with_libganglia_config" != "x"
-	then
-		if test "x$GANGLIA_CPPFLAGS" = "x"
-		then
-			GANGLIA_CPPFLAGS=`"$with_libganglia_config" --cflags 2>/dev/null`
-		fi
+if test "x$with_libganglia" = "xyes"; then
+  if test "x$with_libganglia_config" != "x"; then
+    if test "x$GANGLIA_CPPFLAGS" = "x"; then
+      GANGLIA_CPPFLAGS=`"$with_libganglia_config" --cflags 2>/dev/null`
+    fi
 
-		if test "x$GANGLIA_LDFLAGS" = "x"
-		then
-			GANGLIA_LDFLAGS=`"$with_libganglia_config" --ldflags 2>/dev/null`
-		fi
+    if test "x$GANGLIA_LDFLAGS" = "x"; then
+      GANGLIA_LDFLAGS=`"$with_libganglia_config" --ldflags 2>/dev/null`
+    fi
 
-		if test "x$GANGLIA_LIBS" = "x"
-		then
-			GANGLIA_LIBS=`"$with_libganglia_config" --libs 2>/dev/null`
-		fi
-	else
-		GANGLIA_LIBS="-lganglia"
-	fi
+    if test "x$GANGLIA_LIBS" = "x"; then
+      GANGLIA_LIBS=`"$with_libganglia_config" --libs 2>/dev/null`
+    fi
+  else
+    GANGLIA_LIBS="-lganglia"
+  fi
 fi
 
 SAVE_CPPFLAGS="$CPPFLAGS"
@@ -2251,22 +2407,18 @@ SAVE_LDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS $GANGLIA_CPPFLAGS"
 LDFLAGS="$LDFLAGS $GANGLIA_LDFLAGS"
 
-if test "x$with_libganglia" = "xyes"
-then
-	AC_CHECK_HEADERS(gm_protocol.h,
-	[
-		AC_DEFINE(HAVE_GM_PROTOCOL_H, 1,
-			  [Define to 1 if you have the <gm_protocol.h> header file.])
-	], [with_libganglia="no (gm_protocol.h not found)"])
+if test "x$with_libganglia" = "xyes"; then
+  AC_CHECK_HEADERS([gm_protocol.h],
+    [with_libganglia="yes"],
+    [with_libganglia="no (gm_protocol.h not found)"]
+  )
 fi
 
-if test "x$with_libganglia" = "xyes"
-then
-	AC_CHECK_LIB(ganglia, xdr_Ganglia_value_msg,
-	[
-		AC_DEFINE(HAVE_LIBGANGLIA, 1,
-			  [Define to 1 if you have the ganglia library (-lganglia).])
-	], [with_libganglia="no (symbol xdr_Ganglia_value_msg not found)"])
+if test "x$with_libganglia" = "xyes"; then
+  AC_CHECK_LIB([ganglia], [xdr_Ganglia_value_msg],
+    [with_libganglia="yes"],
+    [with_libganglia="no (symbol xdr_Ganglia_value_msg not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
@@ -2275,49 +2427,44 @@ LDFLAGS="$SAVE_LDFLAGS"
 AC_SUBST(GANGLIA_CPPFLAGS)
 AC_SUBST(GANGLIA_LDFLAGS)
 AC_SUBST(GANGLIA_LIBS)
-AM_CONDITIONAL(BUILD_WITH_LIBGANGLIA, test "x$with_libganglia" = "xyes")
 # }}}
 
 # --with-libgcrypt {{{
 GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS"
 GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS"
 GCRYPT_LIBS="$GCRYPT_LIBS"
-AC_ARG_WITH(libgcrypt, [AS_HELP_STRING([--with-libgcrypt@<:@=PREFIX@:>@], [Path to libgcrypt.])],
-[
- if test -f "$withval" && test -x "$withval"
- then
-	 with_libgcrypt_config="$withval"
-	 with_libgcrypt="yes"
- else if test -f "$withval/bin/gcrypt-config" && test -x "$withval/bin/gcrypt-config"
- then
-	 with_libgcrypt_config="$withval/bin/gcrypt-config"
-	 with_libgcrypt="yes"
- else if test -d "$withval"
- then
-	 GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS -I$withval/include"
-	 GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS -L$withval/lib"
-	 with_libgcrypt="yes"
- else
-	 with_libgcrypt_config="gcrypt-config"
-	 with_libgcrypt="$withval"
- fi; fi; fi
-],
-[
- with_libgcrypt_config="libgcrypt-config"
- with_libgcrypt="yes"
-])
+AC_ARG_WITH([libgcrypt],
+  [AS_HELP_STRING([--with-libgcrypt@<:@=PREFIX@:>@], [Path to libgcrypt.])],
+  [
+    if test -f "$withval" && test -x "$withval"; then
+      with_libgcrypt_config="$withval"
+      with_libgcrypt="yes"
+    else if test -f "$withval/bin/gcrypt-config" && test -x "$withval/bin/gcrypt-config"; then
+      with_libgcrypt_config="$withval/bin/gcrypt-config"
+      with_libgcrypt="yes"
+    else if test -d "$withval"; then
+      GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS -I$withval/include"
+      GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS -L$withval/lib"
+      with_libgcrypt="yes"
+    else
+      with_libgcrypt_config="gcrypt-config"
+      with_libgcrypt="$withval"
+    fi; fi; fi
+  ],
+  [
+    with_libgcrypt_config="libgcrypt-config"
+    with_libgcrypt="yes"
+  ]
+)
 
-if test "x$with_libgcrypt" = "xyes" && test "x$with_libgcrypt_config" != "x"
-then
-	if test "x$GCRYPT_CPPFLAGS" = "x"
-	then
-		GCRYPT_CPPFLAGS=`"$with_libgcrypt_config" --cflags 2>/dev/null`
-	fi
+if test "x$with_libgcrypt" = "xyes" && test "x$with_libgcrypt_config" != "x"; then
+  if test "x$GCRYPT_CPPFLAGS" = "x"; then
+    GCRYPT_CPPFLAGS=`"$with_libgcrypt_config" --cflags 2>/dev/null`
+  fi
 
-	if test "x$GCRYPT_LIBS" = "x"
-	then
-		GCRYPT_LIBS=`"$with_libgcrypt_config" --libs 2>/dev/null`
-	fi
+  if test "x$GCRYPT_LIBS" = "x"; then
+    GCRYPT_LIBS=`"$with_libgcrypt_config" --libs 2>/dev/null`
+  fi
 fi
 
 SAVE_CPPFLAGS="$CPPFLAGS"
@@ -2327,118 +2474,108 @@ CPPFLAGS="$CPPFLAGS $GCRYPT_CPPFLAGS"
 LDFLAGS="$LDFLAGS $GCRYPT_LDFLAGS"
 LIBS="$LIBS $GCRYPT_LIBS"
 
-if test "x$with_libgcrypt" = "xyes"
-then
-	if test "x$GCRYPT_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([gcrypt CPPFLAGS: $GCRYPT_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(gcrypt.h,
-		[with_libgcrypt="yes"],
-		[with_libgcrypt="no (gcrypt.h not found)"])
+if test "x$with_libgcrypt" = "xyes"; then
+  if test "x$GCRYPT_CPPFLAGS" != "x"; then
+    AC_MSG_NOTICE([gcrypt CPPFLAGS: $GCRYPT_CPPFLAGS])
+  fi
+  AC_CHECK_HEADERS([gcrypt.h],
+    [with_libgcrypt="yes"],
+    [with_libgcrypt="no (gcrypt.h not found)"]
+  )
 fi
 
-if test "x$with_libgcrypt" = "xyes"
-then
-	AC_CHECK_LIB(gcrypt, gcry_md_hash_buffer,
-		[with_libgcrypt="yes"],
-		[with_libgcrypt="no (symbol gcry_md_hash_buffer not found)"])
+if test "x$with_libgcrypt" = "xyes"; then
+  AC_CHECK_LIB(gcrypt, gcry_md_hash_buffer,
+    [with_libgcrypt="yes"],
+    [with_libgcrypt="no (symbol gcry_md_hash_buffer not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 LIBS="$SAVE_LIBS"
 
-if test "x$with_libgcrypt" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBGCRYPT, 1, [Define to 1 if you have the gcrypt library (-lgcrypt).])
-fi
-
-AC_SUBST(GCRYPT_CPPFLAGS)
-AC_SUBST(GCRYPT_LDFLAGS)
-AC_SUBST(GCRYPT_LIBS)
-AM_CONDITIONAL(BUILD_WITH_LIBGCRYPT, test "x$with_libgcrypt" = "xyes")
+AC_SUBST([GCRYPT_CPPFLAGS])
+AC_SUBST([GCRYPT_LDFLAGS])
+AC_SUBST([GCRYPT_LIBS])
+AM_CONDITIONAL([BUILD_WITH_LIBGCRYPT], [test "x$with_libgcrypt" = "xyes"])
 # }}}
 
 # --with-libgps {{{
-with_libgps_cflags=""
-with_libgps_ldflags=""
-AC_ARG_WITH(libgps, [AS_HELP_STRING([--with-libgps@<:@=PREFIX@:>@], [Path to libgps.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libgps_cflags="-I$withval/include"
-		with_libgps_ldflags="-L$withval/lib"
-		with_libgps="yes"
-	else
-		with_libgps="$withval"
-	fi
-],
-[
-	with_libgps="yes"
-])
-if test "x$with_libgps" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS $with_libgps_cflags"
+AC_ARG_WITH([libgps],
+  [AS_HELP_STRING([--with-libgps@<:@=PREFIX@:>@], [Path to libgps.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libgps_cflags="-I$withval/include"
+      with_libgps_ldflags="-L$withval/lib"
+      with_libgps="yes"
+    else
+      with_libgps="$withval"
+    fi
+  ],
+  [with_libgps="yes"]
+)
 
-	AC_CHECK_HEADERS(gps.h, [with_libgps="yes"], [with_libgps="no (gps.h not found)"])
+if test "x$with_libgps" = "xyes"; then
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $with_libgps_cflags"
 
-	CFLAGS="$SAVE_CFLAGS"
+  AC_CHECK_HEADERS([gps.h],
+    [with_libgps="yes"],
+    [with_libgps="no (gps.h not found)"]
+  )
+
+  CFLAGS="$SAVE_CFLAGS"
 fi
-if test "x$with_libgps" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CFLAGS="$CFLAGS $with_libgps_cflags"
-	LDFLAGS="$LDFLAGS $with_libgps_ldflags"
 
-	AC_CHECK_LIB(gps, gps_open, [with_libgps="yes"], [with_libgps="no (symbol gps_open not found)"])
+if test "x$with_libgps" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libgps_ldflags"
 
-	CFLAGS="$SAVE_CFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([gps], [gps_open],
+    [with_libgps="yes"],
+    [with_libgps="no (symbol gps_open not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libgps" = "xyes"
-then
-	BUILD_WITH_LIBGPS_CFLAGS="$with_libgps_cflags"
-	BUILD_WITH_LIBGPS_LDFLAGS="$with_libgps_ldflags"
-	BUILD_WITH_LIBGPS_LIBS="-lgps"
-	AC_SUBST(BUILD_WITH_LIBGPS_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBGPS_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBGPS_LIBS)
+
+if test "x$with_libgps" = "xyes"; then
+  BUILD_WITH_LIBGPS_CFLAGS="$with_libgps_cflags"
+  BUILD_WITH_LIBGPS_LDFLAGS="$with_libgps_ldflags"
+  BUILD_WITH_LIBGPS_LIBS="-lgps"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBGPS, test "x$with_libgps" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBGPS_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBGPS_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBGPS_LIBS])
+
 # }}}
 
 # --with-libgrpc++ {{{
-with_libgrpcpp_cppflags=""
-with_libgrpcpp_ldflags=""
-AC_ARG_WITH([libgrpc++], [AS_HELP_STRING([--with-libgrpc++@<:@=PREFIX@:>@], [Path to libgrpc++.])],
+AC_ARG_WITH([libgrpc++],
+  [AS_HELP_STRING([--with-libgrpc++@<:@=PREFIX@:>@], [Path to libgrpc++.])],
   [
     with_grpcpp="$withval"
-    if test "x$withval" != "xno" && test "x$withval" != "xyes"
-    then
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
       with_libgrpcpp_cppflags="-I$withval/include"
       with_libgrpcpp_ldflags="-L$withval/lib"
       with_libgrpcpp="yes"
     fi
-    if test "x$withval" = "xno"
-    then
+    if test "x$withval" = "xno"; then
       with_libgrpcpp="no (disabled on command line)"
     fi
   ],
   [withval="yes"]
 )
-if test "x$withval" = "xyes"
-then
+if test "x$withval" = "xyes"; then
 PKG_CHECK_MODULES([GRPCPP], [grpc++],
   [with_libgrpcpp="yes"],
   [with_libgrpcpp="no (pkg-config could not find libgrpc++)"]
 )
 fi
 
-if test "x$withval" != "xno"
-then
+if test "x$withval" != "xno"; then
   AC_MSG_CHECKING([whether $CXX accepts -std=c++11])
   if test_cxx_flags -std=c++11; then
     AC_MSG_RESULT([yes])
@@ -2448,40 +2585,40 @@ then
   fi
 fi
 
-if test "x$with_libgrpcpp" = "xyes"
-then
+if test "x$with_libgrpcpp" = "xyes"; then
   AC_LANG_PUSH(C++)
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="-std=c++11 $with_libgrpcpp_cppflags $GRPCPP_CFLAGS $CPPFLAGS"
-  AC_CHECK_HEADERS([grpc++/grpc++.h], [],
+  AC_CHECK_HEADERS([grpc++/grpc++.h],
+    [with_libgrpcpp="yes"],
     [with_libgrpcpp="no (<grpc++/grpc++.h> not found)"]
   )
   CPPFLAGS="$SAVE_CPPFLAGS"
   AC_LANG_POP(C++)
 fi
-if test "x$with_libgrpcpp" = "xyes"
-then
+
+if test "x$with_libgrpcpp" = "xyes"; then
   AC_LANG_PUSH(C++)
   SAVE_CPPFLAGS="$CPPFLAGS"
   SAVE_LDFLAGS="$LDFLAGS"
   SAVE_LIBS="$LIBS"
   CPPFLAGS="-std=c++11 $with_libgrpcpp_cppflags $GRPCPP_CFLAGS $CPPFLAGS"
   LDFLAGS="$with_libgrpcpp_ldflags"
-  if test "x$GRPCPP_LIBS" = "x"
-  then
+  if test "x$GRPCPP_LIBS" = "x"; then
     LIBS="-lgrpc++"
   else
     LIBS="$GRPCPP_LIBS"
   fi
   AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM(
-      [[#include <grpc++/grpc++.h>]],
-      [[grpc::ServerBuilder sb;]]
-    )],
+    [
+      AC_LANG_PROGRAM(
+        [[#include <grpc++/grpc++.h>]],
+        [[grpc::ServerBuilder sb;]]
+      )
+    ],
     [
       with_libgrpcpp="yes"
-      if test "x$GRPCPP_LIBS" = "x"
-      then
+      if test "x$GRPCPP_LIBS" = "x"; then
         GRPCPP_LIBS="-lgrpc++"
       fi
     ],
@@ -2492,6 +2629,7 @@ then
   LIBS="$SAVE_LIBS"
   AC_LANG_POP(C++)
 fi
+
 BUILD_WITH_LIBGRPCPP_CPPFLAGS="-std=c++11 $with_libgrpcpp_cppflags $GRPCPP_CFLAGS"
 BUILD_WITH_LIBGRPCPP_LDFLAGS="$with_libgrpcpp_ldflags"
 BUILD_WITH_LIBGRPCPP_LIBS="$GRPCPP_LIBS"
@@ -2500,94 +2638,94 @@ AC_SUBST([BUILD_WITH_LIBGRPCPP_LDFLAGS])
 AC_SUBST([BUILD_WITH_LIBGRPCPP_LIBS])
 # }}}
 
-# --with-libiptc {{{
-AC_ARG_WITH(libiptc, [AS_HELP_STRING([--with-libiptc@<:@=PREFIX@:>@], [Path to libiptc.])],
-[
-	if test "x$withval" = "xyes"
-	then
-		with_libiptc="pkgconfig"
-	else if test "x$withval" = "xno"
-	then
-		with_libiptc="no"
-	else
-		with_libiptc="yes"
-		with_libiptc_cflags="-I$withval/include"
-		with_libiptc_libs="-L$withval/lib"
-	fi; fi
-],
-[
-	if test "x$ac_system" = "xLinux"
-	then
-		with_libiptc="pkgconfig"
-	else
-		with_libiptc="no (Linux only)"
-	fi
-])
+AC_ARG_VAR([GRPC_CPP_PLUGIN], [path to the grpc_cpp_plugin binary])
+AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
+AM_CONDITIONAL([HAVE_GRPC_CPP], [test "x$GRPC_CPP_PLUGIN" != "x"])
 
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	$PKG_CONFIG --exists 'libiptc' 2>/dev/null
-	if test $? -ne 0
-	then
-		with_libiptc="no (pkg-config doesn't know libiptc)"
-	fi
+# --with-libiptc {{{
+AC_ARG_WITH([libiptc],
+  [AS_HELP_STRING([--with-libiptc@<:@=PREFIX@:>@], [Path to libiptc.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libiptc="pkgconfig"
+    else if test "x$withval" = "xno"; then
+      with_libiptc="no"
+    else
+      with_libiptc="yes"
+      with_libiptc_cflags="-I$withval/include"
+      with_libiptc_libs="-L$withval/lib"
+    fi; fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_libiptc="pkgconfig"
+    else
+      with_libiptc="no (Linux only)"
+    fi
+  ]
+)
+
+if test "x$with_libiptc" = "xpkgconfig"; then
+  $PKG_CONFIG --exists 'libiptc' 2>/dev/null
+  if test $? -ne 0; then
+    with_libiptc="no (pkg-config doesn't know libiptc)"
+  fi
 fi
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	with_libiptc_cflags="`$PKG_CONFIG --cflags 'libiptc'`"
-	if test $? -ne 0
-	then
-		with_libiptc="no ($PKG_CONFIG failed)"
-	fi
-	with_libiptc_libs="`$PKG_CONFIG --libs 'libiptc'`"
-	if test $? -ne 0
-	then
-		with_libiptc="no ($PKG_CONFIG failed)"
-	fi
+
+if test "x$with_libiptc" = "xpkgconfig"; then
+  with_libiptc_cflags="`$PKG_CONFIG --cflags 'libiptc'`"
+  if test $? -ne 0; then
+    with_libiptc="no ($PKG_CONFIG failed)"
+  fi
+
+  with_libiptc_libs="`$PKG_CONFIG --libs 'libiptc'`"
+  if test $? -ne 0; then
+    with_libiptc="no ($PKG_CONFIG failed)"
+  fi
 fi
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 CPPFLAGS="$CPPFLAGS $with_libiptc_cflags"
 
 # check whether the header file for libiptc is available.
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	AC_CHECK_HEADERS(libiptc/libiptc.h libiptc/libip6tc.h, ,
-			[with_libiptc="no (header file missing)"])
+if test "x$with_libiptc" = "xpkgconfig"; then
+  AC_CHECK_HEADERS([libiptc/libiptc.h libiptc/libip6tc.h],
+    [],
+    [with_libiptc="no (header file missing)"]
+  )
 fi
+
 # If the header file is available, check for the required type declaractions.
 # They may be missing in old versions of libiptc. In that case, they will be
 # declared in the iptables plugin.
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	AC_CHECK_TYPES([iptc_handle_t, ip6tc_handle_t], [], [])
+if test "x$with_libiptc" = "xpkgconfig"; then
+  AC_CHECK_TYPES([iptc_handle_t, ip6tc_handle_t], [], [])
 fi
+
 # Check for the iptc_init symbol in the library.
 # This could be in iptc or ip4tc
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	SAVE_LIBS="$LIBS"
-	AC_SEARCH_LIBS(iptc_init, [iptc ip4tc],
-			[with_libiptc="pkgconfig"],
-			[with_libiptc="no"],
-			[$with_libiptc_libs])
-	LIBS="$SAVE_LIBS"
+if test "x$with_libiptc" = "xpkgconfig"; then
+  SAVE_LIBS="$LIBS"
+  AC_SEARCH_LIBS([iptc_init], [iptc ip4tc],
+    [with_libiptc="pkgconfig"],
+    [with_libiptc="no"],
+    [$with_libiptc_libs]
+  )
+  LIBS="$SAVE_LIBS"
 fi
-if test "x$with_libiptc" = "xpkgconfig"
-then
-	with_libiptc="yes"
+
+if test "x$with_libiptc" = "xpkgconfig"; then
+  with_libiptc="yes"
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 
-AM_CONDITIONAL(BUILD_WITH_LIBIPTC, test "x$with_libiptc" = "xyes")
-if test "x$with_libiptc" = "xyes"
-then
-	BUILD_WITH_LIBIPTC_CPPFLAGS="$with_libiptc_cflags"
-	BUILD_WITH_LIBIPTC_LDFLAGS="$with_libiptc_libs"
-	AC_SUBST(BUILD_WITH_LIBIPTC_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBIPTC_LDFLAGS)
+if test "x$with_libiptc" = "xyes"; then
+  BUILD_WITH_LIBIPTC_CPPFLAGS="$with_libiptc_cflags"
+  BUILD_WITH_LIBIPTC_LDFLAGS="$with_libiptc_libs"
 fi
+AC_SUBST([BUILD_WITH_LIBIPTC_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBIPTC_LDFLAGS])
 # }}}
 
 # --with-libdpdk {{{
@@ -2626,141 +2764,124 @@ fi
 
 # --with-java {{{
 with_java_home="$JAVA_HOME"
-if test "x$with_java_home" = "x"
-then
-	with_java_home="/usr/lib/jvm"
+if test "x$with_java_home" = "x"; then
+  with_java_home="/usr/lib/jvm"
 fi
+
 JAVAC="$JAVAC"
 JAR="$JAR"
-AC_ARG_WITH(java, [AS_HELP_STRING([--with-java@<:@=PREFIX@:>@], [Path to Java home.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_java="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_java="yes"
-	else
-		with_java_home="$withval"
-		with_java="yes"
-	fi; fi
-],
-[with_java="yes"])
-if test "x$with_java" = "xyes"
-then
-	if test -d "$with_java_home"
-	then
-		AC_MSG_CHECKING([for jni.h])
-		TMPVAR=`find -L "$with_java_home" -name jni.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
-		if test "x$TMPVAR" != "x"
-		then
-			AC_MSG_RESULT([found in $TMPVAR])
-			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
-		else
-			AC_MSG_RESULT([not found])
-		fi
+AC_ARG_WITH([java],
+  [AS_HELP_STRING([--with-java@<:@=PREFIX@:>@], [Path to Java home.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_java="no"
+    else if test "x$withval" = "xyes"; then
+      with_java="yes"
+    else
+      with_java_home="$withval"
+      with_java="yes"
+    fi; fi
+  ],
+  [with_java="yes"]
+)
 
-		AC_MSG_CHECKING([for jni_md.h])
-		TMPVAR=`find -L "$with_java_home" -name jni_md.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
-		if test "x$TMPVAR" != "x"
-		then
-			AC_MSG_RESULT([found in $TMPVAR])
-			JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
-		else
-			AC_MSG_RESULT([not found])
-		fi
+if test "x$with_java" = "xyes"; then
+  if test -d "$with_java_home"; then
+    AC_MSG_CHECKING([for jni.h])
+    TMPVAR=`find -L "$with_java_home" -name jni.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
+    if test "x$TMPVAR" != "x"; then
+      AC_MSG_RESULT([found in $TMPVAR])
+      JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
+    else
+      AC_MSG_RESULT([not found])
+    fi
 
-		AC_MSG_CHECKING([for libjvm.so])
-		TMPVAR=`find -L "$with_java_home" -type f \( -name libjvm.so -o -name libjvm.dylib \) -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
-		if test "x$TMPVAR" != "x"
-		then
-			AC_MSG_RESULT([found in $TMPVAR])
-			JAVA_LDFLAGS="$JAVA_LDFLAGS -L$TMPVAR -Wl,-rpath -Wl,$TMPVAR"
-		else
-			AC_MSG_RESULT([not found])
-		fi
+    AC_MSG_CHECKING([for jni_md.h])
+    TMPVAR=`find -L "$with_java_home" -name jni_md.h -type f -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
+    if test "x$TMPVAR" != "x"; then
+      AC_MSG_RESULT([found in $TMPVAR])
+      JAVA_CPPFLAGS="$JAVA_CPPFLAGS -I$TMPVAR"
+    else
+      AC_MSG_RESULT([not found])
+    fi
 
-		if test "x$JAVAC" = "x"
-		then
-			AC_MSG_CHECKING([for javac])
-			TMPVAR=`find -L "$with_java_home" -name javac -type f 2>/dev/null | LC_ALL=C sort | head -n 1`
-			if test "x$TMPVAR" != "x"
-			then
-				JAVAC="$TMPVAR"
-				AC_MSG_RESULT([$JAVAC])
-			else
-				AC_MSG_RESULT([not found])
-			fi
-		fi
-		if test "x$JAR" = "x"
-		then
-			AC_MSG_CHECKING([for jar])
-			TMPVAR=`find -L "$with_java_home" -name jar -type f 2>/dev/null | LC_ALL=C sort | head -n 1`
-			if test "x$TMPVAR" != "x"
-			then
-				JAR="$TMPVAR"
-				AC_MSG_RESULT([$JAR])
-			else
-				AC_MSG_RESULT([not found])
-			fi
-		fi
-	else if test "x$with_java_home" != "x"
-	then
-		AC_MSG_WARN([JAVA_HOME: No such directory: $with_java_home])
-	fi; fi
+    AC_MSG_CHECKING([for libjvm.so])
+    TMPVAR=`find -L "$with_java_home" -type f \( -name libjvm.so -o -name libjvm.dylib \) -exec 'dirname' '{}' ';' 2>/dev/null | LC_ALL=C sort | head -n 1`
+    if test "x$TMPVAR" != "x"; then
+      AC_MSG_RESULT([found in $TMPVAR])
+      JAVA_LDFLAGS="$JAVA_LDFLAGS -L$TMPVAR -Wl,-rpath -Wl,$TMPVAR"
+    else
+      AC_MSG_RESULT([not found])
+    fi
+
+    if test "x$JAVAC" = "x"; then
+      AC_MSG_CHECKING([for javac])
+      TMPVAR=`find -L "$with_java_home" -name javac -type f 2>/dev/null | LC_ALL=C sort | head -n 1`
+      if test "x$TMPVAR" != "x"; then
+        JAVAC="$TMPVAR"
+        AC_MSG_RESULT([$JAVAC])
+      else
+        AC_MSG_RESULT([not found])
+      fi
+    fi
+
+    if test "x$JAR" = "x"; then
+      AC_MSG_CHECKING([for jar])
+      TMPVAR=`find -L "$with_java_home" -name jar -type f 2>/dev/null | LC_ALL=C sort | head -n 1`
+      if test "x$TMPVAR" != "x"; then
+        JAR="$TMPVAR"
+        AC_MSG_RESULT([$JAR])
+      else
+        AC_MSG_RESULT([not found])
+      fi
+    fi
+  else if test "x$with_java_home" != "x"; then
+    AC_MSG_WARN([JAVA_HOME: No such directory: $with_java_home])
+  fi; fi
 fi
 
-if test "x$JAVA_CPPFLAGS" != "x"
-then
-	AC_MSG_NOTICE([Building with JAVA_CPPFLAGS set to: $JAVA_CPPFLAGS])
+if test "x$JAVA_CPPFLAGS" != "x"; then
+  AC_MSG_NOTICE([Building with JAVA_CPPFLAGS set to: $JAVA_CPPFLAGS])
 fi
-if test "x$JAVA_CFLAGS" != "x"
-then
-	AC_MSG_NOTICE([Building with JAVA_CFLAGS set to: $JAVA_CFLAGS])
+if test "x$JAVA_CFLAGS" != "x"; then
+  AC_MSG_NOTICE([Building with JAVA_CFLAGS set to: $JAVA_CFLAGS])
 fi
-if test "x$JAVA_LDFLAGS" != "x"
-then
-	AC_MSG_NOTICE([Building with JAVA_LDFLAGS set to: $JAVA_LDFLAGS])
+if test "x$JAVA_LDFLAGS" != "x"; then
+  AC_MSG_NOTICE([Building with JAVA_LDFLAGS set to: $JAVA_LDFLAGS])
 fi
-if test "x$JAVA_LIBS" != "x"
-then
-	AC_MSG_NOTICE([Building with JAVA_LIBS set to: $JAVA_LIBS])
+if test "x$JAVA_LIBS" != "x"; then
+  AC_MSG_NOTICE([Building with JAVA_LIBS set to: $JAVA_LIBS])
 fi
-if test "x$JAVAC" = "x"
-then
-	with_javac_path="$PATH"
-	if test "x$with_java_home" != "x"
-	then
-		with_javac_path="$with_java_home:with_javac_path"
-		if test -d "$with_java_home/bin"
-		then
-			with_javac_path="$with_java_home/bin:with_javac_path"
-		fi
-	fi
+if test "x$JAVAC" = "x"; then
+  with_javac_path="$PATH"
+  if test "x$with_java_home" != "x"; then
+    with_javac_path="$with_java_home:with_javac_path"
+    if test -d "$with_java_home/bin"; then
+      with_javac_path="$with_java_home/bin:with_javac_path"
+    fi
+  fi
 
-	AC_PATH_PROG(JAVAC, javac, [], "$with_javac_path")
+  AC_PATH_PROG([JAVAC], [javac], [], "$with_javac_path")
 fi
-if test "x$JAVAC" = "x"
-then
-	with_java="no (javac not found)"
-fi
-if test "x$JAR" = "x"
-then
-	with_jar_path="$PATH"
-	if test "x$with_java_home" != "x"
-	then
-		with_jar_path="$with_java_home:$with_jar_path"
-		if test -d "$with_java_home/bin"
-		then
-			with_jar_path="$with_java_home/bin:$with_jar_path"
-		fi
-	fi
 
-	AC_PATH_PROG(JAR, jar, [], "$with_jar_path")
+if test "x$JAVAC" = "x"; then
+  with_java="no (javac not found)"
 fi
-if test "x$JAR" = "x"
-then
-	with_java="no (jar not found)"
+
+if test "x$JAR" = "x"; then
+  with_jar_path="$PATH"
+  if test "x$with_java_home" != "x"; then
+    with_jar_path="$with_java_home:$with_jar_path"
+    if test -d "$with_java_home/bin"; then
+      with_jar_path="$with_java_home/bin:$with_jar_path"
+    fi
+  fi
+
+  AC_PATH_PROG([JAR], [jar], [], "$with_jar_path")
+fi
+
+if test "x$JAR" = "x"; then
+  with_java="no (jar not found)"
 fi
 
 SAVE_CPPFLAGS="$CPPFLAGS"
@@ -2772,21 +2893,23 @@ CFLAGS="$CFLAGS $JAVA_CFLAGS"
 LDFLAGS="$LDFLAGS $JAVA_LDFLAGS"
 LIBS="$LIBS $JAVA_LIBS"
 
-if test "x$with_java" = "xyes"
-then
-	AC_CHECK_HEADERS(jni.h, [], [with_java="no (jni.h not found)"])
+if test "x$with_java" = "xyes"; then
+  AC_CHECK_HEADERS([jni.h],
+    [with_jave="yes"],
+    [with_java="no (jni.h not found)"])
 fi
-if test "x$with_java" = "xyes"
-then
-	AC_CHECK_LIB(jvm, JNI_CreateJavaVM,
-	[with_java="yes"],
-	[with_java="no (Symbol 'JNI_CreateJavaVM' not found)"],
-	[$JAVA_LIBS $PTHREAD_LIBS])
+
+if test "x$with_java" = "xyes"; then
+  AC_CHECK_LIB([jvm], [JNI_CreateJavaVM],
+    [with_java="yes"],
+    [with_java="no (Symbol 'JNI_CreateJavaVM' not found)"],
+    [$JAVA_LIBS $PTHREAD_LIBS]
+  )
 fi
-if test "x$with_java" = "xyes"
-then
-	JAVA_LIBS="$JAVA_LIBS -ljvm"
-	AC_MSG_NOTICE([Building with JAVA_LIBS set to: $JAVA_LIBS])
+
+if test "x$with_java" = "xyes"; then
+  JAVA_LIBS="$JAVA_LIBS -ljvm"
+  AC_MSG_NOTICE([Building with JAVA_LIBS set to: $JAVA_LIBS])
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
@@ -2794,29 +2917,29 @@ CFLAGS="$SAVE_CFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 LIBS="$SAVE_LIBS"
 
-AC_SUBST(JAVA_CPPFLAGS)
-AC_SUBST(JAVA_CFLAGS)
-AC_SUBST(JAVA_LDFLAGS)
-AC_SUBST(JAVA_LIBS)
-AM_CONDITIONAL(BUILD_WITH_JAVA, test "x$with_java" = "xyes")
+AC_SUBST([JAVA_CPPFLAGS])
+AC_SUBST([JAVA_CFLAGS])
+AC_SUBST([JAVA_LDFLAGS])
+AC_SUBST([JAVA_LIBS])
+AM_CONDITIONAL([BUILD_WITH_JAVA], [test "x$with_java" = "xyes"])
 # }}}
 
 # --with-libldap {{{
-AC_ARG_WITH(libldap, [AS_HELP_STRING([--with-libldap@<:@=PREFIX@:>@], [Path to libldap.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_libldap="yes"
- else if test "x$withval" = "xno"
- then
-	 with_libldap="no"
- else
-	 with_libldap="yes"
-	 LIBLDAP_CPPFLAGS="$LIBLDAP_CPPFLAGS -I$withval/include"
-	 LIBLDAP_LDFLAGS="$LIBLDAP_LDFLAGS -L$withval/lib"
- fi; fi
-],
-[with_libldap="yes"])
+AC_ARG_WITH([libldap],
+  [AS_HELP_STRING([--with-libldap@<:@=PREFIX@:>@], [Path to libldap.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libldap="yes"
+    else if test "x$withval" = "xno"; then
+      with_libldap="no"
+    else
+      with_libldap="yes"
+      LIBLDAP_CPPFLAGS="$LIBLDAP_CPPFLAGS -I$withval/include"
+      LIBLDAP_LDFLAGS="$LIBLDAP_LDFLAGS -L$withval/lib"
+    fi; fi
+  ],
+  [with_libldap="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
@@ -2824,26 +2947,26 @@ SAVE_LDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS $LIBLDAP_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBLDAP_LDFLAGS"
 
-if test "x$with_libldap" = "xyes"
-then
-	if test "x$LIBLDAP_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libldap CPPFLAGS: $LIBLDAP_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(ldap.h,
-	[with_libldap="yes"],
-	[with_libldap="no ('ldap.h' not found)"])
-fi
-if test "x$with_libldap" = "xyes"
-then
-	if test "x$LIBLDAP_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libldap LDFLAGS: $LIBLDAP_LDFLAGS])
-	fi
-	AC_CHECK_LIB(ldap, ldap_initialize,
-	[with_libldap="yes"],
-	[with_libldap="no (symbol 'ldap_initialize' not found)"])
+if test "x$with_libldap" = "xyes"; then
+  if test "x$LIBLDAP_CPPFLAGS" != "x"; then
+    AC_MSG_NOTICE([libldap CPPFLAGS: $LIBLDAP_CPPFLAGS])
+  fi
 
+  AC_CHECK_HEADERS([ldap.h],
+    [with_libldap="yes"],
+    [with_libldap="no ('ldap.h' not found)"]
+  )
+fi
+
+if test "x$with_libldap" = "xyes"; then
+  if test "x$LIBLDAP_LDFLAGS" != "x"; then
+    AC_MSG_NOTICE([libldap LDFLAGS: $LIBLDAP_LDFLAGS])
+  fi
+
+  AC_CHECK_LIB([ldap], [ldap_initialize],
+    [with_libldap="yes"],
+    [with_libldap="no (symbol 'ldap_initialize' not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
@@ -2851,12 +2974,11 @@ LDFLAGS="$SAVE_LDFLAGS"
 
 if test "x$with_libldap" = "xyes"
 then
-	BUILD_WITH_LIBLDAP_CPPFLAGS="$LIBLDAP_CPPFLAGS"
-	BUILD_WITH_LIBLDAP_LDFLAGS="$LIBLDAP_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBLDAP_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBLDAP_LDFLAGS)
+  BUILD_WITH_LIBLDAP_CPPFLAGS="$LIBLDAP_CPPFLAGS"
+  BUILD_WITH_LIBLDAP_LDFLAGS="$LIBLDAP_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBLDAP, test "x$with_libldap" = "xyes")
+AC_SUBST([BUILD_WITH_LIBLDAP_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBLDAP_LDFLAGS])
 # }}}
 
 # --with-liblua {{{
@@ -2940,114 +3062,117 @@ AC_SUBST(BUILD_WITH_LIBLUA_LIBS)
 # }}}
 
 # --with-liblvm2app {{{
-with_liblvm2app_cppflags=""
-with_liblvm2app_ldflags=""
-AC_ARG_WITH(liblvm2app, [AS_HELP_STRING([--with-liblvm2app@<:@=PREFIX@:>@], [Path to liblvm2app.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_liblvm2app="no"
-	else
-		with_liblvm2app="yes"
-		if test "x$withval" != "xyes"
-		then
-			with_liblvm2app_cppflags="-I$withval/include"
-			with_liblvm2app_ldflags="-L$withval/lib"
-		fi
-        fi
-],
-[
-	if test "x$ac_system" = "xLinux"
-	then
-		with_liblvm2app="yes"
-	else
-		with_liblvm2app="no (Linux only library)"
-	fi
-])
-if test "x$with_liblvm2app" = "xyes"
-then
-        SAVE_CPPFLAGS="$CPPFLAGS"
-        CPPFLAGS="$CPPFLAGS $with_liblvm2app_cppflags"
+AC_ARG_WITH([liblvm2app],
+  [AS_HELP_STRING([--with-liblvm2app@<:@=PREFIX@:>@], [Path to liblvm2app.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_liblvm2app="no"
+    else
+      with_liblvm2app="yes"
+      if test "x$withval" != "xyes"; then
+        with_liblvm2app_cppflags="-I$withval/include"
+        with_liblvm2app_ldflags="-L$withval/lib"
+      fi
+    fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_liblvm2app="yes"
+    else
+      with_liblvm2app="no (Linux only library)"
+    fi
+  ]
+)
 
-        AC_CHECK_HEADERS(lvm2app.h, [with_liblvm2app="yes"], [with_liblvm2app="no (lvm2app.h not found)"])
+if test "x$with_liblvm2app" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_liblvm2app_cppflags"
 
-        CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([lvm2app.h],
+    [with_liblvm2app="yes"],
+    [with_liblvm2app="no (lvm2app.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_liblvm2app" = "xyes"
-then
-        SAVE_CPPFLAGS="$CPPFLAGS"
-        SAVE_LDFLAGS="$LDFLAGS"
-        CPPFLAGS="$CPPFLAGS $with_liblvm2app_cppflags"
-        LDFLAGS="$LDFLAGS $with_liblvm2app_ldflags"
+if test "x$with_liblvm2app" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LDFLAGS="$LDFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_liblvm2app_cppflags"
+  LDFLAGS="$LDFLAGS $with_liblvm2app_ldflags"
 
-        AC_CHECK_LIB(lvm2app, lvm_lv_get_property, [with_liblvm2app="yes"], [with_liblvm2app="no (Symbol 'lvm_lv_get_property' not found)"])
+  AC_CHECK_LIB([lvm2app], [lvm_lv_get_property],
+    [with_liblvm2app="yes"],
+    [with_liblvm2app="no (Symbol 'lvm_lv_get_property' not found)"]
+  )
 
-        CPPFLAGS="$SAVE_CPPFLAGS"
-        LDFLAGS="$SAVE_LDFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_liblvm2app" = "xyes"
-then
-        BUILD_WITH_LIBLVM2APP_CPPFLAGS="$with_liblvm2app_cppflags"
-        BUILD_WITH_LIBLVM2APP_LDFLAGS="$with_liblvm2app_ldflags"
-        BUILD_WITH_LIBLVM2APP_LIBS="-llvm2app"
-        AC_SUBST(BUILD_WITH_LIBLVM2APP_CPPFLAGS)
-        AC_SUBST(BUILD_WITH_LIBLVM2APP_LDFLAGS)
-        AC_SUBST(BUILD_WITH_LIBLVM2APP_LIBS)
-        AC_DEFINE(HAVE_LIBLVM2APP, 1, [Define if liblvm2app is present and usable.])
+
+if test "x$with_liblvm2app" = "xyes"; then
+  BUILD_WITH_LIBLVM2APP_CPPFLAGS="$with_liblvm2app_cppflags"
+  BUILD_WITH_LIBLVM2APP_LDFLAGS="$with_liblvm2app_ldflags"
+  BUILD_WITH_LIBLVM2APP_LIBS="-llvm2app"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBLVM2APP, test "x$with_liblvm2app" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBLVM2APP_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBLVM2APP_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBLVM2APP_LIBS])
 # }}}
 
 # --with-libmemcached {{{
-with_libmemcached_cppflags=""
-with_libmemcached_ldflags=""
-AC_ARG_WITH(libmemcached, [AS_HELP_STRING([--with-libmemcached@<:@=PREFIX@:>@], [Path to libmemcached.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libmemcached_cppflags="-I$withval/include"
-		with_libmemcached_ldflags="-L$withval/lib"
-		with_libmemcached="yes"
-	else
-		with_libmemcached="$withval"
-	fi
-],
-[
-	with_libmemcached="yes"
-])
-if test "x$with_libmemcached" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libmemcached_cppflags"
+AC_ARG_WITH([libmemcached],
+  [AS_HELP_STRING([--with-libmemcached@<:@=PREFIX@:>@], [Path to libmemcached.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libmemcached_cppflags="-I$withval/include"
+      with_libmemcached_ldflags="-L$withval/lib"
+      with_libmemcached="yes"
+    else
+      with_libmemcached="$withval"
+    fi
+  ],
+  [with_libmemcached="yes"]
+)
 
-	AC_CHECK_HEADERS(libmemcached/memcached.h, [with_libmemcached="yes"], [with_libmemcached="no (libmemcached/memcached.h not found)"])
+if test "x$with_libmemcached" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libmemcached_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([libmemcached/memcached.h],
+    [with_libmemcached="yes"],
+    [with_libmemcached="no (libmemcached/memcached.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libmemcached" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libmemcached_cppflags"
-	LDFLAGS="$LDFLAGS $with_libmemcached_ldflags"
 
-	AC_CHECK_LIB(memcached, memcached_create, [with_libmemcached="yes"], [with_libmemcached="no (Symbol 'memcached_create' not found)"])
+if test "x$with_libmemcached" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LDFLAGS="$LDFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libmemcached_cppflags"
+  LDFLAGS="$LDFLAGS $with_libmemcached_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([memcached], [memcached_create],
+    [with_libmemcached="yes"],
+    [with_libmemcached="no (Symbol 'memcached_create' not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libmemcached" = "xyes"
-then
-	BUILD_WITH_LIBMEMCACHED_CPPFLAGS="$with_libmemcached_cppflags"
-	BUILD_WITH_LIBMEMCACHED_LDFLAGS="$with_libmemcached_ldflags"
-	BUILD_WITH_LIBMEMCACHED_LIBS="-lmemcached"
-	AC_SUBST(BUILD_WITH_LIBMEMCACHED_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMEMCACHED_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMEMCACHED_LIBS)
-	AC_DEFINE(HAVE_LIBMEMCACHED, 1, [Define if libmemcached is present and usable.])
+
+if test "x$with_libmemcached" = "xyes"; then
+  BUILD_WITH_LIBMEMCACHED_CPPFLAGS="$with_libmemcached_cppflags"
+  BUILD_WITH_LIBMEMCACHED_LDFLAGS="$with_libmemcached_ldflags"
+  BUILD_WITH_LIBMEMCACHED_LIBS="-lmemcached"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBMEMCACHED, test "x$with_libmemcached" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBMEMCACHED_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBMEMCACHED_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBMEMCACHED_LIBS])
 # }}}
 
 # --with-libmicrohttpd {{{
@@ -3115,106 +3240,98 @@ AC_SUBST([BUILD_WITH_LIBMICROHTTPD_LIBS])
 # }}}
 
 # --with-libmodbus {{{
-with_libmodbus_config=""
-with_libmodbus_cflags=""
-with_libmodbus_libs=""
-AC_ARG_WITH(libmodbus, [AS_HELP_STRING([--with-libmodbus@<:@=PREFIX@:>@], [Path to the modbus library.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libmodbus="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libmodbus="use_pkgconfig"
-	else if test -d "$with_libmodbus/lib"
-	then
-		AC_MSG_NOTICE([Not checking for libmodbus: Manually configured])
-		with_libmodbus_cflags="-I$withval/include"
-		with_libmodbus_libs="-L$withval/lib -lmodbus"
-		with_libmodbus="yes"
-	fi; fi; fi
-],
-[with_libmodbus="use_pkgconfig"])
+AC_ARG_WITH([libmodbus],
+  [AS_HELP_STRING([--with-libmodbus@<:@=PREFIX@:>@], [Path to the modbus library.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_libmodbus="no"
+    else if test "x$withval" = "xyes"; then
+      with_libmodbus="use_pkgconfig"
+    else if test -d "$with_libmodbus/lib"; then
+      AC_MSG_NOTICE([Not checking for libmodbus: Manually configured])
+      with_libmodbus_cflags="-I$withval/include"
+      with_libmodbus_libs="-L$withval/lib -lmodbus"
+      with_libmodbus="yes"
+    fi; fi; fi
+  ],
+  [with_libmodbus="use_pkgconfig"]
+)
 
 # configure using pkg-config
-if test "x$with_libmodbus" = "xuse_pkgconfig"
-then
-	AC_MSG_NOTICE([Checking for libmodbus using $PKG_CONFIG])
-	$PKG_CONFIG --exists 'libmodbus' 2>/dev/null
-	if test $? -ne 0
-	then
-		with_libmodbus="no (pkg-config doesn't know libmodbus)"
-	fi
-fi
-if test "x$with_libmodbus" = "xuse_pkgconfig"
-then
-	with_libmodbus_cflags="`$PKG_CONFIG --cflags 'libmodbus'`"
-	if test $? -ne 0
-	then
-		with_libmodbus="no ($PKG_CONFIG failed)"
-	fi
-	with_libmodbus_libs="`$PKG_CONFIG --libs 'libmodbus'`"
-	if test $? -ne 0
-	then
-		with_libmodbus="no ($PKG_CONFIG failed)"
-	fi
-fi
-if test "x$with_libmodbus" = "xuse_pkgconfig"
-then
-	with_libmodbus="yes"
+if test "x$with_libmodbus" = "xuse_pkgconfig"; then
+  AC_MSG_NOTICE([Checking for libmodbus using $PKG_CONFIG])
+  $PKG_CONFIG --exists 'libmodbus' 2>/dev/null
+  if test $? -ne 0; then
+    with_libmodbus="no (pkg-config doesn't know libmodbus)"
+  fi
 fi
 
-# with_libmodbus_cflags and with_libmodbus_libs are set up now, let's do
-# the actual checks.
-if test "x$with_libmodbus" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libmodbus_cflags"
+if test "x$with_libmodbus" = "xuse_pkgconfig"; then
+  with_libmodbus_cflags="`$PKG_CONFIG --cflags 'libmodbus'`"
+  if test $? -ne 0; then
+    with_libmodbus="no ($PKG_CONFIG failed)"
+  fi
 
-	AC_CHECK_HEADERS(modbus.h, [], [with_libmodbus="no (modbus.h not found)"])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  with_libmodbus_libs="`$PKG_CONFIG --libs 'libmodbus'`"
+  if test $? -ne 0
+  then
+    with_libmodbus="no ($PKG_CONFIG failed)"
+  fi
 fi
-if test "x$with_libmodbus" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
 
-	CPPFLAGS="$CPPFLAGS $with_libmodbus_cflags"
-	LDFLAGS="$LDFLAGS $with_libmodbus_libs"
-
-	AC_CHECK_LIB(modbus, modbus_connect,
-		     [with_libmodbus="yes"],
-		     [with_libmodbus="no (symbol modbus_connect not found)"])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+if test "x$with_libmodbus" = "xuse_pkgconfig"; then
+  with_libmodbus="yes"
 fi
-if test "x$with_libmodbus" = "xyes"
-then
-	BUILD_WITH_LIBMODBUS_CFLAGS="$with_libmodbus_cflags"
-	BUILD_WITH_LIBMODBUS_LIBS="$with_libmodbus_libs"
-	AC_SUBST(BUILD_WITH_LIBMODBUS_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMODBUS_LIBS)
+
+if test "x$with_libmodbus" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libmodbus_cflags"
+
+  AC_CHECK_HEADERS([modbus.h],
+    [with_libmodbus="yes"],
+    [with_libmodbus="no (modbus.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
+
+if test "x$with_libmodbus" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libmodbus_libs"
+
+  AC_CHECK_LIB([modbus], [modbus_connect],
+    [with_libmodbus="yes"],
+    [with_libmodbus="no (symbol modbus_connect not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$with_libmodbus" = "xyes"; then
+  BUILD_WITH_LIBMODBUS_CFLAGS="$with_libmodbus_cflags"
+  BUILD_WITH_LIBMODBUS_LIBS="$with_libmodbus_libs"
+fi
+
+AC_SUBST([BUILD_WITH_LIBMODBUS_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBMODBUS_LIBS])
 # }}}
 
 # --with-libmongoc {{{
-AC_ARG_WITH(libmongoc, [AS_HELP_STRING([--with-libmongoc@<:@=PREFIX@:>@], [Path to libmongoc.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_libmongoc="yes"
- else if test "x$withval" = "xno"
- then
-	 with_libmongoc="no"
- else
-	 with_libmongoc="yes"
-	 LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS -I$withval/include"
-	 LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS -L$withval/lib"
- fi; fi
-],
-[with_libmongoc="yes"])
+AC_ARG_WITH([libmongoc],
+  [AS_HELP_STRING([--with-libmongoc@<:@=PREFIX@:>@], [Path to libmongoc.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libmongoc="yes"
+    else if test "x$withval" = "xno"; then
+      with_libmongoc="no"
+    else
+      with_libmongoc="yes"
+      LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS -I$withval/include"
+      LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS -L$withval/lib"
+    fi; fi
+  ],
+  [with_libmongoc="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
@@ -3222,366 +3339,346 @@ SAVE_LDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS $LIBMONGOC_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBMONGOC_LDFLAGS"
 
-if test "x$with_libmongoc" = "xyes"
-then
-	if test "x$LIBMONGOC_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libmongoc CPPFLAGS: $LIBMONGOC_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(mongo.h,
-	[with_libmongoc="yes"],
-	[with_libmongoc="no ('mongo.h' not found)"],
-[#if HAVE_STDINT_H
-# define MONGO_HAVE_STDINT 1
-#else
-# define MONGO_USE_LONG_LONG_INT 1
-#endif
-])
+if test "x$with_libmongoc" = "xyes"; then
+  if test "x$LIBMONGOC_CPPFLAGS" != "x"; then
+    AC_MSG_NOTICE([libmongoc CPPFLAGS: $LIBMONGOC_CPPFLAGS])
+  fi
+
+  AC_CHECK_HEADERS([mongo.h],
+    [with_libmongoc="yes"],
+    [with_libmongoc="no ('mongo.h' not found)"],
+    [[#define MONGO_HAVE_STDINT 1]]
+  )
 fi
-if test "x$with_libmongoc" = "xyes"
-then
-	if test "x$LIBMONGOC_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([libmongoc LDFLAGS: $LIBMONGOC_LDFLAGS])
-	fi
-	AC_CHECK_LIB(mongoc, mongo_run_command,
-	[with_libmongoc="yes"],
-	[with_libmongoc="no (symbol 'mongo_run_command' not found)"])
+
+if test "x$with_libmongoc" = "xyes"; then
+  if test "x$LIBMONGOC_LDFLAGS" != "x"; then
+    AC_MSG_NOTICE([libmongoc LDFLAGS: $LIBMONGOC_LDFLAGS])
+  fi
+
+  AC_CHECK_LIB([mongoc], [mongo_run_command],
+    [with_libmongoc="yes"],
+    [with_libmongoc="no (symbol 'mongo_run_command' not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 
-if test "x$with_libmongoc" = "xyes"
-then
-	BUILD_WITH_LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS"
-	BUILD_WITH_LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBMONGOC_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMONGOC_LDFLAGS)
+if test "x$with_libmongoc" = "xyes"; then
+  BUILD_WITH_LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS"
+  BUILD_WITH_LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBMONGOC, test "x$with_libmongoc" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBMONGOC_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBMONGOC_LDFLAGS])
 # }}}
 
 # --with-libmosquitto {{{
-with_libmosquitto_cppflags=""
-with_libmosquitto_ldflags=""
-AC_ARG_WITH(libmosquitto, [AS_HELP_STRING([--with-libmosquitto@<:@=PREFIX@:>@], [Path to libmosquitto.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libmosquitto_cppflags="-I$withval/include"
-		with_libmosquitto_ldflags="-L$withval/lib"
-		with_libmosquitto="yes"
-	else
-		with_libmosquitto="$withval"
-	fi
-],
-[
-	with_libmosquitto="yes"
-])
-if test "x$with_libmosquitto" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libmosquitto_cppflags"
+AC_ARG_WITH([libmosquitto],
+  [AS_HELP_STRING([--with-libmosquitto@<:@=PREFIX@:>@], [Path to libmosquitto.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libmosquitto_cppflags="-I$withval/include"
+      with_libmosquitto_ldflags="-L$withval/lib"
+      with_libmosquitto="yes"
+    else
+      with_libmosquitto="$withval"
+    fi
+  ],
+  [with_libmosquitto="yes"]
+)
 
-	AC_CHECK_HEADERS(mosquitto.h, [with_libmosquitto="yes"], [with_libmosquitto="no (mosquitto.h not found)"])
+if test "x$with_libmosquitto" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libmosquitto_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([mosquitto.h],
+    [with_libmosquitto="yes"],
+    [with_libmosquitto="no (mosquitto.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libmosquitto" = "xyes"
-then
-	SAVE_LDFLAGS="$LDFLAGS"
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	LDFLAGS="$LDFLAGS $with_libmosquitto_ldflags"
-	CPPFLAGS="$CPPFLAGS $with_libmosquitto_cppflags"
 
-	AC_CHECK_LIB(mosquitto, mosquitto_connect, [with_libmosquitto="yes"], [with_libmosquitto="no (libmosquitto not found)"])
+if test "x$with_libmosquitto" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libmosquitto_ldflags"
 
-	LDFLAGS="$SAVE_LDFLAGS"
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_LIB([mosquitto], [mosquitto_connect],
+    [with_libmosquitto="yes"],
+    [with_libmosquitto="no (libmosquitto not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libmosquitto" = "xyes"
-then
-	BUILD_WITH_LIBMOSQUITTO_CPPFLAGS="$with_libmosquitto_cppflags"
-	BUILD_WITH_LIBMOSQUITTO_LDFLAGS="$with_libmosquitto_ldflags"
-	BUILD_WITH_LIBMOSQUITTO_LIBS="-lmosquitto"
-	AC_SUBST(BUILD_WITH_LIBMOSQUITTO_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMOSQUITTO_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMOSQUITTO_LIBS)
+
+if test "x$with_libmosquitto" = "xyes"; then
+  BUILD_WITH_LIBMOSQUITTO_CPPFLAGS="$with_libmosquitto_cppflags"
+  BUILD_WITH_LIBMOSQUITTO_LDFLAGS="$with_libmosquitto_ldflags"
+  BUILD_WITH_LIBMOSQUITTO_LIBS="-lmosquitto"
 fi
+
+AC_SUBST([BUILD_WITH_LIBMOSQUITTO_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBMOSQUITTO_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBMOSQUITTO_LIBS])
 # }}}
 
 # --with-libmysql {{{
 with_mysql_config="mysql_config"
-with_mysql_cflags=""
-with_mysql_libs=""
-AC_ARG_WITH(libmysql, [AS_HELP_STRING([--with-libmysql@<:@=PREFIX@:>@], [Path to libmysql.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libmysql="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libmysql="yes"
-	else
-		if test -f "$withval" && test -x "$withval";
-		then
-			with_mysql_config="$withval"
-		else if test -x "$withval/bin/mysql_config"
-		then
-			with_mysql_config="$withval/bin/mysql_config"
-		fi; fi
-		with_libmysql="yes"
-	fi; fi
-],
-[
-	with_libmysql="yes"
-])
-if test "x$with_libmysql" = "xyes"
-then
-	with_mysql_cflags=`$with_mysql_config --include 2>/dev/null`
-	mysql_config_status=$?
+AC_ARG_WITH([libmysql],
+  [AS_HELP_STRING([--with-libmysql@<:@=PREFIX@:>@], [Path to libmysql.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_libmysql="no"
+    else if test "x$withval" = "xyes"; then
+      with_libmysql="yes"
+    else
+      if test -f "$withval" && test -x "$withval"; then
+        with_mysql_config="$withval"
+      else if test -x "$withval/bin/mysql_config"; then
+        with_mysql_config="$withval/bin/mysql_config"
+      fi; fi
+      with_libmysql="yes"
+    fi; fi
+  ],
+  [with_libmysql="yes"]
+)
 
-	if test $mysql_config_status -ne 0
-	then
-		with_libmysql="no ($with_mysql_config failed)"
-	else
-		SAVE_CPPFLAGS="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $with_mysql_cflags"
+if test "x$with_libmysql" = "xyes"; then
+  with_mysql_cflags=`$with_mysql_config --include 2>/dev/null`
+  if test $? -ne 0; then
+    with_libmysql="no ($with_mysql_config failed)"
+  else
+    SAVE_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $with_mysql_cflags"
 
-		have_mysql_h="no"
-		have_mysql_mysql_h="no"
-		AC_CHECK_HEADERS(mysql.h, [have_mysql_h="yes"])
+    AC_CHECK_HEADERS([mysql.h],
+      [have_mysql_h="yes"],
+      []
+    )
 
-		if test "x$have_mysql_h" = "xno"
-		then
-			AC_CHECK_HEADERS(mysql/mysql.h, [have_mysql_mysql_h="yes"])
-		fi
+    if test "x$have_mysql_h" != "xyes"; then
+      AC_CHECK_HEADERS([mysql/mysql.h],
+        [have_mysql_mysql_h="yes"],
+        [],
+      )
+    fi
 
-		if test "x$have_mysql_h$have_mysql_mysql_h" = "xnono"
-		then
-			with_libmysql="no (mysql.h not found)"
-		fi
+    if test "x$have_mysql_h" != "xyes" && test "x$have_mysql_mysql_h" != "xyes"; then
+      with_libmysql="no (mysql.h not found)"
+    fi
 
-		CPPFLAGS="$SAVE_CPPFLAGS"
-	fi
+    CPPFLAGS="$SAVE_CPPFLAGS"
+  fi
 fi
-if test "x$with_libmysql" = "xyes"
-then
-	with_mysql_libs=`$with_mysql_config --libs_r 2>/dev/null`
-	mysql_config_status=$?
 
-	if test $mysql_config_status -ne 0
-	then
-		with_libmysql="no ($with_mysql_config failed)"
-	else
-		SAVE_CPPFLAGS="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $with_mysql_cflags"
-		SAVE_LIBS="$LIBS"
-		LIBS="$with_mysql_libs"
-		AC_SEARCH_LIBS([mysql_get_server_version],
-		 [],
-		 [with_libmysql="yes"],
-		 [with_libmysql="no (symbol 'mysql_get_server_version' not found)"],
-		 [])
-		CPPFLAGS="$SAVE_CPPFLAGS"
-		LIBS="$SAVE_LIBS"
-	fi
+if test "x$with_libmysql" = "xyes"; then
+  with_mysql_libs=`$with_mysql_config --libs_r 2>/dev/null`
+  if test $? -ne 0; then
+    with_libmysql="no ($with_mysql_config failed)"
+  else
+    SAVE_LIBS="$LIBS"
+    LIBS="$with_mysql_libs"
+
+    AC_SEARCH_LIBS([mysql_get_server_version],
+      [],
+      [with_libmysql="yes"],
+      [with_libmysql="no (symbol 'mysql_get_server_version' not found in ${LIBS})"],
+      []
+    )
+    LIBS="$SAVE_LIBS"
+  fi
 fi
-if test "x$with_libmysql" = "xyes"
-then
-	BUILD_WITH_LIBMYSQL_CFLAGS="$with_mysql_cflags"
-	BUILD_WITH_LIBMYSQL_LIBS="$with_mysql_libs"
-	AC_SUBST(BUILD_WITH_LIBMYSQL_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMYSQL_LIBS)
+
+if test "x$with_libmysql" = "xyes"; then
+  BUILD_WITH_LIBMYSQL_CFLAGS="$with_mysql_cflags"
+  BUILD_WITH_LIBMYSQL_LIBS="$with_mysql_libs"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBMYSQL, test "x$with_libmysql" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBMYSQL_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBMYSQL_LIBS])
 # }}}
 
 # --with-libmnl {{{
-with_libmnl_cflags=""
-with_libmnl_libs=""
-AC_ARG_WITH(libmnl, [AS_HELP_STRING([--with-libmnl@<:@=PREFIX@:>@], [Path to libmnl.])],
-[
- echo "libmnl: withval = $withval"
- if test "x$withval" = "xyes"
- then
-	 with_libmnl="yes"
- else if test "x$withval" = "xno"
- then
-	 with_libmnl="no"
- else
-	 if test -d "$withval/include"
-	 then
-		 with_libmnl_cflags="-I$withval/include"
-		 with_libmnl_libs="-L$withval/lib -lmnl"
-		 with_libmnl="yes"
-	 else
-		 AC_MSG_ERROR("no such directory: $withval/include")
-	 fi
- fi; fi
-],
-[
- if test "x$ac_system" = "xLinux"
- then
-	 with_libmnl="yes"
- else
-	 with_libmnl="no (Linux only library)"
- fi
-])
-if test "x$with_libmnl" = "xyes"
-then
-	if $PKG_CONFIG --exists libmnl 2>/dev/null; then
-	  with_libmnl_cflags="$with_libmnl_ldflags `$PKG_CONFIG --cflags libmnl`"
-	  with_libmnl_libs="$with_libmnl_libs `$PKG_CONFIG --libs libmnl`"
-	fi
+AC_ARG_WITH([libmnl],
+  [AS_HELP_STRING([--with-libmnl@<:@=PREFIX@:>@], [Path to libmnl.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_libmnl="yes"
+     else if test "x$withval" = "xno"; then
+       with_libmnl="no"
+     else
+       if test -d "$withval/include"; then
+         with_libmnl_cflags="-I$withval/include"
+         with_libmnl_libs="-L$withval/lib -lmnl"
+         with_libmnl="yes"
+       else
+         AC_MSG_ERROR("no such directory: $withval/include")
+       fi
+     fi; fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_libmnl="yes"
+    else
+      with_libmnl="no (Linux only library)"
+    fi
+  ]
+)
 
-	AC_CHECK_HEADERS(libmnl.h libmnl/libmnl.h,
-	[
-	 with_libmnl="yes"
-	 break
-	], [],
-[#include <stdio.h>
-#include <sys/types.h>
-#include <asm/types.h>
-#include <sys/socket.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>])
-	AC_CHECK_HEADERS(linux/gen_stats.h linux/pkt_sched.h, [], [],
-[#include <stdio.h>
-#include <sys/types.h>
-#include <asm/types.h>
-#include <sys/socket.h>])
+if test "x$with_libmnl" = "xyes"; then
+  if $PKG_CONFIG --exists libmnl 2>/dev/null; then
+    with_libmnl_cflags="$with_libmnl_ldflags `$PKG_CONFIG --cflags libmnl`"
+    with_libmnl_libs="$with_libmnl_libs `$PKG_CONFIG --libs libmnl`"
+  fi
 
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[
-#include <stdio.h>
-#include <sys/types.h>
-#include <asm/types.h>
-#include <sys/socket.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
-]],
-[[
-int retval = TCA_STATS2;
-return (retval);
-]]
-	)],
-	[AC_DEFINE([HAVE_TCA_STATS2], [1], [True if the enum-member TCA_STATS2 exists])])
+  AC_CHECK_HEADERS([libmnl.h libmnl/libmnl.h],
+    [
+      with_libmnl="yes"
+      break
+    ],
+    [],
+    [[
+      #include <stdio.h>
+      #include <sys/types.h>
+      #include <asm/types.h>
+      #include <sys/socket.h>
+      #include <linux/netlink.h>
+      #include <linux/rtnetlink.h>]]
+  )
 
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[
-#include <stdio.h>
-#include <sys/types.h>
-#include <asm/types.h>
-#include <sys/socket.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
-]],
-[[
-int retval = TCA_STATS;
-return (retval);
-]]
-	)],
-	[AC_DEFINE([HAVE_TCA_STATS], 1, [True if the enum-member TCA_STATS exists])])
+  AC_CHECK_HEADERS([linux/gen_stats.h linux/pkt_sched.h],
+    [],
+    [],
+    [[
+      #include <stdio.h>
+      #include <sys/types.h>
+      #include <asm/types.h>
+      #include <sys/socket.h>
+    ]]
+  )
+
+  AC_COMPILE_IFELSE(
+    [
+      AC_LANG_PROGRAM(
+        [[
+          #include <stdio.h>
+          #include <sys/types.h>
+          #include <asm/types.h>
+          #include <sys/socket.h>
+          #include <linux/netlink.h>
+          #include <linux/rtnetlink.h>
+        ]],
+        [[
+          int retval = TCA_STATS2;
+          return (retval);
+        ]]
+      )
+    ],
+    [AC_DEFINE([HAVE_TCA_STATS2], [1], [True if the enum-member TCA_STATS2 exists])]
+  )
+
+  AC_COMPILE_IFELSE(
+    [
+      AC_LANG_PROGRAM(
+        [[
+          #include <stdio.h>
+          #include <sys/types.h>
+          #include <asm/types.h>
+          #include <sys/socket.h>
+          #include <linux/netlink.h>
+          #include <linux/rtnetlink.h>
+        ]],
+        [[
+          int retval = TCA_STATS;
+          return (retval);
+        ]]
+      )
+    ],
+    [AC_DEFINE([HAVE_TCA_STATS], 1, [True if the enum-member TCA_STATS exists])]
+  )
+
+  AC_CHECK_MEMBERS([struct rtnl_link_stats64.tx_window_errors],
+    [AC_DEFINE(HAVE_RTNL_LINK_STATS64, 1, [Define if struct rtnl_link_stats64 exists and is usable.])],
+    [],
+    [[#include <linux/if_link.h>]]
+  )
+
+  AC_CHECK_LIB([mnl], [mnl_nlmsg_get_payload],
+    [with_libmnl="yes"],
+    [with_libmnl="no (symbol 'mnl_nlmsg_get_payload' not found)"],
+    [$with_libmnl_libs]
+  )
 fi
-if test "x$with_libmnl" = "xyes"
-then
-	AC_CHECK_MEMBERS([struct rtnl_link_stats64.tx_window_errors],
-	[AC_DEFINE(HAVE_RTNL_LINK_STATS64, 1, [Define if struct rtnl_link_stats64 exists and is usable.])],
-	[],
-	[
-	#include <linux/if_link.h>
-	])
+
+if test "x$with_libmnl" = "xyes"; then
+  BUILD_WITH_LIBMNL_CFLAGS="$with_libmnl_cflags"
+  BUILD_WITH_LIBMNL_LIBS="$with_libmnl_libs"
 fi
-if test "x$with_libmnl" = "xyes"
-then
-	AC_CHECK_LIB(mnl, mnl_nlmsg_get_payload,
-		     [with_libmnl="yes"],
-		     [with_libmnl="no (symbol 'mnl_nlmsg_get_payload' not found)"],
-		     [$with_libmnl_libs])
-fi
-if test "x$with_libmnl" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBMNL, 1, [Define if libmnl is present and usable.])
-	BUILD_WITH_LIBMNL_CFLAGS="$with_libmnl_cflags"
-	BUILD_WITH_LIBMNL_LIBS="$with_libmnl_libs"
-	AC_SUBST(BUILD_WITH_LIBMNL_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBMNL_LIBS)
-fi
-AM_CONDITIONAL(BUILD_WITH_LIBMNL, test "x$with_libmnl" = "xyes")
+AC_SUBST([BUILD_WITH_LIBMNL_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBMNL_LIBS])
 # }}}
 
 # --with-libnetapp {{{
 AC_ARG_VAR([LIBNETAPP_CPPFLAGS], [C preprocessor flags required to build with libnetapp])
 AC_ARG_VAR([LIBNETAPP_LDFLAGS],  [Linker flags required to build with libnetapp])
 AC_ARG_VAR([LIBNETAPP_LIBS],     [Other libraries required to link against libnetapp])
-LIBNETAPP_CPPFLAGS="$LIBNETAPP_CPPFLAGS"
-LIBNETAPP_LDFLAGS="$LIBNETAPP_LDFLAGS"
-LIBNETAPP_LIBS="$LIBNETAPP_LIBS"
-AC_ARG_WITH(libnetapp, [AS_HELP_STRING([--with-libnetapp@<:@=PREFIX@:>@], [Path to libnetapp.])],
-[
- if test -d "$withval"
- then
-	 LIBNETAPP_CPPFLAGS="$LIBNETAPP_CPPFLAGS -I$withval/include"
-	 LIBNETAPP_LDFLAGS="$LIBNETAPP_LDFLAGS -L$withval/lib"
-	 with_libnetapp="yes"
- else
-	 with_libnetapp="$withval"
- fi
-],
-[
- with_libnetapp="yes"
-])
+AC_ARG_WITH([libnetapp],
+  [AS_HELP_STRING([--with-libnetapp@<:@=PREFIX@:>@], [Path to libnetapp.])],
+  [
+   if test -d "$withval"; then
+     LIBNETAPP_CPPFLAGS="$LIBNETAPP_CPPFLAGS -I$withval/include"
+     LIBNETAPP_LDFLAGS="$LIBNETAPP_LDFLAGS -L$withval/lib"
+     with_libnetapp="yes"
+   else
+     with_libnetapp="$withval"
+   fi
+  ],
+  [with_libnetapp="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS $LIBNETAPP_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBNETAPP_LDFLAGS"
 
-if test "x$with_libnetapp" = "xyes"
-then
-	if test "x$LIBNETAPP_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([netapp CPPFLAGS: $LIBNETAPP_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(netapp_api.h,
-		[with_libnetapp="yes"],
-		[with_libnetapp="no (netapp_api.h not found)"])
+if test "x$with_libnetapp" = "xyes"; then
+  if test "x$LIBNETAPP_CPPFLAGS" != "x"; then
+    AC_MSG_NOTICE([netapp CPPFLAGS: $LIBNETAPP_CPPFLAGS])
+  fi
+  AC_CHECK_HEADERS([netapp_api.h],
+    [with_libnetapp="yes"],
+    [with_libnetapp="no (netapp_api.h not found)"]
+  )
 fi
 
-if test "x$with_libnetapp" = "xyes"
-then
-	if test "x$LIBNETAPP_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([netapp LDFLAGS: $LIBNETAPP_LDFLAGS])
-	fi
+if test "x$with_libnetapp" = "xyes"; then
+  if test "x$LIBNETAPP_LDFLAGS" != "x"; then
+    AC_MSG_NOTICE([netapp LDFLAGS: $LIBNETAPP_LDFLAGS])
+  fi
 
-	if test "x$LIBNETAPP_LIBS" = "x"
-	then
-		LIBNETAPP_LIBS="$PTHREAD_LIBS -lxml -ladt -lssl -lm -lcrypto -lz"
-	fi
-	AC_MSG_NOTICE([netapp LIBS: $LIBNETAPP_LIBS])
+  if test "x$LIBNETAPP_LIBS" = "x"; then
+    LIBNETAPP_LIBS="$PTHREAD_LIBS -lxml -ladt -lssl -lm -lcrypto -lz"
+  fi
 
-	AC_CHECK_LIB(netapp, na_server_invoke_elem,
-		[with_libnetapp="yes"],
-		[with_libnetapp="no (symbol na_server_invoke_elem not found)"],
-		[$LIBNETAPP_LIBS])
-	LIBNETAPP_LIBS="-lnetapp $LIBNETAPP_LIBS"
+  AC_MSG_NOTICE([netapp LIBS: $LIBNETAPP_LIBS])
+
+  AC_CHECK_LIB([netapp], [na_server_invoke_elem],
+    [with_libnetapp="yes"],
+    [with_libnetapp="no (symbol na_server_invoke_elem not found)"],
+    [$LIBNETAPP_LIBS]
+  )
+
+  LIBNETAPP_LIBS="-lnetapp $LIBNETAPP_LIBS"
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 
-if test "x$with_libnetapp" = "xyes"
-then
-	AC_DEFINE(HAVE_LIBNETAPP, 1, [Define to 1 if you have the netapp library (-lnetapp).])
-fi
-
-AC_SUBST(LIBNETAPP_CPPFLAGS)
-AC_SUBST(LIBNETAPP_LDFLAGS)
-AC_SUBST(LIBNETAPP_LIBS)
-AM_CONDITIONAL(BUILD_WITH_LIBNETAPP, test "x$with_libnetapp" = "xyes")
+AC_SUBST([LIBNETAPP_CPPFLAGS])
+AC_SUBST([LIBNETAPP_LDFLAGS])
+AC_SUBST([LIBNETAPP_LIBS])
 # }}}
 
 # --with-libnetsnmp {{{
@@ -3605,7 +3702,10 @@ then
 	SAVE_CPPFLAGS="$CPPFLAGS"
 	CPPFLAGS="$CPPFLAGS $with_libnetsnmp_cppflags"
 
-	AC_CHECK_HEADERS(net-snmp/net-snmp-config.h, [], [with_libnetsnmp="no (net-snmp/net-snmp-config.h not found)"])
+    AC_CHECK_HEADERS([net-snmp/net-snmp-config.h],
+      [with_libnetsnmp="yes"],
+      [with_libnetsnmp="no (net-snmp/net-snmp-config.h not found)"]
+    )
 
 	CPPFLAGS="$SAVE_CPPFLAGS"
 fi
@@ -3632,552 +3732,496 @@ AC_SUBST(BUILD_WITH_LIBNETSNMP_LDFLAGS)
 AC_SUBST(BUILD_WITH_LIBNETSNMP_LIBS)
 # }}}
 
-# --with-liboconfig {{{
-with_own_liboconfig="no"
-liboconfig_LDFLAGS="$LDFLAGS"
-liboconfig_CPPFLAGS="$CPPFLAGS"
-AC_ARG_WITH(liboconfig, [AS_HELP_STRING([--with-liboconfig@<:@=PREFIX@:>@], [Path to liboconfig.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		if test -d "$withval/lib"
-		then
-			liboconfig_LDFLAGS="$LDFLAGS -L$withval/lib"
-		fi
-		if test -d "$withval/include"
-		then
-			liboconfig_CPPFLAGS="$CPPFLAGS -I$withval/include"
-		fi
-	fi
-	if test "x$withval" = "xno"
-	then
-		AC_MSG_ERROR("liboconfig is required")
-	fi
-],
-[
-	with_liboconfig="yes"
-])
-
-save_LDFLAGS="$LDFLAGS"
-save_CPPFLAGS="$CPPFLAGS"
-LDFLAGS="$liboconfig_LDFLAGS"
-CPPFLAGS="$liboconfig_CPPFLAGS"
-AC_CHECK_LIB(oconfig, oconfig_parse_file,
-[
-	with_liboconfig="yes"
-	with_own_liboconfig="no"
-],
-[
-	with_liboconfig="yes"
-	with_own_liboconfig="yes"
-	LDFLAGS="$save_LDFLAGS"
-	CPPFLAGS="$save_CPPFLAGS"
-])
-
-AM_CONDITIONAL(BUILD_WITH_OWN_LIBOCONFIG, test "x$with_own_liboconfig" = "xyes")
-if test "x$with_own_liboconfig" = "xyes"
-then
-	with_liboconfig="yes (shipped version)"
-fi
-# }}}
-
 # --with-liboping {{{
-AC_ARG_WITH(liboping, [AS_HELP_STRING([--with-liboping@<:@=PREFIX@:>@], [Path to liboping.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_liboping="yes"
- else if test "x$withval" = "xno"
- then
-	 with_liboping="no"
- else
-	 with_liboping="yes"
-	 LIBOPING_CPPFLAGS="$LIBOPING_CPPFLAGS -I$withval/include"
-	 LIBOPING_LDFLAGS="$LIBOPING_LDFLAGS -L$withval/lib"
- fi; fi
-],
-[with_liboping="yes"])
+AC_ARG_WITH([liboping],
+  [AS_HELP_STRING([--with-liboping@<:@=PREFIX@:>@], [Path to liboping.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_liboping="yes"
+    else if test "x$withval" = "xno"; then
+      with_liboping="no"
+    else
+      with_liboping="yes"
+      LIBOPING_CPPFLAGS="-I$withval/include"
+      LIBOPING_LDFLAGS="-L$withval/lib"
+    fi; fi
+  ],
+  [with_liboping="yes"]
+)
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
-
 CPPFLAGS="$CPPFLAGS $LIBOPING_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBOPING_LDFLAGS"
 
-if test "x$with_liboping" = "xyes"
-then
-	if test "x$LIBOPING_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([liboping CPPFLAGS: $LIBOPING_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(oping.h,
-	[with_liboping="yes"],
-	[with_liboping="no (oping.h not found)"])
+if test "x$with_liboping" = "xyes"; then
+  AC_CHECK_HEADERS([oping.h],
+    [with_liboping="yes"],
+    [with_liboping="no (oping.h not found)"]
+  )
 fi
-if test "x$with_liboping" = "xyes"
-then
-	if test "x$LIBOPING_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([liboping LDFLAGS: $LIBOPING_LDFLAGS])
-	fi
-	AC_CHECK_LIB(oping, ping_construct,
-	[with_liboping="yes"],
-	[with_liboping="no (symbol 'ping_construct' not found)"])
+
+if test "x$with_liboping" = "xyes"; then
+  AC_CHECK_LIB([oping], [ping_construct],
+    [with_liboping="yes"],
+    [with_liboping="no (symbol 'ping_construct' not found)"]
+  )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 
-if test "x$with_liboping" = "xyes"
-then
-	BUILD_WITH_LIBOPING_CPPFLAGS="$LIBOPING_CPPFLAGS"
-	BUILD_WITH_LIBOPING_LDFLAGS="$LIBOPING_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBOPING_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBOPING_LDFLAGS)
+if test "x$with_liboping" = "xyes"; then
+  BUILD_WITH_LIBOPING_CPPFLAGS="$LIBOPING_CPPFLAGS"
+  BUILD_WITH_LIBOPING_LDFLAGS="$LIBOPING_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBOPING, test "x$with_liboping" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBOPING_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBOPING_LDFLAGS])
 # }}}
 
 # --with-oracle {{{
-with_oracle_cppflags=""
-with_oracle_libs=""
-AC_ARG_WITH(oracle, [AS_HELP_STRING([--with-oracle@<:@=ORACLE_HOME@:>@], [Path to Oracle.])],
-[
-	if test "x$withval" = "xyes"
-	then
-		if test "x$ORACLE_HOME" = "x"
-		then
-			AC_MSG_WARN([Use of the Oracle library has been forced, but the environment variable ORACLE_HOME is not set.])
-		fi
-		with_oracle="yes"
-	else if test "x$withval" = "xno"
-	then
-		with_oracle="no"
-	else
-		with_oracle="yes"
-		ORACLE_HOME="$withval"
-	fi; fi
-],
-[
-	if test "x$ORACLE_HOME" = "x"
-	then
-		with_oracle="no (ORACLE_HOME is not set)"
-	else
-		with_oracle="yes"
-	fi
-])
-if test "x$ORACLE_HOME" != "x"
-then
-	with_oracle_cppflags="-I$ORACLE_HOME/rdbms/public"
+AC_ARG_WITH([oracle],
+  [AS_HELP_STRING([--with-oracle@<:@=ORACLE_HOME@:>@], [Path to Oracle.])],
+  [
+    if test "x$withval" = "xyes"; then
+      if test "x$ORACLE_HOME" = "x"; then
+        AC_MSG_WARN([Use of the Oracle library has been forced, but the environment variable ORACLE_HOME is not set.])
+      fi
+      with_oracle="yes"
+    else if test "x$withval" = "xno"; then
+      with_oracle="no"
+    else
+      with_oracle="yes"
+      ORACLE_HOME="$withval"
+    fi; fi
+  ],
+  [
+    if test "x$ORACLE_HOME" = "x"; then
+      with_oracle="no (ORACLE_HOME is not set)"
+    else
+      with_oracle="yes"
+    fi
+  ]
+)
 
-	if test -e "$ORACLE_HOME/lib/ldflags"
-	then
-		with_oracle_libs=`cat "$ORACLE_HOME/lib/ldflags"`
-	fi
-	#with_oracle_libs="-L$ORACLE_HOME/lib $with_oracle_libs -lclntsh"
-	with_oracle_libs="-L$ORACLE_HOME/lib -lclntsh"
+if test "x$ORACLE_HOME" != "x"; then
+  with_oracle_cppflags="-I$ORACLE_HOME/rdbms/public"
+  if test -e "$ORACLE_HOME/lib/ldflags"; then
+    with_oracle_libs=`cat "$ORACLE_HOME/lib/ldflags"`
+  fi
+  with_oracle_libs="-L$ORACLE_HOME/lib -lclntsh"
 fi
-if test "x$with_oracle" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_oracle_cppflags"
 
-	AC_CHECK_HEADERS(oci.h, [with_oracle="yes"], [with_oracle="no (oci.h not found)"])
+if test "x$with_oracle" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_oracle_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([oci.h],
+    [with_oracle="yes"],
+    [with_oracle="no (oci.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_oracle" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LIBS="$LIBS"
-	CPPFLAGS="$CPPFLAGS $with_oracle_cppflags"
-	LIBS="$LIBS $with_oracle_libs"
 
-	AC_CHECK_FUNC(OCIEnvCreate, [with_oracle="yes"], [with_oracle="no (Symbol 'OCIEnvCreate' not found)"])
+if test "x$with_oracle" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $with_oracle_cppflags"
+  LIBS="$LIBS $with_oracle_libs"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LIBS="$SAVE_LIBS"
+  AC_CHECK_FUNC([OCIEnvCreate],
+    [with_oracle="yes"],
+    [with_oracle="no (Symbol 'OCIEnvCreate' not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LIBS="$SAVE_LIBS"
 fi
-if test "x$with_oracle" = "xyes"
-then
-	BUILD_WITH_ORACLE_CPPFLAGS="$with_oracle_cppflags"
-	BUILD_WITH_ORACLE_LIBS="$with_oracle_libs"
-	AC_SUBST(BUILD_WITH_ORACLE_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_ORACLE_LIBS)
+
+if test "x$with_oracle" = "xyes"; then
+  BUILD_WITH_ORACLE_CPPFLAGS="$with_oracle_cppflags"
+  BUILD_WITH_ORACLE_LIBS="$with_oracle_libs"
 fi
+
+AC_SUBST([BUILD_WITH_ORACLE_CPPFLAGS])
+AC_SUBST([BUILD_WITH_ORACLE_LIBS])
 # }}}
 
 # --with-libowcapi {{{
-with_libowcapi_cppflags=""
-with_libowcapi_ldflags=""
-AC_ARG_WITH(libowcapi, [AS_HELP_STRING([--with-libowcapi@<:@=PREFIX@:>@], [Path to libowcapi.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libowcapi_cppflags="-I$withval/include"
-		with_libowcapi_ldflags="-L$withval/lib"
-		with_libowcapi="yes"
-	else
-		with_libowcapi="$withval"
-	fi
-],
-[
-	with_libowcapi="yes"
-])
-if test "x$with_libowcapi" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libowcapi_cppflags"
+AC_ARG_WITH([libowcapi],
+  [AS_HELP_STRING([--with-libowcapi@<:@=PREFIX@:>@], [Path to libowcapi.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libowcapi_cppflags="-I$withval/include"
+      with_libowcapi_ldflags="-L$withval/lib"
+      with_libowcapi="yes"
+    else
+      with_libowcapi="$withval"
+    fi
+  ],
+  [with_libowcapi="yes"]
+)
 
-	AC_CHECK_HEADERS(owcapi.h, [with_libowcapi="yes"], [with_libowcapi="no (owcapi.h not found)"])
+if test "x$with_libowcapi" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libowcapi_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([owcapi.h],
+    [with_libowcapi="yes"],
+    [with_libowcapi="no (owcapi.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libowcapi" = "xyes"
-then
-	SAVE_LDFLAGS="$LDFLAGS"
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	LDFLAGS="$LDFLAGS $with_libowcapi_ldflags"
-	CPPFLAGS="$with_libowcapi_cppflags"
 
-	AC_CHECK_LIB(owcapi, OW_get, [with_libowcapi="yes"], [with_libowcapi="no (libowcapi not found)"])
+if test "x$with_libowcapi" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libowcapi_ldflags"
 
-	LDFLAGS="$SAVE_LDFLAGS"
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_LIB([owcapi], [OW_get],
+    [with_libowcapi="yes"],
+    [with_libowcapi="no (libowcapi not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libowcapi" = "xyes"
-then
-	BUILD_WITH_LIBOWCAPI_CPPFLAGS="$with_libowcapi_cppflags"
-	BUILD_WITH_LIBOWCAPI_LDFLAGS="$with_libowcapi_ldflags"
-	BUILD_WITH_LIBOWCAPI_LIBS="-lowcapi"
-	AC_SUBST(BUILD_WITH_LIBOWCAPI_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBOWCAPI_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBOWCAPI_LIBS)
+
+if test "x$with_libowcapi" = "xyes"; then
+  BUILD_WITH_LIBOWCAPI_CPPFLAGS="$with_libowcapi_cppflags"
+  BUILD_WITH_LIBOWCAPI_LDFLAGS="$with_libowcapi_ldflags"
+  BUILD_WITH_LIBOWCAPI_LIBS="-lowcapi"
 fi
+
+AC_SUBST([BUILD_WITH_LIBOWCAPI_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBOWCAPI_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBOWCAPI_LIBS])
 # }}}
 
 # --with-libpcap {{{
-AC_ARG_WITH(libpcap, [AS_HELP_STRING([--with-libpcap@<:@=PREFIX@:>@], [Path to libpcap.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		LDFLAGS="$LDFLAGS -L$withval/lib"
-		CPPFLAGS="$CPPFLAGS -I$withval/include"
-		with_libpcap="yes"
-	else
-		with_libpcap="$withval"
-	fi
-],
-[
-	with_libpcap="yes"
-])
-if test "x$with_libpcap" = "xyes"
-then
-	AC_CHECK_LIB(pcap, pcap_open_live,
-	[
-		AC_DEFINE(HAVE_LIBPCAP, 1, [Define to 1 if you have the pcap library (-lpcap).])
-	], [with_libpcap="no (libpcap not found)"])
+AC_ARG_WITH([libpcap],
+  [AS_HELP_STRING([--with-libpcap@<:@=PREFIX@:>@], [Path to libpcap.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libpcap_cppflags="-I$withval/include"
+      with_libpcap_ldflags="$LDFLAGS -L$withval/lib"
+      with_libpcap="yes"
+    else
+      with_libpcap="$withval"
+    fi
+  ],
+  [with_libpcap="yes"]
+)
+
+if test "x$with_libpcap" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libpcap_cppflags"
+
+  AC_CHECK_HEADERS([pcap.h],
+    [with_libpcap="yes"],
+    [with_libpcap="no (pcap.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libpcap" = "xyes"
-then
-	AC_CHECK_HEADERS(pcap.h,,
-			 [with_libpcap="no (pcap.h not found)"])
+
+if test "x$with_libpcap" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libpcap_ldflags"
+
+  AC_CHECK_LIB([pcap], [pcap_open_live],
+    [with_libpcap="yes"],
+    [with_libpcap="no (libpcap not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libpcap" = "xyes"
-then
-	AC_CACHE_CHECK([whether libpcap has PCAP_ERROR_IFACE_NOT_UP],
-		       [c_cv_libpcap_have_pcap_error_iface_not_up],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <pcap.h>
-]]],
-[[[
-  int val = PCAP_ERROR_IFACE_NOT_UP;
-  return(val);
-]]]
-		       )],
-		       [c_cv_libpcap_have_pcap_error_iface_not_up="yes"],
-		       [c_cv_libpcap_have_pcap_error_iface_not_up="no"]))
+
+if test "x$with_libpcap" = "xyes"; then
+  AC_CACHE_CHECK([whether libpcap has PCAP_ERROR_IFACE_NOT_UP],
+    [c_cv_libpcap_have_pcap_error_iface_not_up],
+    [
+      AC_COMPILE_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[#include <pcap.h>]],
+            [[
+              int val = PCAP_ERROR_IFACE_NOT_UP;
+              return(val);
+            ]]
+          )
+        ],
+        [c_cv_libpcap_have_pcap_error_iface_not_up="yes"],
+        [c_cv_libpcap_have_pcap_error_iface_not_up="no"]
+      )
+    ]
+  )
 fi
-if test "x$c_cv_libpcap_have_pcap_error_iface_not_up" != "xyes"
-then
-		with_libpcap="no (pcap.h misses PCAP_ERROR_IFACE_NOT_UP)"
+
+if test "x$c_cv_libpcap_have_pcap_error_iface_not_up" != "xyes"; then
+  with_libpcap="no (pcap.h misses PCAP_ERROR_IFACE_NOT_UP)"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBPCAP, test "x$with_libpcap" = "xyes")
+
+if test "x$with_libpcap" = "xyes"; then
+  BUILD_WITH_LIBPCAP_CPPFLAGS="$with_libpcap_cppflags"
+  BUILD_WITH_LIBPCAP_LDFLAGS="$with_libpcap_ldflags"
+  BUILD_WITH_LIBPCAP_LIBS="-lpcap"
+fi
+
+AC_SUBST([BUILD_WITH_LIBPCAP_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBPCAP_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBPCAP_LIBS])
 # }}}
 
 # --with-libperl {{{
-perl_interpreter="perl"
-AC_ARG_WITH(libperl, [AS_HELP_STRING([--with-libperl@<:@=PREFIX@:>@], [Path to libperl.])],
-[
-	if test -f "$withval" && test -x "$withval"
-	then
-		perl_interpreter="$withval"
-		with_libperl="yes"
-	else if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		LDFLAGS="$LDFLAGS -L$withval/lib"
-		CPPFLAGS="$CPPFLAGS -I$withval/include"
-		perl_interpreter="$withval/bin/perl"
-		with_libperl="yes"
-	else
-		with_libperl="$withval"
-	fi; fi
-],
-[
-	with_libperl="yes"
-])
+AC_ARG_WITH([libperl],
+  [AS_HELP_STRING([--with-libperl@<:@=PREFIX@:>@], [Path to libperl.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      LDFLAGS="$LDFLAGS -L$withval/lib"
+      CPPFLAGS="$CPPFLAGS -I$withval/include"
+      with_libperl="yes"
+    else
+      with_libperl="$withval"
+    fi
+  ],
+  [with_libperl="yes"]
+)
 
-AC_MSG_CHECKING([for perl])
-perl_interpreter=`which "$perl_interpreter" 2> /dev/null`
-if test -x "$perl_interpreter"
-then
-	AC_MSG_RESULT([yes ($perl_interpreter)])
-else
-	perl_interpreter=""
-	AC_MSG_RESULT([no])
+AC_ARG_VAR([PERL], [path to Perl interpreter])
+AC_PATH_PROG([PERL], [perl])
+
+if test "x$PERL" = "x"; then
+  with_libperl="no (no Perl interpreter found)"
 fi
 
-AC_SUBST(PERL, "$perl_interpreter")
-
-if test "x$with_libperl" = "xyes" \
-	&& test -n "$perl_interpreter"
-then
+if test "x$with_libperl" = "xyes"; then
   SAVE_CFLAGS="$CFLAGS"
   SAVE_LIBS="$LIBS"
-dnl ARCHFLAGS="" -> disable multi -arch on OSX (see Config_heavy.pl:fetch_string)
-  PERL_CFLAGS=`ARCHFLAGS="" $perl_interpreter -MExtUtils::Embed -e perl_inc`
-  PERL_LIBS=`ARCHFLAGS="" $perl_interpreter -MExtUtils::Embed -e ldopts`
+  dnl ARCHFLAGS="" -> disable multi -arch on OSX (see Config_heavy.pl:fetch_string)
+  PERL_CFLAGS=`ARCHFLAGS="" $PERL -MExtUtils::Embed -e perl_inc`
+  PERL_LIBS=`ARCHFLAGS="" $PERL -MExtUtils::Embed -e ldopts`
   CFLAGS="$CFLAGS $PERL_CFLAGS"
   LIBS="$LIBS $PERL_LIBS"
 
   AC_CACHE_CHECK([for libperl],
     [c_cv_have_libperl],
-    AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#define PERL_NO_GET_CONTEXT
-#include <EXTERN.h>
-#include <perl.h>
-#include <XSUB.h>
-]]],
-[[[
-       dTHX;
-       load_module (PERL_LOADMOD_NOIMPORT,
-			 newSVpv ("Collectd::Plugin::FooBar", 24),
-			 Nullsv);
-]]]
-      )],
-      [c_cv_have_libperl="yes"],
-      [c_cv_have_libperl="no"]
-    )
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #define PERL_NO_GET_CONTEXT
+              #include <EXTERN.h>
+              #include <perl.h>
+              #include <XSUB.h>
+            ]],
+            [[
+              dTHX;
+              load_module (PERL_LOADMOD_NOIMPORT,
+                newSVpv ("Collectd::Plugin::FooBar", 24),
+                Nullsv);
+            ]]
+          )
+        ],
+        [c_cv_have_libperl="yes"],
+        [c_cv_have_libperl="no"]
+      )
+    ]
   )
 
-  if test "x$c_cv_have_libperl" = "xyes"
-  then
-	  AC_DEFINE(HAVE_LIBPERL, 1, [Define if libperl is present and usable.])
-	  AC_SUBST(PERL_CFLAGS)
-	  AC_SUBST(PERL_LIBS)
-  else
-	  with_libperl="no"
+  CFLAGS="$SAVE_CFLAGS"
+  LIBS="$SAVE_LIBS"
+
+  if test "x$c_cv_have_libperl" = "xno"; then
+    with_libperl="no"
+  fi
+fi
+
+if test "x$with_libperl" = "xyes"; then
+  SAVE_CFLAGS="$CFLAGS"
+  SAVE_LIBS="$LIBS"
+  CFLAGS="$CFLAGS $PERL_CFLAGS"
+  LIBS="$LIBS $PERL_LIBS"
+
+  AC_CACHE_CHECK([if Perl supports ithreads],
+    [c_cv_have_perl_ithreads],
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <EXTERN.h>
+              #include <perl.h>
+              #include <XSUB.h>
+
+              #if !defined(USE_ITHREADS)
+              # error "Perl does not support ithreads!"
+              #endif /* !defined(USE_ITHREADS) */
+            ]],
+            []
+          )
+        ],
+        [c_cv_have_perl_ithreads="yes"],
+        [c_cv_have_perl_ithreads="no"]
+      )
+    ]
+  )
+
+  CFLAGS="$SAVE_CFLAGS"
+  LIBS="$SAVE_LIBS"
+fi
+
+if test "x$with_libperl" = "xyes"; then
+  # trigger an error if Perl_load_module*() uses __attribute__nonnull__(3)
+  # (see issues #41 and #42)
+  SAVE_CFLAGS="$CFLAGS"
+  SAVE_LIBS="$LIBS"
+  CFLAGS="$CFLAGS $PERL_CFLAGS -Wall -Werror"
+  LIBS="$LIBS $PERL_LIBS"
+
+  AC_CACHE_CHECK([for broken Perl_load_module()],
+    [c_cv_have_broken_perl_load_module],
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #define PERL_NO_GET_CONTEXT
+              #include <EXTERN.h>
+              #include <perl.h>
+              #include <XSUB.h>
+            ]],
+            [[
+              dTHX;
+              load_module (PERL_LOADMOD_NOIMPORT,
+                newSVpv ("Collectd::Plugin::FooBar", 24),
+                Nullsv);
+            ]]
+          )
+        ],
+        [c_cv_have_broken_perl_load_module="no"],
+        [c_cv_have_broken_perl_load_module="yes"]
+      )
+    ]
+  )
+
+  CFLAGS="$SAVE_CFLAGS"
+  LIBS="$SAVE_LIBS"
+fi
+
+if test "x$c_cv_have_broken_perl_load_module" = "xyes"; then
+  PERL_CFLAGS="$PERL_CFLAGS -Wno-nonnull"
+fi
+
+if test "x$with_libperl" = "xyes"; then
+  SAVE_CFLAGS="$CFLAGS"
+  SAVE_LIBS="$LIBS"
+  CFLAGS="$CFLAGS $PERL_CFLAGS"
+  LIBS="$LIBS $PERL_LIBS"
+
+  AC_CHECK_MEMBER(
+    [struct mgvtbl.svt_local],
+    [have_struct_mgvtbl_svt_local="yes"],
+    [have_struct_mgvtbl_svt_local="no"],
+    [[
+      #include <EXTERN.h>
+      #include <perl.h>
+      #include <XSUB.h>
+    ]]
+  )
+
+  if test "x$have_struct_mgvtbl_svt_local" = "xyes"; then
+    AC_DEFINE([HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL], [1], [Define if Perls struct mgvtbl has member svt_local.])
   fi
 
   CFLAGS="$SAVE_CFLAGS"
   LIBS="$SAVE_LIBS"
-else if test -z "$perl_interpreter"; then
-  with_libperl="no (no perl interpreter found)"
-  c_cv_have_libperl="no"
-fi; fi
-AM_CONDITIONAL(BUILD_WITH_LIBPERL, test "x$with_libperl" = "xyes")
-
-if test "x$with_libperl" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LIBS="$LIBS"
-	CFLAGS="$CFLAGS $PERL_CFLAGS"
-	LIBS="$LIBS $PERL_LIBS"
-
-	AC_CACHE_CHECK([if perl supports ithreads],
-		[c_cv_have_perl_ithreads],
-		AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <EXTERN.h>
-#include <perl.h>
-#include <XSUB.h>
-
-#if !defined(USE_ITHREADS)
-# error "Perl does not support ithreads!"
-#endif /* !defined(USE_ITHREADS) */
-]]],
-[[[ ]]]
-			)],
-			[c_cv_have_perl_ithreads="yes"],
-			[c_cv_have_perl_ithreads="no"]
-		)
-	)
-
-	if test "x$c_cv_have_perl_ithreads" = "xyes"
-	then
-		AC_DEFINE(HAVE_PERL_ITHREADS, 1, [Define if Perl supports ithreads.])
-	fi
-
-	CFLAGS="$SAVE_CFLAGS"
-	LIBS="$SAVE_LIBS"
 fi
+AC_SUBST([PERL_CFLAGS])
+AC_SUBST([PERL_LIBS])
 
-if test "x$with_libperl" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LIBS="$LIBS"
-	# trigger an error if Perl_load_module*() uses __attribute__nonnull__(3)
-	# (see issues #41 and #42)
-	CFLAGS="$CFLAGS $PERL_CFLAGS -Wall -Werror"
-	LIBS="$LIBS $PERL_LIBS"
-
-	AC_CACHE_CHECK([for broken Perl_load_module()],
-		[c_cv_have_broken_perl_load_module],
-		AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#define PERL_NO_GET_CONTEXT
-#include <EXTERN.h>
-#include <perl.h>
-#include <XSUB.h>
-]]],
-[[[
-			 dTHX;
-			 load_module (PERL_LOADMOD_NOIMPORT,
-			     newSVpv ("Collectd::Plugin::FooBar", 24),
-			     Nullsv);
-]]]
-			)],
-			[c_cv_have_broken_perl_load_module="no"],
-			[c_cv_have_broken_perl_load_module="yes"]
-		)
-	)
-
-	CFLAGS="$SAVE_CFLAGS"
-	LIBS="$SAVE_LIBS"
-fi
-AM_CONDITIONAL(HAVE_BROKEN_PERL_LOAD_MODULE,
-		test "x$c_cv_have_broken_perl_load_module" = "xyes")
-
-if test "x$with_libperl" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LIBS="$LIBS"
-	CFLAGS="$CFLAGS $PERL_CFLAGS"
-	LIBS="$LIBS $PERL_LIBS"
-
-	AC_CHECK_MEMBER(
-		[struct mgvtbl.svt_local],
-		[have_struct_mgvtbl_svt_local="yes"],
-		[have_struct_mgvtbl_svt_local="no"],
-		[
-#include <EXTERN.h>
-#include <perl.h>
-#include <XSUB.h>
-		])
-
-	if test "x$have_struct_mgvtbl_svt_local" = "xyes"
-	then
-		AC_DEFINE(HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL, 1,
-				  [Define if Perl's struct mgvtbl has member svt_local.])
-	fi
-
-	CFLAGS="$SAVE_CFLAGS"
-	LIBS="$SAVE_LIBS"
-fi
 # }}}
 
 # --with-libpq {{{
 with_pg_config="pg_config"
-with_libpq_includedir=""
-with_libpq_libdir=""
-with_libpq_cppflags=""
-with_libpq_ldflags=""
-AC_ARG_WITH(libpq, [AS_HELP_STRING([--with-libpq@<:@=PREFIX@:>@],
-	[Path to libpq.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libpq="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libpq="yes"
-	else
-		if test -f "$withval" && test -x "$withval";
-		then
-			with_pg_config="$withval"
-		else if test -x "$withval/bin/pg_config"
-		then
-			with_pg_config="$withval/bin/pg_config"
-		fi; fi
-		with_libpq="yes"
-	fi; fi
-],
-[
-	with_libpq="yes"
-])
-if test "x$with_libpq" = "xyes"
-then
-	with_libpq_includedir=`$with_pg_config --includedir 2> /dev/null`
-	pg_config_status=$?
+AC_ARG_WITH([libpq],
+  [AS_HELP_STRING([--with-libpq@<:@=PREFIX@:>@], [Path to libpq.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_libpq="$withval"
+    else
+      if test -f "$withval" && test -x "$withval"; then
+        with_pg_config="$withval"
+      else if test -x "$withval/bin/pg_config"; then
+        with_pg_config="$withval/bin/pg_config"
+      fi; fi
+      with_libpq="yes"
+    fi
+  ],
+  [with_libpq="yes"]
+)
 
-	if test $pg_config_status -eq 0
-	then
-		if test -n "$with_libpq_includedir"; then
-			for dir in $with_libpq_includedir; do
-				with_libpq_cppflags="$with_libpq_cppflags -I$dir"
-			done
-		fi
-	else
-		AC_MSG_WARN([$with_pg_config returned with status $pg_config_status])
-	fi
+if test "x$with_libpq" = "xyes"; then
+  with_libpq_includedir=`$with_pg_config --includedir 2> /dev/null`
+  pg_config_status=$?
 
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libpq_cppflags"
+  if test $pg_config_status -eq 0; then
+    if test -n "$with_libpq_includedir"; then
+      for dir in $with_libpq_includedir; do
+        with_libpq_cppflags="$with_libpq_cppflags -I$dir"
+      done
+    fi
+  else
+    AC_MSG_WARN([$with_pg_config returned with status $pg_config_status])
+  fi
 
-	AC_CHECK_HEADERS(libpq-fe.h, [],
-		[with_libpq="no (libpq-fe.h not found)"], [])
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libpq_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([libpq-fe.h],
+    [with_libpq="yes"],
+    [with_libpq="no (libpq-fe.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libpq" = "xyes"
-then
-	with_libpq_libdir=`$with_pg_config --libdir 2> /dev/null`
-	pg_config_status=$?
 
-	if test $pg_config_status -eq 0
-	then
-		if test -n "$with_libpq_libdir"; then
-			for dir in $with_libpq_libdir; do
-				with_libpq_ldflags="$with_libpq_ldflags -L$dir"
-			done
-		fi
-	else
-		AC_MSG_WARN([$with_pg_config returned with status $pg_config_status])
-	fi
+if test "x$with_libpq" = "xyes"; then
+  with_libpq_libdir=`$with_pg_config --libdir 2> /dev/null`
+  pg_config_status=$?
 
-	SAVE_LDFLAGS="$LDFLAGS"
-	LDFLAGS="$LDFLAGS $with_libpq_ldflags"
+  if test $pg_config_status -eq 0
+  then
+    if test -n "$with_libpq_libdir"; then
+      for dir in $with_libpq_libdir; do
+        with_libpq_ldflags="$with_libpq_ldflags -L$dir"
+      done
+    fi
+  else
+    AC_MSG_WARN([$with_pg_config returned with status $pg_config_status])
+  fi
 
-	AC_CHECK_LIB(pq, PQconnectdb,
-		[with_libpq="yes"],
-		[with_libpq="no (symbol 'PQconnectdb' not found)"])
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libpq_ldflags"
 
-	AC_CHECK_LIB(pq, PQserverVersion,
-		[with_libpq="yes"],
-		[with_libpq="no (symbol 'PQserverVersion' not found)"])
+  AC_CHECK_LIB([pq], [PQserverVersion],
+    [with_libpq="yes"],
+    [with_libpq="no (symbol 'PQserverVersion' not found)"])
 
-	LDFLAGS="$SAVE_LDFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libpq" = "xyes"
-then
-	BUILD_WITH_LIBPQ_CPPFLAGS="$with_libpq_cppflags"
-	BUILD_WITH_LIBPQ_LDFLAGS="$with_libpq_ldflags"
-	AC_SUBST(BUILD_WITH_LIBPQ_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBPQ_LDFLAGS)
+
+if test "x$with_libpq" = "xyes"; then
+  BUILD_WITH_LIBPQ_CPPFLAGS="$with_libpq_cppflags"
+  BUILD_WITH_LIBPQ_LDFLAGS="$with_libpq_ldflags"
+  BUILD_WITH_LIBPQ_LIBS="-lpq"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBPQ, test "x$with_libpq" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBPQ_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBPQ_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBPQ_LIBS])
 # }}}
 
 # --with-libpqos {{{
@@ -4232,31 +4276,29 @@ fi
 # --with-libprotobuf {{{
 with_libprotobuf_cppflags=""
 with_libprotobuf_ldflags=""
-AC_ARG_WITH([libprotobuf], [AS_HELP_STRING([--with-libprotobuf@<:@=PREFIX@:>@], [Path to libprotobuf.])],
+AC_ARG_WITH([libprotobuf],
+  [AS_HELP_STRING([--with-libprotobuf@<:@=PREFIX@:>@], [Path to libprotobuf.])],
   [
-    if test "x$withval" != "xno" && test "x$withval" != "xyes"
-    then
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
       with_libprotobuf_cppflags="-I$withval/include"
       with_libprotobuf_ldflags="-L$withval/lib"
       with_libprotobuf="yes"
     fi
-    if test "x$withval" = "xno"
-    then
+    if test "x$withval" = "xno"; then
       with_libprotobuf="no (disabled on command line)"
     fi
   ],
   [withval="yes"]
 )
-if test "x$withval" = "xyes"
-then
-PKG_CHECK_MODULES([PROTOBUF], [protobuf],
-  [with_libprotobuf="yes"],
-  [with_libprotobuf="no (pkg-config could not find libprotobuf)"]
-)
+
+if test "x$withval" = "xyes"; then
+  PKG_CHECK_MODULES([PROTOBUF], [protobuf],
+    [with_libprotobuf="yes"],
+    [with_libprotobuf="no (pkg-config could not find libprotobuf)"]
+  )
 fi
 
-if test "x$withval" != "xno"
-then
+if test "x$withval" != "xno"; then
   SAVE_LDFLAGS="$LDFLAGS"
   SAVE_LIBS="$LIBS"
   LDFLAGS="$with_libprotobuf_ldflags"
@@ -4282,6 +4324,7 @@ then
   LDFLAGS="$SAVE_LDFLAGS"
   LIBS="$SAVE_LIBS"
 fi
+
 BUILD_WITH_LIBPROTOBUF_CPPFLAGS="$with_libprotobuf_cppflags $PROTOBUF_CFLAGS"
 BUILD_WITH_LIBPROTOBUF_LDFLAGS="$with_libprotobuf_ldflags"
 BUILD_WITH_LIBPROTOBUF_LIBS="$PROTOBUF_LIBS"
@@ -4290,34 +4333,46 @@ AC_SUBST([BUILD_WITH_LIBPROTOBUF_LDFLAGS])
 AC_SUBST([BUILD_WITH_LIBPROTOBUF_LIBS])
 # }}}
 
+AC_ARG_VAR([PROTOC], [path to the protoc binary])
+AC_PATH_PROG([PROTOC], [protoc])
+have_protoc3="no"
+if test "x$PROTOC" != "x"; then
+  AC_MSG_CHECKING([for protoc 3.0.0+])
+  if $PROTOC --version | $EGREP libprotoc.3 >/dev/null; then
+    protoc3="yes (`$PROTOC --version`)"
+    have_protoc3="yes"
+  else
+    protoc3="no (`$PROTOC --version`)"
+  fi
+  AC_MSG_RESULT([$protoc3])
+fi
+AM_CONDITIONAL([HAVE_PROTOC3], [test "x$have_protoc3" = "xyes"])
+
 # --with-libprotobuf-c {{{
-with_libprotobuf_c_cppflags=""
-with_libprotobuf_c_ldflags=""
-AC_ARG_WITH([libprotobuf-c], [AS_HELP_STRING([--with-libprotobuf-c@<:@=PREFIX@:>@], [Path to libprotobuf-c.])],
+AC_ARG_WITH([libprotobuf-c],
+  [AS_HELP_STRING([--with-libprotobuf-c@<:@=PREFIX@:>@], [Path to libprotobuf-c.])],
   [
-    if test "x$withval" != "xno" && test "x$withval" != "xyes"
-    then
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
       with_libprotobuf_c_cppflags="-I$withval/include"
       with_libprotobuf_c_ldflags="-L$withval/lib"
       with_libprotobuf_c="yes"
     fi
-    if test "x$withval" = "xno"
-    then
+
+    if test "x$withval" = "xno"; then
       with_libprotobuf_c="no (disabled on command line)"
     fi
   ],
   [withval="yes"]
 )
-if test "x$withval" = "xyes"
-then
-PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c],
-  [with_libprotobuf_c="yes"],
-  [with_libprotobuf_c="no (pkg-config could not find libprotobuf-c)"]
-)
+
+if test "x$withval" = "xyes"; then
+  PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c],
+    [with_libprotobuf_c="yes"],
+    [with_libprotobuf_c="no (pkg-config could not find libprotobuf-c)"]
+  )
 fi
 
-if test "x$withval" != "xno"
-then
+if test "x$withval" != "xno"; then
   SAVE_LDFLAGS="$LDFLAGS"
   SAVE_LIBS="$LIBS"
   LDFLAGS="$with_libprotobuf_c_ldflags"
@@ -4326,10 +4381,10 @@ then
     [
       SAVE_CPPFLAGS="$CPPFLAGS"
       CPPFLAGS="$with_libprotobuf_c_cppflags $PROTOBUF_C_CFLAGS"
-      if test "x$PROTOBUF_C_LIBS" = "x"
-      then
+      if test "x$PROTOBUF_C_LIBS" = "x"; then
         PROTOBUF_C_LIBS="-lprotobuf-c"
       fi
+
       AC_CHECK_HEADERS([protobuf-c/protobuf-c.h google/protobuf-c/protobuf-c.h],
         [
           with_libprotobuf_c="yes"
@@ -4337,6 +4392,7 @@ then
         ],
         [with_libprotobuf_c="no (<protobuf-c.h> not found)"]
       )
+
       CPPFLAGS="$SAVE_CPPFLAGS"
     ],
     [with_libprotobuf_c="no (libprotobuf-c not found)"]
@@ -4344,6 +4400,7 @@ then
   LDFLAGS="$SAVE_LDFLAGS"
   LIBS="$SAVE_LIBS"
 fi
+
 BUILD_WITH_LIBPROTOBUF_C_CPPFLAGS="$with_libprotobuf_c_cppflags $PROTOBUF_C_CFLAGS"
 BUILD_WITH_LIBPROTOBUF_C_LDFLAGS="$with_libprotobuf_c_ldflags"
 BUILD_WITH_LIBPROTOBUF_C_LIBS="$PROTOBUF_C_LIBS"
@@ -4352,18 +4409,26 @@ AC_SUBST([BUILD_WITH_LIBPROTOBUF_C_LDFLAGS])
 AC_SUBST([BUILD_WITH_LIBPROTOBUF_C_LIBS])
 # }}}
 
+AC_ARG_VAR([PROTOC_C], [path to the protoc-c binary])
+AC_PATH_PROG([PROTOC_C], [protoc-c])
+if test "x$PROTOC_C" = "x"
+then
+  have_protoc_c="no (protoc-c compiler not found)"
+else
+  have_protoc_c="yes"
+fi
+
 # --with-libpython {{{
 AC_ARG_VAR([LIBPYTHON_CPPFLAGS], [Preprocessor flags for libpython])
 AC_ARG_VAR([LIBPYTHON_LDFLAGS], [Linker flags for libpython])
 AC_ARG_VAR([LIBPYTHON_LIBS], [Libraries for libpython])
 
 AC_ARG_WITH([libpython],
-  [AS_HELP_STRING([--with-libpython],
-    [if we should build with libpython @<:@default=yes@:>@])
-  ],
+  [AS_HELP_STRING([--with-libpython], [if we should build with libpython @<:@default=yes@:>@])],
   [with_libpython="$withval"],
   [with_libpython="check"]
 )
+
 if test "$with_libpython" != "no"; then
   if test "$LIBPYTHON_CPPFLAGS" = "" && test "$LIBPYTHON_LDFLAGS" = ""; then
     AC_ARG_VAR([PYTHON_CONFIG], [path to python-config])
@@ -4401,6 +4466,7 @@ if test "$with_libpython" != "xno"; then
   CPPFLAGS="$LIBPYTHON_CPPFLAGS $CPPFLAGS"
   LDFLAGS="$LIBPYTHON_LDFLAGS $LDFLAGS"
   LIBS="$LIBPYTHON_LIBS $LIBS"
+
   AC_CHECK_HEADERS([Python.h],
     [
       AC_MSG_CHECKING([for libpython])
@@ -4415,6 +4481,7 @@ if test "$with_libpython" != "xno"; then
     ],
     [with_libpython="no"]
   )
+
   CPPFLAGS="$SAVE_CPPFLAGS"
   LDFLAGS="$SAVE_LDFLAGS"
   LIBS="$SAVE_LIBS"
@@ -4422,234 +4489,237 @@ fi
 # }}} --with-libpython
 
 # --with-librabbitmq {{{
-with_librabbitmq_cppflags=""
-with_librabbitmq_ldflags=""
-AC_ARG_WITH(librabbitmq, [AS_HELP_STRING([--with-librabbitmq@<:@=PREFIX@:>@], [Path to librabbitmq.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_librabbitmq_cppflags="-I$withval/include"
-		with_librabbitmq_ldflags="-L$withval/lib"
-		with_librabbitmq="yes"
-	else
-		with_librabbitmq="$withval"
-	fi
-],
-[
-	with_librabbitmq="yes"
-])
-SAVE_CPPFLAGS="$CPPFLAGS"
-SAVE_LDFLAGS="$LDFLAGS"
-CPPFLAGS="$CPPFLAGS $with_librabbitmq_cppflags"
-LDFLAGS="$LDFLAGS $with_librabbitmq_ldflags"
-if test "x$with_librabbitmq" = "xyes"
-then
-	AC_CHECK_HEADERS(amqp.h, [with_librabbitmq="yes"], [with_librabbitmq="no (amqp.h not found)"])
-fi
-if test "x$with_librabbitmq" = "xyes"
-then
-	# librabbitmq up to version 0.9.1 provides "library_errno", later
-	# versions use "library_error". The library does not provide a version
-	# macro :( Use "AC_CHECK_MEMBERS" (plural) for automatic defines.
-	AC_CHECK_MEMBERS([amqp_rpc_reply_t.library_errno],,,
-			 [
-#if HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
-#if HAVE_STDIO_H
-# include <stdio.h>
-#endif
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-#if HAVE_INTTYPES_H
-# include <inttypes.h>
-#endif
-#include <amqp.h>
-                         ])
-fi
-if test "x$with_librabbitmq" = "xyes"
-then
-	AC_CHECK_LIB(rabbitmq, amqp_basic_publish, [with_librabbitmq="yes"], [with_librabbitmq="no (Symbol 'amqp_basic_publish' not found)"])
-fi
-if test "x$with_librabbitmq" = "xyes"
-then
-	BUILD_WITH_LIBRABBITMQ_CPPFLAGS="$with_librabbitmq_cppflags"
-	BUILD_WITH_LIBRABBITMQ_LDFLAGS="$with_librabbitmq_ldflags"
-	BUILD_WITH_LIBRABBITMQ_LIBS="-lrabbitmq"
-	AC_SUBST(BUILD_WITH_LIBRABBITMQ_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBRABBITMQ_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBRABBITMQ_LIBS)
-	AC_DEFINE(HAVE_LIBRABBITMQ, 1, [Define if librabbitmq is present and usable.])
-fi
-CPPFLAGS="$SAVE_CPPFLAGS"
-LDFLAGS="$SAVE_LDFLAGS"
-AM_CONDITIONAL(BUILD_WITH_LIBRABBITMQ, test "x$with_librabbitmq" = "xyes")
+AC_ARG_WITH([librabbitmq],
+  [AS_HELP_STRING([--with-librabbitmq@<:@=PREFIX@:>@], [Path to librabbitmq.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_librabbitmq_cppflags="-I$withval/include"
+      with_librabbitmq_ldflags="-L$withval/lib"
+      with_librabbitmq="yes"
+    else
+      with_librabbitmq="$withval"
+    fi
+  ],
+  [with_librabbitmq="yes"]
+)
 
-with_amqp_tcp_socket="no"
-if test "x$with_librabbitmq" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	SAVE_LIBS="$LIBS"
-	CPPFLAGS="$CPPFLAGS $with_librabbitmq_cppflags"
-	LDFLAGS="$LDFLAGS $with_librabbitmq_ldflags"
-	LIBS="-lrabbitmq"
+if test "x$with_librabbitmq" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_librabbitmq_cppflags"
 
-	AC_CHECK_HEADERS(amqp_tcp_socket.h amqp_socket.h)
-	AC_CHECK_FUNC(amqp_tcp_socket_new, [with_amqp_tcp_socket="yes"], [with_amqp_tcp_socket="no"])
-	if test "x$with_amqp_tcp_socket" = "xyes"
-	then
-		AC_DEFINE(HAVE_AMQP_TCP_SOCKET, 1,
-				[Define if librabbitmq provides the new TCP socket interface.])
-	fi
+  AC_CHECK_HEADERS([amqp.h],
+    [with_librabbitmq="yes"],
+    [with_librabbitmq="no (amqp.h not found)"]
+  )
 
-	AC_CHECK_DECLS(amqp_socket_close,
-				[amqp_socket_close_decl="yes"], [amqp_socket_close_decl="no"],
-				[[
-#include <amqp.h>
-#ifdef HAVE_AMQP_TCP_SOCKET_H
-# include <amqp_tcp_socket.h>
-#endif
-#ifdef HAVE_AMQP_SOCKET_H
-# include <amqp_socket.h>
-#endif
-				]])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
-	LIBS="$SAVE_LIBS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
+
+if test "x$with_librabbitmq" = "xyes"; then
+  # librabbitmq up to version 0.9.1 provides "library_errno", later
+  # versions use "library_error". The library does not provide a version
+  # macro :(.
+
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_librabbitmq_cppflags"
+
+  AC_CHECK_MEMBERS([amqp_rpc_reply_t.library_errno],
+    [],
+    [],
+    [[
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <stdint.h>
+      #include <inttypes.h>
+      #include <amqp.h>
+    ]]
+  )
+  CPPFLAGS="$SAVE_CPPFLAGS"
+
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_librabbitmq_ldflags"
+
+  AC_CHECK_LIB([rabbitmq], [amqp_basic_publish],
+    [with_librabbitmq="yes"],
+    [with_librabbitmq="no (Symbol 'amqp_basic_publish' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$with_librabbitmq" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LDFLAGS="$LDFLAGS"
+  SAVE_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $with_librabbitmq_cppflags"
+  LDFLAGS="$LDFLAGS $with_librabbitmq_ldflags"
+  LIBS="-lrabbitmq"
+
+  AC_CHECK_HEADERS([amqp_tcp_socket.h amqp_socket.h])
+  AC_CHECK_FUNC([amqp_tcp_socket_new],
+    [
+      AC_DEFINE([HAVE_AMQP_TCP_SOCKET], [1],
+        [Define if librabbitmq provides the new TCP socket interface.])
+    ],
+    []
+  )
+
+  AC_CHECK_DECLS([amqp_socket_close],
+    [],
+    [],
+    [[
+      #include <amqp.h>
+      #ifdef HAVE_AMQP_TCP_SOCKET_H
+      # include <amqp_tcp_socket.h>
+      #endif
+      #ifdef HAVE_AMQP_SOCKET_H
+      # include <amqp_socket.h>
+      #endif
+    ]]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
+  LIBS="$SAVE_LIBS"
+fi
+
+if test "x$with_librabbitmq" = "xyes"; then
+  BUILD_WITH_LIBRABBITMQ_CPPFLAGS="$with_librabbitmq_cppflags"
+  BUILD_WITH_LIBRABBITMQ_LDFLAGS="$with_librabbitmq_ldflags"
+  BUILD_WITH_LIBRABBITMQ_LIBS="-lrabbitmq"
+fi
+
+AC_SUBST(BUILD_WITH_LIBRABBITMQ_CPPFLAGS)
+AC_SUBST(BUILD_WITH_LIBRABBITMQ_LDFLAGS)
+AC_SUBST(BUILD_WITH_LIBRABBITMQ_LIBS)
+
 # }}}
 
 # --with-librdkafka {{{
-AC_ARG_WITH(librdkafka, [AS_HELP_STRING([--with-librdkafka@<:@=PREFIX@:>@], [Path to librdkafka.])],
-[
-  if test "x$withval" != "xno" && test "x$withval" != "xyes"
-  then
-    with_librdkafka_cppflags="-I$withval/include"
-    with_librdkafka_ldflags="-L$withval/lib"
-    with_librdkafka_rpath="$withval/lib"
-    with_librdkafka="yes"
+AC_ARG_WITH([librdkafka],
+  [AS_HELP_STRING([--with-librdkafka@<:@=PREFIX@:>@], [Path to librdkafka.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_librdkafka_cppflags="-I$withval/include"
+      with_librdkafka_ldflags="-L$withval/lib"
+      with_librdkafka_rpath="$withval/lib"
+      with_librdkafka="yes"
+    else
+      with_librdkafka="$withval"
+    fi
+  ],
+  [with_librdkafka="yes"]
+)
+
+if test "x$with_librdkafka" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_librdkafka_cppflags"
+
+  AC_CHECK_HEADERS([librdkafka/rdkafka.h],
+    [with_librdkafka="yes"],
+    [with_librdkafka="no (librdkafka/rdkafka.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
+if test "x$with_librdkafka" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_librdkafka_ldflags"
+
+  AC_CHECK_LIB([rdkafka], [rd_kafka_new],
+    [with_librdkafka="yes"],
+    [with_librdkafka="no (Symbol 'rd_kafka_new' not found)"])
+
+  AC_CHECK_LIB([rdkafka], [rd_kafka_conf_set_log_cb],
+    [with_librdkafka_log_cb="yes"],
+    [with_librdkafka_log_cb="no"])
+
+  AC_CHECK_LIB([rdkafka], [rd_kafka_set_logger],
+    [with_librdkafka_logger="yes"],
+    [with_librdkafka_logger="no"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$with_librdkafka" = "xyes"; then
+  BUILD_WITH_LIBRDKAFKA_CPPFLAGS="$with_librdkafka_cppflags"
+  BUILD_WITH_LIBRDKAFKA_LDFLAGS="$with_librdkafka_ldflags"
+
+  if test "x$with_librdkafka_rpath" != "x"; then
+    BUILD_WITH_LIBRDKAFKA_LIBS="-Wl,-rpath,$with_librdkafka_rpath -lrdkafka"
   else
-    with_librdkafka="$withval"
+    BUILD_WITH_LIBRDKAFKA_LIBS="-lrdkafka"
   fi
-],
-[
-  with_librdkafka="yes"
-])
-SAVE_CPPFLAGS="$CPPFLAGS"
-SAVE_LDFLAGS="$LDFLAGS"
 
-CPPFLAGS="$CPPFLAGS $with_librdkafka_cppflags"
-LDFLAGS="$LDFLAGS $with_librdkafka_ldflags"
-
-if test "x$with_librdkafka" = "xyes"
-then
-	AC_CHECK_HEADERS(librdkafka/rdkafka.h, [with_librdkafka="yes"], [with_librdkafka="no (librdkafka/rdkafka.h not found)"])
-fi
-
-if test "x$with_librdkafka" = "xyes"
-then
-	AC_CHECK_LIB(rdkafka, rd_kafka_new, [with_librdkafka="yes"], [with_librdkafka="no (Symbol 'rd_kafka_new' not found)"])
-  AC_CHECK_LIB(rdkafka, rd_kafka_conf_set_log_cb, [with_librdkafka_log_cb="yes"], [with_librdkafka_log_cb="no"])
-  AC_CHECK_LIB(rdkafka, rd_kafka_set_logger, [with_librdkafka_logger="yes"], [with_librdkafka_logger="no"])
-fi
-if test "x$with_librdkafka" = "xyes"
-then
-	BUILD_WITH_LIBRDKAFKA_CPPFLAGS="$with_librdkafka_cppflags"
-	BUILD_WITH_LIBRDKAFKA_LDFLAGS="$with_librdkafka_ldflags"
-	if test "x$with_librdkafka_rpath" != "x"
-	then
-		BUILD_WITH_LIBRDKAFKA_LIBS="-Wl,-rpath,$with_librdkafka_rpath -lrdkafka"
-	else
-		BUILD_WITH_LIBRDKAFKA_LIBS="-lrdkafka"
-	fi
-	AC_SUBST(BUILD_WITH_LIBRDKAFKA_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBRDKAFKA_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBRDKAFKA_LIBS)
-	AC_DEFINE(HAVE_LIBRDKAFKA, 1, [Define if librdkafka is present and usable.])
-  if test "x$with_librdkafka_log_cb" = "xyes"
-  then
-        AC_DEFINE(HAVE_LIBRDKAFKA_LOG_CB, 1, [Define if librdkafka log facility is present and usable.])
-  else if test "x$with_librdkafka_logger" = "xyes"
-  then
-        AC_DEFINE(HAVE_LIBRDKAFKA_LOGGER, 1, [Define if librdkafka log facility is present and usable.])
+  if test "x$with_librdkafka_log_cb" = "xyes"; then
+    AC_DEFINE(HAVE_LIBRDKAFKA_LOG_CB, 1, [Define if librdkafka log facility is present and usable.])
+  else if test "x$with_librdkafka_logger" = "xyes"; then
+    AC_DEFINE(HAVE_LIBRDKAFKA_LOGGER, 1, [Define if librdkafka log facility is present and usable.])
   fi; fi
 fi
-CPPFLAGS="$SAVE_CPPFLAGS"
-LDFLAGS="$SAVE_LDFLAGS"
-AM_CONDITIONAL(BUILD_WITH_LIBRDKAFKA, test "x$with_librdkafka" = "xyes")
 
+AC_SUBST([BUILD_WITH_LIBRDKAFKA_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBRDKAFKA_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBRDKAFKA_LIBS])
 # }}}
 
 # --with-librouteros {{{
-AC_ARG_WITH(librouteros, [AS_HELP_STRING([--with-librouteros@<:@=PREFIX@:>@], [Path to librouteros.])],
-[
- if test "x$withval" = "xyes"
- then
-	 with_librouteros="yes"
- else if test "x$withval" = "xno"
- then
-	 with_librouteros="no"
- else
-	 with_librouteros="yes"
-	 LIBROUTEROS_CPPFLAGS="$LIBROUTEROS_CPPFLAGS -I$withval/include"
-	 LIBROUTEROS_LDFLAGS="$LIBROUTEROS_LDFLAGS -L$withval/lib"
- fi; fi
-],
-[with_librouteros="yes"])
+AC_ARG_WITH([librouteros],
+  [AS_HELP_STRING([--with-librouteros@<:@=PREFIX@:>@], [Path to librouteros.])],
+  [
+    if test "x$withval" = "xyes" || test "x$withval" = "xno"; then
+      with_librouteros="$witval"
+    else
+      with_librouteros_cppflags="-I$withval/include"
+      with_librouteros_ldflags="-L$withval/lib"
+      with_librouteros="yes"
+   fi
+  ],
+  [with_librouteros="yes"]
+)
 
-SAVE_CPPFLAGS="$CPPFLAGS"
-SAVE_LDFLAGS="$LDFLAGS"
+if test "x$with_librouteros" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_librouteros_cppflags"
 
-CPPFLAGS="$CPPFLAGS $LIBROUTEROS_CPPFLAGS"
-LDFLAGS="$LDFLAGS $LIBROUTEROS_LDFLAGS"
+  AC_CHECK_HEADERS([routeros_api.h],
+    [with_librouteros="yes"],
+    [with_librouteros="no (routeros_api.h not found)"]
+  )
 
-if test "x$with_librouteros" = "xyes"
-then
-	if test "x$LIBROUTEROS_CPPFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([librouteros CPPFLAGS: $LIBROUTEROS_CPPFLAGS])
-	fi
-	AC_CHECK_HEADERS(routeros_api.h,
-	[with_librouteros="yes"],
-	[with_librouteros="no (routeros_api.h not found)"])
-fi
-if test "x$with_librouteros" = "xyes"
-then
-	if test "x$LIBROUTEROS_LDFLAGS" != "x"
-	then
-		AC_MSG_NOTICE([librouteros LDFLAGS: $LIBROUTEROS_LDFLAGS])
-	fi
-	AC_CHECK_LIB(routeros, ros_interface,
-	[with_librouteros="yes"],
-	[with_librouteros="no (symbol 'ros_interface' not found)"])
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-CPPFLAGS="$SAVE_CPPFLAGS"
-LDFLAGS="$SAVE_LDFLAGS"
+if test "x$with_librouteros" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_librouteros_ldflags"
 
-if test "x$with_librouteros" = "xyes"
-then
-	BUILD_WITH_LIBROUTEROS_CPPFLAGS="$LIBROUTEROS_CPPFLAGS"
-	BUILD_WITH_LIBROUTEROS_LDFLAGS="$LIBROUTEROS_LDFLAGS"
-	AC_SUBST(BUILD_WITH_LIBROUTEROS_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBROUTEROS_LDFLAGS)
+  AC_CHECK_LIB([routeros], [ros_interface],
+    [with_librouteros="yes"],
+    [with_librouteros="no (symbol 'ros_interface' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBROUTEROS, test "x$with_librouteros" = "xyes")
+
+if test "x$with_librouteros" = "xyes"; then
+  BUILD_WITH_LIBROUTEROS_CPPFLAGS="$with_librouteros_cppflags"
+  BUILD_WITH_LIBROUTEROS_LDFLAGS="$with_librouteros_ldflags"
+fi
+
+AC_SUBST([BUILD_WITH_LIBROUTEROS_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBROUTEROS_LDFLAGS])
 # }}}
 
 # --with-librrd {{{
-librrd_cflags=""
-librrd_ldflags=""
 librrd_threadsafe="no"
 librrd_rrdc_update="no"
-AC_ARG_WITH(librrd,
+AC_ARG_WITH([librrd],
   [AS_HELP_STRING([--with-librrd@<:@=PREFIX@:>@], [Path to rrdtool.])],
   [
-    if test "x$withval" != "xno" && test "x$withval" != "xyes"
-    then
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
       librrd_cflags="-I$withval/include"
       librrd_ldflags="-L$withval/lib"
       with_librrd="yes"
@@ -4660,8 +4730,7 @@ AC_ARG_WITH(librrd,
   [with_librrd="yes"]
 )
 
-if test "x$with_librrd" = "xyes"
-then
+if test "x$with_librrd" = "xyes"; then
   SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS $librrd_ldflags"
   PKG_CHECK_MODULES([RRD], [librrd >= 1.6.0],
@@ -4686,8 +4755,7 @@ then
   CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_librrd" = "xyes" && test "x$librrd_threadsafe" = "xno"
-then
+if test "x$with_librrd" = "xyes" && test "x$librrd_threadsafe" = "xno"; then
   SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS $librrd_ldflags"
 
@@ -4705,8 +4773,7 @@ then
   LDFLAGS="$SAVE_LDFLAGS"
 fi
 
-if test "x$with_librrd" = "xyes" && test "x$librrd_threadsafe" = "xno"
-then
+if test "x$with_librrd" = "xyes" && test "x$librrd_threadsafe" = "xno"; then
   SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS $librrd_ldflags"
 
@@ -4723,82 +4790,78 @@ then
   LDFLAGS="$SAVE_LDFLAGS"
 fi
 
-if test "x$with_librrd" = "xyes"
-then
+if test "x$with_librrd" = "xyes"; then
   BUILD_WITH_LIBRRD_CFLAGS="$RRD_CFLAGS $librrd_cflags"
   BUILD_WITH_LIBRRD_LDFLAGS="$librrd_ldflags"
   BUILD_WITH_LIBRRD_LIBS="$RRD_LIBS"
-  AC_SUBST(BUILD_WITH_LIBRRD_CFLAGS)
-  AC_SUBST(BUILD_WITH_LIBRRD_LDFLAGS)
-  AC_SUBST(BUILD_WITH_LIBRRD_LIBS)
 fi
-if test "x$librrd_threadsafe" = "xyes"
-then
+
+if test "x$librrd_threadsafe" = "xyes"; then
   AC_DEFINE([HAVE_THREADSAFE_LIBRRD], [1],
     [Define to 1 if the rrd library is thread-safe]
   )
 fi
+
+AC_SUBST([BUILD_WITH_LIBRRD_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBRRD_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBRRD_LIBS])
 # }}}
 
 # --with-libsensors {{{
-with_sensors_cflags=""
-with_sensors_ldflags=""
-AC_ARG_WITH(libsensors, [AS_HELP_STRING([--with-libsensors@<:@=PREFIX@:>@], [Path to lm_sensors.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libsensors="no"
-	else
-		with_libsensors="yes"
-		if test "x$withval" != "xyes"
-		then
-			with_sensors_cflags="-I$withval/include"
-			with_sensors_ldflags="-L$withval/lib"
-			with_libsensors="yes"
-		fi
-	fi
-],
-[
-	if test "x$ac_system" = "xLinux"
-	then
-		with_libsensors="yes"
-	else
-		with_libsensors="no (Linux only library)"
-	fi
-])
-if test "x$with_libsensors" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_sensors_cflags"
+AC_ARG_WITH([libsensors],
+  [AS_HELP_STRING([--with-libsensors@<:@=PREFIX@:>@], [Path to lm_sensors.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_libsensors="$withval"
+    else
+      with_sensors_cppflags="-I$withval/include"
+      with_sensors_ldflags="-L$withval/lib"
+      with_libsensors="yes"
+    fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_libsensors="yes"
+    else
+      with_libsensors="no (Linux only library)"
+    fi
+  ]
+)
 
-	AC_CHECK_HEADERS(sensors/sensors.h, [], [with_libsensors="no (sensors/sensors.h not found)"])
+if test "x$with_libsensors" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_sensors_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([sensors/sensors.h],
+    [with_libsensors="yes"],
+    [with_libsensors="no (sensors/sensors.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libsensors" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_sensors_cflags"
-	LDFLAGS="$LDFLAGS $with_sensors_ldflags"
 
-	AC_CHECK_LIB(sensors, sensors_init,
-	[
-		AC_DEFINE(HAVE_LIBSENSORS, 1, [Define to 1 if you have the sensors library (-lsensors).])
-	],
-	[with_libsensors="no (libsensors not found)"])
+if test "x$with_libsensors" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_sensors_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([sensors], [sensors_init],
+    [with_libsensors="yes"],
+    [with_libsensors="no (libsensors not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libsensors" = "xyes"
-then
-	BUILD_WITH_LIBSENSORS_CFLAGS="$with_sensors_cflags"
-	BUILD_WITH_LIBSENSORS_LDFLAGS="$with_sensors_ldflags"
-	AC_SUBST(BUILD_WITH_LIBSENSORS_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBSENSORS_LDFLAGS)
+
+if test "x$with_libsensors" = "xyes"; then
+  BUILD_WITH_LIBSENSORS_CPPFLAGS="$with_sensors_cppflags"
+  BUILD_WITH_LIBSENSORS_LDFLAGS="$with_sensors_ldflags"
+  BUILD_WITH_LIBSENSORS_LIBS="-lsensors"
 fi
-AM_CONDITIONAL(BUILD_WITH_LM_SENSORS, test "x$with_libsensors" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBSENSORS_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBSENSORS_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBSENSORS_LIBS])
+
 # }}}
 
 # libsigrok {{{
@@ -4811,35 +4874,29 @@ PKG_CHECK_MODULES([LIBSIGROK], [libsigrok < 0.4],
 # }}}
 
 # --with-libstatgrab {{{
-with_libstatgrab_cflags=""
-with_libstatgrab_ldflags=""
-AC_ARG_WITH(libstatgrab, [AS_HELP_STRING([--with-libstatgrab@<:@=PREFIX@:>@], [Path to libstatgrab.])],
-[
- if test "x$withval" != "xno" \
-   && test "x$withval" != "xyes"
- then
-   with_libstatgrab_cflags="-I$withval/include"
-   with_libstatgrab_ldflags="-L$withval/lib -lstatgrab"
-   with_libstatgrab="yes"
-   with_libstatgrab_pkg_config="no"
- else
-   with_libstatgrab="$withval"
-   with_libstatgrab_pkg_config="yes"
- fi
- ],
-[
- with_libstatgrab="yes"
- with_libstatgrab_pkg_config="yes"
-])
+AC_ARG_WITH([libstatgrab],
+  [AS_HELP_STRING([--with-libstatgrab@<:@=PREFIX@:>@], [Path to libstatgrab.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libstatgrab_cflags="-I$withval/include"
+      with_libstatgrab_ldflags="-L$withval/lib -lstatgrab"
+      with_libstatgrab="yes"
+      with_libstatgrab_pkg_config="no"
+    else
+      with_libstatgrab="$withval"
+      with_libstatgrab_pkg_config="yes"
+    fi
+  ],
+  [
+    with_libstatgrab="yes"
+    with_libstatgrab_pkg_config="yes"
+  ])
 
-if test "x$with_libstatgrab" = "xyes" \
-  && test "x$with_libstatgrab_pkg_config" = "xyes"
-then
+if test "x$with_libstatgrab" = "xyes" && test "x$with_libstatgrab_pkg_config" = "xyes"; then
   AC_MSG_CHECKING([pkg-config for libstatgrab])
   temp_result="found"
   $PKG_CONFIG --exists libstatgrab 2>/dev/null
-  if test "$?" != "0"
-  then
+  if test "$?" != "0"; then
     with_libstatgrab_pkg_config="no"
     with_libstatgrab="no (pkg-config doesn't know libstatgrab)"
     temp_result="not found"
@@ -4847,14 +4904,10 @@ then
   AC_MSG_RESULT([$temp_result])
 fi
 
-if test "x$with_libstatgrab" = "xyes" \
-  && test "x$with_libstatgrab_pkg_config" = "xyes" \
-  && test "x$with_libstatgrab_cflags" = "x"
-then
+if test "x$with_libstatgrab" = "xyes" && test "x$with_libstatgrab_pkg_config" = "xyes" && test "x$with_libstatgrab_cflags" = "x"; then
   AC_MSG_CHECKING([for libstatgrab CFLAGS])
   temp_result="`$PKG_CONFIG --cflags libstatgrab`"
-  if test "$?" = "0"
-  then
+  if test "$?" = "0"; then
     with_libstatgrab_cflags="$temp_result"
   else
     with_libstatgrab="no ($PKG_CONFIG --cflags libstatgrab failed)"
@@ -4863,10 +4916,7 @@ then
   AC_MSG_RESULT([$temp_result])
 fi
 
-if test "x$with_libstatgrab" = "xyes" \
-  && test "x$with_libstatgrab_pkg_config" = "xyes" \
-  && test "x$with_libstatgrab_ldflags" = "x"
-then
+if test "x$with_libstatgrab" = "xyes" && test "x$with_libstatgrab_pkg_config" = "xyes" && test "x$with_libstatgrab_ldflags" = "x"; then
   AC_MSG_CHECKING([for libstatgrab LDFLAGS])
   temp_result="`$PKG_CONFIG --libs libstatgrab`"
   if test "$?" = "0"
@@ -4879,36 +4929,31 @@ then
   AC_MSG_RESULT([$temp_result])
 fi
 
-if test "x$with_libstatgrab" = "xyes"
-then
+if test "x$with_libstatgrab" = "xyes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $with_libstatgrab_cflags"
 
-  AC_CHECK_HEADERS(statgrab.h,
-		   [with_libstatgrab="yes"],
-		   [with_libstatgrab="no (statgrab.h not found)"])
+  AC_CHECK_HEADERS([statgrab.h],
+    [with_libstatgrab="yes"],
+    [with_libstatgrab="no (statgrab.h not found)"]
+  )
 
   CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_libstatgrab" = "xyes"
-then
-  SAVE_CFLAGS="$CFLAGS"
+if test "x$with_libstatgrab" = "xyes"; then
   SAVE_LDFLAGS="$LDFLAGS"
-
-  CFLAGS="$CFLAGS $with_libstatgrab_cflags"
   LDFLAGS="$LDFLAGS $with_libstatgrab_ldflags"
 
-  AC_CHECK_LIB(statgrab, sg_init,
-	       [with_libstatgrab="yes"],
-	       [with_libstatgrab="no (symbol sg_init not found)"])
+  AC_CHECK_LIB([statgrab], [sg_init],
+    [with_libstatgrab="yes"],
+    [with_libstatgrab="no (symbol sg_init not found)"]
+  )
 
-  CFLAGS="$SAVE_CFLAGS"
   LDFLAGS="$SAVE_LDFLAGS"
 fi
 
-if test "x$with_libstatgrab" = "xyes"
-then
+if test "x$with_libstatgrab" = "xyes"; then
   SAVE_CFLAGS="$CFLAGS"
   SAVE_LDFLAGS="$LDFLAGS"
   SAVE_LIBS="$LIBS"
@@ -4918,19 +4963,24 @@ then
   LIBS="-lstatgrab $LIBS"
 
   AC_CACHE_CHECK([if libstatgrab >= 0.90],
-          [c_cv_have_libstatgrab_0_90],
-          AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <stdio.h>
-#include <statgrab.h>
-]]],
-[[[
-      if (sg_init()) return 0;
-]]]
-    )],
-    [c_cv_have_libstatgrab_0_90="no"],
-    [c_cv_have_libstatgrab_0_90="yes"]
+    [c_cv_have_libstatgrab_0_90],
+    [
+      AC_LINK_IFELSE(
+        [
+          AC_LANG_PROGRAM(
+            [[
+              #include <stdio.h>
+              #include <statgrab.h>
+            ]],
+            [[
+              if (sg_init()) return 0;
+            ]]
           )
+        ],
+        [c_cv_have_libstatgrab_0_90="no"],
+        [c_cv_have_libstatgrab_0_90="yes"]
+      )
+    ]
   )
 
   CFLAGS="$SAVE_CFLAGS"
@@ -4938,832 +4988,782 @@ then
   LIBS="$SAVE_LIBS"
 fi
 
-AM_CONDITIONAL(BUILD_WITH_LIBSTATGRAB, test "x$with_libstatgrab" = "xyes")
-if test "x$with_libstatgrab" = "xyes"
-then
-  AC_DEFINE(HAVE_LIBSTATGRAB, 1, [Define to 1 if you have the 'statgrab' library (-lstatgrab)])
+AM_CONDITIONAL([BUILD_WITH_LIBSTATGRAB], [test "x$with_libstatgrab" = "xyes"])
+
+if test "x$with_libstatgrab" = "xyes"; then
+  AC_DEFINE([HAVE_LIBSTATGRAB], [1],
+    [Define to 1 if you have the 'statgrab' library (-lstatgrab)]
+  )
+
+  if test "x$c_cv_have_libstatgrab_0_90" = "xyes"; then
+    AC_DEFINE([HAVE_LIBSTATGRAB_0_90], [1],
+      [Define to 1 if libstatgrab version >= 0.90]
+    )
+  fi
+
   BUILD_WITH_LIBSTATGRAB_CFLAGS="$with_libstatgrab_cflags"
   BUILD_WITH_LIBSTATGRAB_LDFLAGS="$with_libstatgrab_ldflags"
-  AC_SUBST(BUILD_WITH_LIBSTATGRAB_CFLAGS)
-  AC_SUBST(BUILD_WITH_LIBSTATGRAB_LDFLAGS)
-  if test "x$c_cv_have_libstatgrab_0_90" = "xyes"
-  then
-        AC_DEFINE(HAVE_LIBSTATGRAB_0_90, 1, [Define to 1 if libstatgrab version >= 0.90])
-  fi
+
 fi
+
+AC_SUBST([BUILD_WITH_LIBSTATGRAB_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBSTATGRAB_LDFLAGS])
 # }}}
 
 # --with-libtokyotyrant {{{
-with_libtokyotyrant_cppflags=""
-with_libtokyotyrant_ldflags=""
-with_libtokyotyrant_libs=""
-AC_ARG_WITH(libtokyotyrant, [AS_HELP_STRING([--with-libtokyotyrant@<:@=PREFIX@:>@], [Path to libtokyotyrant.])],
-[
-  if test "x$withval" = "xno"
-  then
-    with_libtokyotyrant="no"
-  else if test "x$withval" = "xyes"
-  then
-    with_libtokyotyrant="yes"
-  else
-    with_libtokyotyrant_cppflags="-I$withval/include"
-    with_libtokyotyrant_ldflags="-L$withval/include"
-    with_libtokyotyrant_libs="-ltokyotyrant"
-    with_libtokyotyrant="yes"
-  fi; fi
-],
-[
-  with_libtokyotyrant="yes"
-])
+AC_ARG_WITH([libtokyotyrant],
+  [AS_HELP_STRING([--with-libtokyotyrant@<:@=PREFIX@:>@], [Path to libtokyotyrant.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_libtokyotyrant="$withval"
+    else
+      with_libtokyotyrant_cppflags="-I$withval/include"
+      with_libtokyotyrant_ldflags="-L$withval/include"
+      with_libtokyotyrant_libs="-ltokyotyrant"
+      with_libtokyotyrant="yes"
+    fi
+  ],
+  [with_libtokyotyrant="yes"]
+)
 
-if test "x$with_libtokyotyrant" = "xyes"
-then
-  if $PKG_CONFIG --exists tokyotyrant
-  then
+if test "x$with_libtokyotyrant" = "xyes"; then
+  if $PKG_CONFIG --exists tokyotyrant; then
     with_libtokyotyrant_cppflags="$with_libtokyotyrant_cppflags `$PKG_CONFIG --cflags tokyotyrant`"
     with_libtokyotyrant_ldflags="$with_libtokyotyrant_ldflags `$PKG_CONFIG --libs-only-L tokyotyrant`"
     with_libtokyotyrant_libs="$with_libtokyotyrant_libs `$PKG_CONFIG --libs-only-l tokyotyrant`"
   fi
 fi
 
-SAVE_CPPFLAGS="$CPPFLAGS"
-SAVE_LDFLAGS="$LDFLAGS"
-CPPFLAGS="$CPPFLAGS $with_libtokyotyrant_cppflags"
-LDFLAGS="$LDFLAGS $with_libtokyotyrant_ldflags"
+if test "x$with_libtokyotyrant" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libtokyotyrant_cppflags"
 
-if test "x$with_libtokyotyrant" = "xyes"
-then
-  AC_CHECK_HEADERS(tcrdb.h,
-  [
-          AC_DEFINE(HAVE_TCRDB_H, 1,
-                    [Define to 1 if you have the <tcrdb.h> header file.])
-  ], [with_libtokyotyrant="no (tcrdb.h not found)"])
+  AC_CHECK_HEADERS([tcrdb.h],
+    [with_libtokyotyrant="yes"],
+    [with_libtokyotyrant="no (tcrdb.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_libtokyotyrant" = "xyes"
-then
-  AC_CHECK_LIB(tokyotyrant, tcrdbrnum,
-  [
-          AC_DEFINE(HAVE_LIBTOKYOTYRANT, 1,
-                    [Define to 1 if you have the tokyotyrant library (-ltokyotyrant).])
-  ],
-  [with_libtokyotyrant="no (symbol tcrdbrnum not found)"],
-  [$with_libtokyotyrant_libs])
+if test "x$with_libtokyotyrant" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libtokyotyrant_ldflags"
+
+  AC_CHECK_LIB([tokyotyrant], [tcrdbrnum],
+    [with_libtokyotyrant="yes"],
+    [with_libtokyotyrant="no (symbol tcrdbrnum not found)"],
+    [$with_libtokyotyrant_libs]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
 
-CPPFLAGS="$SAVE_CPPFLAGS"
-LDFLAGS="$SAVE_LDFLAGS"
-
-if test "x$with_libtokyotyrant" = "xyes"
-then
+if test "x$with_libtokyotyrant" = "xyes"; then
   BUILD_WITH_LIBTOKYOTYRANT_CPPFLAGS="$with_libtokyotyrant_cppflags"
   BUILD_WITH_LIBTOKYOTYRANT_LDFLAGS="$with_libtokyotyrant_ldflags"
   BUILD_WITH_LIBTOKYOTYRANT_LIBS="$with_libtokyotyrant_libs"
-  AC_SUBST(BUILD_WITH_LIBTOKYOTYRANT_CPPFLAGS)
-  AC_SUBST(BUILD_WITH_LIBTOKYOTYRANT_LDFLAGS)
-  AC_SUBST(BUILD_WITH_LIBTOKYOTYRANT_LIBS)
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBTOKYOTYRANT, test "x$with_libtokyotyrant" = "xyes")
+AC_SUBST([BUILD_WITH_LIBTOKYOTYRANT_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBTOKYOTYRANT_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBTOKYOTYRANT_LIBS])
 # }}}
 
 # --with-libudev {{{
-with_libudev_cflags=""
-with_libudev_ldflags=""
-AC_ARG_WITH(libudev, [AS_HELP_STRING([--with-libudev@<:@=PREFIX@:>@], [Path to libudev.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libudev="no"
-	else
-		with_libudev="yes"
-		if test "x$withval" != "xyes"
-		then
-			with_libudev_cflags="-I$withval/include"
-			with_libudev_ldflags="-L$withval/lib"
-			with_libudev="yes"
-		fi
-	fi
-],
-[
-	if test "x$ac_system" = "xLinux"
-	then
-		with_libudev="yes"
-	else
-		with_libudev="no (Linux only library)"
-	fi
-])
-if test "x$with_libudev" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libudev_cflags"
+AC_ARG_WITH([libudev],
+  [AS_HELP_STRING([--with-libudev@<:@=PREFIX@:>@], [Path to libudev.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_libudev="$withval"
+    else
+      with_libudev_cppflags="-I$withval/include"
+      with_libudev_ldflags="-L$withval/lib"
+      with_libudev="yes"
+    fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_libudev="yes"
+    else
+      with_libudev="no (Linux only library)"
+    fi
+  ]
+)
 
-	AC_CHECK_HEADERS(libudev.h, [], [with_libudev="no (libudev.h not found)"])
+if test "x$with_libudev" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libudev_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([libudev.h],
+    [with_libudev="yes"],
+    [with_libudev="no (libudev.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libudev" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libudev_cflags"
-	LDFLAGS="$LDFLAGS $with_libudev_ldflags"
 
-	AC_CHECK_LIB(udev, udev_new,
-	[
-		AC_DEFINE(HAVE_LIBUDEV, 1, [Define to 1 if you have the udev library (-ludev).])
-	],
-	[with_libudev="no (libudev not found)"])
+if test "x$with_libudev" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libudev_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([udev], [udev_new],
+    [with_libudev="yes"],
+    [with_libudev="no (libudev not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libudev" = "xyes"
-then
-	BUILD_WITH_LIBUDEV_CFLAGS="$with_libudev_cflags"
-	BUILD_WITH_LIBUDEV_LDFLAGS="$with_libudev_ldflags"
-	BUILD_WITH_LIBUDEV_LIBS="-ludev"
-	AC_SUBST(BUILD_WITH_LIBUDEV_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBUDEV_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBUDEV_LIBS)
+
+if test "x$with_libudev" = "xyes"; then
+  BUILD_WITH_LIBUDEV_CPPFLAGS="$with_libudev_cppflags"
+  BUILD_WITH_LIBUDEV_LDFLAGS="$with_libudev_ldflags"
+  BUILD_WITH_LIBUDEV_LIBS="-ludev"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBUDEV, test "x$with_libudev" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBUDEV_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBUDEV_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBUDEV_LIBS])
+
+AM_CONDITIONAL([BUILD_WITH_LIBUDEV], [test "x$with_libudev" = "xyes"])
 # }}}
 
 # --with-libupsclient {{{
 with_libupsclient_config=""
-with_libupsclient_cflags=""
-with_libupsclient_libs=""
-AC_ARG_WITH(libupsclient, [AS_HELP_STRING([--with-libupsclient@<:@=PREFIX@:>@], [Path to the upsclient library.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libupsclient="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libupsclient="use_pkgconfig"
-	else
-		if test -x "$withval"
-		then
-			with_libupsclient_config="$withval"
-			with_libupsclient="use_libupsclient_config"
-		else if test -x "$withval/bin/libupsclient-config"
-		then
-			with_libupsclient_config="$withval/bin/libupsclient-config"
-			with_libupsclient="use_libupsclient_config"
-		else
-			AC_MSG_NOTICE([Not checking for libupsclient: Manually configured])
-			with_libupsclient_cflags="-I$withval/include"
-			with_libupsclient_libs="-L$withval/lib -lupsclient"
-			with_libupsclient="yes"
-		fi; fi
-	fi; fi
-],
-[with_libupsclient="use_pkgconfig"])
+AC_ARG_WITH([libupsclient],
+  [AS_HELP_STRING([--with-libupsclient@<:@=PREFIX@:>@], [Path to the upsclient library.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_libupsclient="no"
+    else if test "x$withval" = "xyes"; then
+      with_libupsclient="use_pkgconfig"
+    else
+      if test -x "$withval"; then
+        with_libupsclient_config="$withval"
+        with_libupsclient="use_libupsclient_config"
+      else if test -x "$withval/bin/libupsclient-config"; then
+        with_libupsclient_config="$withval/bin/libupsclient-config"
+        with_libupsclient="use_libupsclient_config"
+      else
+        AC_MSG_NOTICE([Not checking for libupsclient: Manually configured])
+        with_libupsclient_cflags="-I$withval/include"
+        with_libupsclient_libs="-L$withval/lib -lupsclient"
+        with_libupsclient="yes"
+      fi; fi
+    fi; fi
+  ],
+  [with_libupsclient="use_pkgconfig"]
+)
 
 # configure using libupsclient-config
-if test "x$with_libupsclient" = "xuse_libupsclient_config"
-then
-	AC_MSG_NOTICE([Checking for libupsclient using $with_libupsclient_config])
-	with_libupsclient_cflags="`$with_libupsclient_config --cflags`"
-	if test $? -ne 0
-	then
-		with_libupsclient="no ($with_libupsclient_config failed)"
-	fi
-	with_libupsclient_libs="`$with_libupsclient_config --libs`"
-	if test $? -ne 0
-	then
-		with_libupsclient="no ($with_libupsclient_config failed)"
-	fi
+if test "x$with_libupsclient" = "xuse_libupsclient_config"; then
+  with_libupsclient_cflags="`$with_libupsclient_config --cflags`"
+  if test $? -ne 0; then
+    with_libupsclient="no ($with_libupsclient_config failed)"
+  fi
+  with_libupsclient_libs="`$with_libupsclient_config --libs`"
+  if test $? -ne 0; then
+    with_libupsclient="no ($with_libupsclient_config failed)"
+  fi
 fi
-if test "x$with_libupsclient" = "xuse_libupsclient_config"
-then
-	with_libupsclient="yes"
+
+if test "x$with_libupsclient" = "xuse_libupsclient_config"; then
+  with_libupsclient="yes"
 fi
 
 # configure using pkg-config
-if test "x$with_libupsclient" = "xuse_pkgconfig"
-then
-	AC_MSG_NOTICE([Checking for libupsclient using $PKG_CONFIG])
-	$PKG_CONFIG --exists 'libupsclient' 2>/dev/null
-	if test $? -ne 0
-	then
-		with_libupsclient="no (pkg-config doesn't know libupsclient)"
-	fi
-fi
-if test "x$with_libupsclient" = "xuse_pkgconfig"
-then
-	with_libupsclient_cflags="`$PKG_CONFIG --cflags 'libupsclient'`"
-	if test $? -ne 0
-	then
-		with_libupsclient="no ($PKG_CONFIG failed)"
-	fi
-	with_libupsclient_libs="`$PKG_CONFIG --libs 'libupsclient'`"
-	if test $? -ne 0
-	then
-		with_libupsclient="no ($PKG_CONFIG failed)"
-	fi
-fi
-if test "x$with_libupsclient" = "xuse_pkgconfig"
-then
-	with_libupsclient="yes"
+if test "x$with_libupsclient" = "xuse_pkgconfig"; then
+  AC_MSG_NOTICE([Checking for libupsclient using $PKG_CONFIG])
+  $PKG_CONFIG --exists 'libupsclient' 2>/dev/null
+  if test $? -ne 0; then
+    with_libupsclient="no (pkg-config doesn't know libupsclient)"
+  fi
 fi
 
-# with_libupsclient_cflags and with_libupsclient_libs are set up now, let's do
-# the actual checks.
-if test "x$with_libupsclient" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libupsclient_cflags"
+if test "x$with_libupsclient" = "xuse_pkgconfig"; then
+  with_libupsclient_cflags="`$PKG_CONFIG --cflags 'libupsclient'`"
+  if test $? -ne 0; then
+    with_libupsclient="no ($PKG_CONFIG failed)"
+  fi
 
-	AC_CHECK_HEADERS(upsclient.h, [], [with_libupsclient="no (upsclient.h not found)"])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  with_libupsclient_libs="`$PKG_CONFIG --libs 'libupsclient'`"
+  if test $? -ne 0; then
+    with_libupsclient="no ($PKG_CONFIG failed)"
+  fi
 fi
-if test "x$with_libupsclient" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
 
-	CPPFLAGS="$CPPFLAGS $with_libupsclient_cflags"
-	LDFLAGS="$LDFLAGS $with_libupsclient_libs"
-
-	AC_CHECK_LIB(upsclient, upscli_connect,
-		     [with_libupsclient="yes"],
-		     [with_libupsclient="no (symbol upscli_connect not found)"])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+if test "x$with_libupsclient" = "xuse_pkgconfig"; then
+  with_libupsclient="yes"
 fi
-if test "x$with_libupsclient" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libupsclient_cflags"
 
-	AC_CHECK_TYPES([UPSCONN_t, UPSCONN], [], [],
-[#include <stdlib.h>
-#include <stdio.h>
-#include <upsclient.h>])
+if test "x$with_libupsclient" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libupsclient_cflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([upsclient.h],
+    [with_libupsclient="yes"],
+    [with_libupsclient="no (upsclient.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libupsclient" = "xyes"
-then
-	BUILD_WITH_LIBUPSCLIENT_CFLAGS="$with_libupsclient_cflags"
-	BUILD_WITH_LIBUPSCLIENT_LIBS="$with_libupsclient_libs"
-	AC_SUBST(BUILD_WITH_LIBUPSCLIENT_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBUPSCLIENT_LIBS)
+
+if test "x$with_libupsclient" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libupsclient_libs"
+
+  AC_CHECK_LIB([upsclient], [upscli_connect],
+    [with_libupsclient="yes"],
+    [with_libupsclient="no (symbol upscli_connect not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
+
+if test "x$with_libupsclient" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libupsclient_cflags"
+
+  AC_CHECK_TYPES([UPSCONN_t, UPSCONN],
+    [],
+    [],
+    [[
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <upsclient.h>
+    ]]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
+if test "x$with_libupsclient" = "xyes"; then
+  BUILD_WITH_LIBUPSCLIENT_CFLAGS="$with_libupsclient_cflags"
+  BUILD_WITH_LIBUPSCLIENT_LIBS="$with_libupsclient_libs"
+fi
+
+AC_SUBST([BUILD_WITH_LIBUPSCLIENT_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBUPSCLIENT_LIBS])
 # }}}
 
 # --with-libxenctrl {{{
-with_libxenctrl_cppflags=""
-with_libxenctrl_ldflags=""
-AC_ARG_WITH(libxenctrl, [AS_HELP_STRING([--with-libxenctrl@<:@=PREFIX@:>@], [Path to libxenctrl.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libxenctrl_cppflags="-I$withval/include"
-		with_libxenctrl_ldflags="-L$withval/lib"
-		with_libxenctrl="yes"
-	else
-		with_libxenctrl="$withval"
-	fi
-],
-[
-	with_libxenctrl="yes"
-])
-if test "x$with_libxenctrl" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libxenctrl_cppflags"
+AC_ARG_WITH([libxenctrl],
+  [AS_HELP_STRING([--with-libxenctrl@<:@=PREFIX@:>@], [Path to libxenctrl.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libxenctrl_cppflags="-I$withval/include"
+      with_libxenctrl_ldflags="-L$withval/lib"
+      with_libxenctrl="yes"
+    else
+      with_libxenctrl="$withval"
+    fi
+  ],
+  [with_libxenctrl="yes"]
+)
 
-	AC_CHECK_HEADERS(xenctrl.h, [with_libxenctrl="yes"], [with_libxenctrl="no (xenctrl.h not found)"])
+if test "x$with_libxenctrl" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libxenctrl_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([xenctrl.h],
+    [with_libxenctrl="yes"],
+    [with_libxenctrl="no (xenctrl.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libxenctrl" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libxenctrl_cppflags"
-	LDFLAGS="$LDFLAGS $with_libxenctrl_ldflags"
 
-	#Xen versions older than 3.4 has no xc_getcpuinfo()
-	AC_CHECK_LIB(xenctrl, xc_getcpuinfo, [with_libxenctrl="yes"], [with_libxenctrl="no (symbol 'xc_getcpuinfo' not found)"], [])
+if test "x$with_libxenctrl" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libxenctrl_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
-	LIBXENCTL_CPPFLAGS="$with_libxenctl_cppflags"
-	LIBXENCTL_LDFLAGS="$with_libxenctl_ldflags"
-	AC_SUBST(LIBXENCTL_CPPFLAGS)
-	AC_SUBST(LIBXENCTL_LDFLAGS)
+  #Xen versions older than 3.4 has no xc_getcpuinfo()
+  AC_CHECK_LIB([xenctrl], [xc_getcpuinfo],
+    [with_libxenctrl="yes"],
+    [with_libxenctrl="no (symbol 'xc_getcpuinfo' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
+
+LIBXENCTL_CPPFLAGS="$with_libxenctl_cppflags"
+LIBXENCTL_LDFLAGS="$with_libxenctl_ldflags"
+AC_SUBST([LIBXENCTL_CPPFLAGS])
+AC_SUBST([LIBXENCTL_LDFLAGS])
 # }}}
 
 # --with-libxmms {{{
 with_xmms_config="xmms-config"
-with_xmms_cflags=""
-with_xmms_libs=""
-AC_ARG_WITH(libxmms, [AS_HELP_STRING([--with-libxmms@<:@=PREFIX@:>@], [Path to libxmms.])],
-[
-	if test "x$withval" != "xno" \
-		&& test "x$withval" != "xyes"
-	then
-		if test -f "$withval" && test -x "$withval";
-		then
-			with_xmms_config="$withval"
-		else if test -x "$withval/bin/xmms-config"
-		then
-			with_xmms_config="$withval/bin/xmms-config"
-		fi; fi
-		with_libxmms="yes"
-	else if test "x$withval" = "xno"
-	then
-		with_libxmms="no"
-	else
-		with_libxmms="yes"
-	fi; fi
-],
-[
-	with_libxmms="yes"
-])
-if test "x$with_libxmms" = "xyes"
-then
-	with_xmms_cflags=`$with_xmms_config --cflags 2>/dev/null`
-	xmms_config_status=$?
+AC_ARG_WITH([libxmms],
+  [AS_HELP_STRING([--with-libxmms@<:@=PREFIX@:>@], [Path to libxmms.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_libxmms="$withval"
+    else
+      if test -f "$withval" && test -x "$withval"; then
+        with_xmms_config="$withval"
+      else if test -x "$withval/bin/xmms-config"; then
+        with_xmms_config="$withval/bin/xmms-config"
+      fi; fi
+      with_libxmms="yes"
+    fi
+  ],
+  [with_libxmms="yes"]
+)
 
-	if test $xmms_config_status -ne 0
-	then
-		with_libxmms="no"
-	fi
+if test "x$with_libxmms" = "xyes"; then
+  with_xmms_cflags=`$with_xmms_config --cflags 2>/dev/null`
+  if test $? -ne 0; then
+    with_libxmms="no"
+  fi
 fi
-if test "x$with_libxmms" = "xyes"
-then
-	with_xmms_libs=`$with_xmms_config --libs 2>/dev/null`
-	xmms_config_status=$?
 
-	if test $xmms_config_status -ne 0
-	then
-		with_libxmms="no"
-	fi
+if test "x$with_libxmms" = "xyes"; then
+  with_xmms_libs=`$with_xmms_config --libs 2>/dev/null`
+  if test $? -ne 0; then
+    with_libxmms="no"
+  fi
 fi
-if test "x$with_libxmms" = "xyes"
-then
-	AC_CHECK_LIB(xmms, xmms_remote_get_info,
-	[
-		BUILD_WITH_LIBXMMS_CFLAGS="$with_xmms_cflags"
-		BUILD_WITH_LIBXMMS_LIBS="$with_xmms_libs"
-		AC_SUBST(BUILD_WITH_LIBXMMS_CFLAGS)
-		AC_SUBST(BUILD_WITH_LIBXMMS_LIBS)
-	],
-	[
-		with_libxmms="no"
-	],
-	[$with_xmms_libs])
+
+if test "x$with_libxmms" = "xyes"; then
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$with_xmms_cflags"
+
+  AC_CHECK_HEADER([xmmsctrl.h],
+    [with_libxmms="yes"],
+    [with_libxmms="no"],
+  )
+
+  CFLAGS="$SAVE_CFLAGS"
 fi
-with_libxmms_numeric=0
-if test "x$with_libxmms" = "xyes"
-then
-	with_libxmms_numeric=1
+
+if test "x$with_libxmms" = "xyes"; then
+  SAVE_LIBS="$LIBS"
+  LIBS="$with_xmms_libs"
+
+  AC_CHECK_LIB([xmms], [xmms_remote_get_info],
+    [with_libxmss="yes"],
+    [with_libxmms="no"],
+    [$with_xmms_libs]
+
+  )
+
+  LIBS="$SAVE_LIBS"
 fi
-AC_DEFINE_UNQUOTED(HAVE_LIBXMMS, [$with_libxmms_numeric], [Define to 1 if you have the 'xmms' library (-lxmms).])
-AM_CONDITIONAL(BUILD_WITH_LIBXMMS, test "x$with_libxmms" = "xyes")
+
+BUILD_WITH_LIBXMMS_CFLAGS="$with_xmms_cflags"
+BUILD_WITH_LIBXMMS_LIBS="$with_xmms_libs"
+
+AC_SUBST([BUILD_WITH_LIBXMMS_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBXMMS_LIBS])
 # }}}
 
 # --with-libyajl {{{
-with_libyajl_cppflags=""
-with_libyajl_ldflags=""
-AC_ARG_WITH(libyajl, [AS_HELP_STRING([--with-libyajl@<:@=PREFIX@:>@], [Path to libyajl.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libyajl_cppflags="-I$withval/include"
-		with_libyajl_ldflags="-L$withval/lib"
-		with_libyajl="yes"
-	else
-		with_libyajl="$withval"
-	fi
-],
-[
-	with_libyajl="yes"
-])
-if test "x$with_libyajl" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libyajl_cppflags"
+AC_ARG_WITH([libyajl],
+  [AS_HELP_STRING([--with-libyajl@<:@=PREFIX@:>@], [Path to libyajl.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libyajl_cppflags="-I$withval/include"
+      with_libyajl_ldflags="-L$withval/lib"
+      with_libyajl="yes"
+    else
+      with_libyajl="$withval"
+    fi
+  ],
+  [with_libyajl="yes"]
+)
 
-	AC_CHECK_HEADERS(yajl/yajl_parse.h, [with_libyajl="yes"], [with_libyajl="no (yajl/yajl_parse.h not found)"])
-	AC_CHECK_HEADERS(yajl/yajl_version.h)
+if test "x$with_libyajl" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libyajl_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([yajl/yajl_parse.h],
+    [with_libyajl="yes"],
+    [with_libyajl="no (yajl/yajl_parse.h not found)"]
+  )
+
+  AC_CHECK_HEADERS([yajl/yajl_version.h])
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libyajl" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libyajl_cppflags"
-	LDFLAGS="$LDFLAGS $with_libyajl_ldflags"
 
-	AC_CHECK_LIB(yajl, yajl_alloc, [with_libyajl="yes"], [with_libyajl="no (Symbol 'yajl_alloc' not found)"])
+if test "x$with_libyajl" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libyajl_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([yajl], [yajl_alloc],
+    [with_libyajl="yes"],
+    [with_libyajl="no (Symbol 'yajl_alloc' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libyajl" = "xyes"
-then
-	BUILD_WITH_LIBYAJL_CPPFLAGS="$with_libyajl_cppflags"
-	BUILD_WITH_LIBYAJL_LDFLAGS="$with_libyajl_ldflags"
-	BUILD_WITH_LIBYAJL_LIBS="-lyajl"
-	AC_SUBST(BUILD_WITH_LIBYAJL_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBYAJL_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBYAJL_LIBS)
-	AC_DEFINE(HAVE_LIBYAJL, 1, [Define if libyajl is present and usable.])
+
+if test "x$with_libyajl" = "xyes"; then
+  BUILD_WITH_LIBYAJL_CPPFLAGS="$with_libyajl_cppflags"
+  BUILD_WITH_LIBYAJL_LDFLAGS="$with_libyajl_ldflags"
+  BUILD_WITH_LIBYAJL_LIBS="-lyajl"
+  AC_DEFINE([HAVE_LIBYAJL], [1], [Define if libyajl is present and usable.])
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBYAJL, test "x$with_libyajl" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBYAJL_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBYAJL_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBYAJL_LIBS])
+
+AM_CONDITIONAL([BUILD_WITH_LIBYAJL], [test "x$with_libyajl" = "xyes"])
 # }}}
 
 # --with-mic {{{
-with_mic_cflags="-I/opt/intel/mic/sysmgmt/sdk/include"
-with_mic_ldpath="-L/opt/intel/mic/sysmgmt/sdk/lib/Linux"
-with_mic_libs=""
-AC_ARG_WITH(mic,[AS_HELP_STRING([--with-mic@<:@=PREFIX@:>@], [Path to Intel MIC Access API.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_mic="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_mic="yes"
-	else if test -d "$with_mic/lib"
-	then
-		AC_MSG_NOTICE([Not checking for Intel Mic: Manually configured])
-		with_mic_cflags="-I$withval/include"
-		with_mic_ldpath="-L$withval/lib/Linux"
-		with_mic_libs="$PTHREAD_LIBS -lMicAccessSDK -lscif"
-		with_mic="yes"
-	fi; fi; fi
-],
-[with_mic="yes"])
-if test "x$with_mic" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_mic_cflags"
-	AC_CHECK_HEADERS(MicAccessApi.h,[],[with_mic="no (MicAccessApi not found)"])
-	CPPFLAGS="$SAVE_CPPFLAGS"
-fi
-if test "x$with_mic" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
+with_mic_cppflags="-I/opt/intel/mic/sysmgmt/sdk/include"
+with_mic_ldflags="-L/opt/intel/mic/sysmgmt/sdk/lib/Linux"
+with_mic_libs="-lMicAccessSDK -scif"
+AC_ARG_WITH([mic],
+  [AS_HELP_STRING([--with-mic@<:@=PREFIX@:>@], [Path to Intel MIC Access API.])],
+  [
+    if test "x$withval" = "xno" || test "x$withval" = "xyes"; then
+      with_mic="$withval"
+    else if test -d "$with_mic/lib"; then
+      with_mic_cppflags="-I$withval/include"
+      with_mic_ldflags="-L$withval/lib/Linux"
+      with_mic="yes"
+    fi; fi
+  ],
+  [with_mic="yes"]
+)
 
-	CPPFLAGS="$CPPFLAGS $with_mic_cflags"
-	LDFLAGS="$LDFLAGS $with_mic_ldpath"
+if test "x$with_mic" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_mic_cppflags"
 
-	AC_CHECK_LIB(MicAccessSDK, MicInitAPI,
-			[with_mic_ldpath="$with_mic_ldpath"
-			with_mic_libs="$PTHREAD_LIBS -lMicAccessSDK -lscif"],
-			[with_mic="no (symbol MicInitAPI not found)"],[$PTHREAD_LIBS -lscif])
+  AC_CHECK_HEADERS([MicAccessApi.h],
+    [with_mic="yes"],
+    [with_mic="no (MicAccessApi not found)"]
+  )
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_mic" = "xyes"
-then
-	BUILD_WITH_MIC_CPPFLAGS="$with_mic_cflags"
-	BUILD_WITH_MIC_LIBPATH="$with_mic_ldpath"
-	BUILD_WITH_MIC_LDADD="$with_mic_libs"
-	AC_SUBST(BUILD_WITH_MIC_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_MIC_LIBPATH)
-	AC_SUBST(BUILD_WITH_MIC_LDADD)
+if test "x$with_mic" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_mic_ldflags"
+
+  AC_CHECK_LIB([MicAccessSDK], [MicInitAPI],
+    [with_mic="yes"],
+    [with_mic="no (symbol MicInitAPI not found)"],
+    [$PTHREAD_LIBS -lscif]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
+
+if test "x$with_mic" = "xyes"; then
+  BUILD_WITH_MIC_CPPFLAGS="$with_mic_cppflags"
+  BUILD_WITH_MIC_LDFLAGS="$with_mic_ldflags"
+  BUILD_WITH_MIC_LIBS="$with_mic_libs"
+fi
+AC_SUBST([BUILD_WITH_MIC_CPPFLAGS])
+AC_SUBST([BUILD_WITH_MIC_LDFLAGS])
+AC_SUBST([BUILD_WITH_MIC_LIBS])
 #}}}
 
 # --with-libvarnish {{{
-with_libvarnish_cppflags=""
-with_libvarnish_cflags=""
-with_libvarnish_libs=""
-AC_ARG_WITH(libvarnish, [AS_HELP_STRING([--with-libvarnish@<:@=PREFIX@:>@], [Path to libvarnish.])],
-[
-	if test "x$withval" = "xno"
-	then
-		with_libvarnish="no"
-	else if test "x$withval" = "xyes"
-	then
-		with_libvarnish="use_pkgconfig"
-	else if test -d "$with_libvarnish/lib"
-	then
-		AC_MSG_NOTICE([Not checking for libvarnish: Manually configured])
-		with_libvarnish_cflags="-I$withval/include"
-		with_libvarnish_libs="-L$withval/lib -lvarnishapi"
-		with_libvarnish="yes"
-	fi; fi; fi
-],
-[with_libvarnish="use_pkgconfig"])
+AC_ARG_WITH([libvarnish],
+  [AS_HELP_STRING([--with-libvarnish@<:@=PREFIX@:>@], [Path to libvarnish.])],
+  [
+    if test "x$withval" = "xno"; then
+      with_libvarnish="no"
+    else if test "x$withval" = "xyes"; then
+      with_libvarnish="use_pkgconfig"
+    else if test -d "$with_libvarnish/lib"; then
+      with_libvarnish_cflags="-I$withval/include"
+      with_libvarnish_libs="-L$withval/lib -lvarnishapi"
+      with_libvarnish="yes"
+    fi; fi; fi
+  ],
+  [with_libvarnish="use_pkgconfig"]
+)
 
 # configure using pkg-config
-if test "x$with_libvarnish" = "xuse_pkgconfig"
-then
-	AC_MSG_NOTICE([Checking for varnishapi using $PKG_CONFIG])
-	$PKG_CONFIG --exists 'varnishapi' 2>/dev/null
-	if test $? -ne 0
-	then
-		with_libvarnish="no (pkg-config doesn't know varnishapi)"
-	fi
-fi
-if test "x$with_libvarnish" = "xuse_pkgconfig"
-then
-	with_libvarnish_cflags="`$PKG_CONFIG --cflags 'varnishapi'`"
-	if test $? -ne 0
-	then
-		with_libvarnish="no ($PKG_CONFIG failed)"
-	fi
-	with_libvarnish_libs="`$PKG_CONFIG --libs 'varnishapi'`"
-	if test $? -ne 0
-	then
-		with_libvarnish="no ($PKG_CONFIG failed)"
-	fi
-fi
-if test "x$with_libvarnish" = "xuse_pkgconfig"
-then
-	with_libvarnish="yes"
+if test "x$with_libvarnish" = "xuse_pkgconfig"; then
+  $PKG_CONFIG --exists 'varnishapi' 2>/dev/null
+  if test $? -ne 0; then
+    with_libvarnish="no (pkg-config doesn't know varnishapi)"
+  fi
 fi
 
-# with_libvarnish_cflags and with_libvarnish_libs are set up now, let's do
-# the actual checks.
-if test "x$with_libvarnish" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
+if test "x$with_libvarnish" = "xuse_pkgconfig"; then
+  with_libvarnish_cflags="`$PKG_CONFIG --cflags 'varnishapi'`"
+  if test $? -ne 0; then
+    with_libvarnish="no ($PKG_CONFIG failed)"
+  fi
 
-	CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
-
-	AC_CHECK_HEADERS(vapi/vsc.h,
-		[AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
-		[AC_CHECK_HEADERS(vsc.h,
-			[AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support])],
-			[AC_CHECK_HEADERS(varnishapi.h,
-				[AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
-				[with_libvarnish="no (found none of the varnish header files)"])])])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  with_libvarnish_libs="`$PKG_CONFIG --libs 'varnishapi'`"
+  if test $? -ne 0; then
+    with_libvarnish="no ($PKG_CONFIG failed)"
+  fi
 fi
-if test "x$with_libvarnish" = "xyes"
-then
-	BUILD_WITH_LIBVARNISH_CFLAGS="$with_libvarnish_cflags"
-	BUILD_WITH_LIBVARNISH_LIBS="$with_libvarnish_libs"
-	AC_SUBST(BUILD_WITH_LIBVARNISH_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBVARNISH_LIBS)
+if test "x$with_libvarnish" = "xuse_pkgconfig"; then
+  with_libvarnish="yes"
 fi
+
+if test "x$with_libvarnish" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
+
+  AC_CHECK_HEADERS([vapi/vsc.h],
+    [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
+    [
+      AC_CHECK_HEADERS([vsc.h],
+        [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
+        [
+          AC_CHECK_HEADERS([varnishapi.h],
+            [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
+            [with_libvarnish="no (found none of the varnish header files)"]
+          )
+        ]
+      )
+    ]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
+if test "x$with_libvarnish" = "xyes"; then
+  BUILD_WITH_LIBVARNISH_CFLAGS="$with_libvarnish_cflags"
+  BUILD_WITH_LIBVARNISH_LIBS="$with_libvarnish_libs"
+fi
+
+AC_SUBST([BUILD_WITH_LIBVARNISH_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBVARNISH_LIBS])
 # }}}
 
 # pkg-config --exists 'libxml-2.0'; pkg-config --exists libvirt {{{
-with_libxml2="no (pkg-config isn't available)"
-with_libxml2_cflags=""
-with_libxml2_ldflags=""
-with_libvirt="no (pkg-config isn't available)"
-with_libvirt_cflags=""
-with_libvirt_ldflags=""
 $PKG_CONFIG --exists 'libxml-2.0' 2>/dev/null
-if test "$?" = "0"
-then
-	with_libxml2="yes"
+if test $? -eq 0; then
+  with_libxml2="yes"
 else
-	with_libxml2="no (pkg-config doesn't know libxml-2.0)"
+  with_libxml2="no (pkg-config doesn't know libxml-2.0)"
 fi
 
 $PKG_CONFIG --exists libvirt 2>/dev/null
-if test "$?" = "0"
-then
-	with_libvirt="yes"
+if test $? = 0; then
+  with_libvirt="yes"
 else
-	with_libvirt="no (pkg-config doesn't know libvirt)"
+  with_libvirt="no (pkg-config doesn't know libvirt)"
 fi
-if test "x$with_libxml2" = "xyes"
-then
-	with_libxml2_cflags="`$PKG_CONFIG --cflags libxml-2.0`"
-	if test $? -ne 0
-	then
-		with_libxml2="no"
-	fi
-	with_libxml2_ldflags="`$PKG_CONFIG --libs libxml-2.0`"
-	if test $? -ne 0
-	then
-		with_libxml2="no"
-	fi
-fi
-if test "x$with_libxml2" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libxml2_cflags"
 
-	AC_CHECK_HEADERS(libxml/parser.h, [],
-		      [with_libxml2="no (libxml/parser.h not found)"])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
-fi
-if test "x$with_libxml2" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-
-	CFLAGS="$CFLAGS $with_libxml2_cflags"
-	LDFLAGS="$LDFLAGS $with_libxml2_ldflags"
-
-	AC_CHECK_LIB(xml2, xmlXPathEval,
-		     [with_libxml2="yes"],
-		     [with_libxml2="no (symbol xmlXPathEval not found)"])
-
-	CFLAGS="$SAVE_CFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
-fi
-dnl Add the right compiler flags and libraries.
 if test "x$with_libxml2" = "xyes"; then
-	BUILD_WITH_LIBXML2_CFLAGS="$with_libxml2_cflags"
-	BUILD_WITH_LIBXML2_LIBS="$with_libxml2_ldflags"
-	AC_SUBST(BUILD_WITH_LIBXML2_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBXML2_LIBS)
+  with_libxml2_cflags="`$PKG_CONFIG --cflags libxml-2.0`"
+  if test $? -ne 0; then
+    with_libxml2="no"
+  fi
+
+  with_libxml2_ldflags="`$PKG_CONFIG --libs libxml-2.0`"
+  if test $? -ne 0; then
+    with_libxml2="no"
+  fi
 fi
-if test "x$with_libvirt" = "xyes"
-then
-	with_libvirt_cflags="`$PKG_CONFIG --cflags libvirt`"
-	if test $? -ne 0
-	then
-		with_libvirt="no"
-	fi
-	with_libvirt_ldflags="`$PKG_CONFIG --libs libvirt`"
-	if test $? -ne 0
-	then
-		with_libvirt="no"
-	fi
+
+if test "x$with_libxml2" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libxml2_cflags"
+
+  AC_CHECK_HEADERS([libxml/parser.h],
+    [with_libxml2="yes"],
+    [with_libxml2="no (libxml/parser.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libvirt" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libvirt_cflags"
 
-	AC_CHECK_HEADERS(libvirt/libvirt.h, [],
-		      [with_libvirt="no (libvirt/libvirt.h not found)"])
+if test "x$with_libxml2" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libxml2_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_LIB([xml2], [xmlXPathEval],
+    [with_libxml2="yes"],
+    [with_libxml2="no (symbol xmlXPathEval not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libvirt" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
 
-	CFLAGS="$CFLAGS $with_libvirt_cflags"
-	LDFLAGS="$LDFLAGS $with_libvirt_ldflags"
-
-	AC_CHECK_LIB(virt, virDomainBlockStats,
-		     [with_libvirt="yes"],
-		     [with_libvirt="no (symbol virDomainBlockStats not found)"])
-
-	CFLAGS="$SAVE_CFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+if test "x$with_libxml2" = "xyes"; then
+  BUILD_WITH_LIBXML2_CFLAGS="$with_libxml2_cflags"
+  BUILD_WITH_LIBXML2_LIBS="$with_libxml2_ldflags"
 fi
-dnl Add the right compiler flags and libraries.
+
+AC_SUBST([BUILD_WITH_LIBXML2_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBXML2_LIBS])
+
 if test "x$with_libvirt" = "xyes"; then
-	BUILD_WITH_LIBVIRT_CFLAGS="$with_libvirt_cflags"
-	BUILD_WITH_LIBVIRT_LIBS="$with_libvirt_ldflags"
-	AC_SUBST(BUILD_WITH_LIBVIRT_CFLAGS)
-	AC_SUBST(BUILD_WITH_LIBVIRT_LIBS)
+  with_libvirt_cflags="`$PKG_CONFIG --cflags libvirt`"
+  if test $? -ne 0; then
+    with_libvirt="no"
+  fi
+
+  with_libvirt_ldflags="`$PKG_CONFIG --libs libvirt`"
+  if test $? -ne 0; then
+    with_libvirt="no"
+  fi
 fi
+
+if test "x$with_libvirt" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libvirt_cflags"
+
+  AC_CHECK_HEADERS([libvirt/libvirt.h],
+    [with_libvirt="yes"],
+    [with_libvirt="no (libvirt/libvirt.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
+if test "x$with_libvirt" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libvirt_ldflags"
+
+  AC_CHECK_LIB([virt], [virDomainBlockStats],
+    [with_libvirt="yes"],
+    [with_libvirt="no (symbol virDomainBlockStats not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$with_libvirt" = "xyes"; then
+  BUILD_WITH_LIBVIRT_CFLAGS="$with_libvirt_cflags"
+  BUILD_WITH_LIBVIRT_LIBS="$with_libvirt_ldflags"
+fi
+
+AC_SUBST([BUILD_WITH_LIBVIRT_CFLAGS])
+AC_SUBST([BUILD_WITH_LIBVIRT_LIBS])
 # }}}
 
 # $PKG_CONFIG --exists OpenIPMIpthread {{{
 with_libopenipmipthread="yes"
-with_libopenipmipthread_cflags=""
-with_libopenipmipthread_libs=""
+AC_MSG_CHECKING([for libOpenIPMIpthread])
+$PKG_CONFIG --exists OpenIPMIpthread 2>/dev/null
+if test $? -ne 0; then
+  with_libopenipmipthread="no (pkg-config doesn't know OpenIPMIpthread)"
+fi
+AC_MSG_RESULT([$with_libopenipmipthread])
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	AC_MSG_CHECKING([for libOpenIPMIpthread])
-	$PKG_CONFIG --exists OpenIPMIpthread 2>/dev/null
-	if test "$?" != "0"
-	then
-		with_libopenipmipthread="no (pkg-config doesn't know OpenIPMIpthread)"
-	fi
-	AC_MSG_RESULT([$with_libopenipmipthread])
+if test "x$with_libopenipmipthread" = "xyes"; then
+  AC_MSG_CHECKING([for libOpenIPMIpthread CFLAGS])
+  temp_result="`$PKG_CONFIG --cflags OpenIPMIpthread`"
+  if test $? -eq 0; then
+    with_libopenipmipthread_cflags="$temp_result"
+  else
+    with_libopenipmipthread="no ($PKG_CONFIG --cflags OpenIPMIpthread failed)"
+    temp_result="$PKG_CONFIG --cflags OpenIPMIpthread failed"
+  fi
+  AC_MSG_RESULT([$temp_result])
 fi
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	AC_MSG_CHECKING([for libOpenIPMIpthread CFLAGS])
-	temp_result="`$PKG_CONFIG --cflags OpenIPMIpthread`"
-	if test "$?" = "0"
-	then
-		with_libopenipmipthread_cflags="$temp_result"
-	else
-		with_libopenipmipthread="no ($PKG_CONFIG --cflags OpenIPMIpthread failed)"
-		temp_result="$PKG_CONFIG --cflags OpenIPMIpthread failed"
-	fi
-	AC_MSG_RESULT([$temp_result])
+if test "x$with_libopenipmipthread" = "xyes"; then
+  AC_MSG_CHECKING([for libOpenIPMIpthread LDFLAGS])
+  temp_result="`$PKG_CONFIG --libs OpenIPMIpthread`"
+  if test $? -eq 0; then
+    with_libopenipmipthread_ldflags="$temp_result"
+  else
+    with_libopenipmipthread="no ($PKG_CONFIG --libs OpenIPMIpthread failed)"
+    temp_result="$PKG_CONFIG --libs OpenIPMIpthread failed"
+  fi
+  AC_MSG_RESULT([$temp_result])
 fi
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	AC_MSG_CHECKING([for libOpenIPMIpthread LDFLAGS])
-	temp_result="`$PKG_CONFIG --libs OpenIPMIpthread`"
-	if test "$?" = "0"
-	then
-		with_libopenipmipthread_ldflags="$temp_result"
-	else
-		with_libopenipmipthread="no ($PKG_CONFIG --libs OpenIPMIpthread failed)"
-		temp_result="$PKG_CONFIG --libs OpenIPMIpthread failed"
-	fi
-	AC_MSG_RESULT([$temp_result])
+if test "x$with_libopenipmipthread" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libopenipmipthread_cflags"
+
+  AC_CHECK_HEADERS([OpenIPMI/ipmi_smi.h],
+    [with_libopenipmipthread="yes"],
+    [with_libopenipmipthread="no (OpenIPMI/ipmi_smi.h not found)"],
+    [[
+      #include <OpenIPMI/ipmiif.h>
+      #include <OpenIPMI/ipmi_err.h>
+      #include <OpenIPMI/ipmi_posix.h>
+      #include <OpenIPMI/ipmi_conn.h>
+    ]]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libopenipmipthread_cflags"
-
-	AC_CHECK_HEADERS(OpenIPMI/ipmi_smi.h,
-			 [with_libopenipmipthread="yes"],
-			 [with_libopenipmipthread="no (OpenIPMI/ipmi_smi.h not found)"],
-[#include <OpenIPMI/ipmiif.h>
-#include <OpenIPMI/ipmi_err.h>
-#include <OpenIPMI/ipmi_posix.h>
-#include <OpenIPMI/ipmi_conn.h>
-])
-
-	CPPFLAGS="$SAVE_CPPFLAGS"
+if test "x$with_libopenipmipthread" = "xyes"; then
+  BUILD_WITH_OPENIPMI_CFLAGS="$with_libopenipmipthread_cflags"
+  BUILD_WITH_OPENIPMI_LIBS="$with_libopenipmipthread_ldflags"
 fi
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	BUILD_WITH_OPENIPMI_CFLAGS="$with_libopenipmipthread_cflags"
-	BUILD_WITH_OPENIPMI_LIBS="$with_libopenipmipthread_ldflags"
-	AC_SUBST(BUILD_WITH_OPENIPMI_CFLAGS)
-	AC_SUBST(BUILD_WITH_OPENIPMI_LIBS)
-fi
+AC_SUBST([BUILD_WITH_OPENIPMI_CFLAGS])
+AC_SUBST([BUILD_WITH_OPENIPMI_LIBS])
 # }}}
 
 # --with-libatasmart {{{
-with_libatasmart_cppflags=""
-with_libatasmart_ldflags=""
-AC_ARG_WITH(libatasmart, [AS_HELP_STRING([--with-libatasmart@<:@=PREFIX@:>@], [Path to libatasmart.])],
-[
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		with_libatasmart_cppflags="-I$withval/include"
-		with_libatasmart_ldflags="-L$withval/lib"
-		with_libatasmart="yes"
-	else
-		with_libatasmart="$withval"
-	fi
-],
-[
-	if test "x$ac_system" = "xLinux"
-	then
-		with_libatasmart="yes"
-	else
-		with_libatasmart="no (Linux only library)"
-	fi
-])
-if test "x$with_libatasmart" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libatasmart_cppflags"
+AC_ARG_WITH([libatasmart],
+  [AS_HELP_STRING([--with-libatasmart@<:@=PREFIX@:>@], [Path to libatasmart.])],
+  [
+    if test "x$withval" != "xno" && test "x$withval" != "xyes"; then
+      with_libatasmart_cppflags="-I$withval/include"
+      with_libatasmart_ldflags="-L$withval/lib"
+      with_libatasmart="yes"
+    else
+      with_libatasmart="$withval"
+    fi
+  ],
+  [
+    if test "x$ac_system" = "xLinux"; then
+      with_libatasmart="yes"
+    else
+      with_libatasmart="no (Linux only library)"
+    fi
+  ]
+)
 
-	AC_CHECK_HEADERS(atasmart.h, [with_libatasmart="yes"], [with_libatasmart="no (atasmart.h not found)"])
+if test "x$with_libatasmart" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libatasmart_cppflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
+  AC_CHECK_HEADERS([atasmart.h],
+    [with_libatasmart="yes"],
+    [with_libatasmart="no (atasmart.h not found)"])
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
-if test "x$with_libatasmart" = "xyes"
-then
-	SAVE_CPPFLAGS="$CPPFLAGS"
-	SAVE_LDFLAGS="$LDFLAGS"
-	CPPFLAGS="$CPPFLAGS $with_libatasmart_cppflags"
-	LDFLAGS="$LDFLAGS $with_libatasmart_ldflags"
 
-	AC_CHECK_LIB(atasmart, sk_disk_open, [with_libatasmart="yes"], [with_libatasmart="no (Symbol 'sk_disk_open' not found)"])
+if test "x$with_libatasmart" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libatasmart_ldflags"
 
-	CPPFLAGS="$SAVE_CPPFLAGS"
-	LDFLAGS="$SAVE_LDFLAGS"
+  AC_CHECK_LIB([atasmart], [sk_disk_open],
+    [with_libatasmart="yes"],
+    [with_libatasmart="no (Symbol 'sk_disk_open' not found)"]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
 fi
-if test "x$with_libatasmart" = "xyes"
-then
-	BUILD_WITH_LIBATASMART_CPPFLAGS="$with_libatasmart_cppflags"
-	BUILD_WITH_LIBATASMART_LDFLAGS="$with_libatasmart_ldflags"
-	BUILD_WITH_LIBATASMART_LIBS="-latasmart"
-	AC_SUBST(BUILD_WITH_LIBATASMART_CPPFLAGS)
-	AC_SUBST(BUILD_WITH_LIBATASMART_LDFLAGS)
-	AC_SUBST(BUILD_WITH_LIBATASMART_LIBS)
-	AC_DEFINE(HAVE_LIBATASMART, 1, [Define if libatasmart is present and usable.])
+
+if test "x$with_libatasmart" = "xyes"; then
+  BUILD_WITH_LIBATASMART_CPPFLAGS="$with_libatasmart_cppflags"
+  BUILD_WITH_LIBATASMART_LDFLAGS="$with_libatasmart_ldflags"
+  BUILD_WITH_LIBATASMART_LIBS="-latasmart"
 fi
-AM_CONDITIONAL(BUILD_WITH_LIBATASMART, test "x$with_libatasmart" = "xyes")
+
+AC_SUBST([BUILD_WITH_LIBATASMART_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBATASMART_LDFLAGS])
+AC_SUBST([BUILD_WITH_LIBATASMART_LIBS])
 # }}}
 
 PKG_CHECK_MODULES([LIBNOTIFY], [libnotify],
-		[with_libnotify="yes"],
-		[with_libnotify="no (pkg-config doesn't know libnotify)"]
+  [with_libnotify="yes"],
+  [with_libnotify="no (pkg-config doesn't know libnotify)"]
 )
 
 PKG_CHECK_MODULES([LIBRIEMANN_CLIENT], [riemann-client >= 1.6.0],
  [with_libriemann_client="yes"],
- [with_libriemann_client="no (pkg-config doesn't know libriemann-client)"])
+ [with_libriemann_client="no (pkg-config doesn't know libriemann-client)"]
+)
 
 # Check for enabled/disabled features
 #
@@ -5771,61 +5771,59 @@ PKG_CHECK_MODULES([LIBRIEMANN_CLIENT], [riemann-client >= 1.6.0],
 # AC_COLLECTD(name, enable/disable, info-text, feature/module)
 # ------------------------------------------------------------
 dnl
-m4_define([my_toupper], [m4_translit([$1], m4_defn([m4_cr_letters]), m4_defn([m4_cr_LETTERS]))])
+m4_define([my_toupper],[m4_translit([$1], m4_defn([m4_cr_letters]), m4_defn([m4_cr_LETTERS]))])
 dnl
 AC_DEFUN(
-	[AC_COLLECTD],
-	[
-	m4_if([$1], [], [AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 1st argument must not be empty])])dnl
-	m4_if(
-		[$2],
-		[enable],
-		[dnl
-		m4_define([EnDis],[disabled])dnl
-		m4_define([YesNo],[no])dnl
-		],dnl
-		[m4_if(
-			[$2],
-			[disable],
-			[dnl
-			m4_define([EnDis],[enabled])dnl
-			m4_define([YesNo],[yes])dnl
-			],
-			[dnl
-			AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 2nd argument must be either enable or disable])dnl
-			]dnl
-		)]dnl
-	)dnl
-	m4_if([$3], [feature], [],
-		[m4_if(
-			[$3], [module], [],
-			[dnl
-			AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 3rd argument must be either feature or disable])dnl
-			]dnl
-		)]dnl
-	)dnl
-	AC_ARG_ENABLE(
-		[$1],
-		AS_HELP_STRING([--$2-$1], [$2 $4 (EnDis by def)]),
-		[],
-		enable_$1='[YesNo]'dnl
-	)# AC_ARG_ENABLE
-if test "x$enable_$1" = "xno"
-then
-	collectd_$1=0
-else
-	if test "x$enable_$1" = "xyes"
-	then
-		collectd_$1=1
-	else
-		AC_MSG_NOTICE([please specify either --enable-$1 or --disable-$1; enabling $1.])
-		collectd_$1=1
-		enable_$1='yes'
-	fi
-fi
-	AC_DEFINE_UNQUOTED([COLLECT_]my_toupper([$1]), [$collectd_$1], [wether or not to enable $3 $4])
-	AM_CONDITIONAL([BUILD_]my_toupper([$3])[_]my_toupper([$1]), [test "x$enable_$1" = "xyes"])dnl
-	]dnl
+  [AC_COLLECTD],
+  [
+  m4_if([$1], [], [AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 1st argument must not be empty])])dnl
+  m4_if(
+    [$2],
+    [enable],
+    [dnl
+    m4_define([EnDis],[disabled])dnl
+    m4_define([YesNo],[no])dnl
+    ],dnl
+    [m4_if(
+      [$2],
+      [disable],
+      [dnl
+      m4_define([EnDis],[enabled])dnl
+      m4_define([YesNo],[yes])dnl
+      ],
+      [dnl
+      AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 2nd argument must be either enable or disable])dnl
+      ]dnl
+    )]dnl
+  )dnl
+  m4_if([$3], [feature], [],
+    [m4_if(
+      [$3], [module], [],
+      [dnl
+      AC_FATAL([AC_COLLECTD([$1], [$2], [$3], [$4]): 3rd argument must be either feature or disable])dnl
+      ]dnl
+    )]dnl
+  )dnl
+  AC_ARG_ENABLE(
+    [$1],
+    AS_HELP_STRING([--$2-$1], [$2 $4 (EnDis by def)]),
+    [],
+    enable_$1='[YesNo]'dnl
+  )# AC_ARG_ENABLE
+  if test "x$enable_$1" = "xno"; then
+    collectd_$1=0
+  else
+    if test "x$enable_$1" = "xyes"; then
+      collectd_$1=1
+    else
+      AC_MSG_NOTICE([please specify either --enable-$1 or --disable-$1; enabling $1.])
+      collectd_$1=1
+      enable_$1='yes'
+    fi
+  fi
+  AC_DEFINE_UNQUOTED([COLLECT_]my_toupper([$1]), [$collectd_$1], [whether or not to enable $3 $4])
+  AM_CONDITIONAL([BUILD_]my_toupper([$3])[_]my_toupper([$1]), [test "x$enable_$1" = "xyes"])dnl
+  ]dnl
 )# AC_COLLECTD(name, enable/disable, info-text, feature/module)
 
 # AC_PLUGIN(name, default, info)
@@ -5836,47 +5834,42 @@ AC_DEFUN(
   [
     enable_plugin="no"
     force="no"
-    AC_ARG_ENABLE([$1], AS_HELP_STRING([--enable-$1],[$3]),
-    [
-     if test "x$enableval" = "xyes"
-     then
-	     enable_plugin="yes"
-     else if test "x$enableval" = "xforce"
-     then
-	     enable_plugin="yes"
-	     force="yes"
-     else
-	     enable_plugin="no (disabled on command line)"
-     fi; fi
-    ],
-    [
-	 if test "x$enable_all_plugins" = "xauto"
-	 then
-	     if test "x$2" = "xyes"
-	     then
-		     enable_plugin="yes"
-	     else
-		     enable_plugin="$2"
-	     fi
-	 else
-	     enable_plugin="$enable_all_plugins"
-	 fi
-    ])
-    if test "x$enable_plugin" = "xyes"
-    then
-	    if test "x$2" = "xyes" || test "x$force" = "xyes"
-	    then
-		    AC_DEFINE([HAVE_PLUGIN_]my_toupper([$1]), 1, [Define to 1 if the $1 plugin is enabled.])
-		    if test "x$2" != "xyes"
-		    then
-			    dependency_warning="yes"
-		    fi
-	    else # User passed "yes" but dependency checking yielded "no" => Dependency problem.
-		    dependency_error="yes"
-		    enable_plugin="$2 (dependency error)"
-	    fi
+    AC_ARG_ENABLE([$1],
+      [AS_HELP_STRING([--enable-$1],[$3])],
+      [
+        if test "x$enableval" = "xyes"; then
+          enable_plugin="yes"
+        else if test "x$enableval" = "xforce"; then
+          enable_plugin="yes"
+          force="yes"
+        else
+          enable_plugin="no (disabled on command line)"
+        fi; fi
+      ],
+      [
+        if test "x$enable_all_plugins" = "xauto"; then
+          if test "x$2" = "xyes"; then
+            enable_plugin="yes"
+          else
+            enable_plugin="$2"
+          fi
+        else
+          enable_plugin="$enable_all_plugins"
+        fi
+      ]
+    )
+    if test "x$enable_plugin" = "xyes"; then
+      if test "x$2" = "xyes" || test "x$force" = "xyes"; then
+        AC_DEFINE([HAVE_PLUGIN_]my_toupper([$1]), 1, [Define to 1 if the $1 plugin is enabled.])
+        if test "x$2" != "xyes"; then
+          dependency_warning="yes"
+        fi
+      else # User passed "yes" but dependency checking yielded "no" => Dependency problem.
+        dependency_error="yes"
+        enable_plugin="$2 (dependency error)"
+      fi
     fi
-    AM_CONDITIONAL([BUILD_PLUGIN_]my_toupper([$1]), test "x$enable_plugin" = "xyes")
+    AM_CONDITIONAL([BUILD_PLUGIN_]my_toupper([$1]), [test "x$enable_plugin" = "xyes"])
     enable_$1="$enable_plugin"
   ]
 )# AC_PLUGIN(name, default, info)
@@ -5918,6 +5911,7 @@ plugin_grpc="no"
 plugin_hugepages="no"
 plugin_intel_rdt="no"
 plugin_interface="no"
+plugin_ipc="no"
 plugin_ipmi="no"
 plugin_ipvs="no"
 plugin_irq="no"
@@ -5953,369 +5947,297 @@ plugin_zone="no"
 plugin_zookeeper="no"
 
 # Linux
-if test "x$ac_system" = "xLinux"
-then
-	plugin_battery="yes"
-	plugin_cgroups="yes"
-	plugin_conntrack="yes"
-	plugin_contextswitch="yes"
-	plugin_cpu="yes"
-	plugin_cpufreq="yes"
-	plugin_disk="yes"
-	plugin_drbd="yes"
-	plugin_entropy="yes"
-	plugin_fhcount="yes"
-	plugin_fscache="yes"
-	plugin_hugepages="yes"
-	plugin_interface="yes"
-	plugin_ipc="yes"
-	plugin_irq="yes"
-	plugin_load="yes"
-	plugin_lvm="yes"
-	plugin_memory="yes"
-	plugin_nfs="yes"
-	plugin_numa="yes"
-	plugin_processes="yes"
-	plugin_protocols="yes"
-	plugin_serial="yes"
-	plugin_swap="yes"
-	plugin_tcpconns="yes"
-	plugin_thermal="yes"
-	plugin_uptime="yes"
-	plugin_vmem="yes"
-	plugin_vserver="yes"
-	plugin_wireless="yes"
-	plugin_zfs_arc="yes"
+if test "x$ac_system" = "xLinux"; then
+  plugin_battery="yes"
+  plugin_cgroups="yes"
+  plugin_conntrack="yes"
+  plugin_contextswitch="yes"
+  plugin_cpu="yes"
+  plugin_cpufreq="yes"
+  plugin_disk="yes"
+  plugin_drbd="yes"
+  plugin_entropy="yes"
+  plugin_fhcount="yes"
+  plugin_fscache="yes"
+  plugin_hugepages="yes"
+  plugin_interface="yes"
+  plugin_ipc="yes"
+  plugin_irq="yes"
+  plugin_load="yes"
+  plugin_lvm="yes"
+  plugin_memory="yes"
+  plugin_nfs="yes"
+  plugin_numa="yes"
+  plugin_processes="yes"
+  plugin_protocols="yes"
+  plugin_serial="yes"
+  plugin_swap="yes"
+  plugin_tcpconns="yes"
+  plugin_thermal="yes"
+  plugin_uptime="yes"
+  plugin_vmem="yes"
+  plugin_vserver="yes"
+  plugin_wireless="yes"
+  plugin_zfs_arc="yes"
 
-	if test "x$have_linux_ip_vs_h" = "xyes" || test "x$have_net_ip_vs_h" = "xyes" || test "x$have_ip_vs_h" = "xyes"
-	then
-		plugin_ipvs="yes"
-	fi
-	if test "x$c_cv_have_usable_asm_msrindex_h" = "xyes" && test "x$have_cpuid_h" = "xyes"
-	then
-		plugin_turbostat="yes"
-	fi
-	
-	if test "x$c_cv_have_clock_boottime_monotonic" = "xyes"
-	then
-		plugin_cpusleep="yes"
-	fi
+  if test "x$have_linux_ip_vs_h" = "xyes" || test "x$have_net_ip_vs_h" = "xyes" || test "x$have_ip_vs_h" = "xyes"; then
+    plugin_ipvs="yes"
+  fi
+
+  if test "x$c_cv_have_usable_asm_msrindex_h" = "xyes" && test "x$have_cpuid_h" = "xyes" && test "x$have_capability" = "xyes"; then
+    plugin_turbostat="yes"
+  fi
+  
+  if test "x$c_cv_have_clock_boottime_monotonic" = "xyes"; then
+    plugin_cpusleep="yes"
+  fi
 fi
 
-if test "x$ac_system" = "xOpenBSD"
-then
-	plugin_tcpconns="yes"
+if test "x$ac_system" = "xOpenBSD"; then
+  plugin_tcpconns="yes"
 fi
 
-if test "x$ac_system" = "xNetBSD"
-then
-	plugin_disk="yes"
-	plugin_entropy="yes"
-	plugin_irq="yes"
-	plugin_processes="yes"
+if test "x$ac_system" = "xNetBSD"; then
+  plugin_disk="yes"
+  plugin_entropy="yes"
+  plugin_irq="yes"
+  plugin_processes="yes"
 fi
 
 # Mac OS X devices
-if test "x$with_libiokit" = "xyes"
-then
-	plugin_battery="yes"
-	plugin_disk="yes"
+if test "x$with_libiokit" = "xyes"; then
+  plugin_battery="yes"
+  plugin_disk="yes"
 fi
 
 # AIX
 
-if test "x$ac_system" = "xAIX"
-then
-	plugin_ipc="yes"
-	plugin_tcpconns="yes"
+if test "x$ac_system" = "xAIX"; then
+  plugin_ipc="yes"
+  plugin_tcpconns="yes"
 fi
 
 # FreeBSD
 
-if test "x$ac_system" = "xFreeBSD"
-then
-	plugin_disk="yes"
-	plugin_zfs_arc="yes"
+if test "x$ac_system" = "xFreeBSD"; then
+  plugin_disk="yes"
+  plugin_zfs_arc="yes"
 fi
 
 
-if test "x$with_perfstat" = "xyes"
-then
-	plugin_contextswitch="yes"
-	plugin_cpu="yes"
-	plugin_disk="yes"
-	plugin_interface="yes"
-	plugin_load="yes"
-	plugin_memory="yes"
-	plugin_swap="yes"
-	plugin_uptime="yes"
+if test "x$with_perfstat" = "xyes"; then
+  plugin_contextswitch="yes"
+  plugin_cpu="yes"
+  plugin_disk="yes"
+  plugin_interface="yes"
+  plugin_load="yes"
+  plugin_memory="yes"
+  plugin_swap="yes"
+  plugin_uptime="yes"
 fi
 
-if test "x$with_procinfo" = "xyes"
-then
-	plugin_processes="yes"
+if test "x$with_procinfo" = "xyes"; then
+  plugin_processes="yes"
 fi
 
 # Solaris
-if test "x$with_kstat" = "xyes"
-then
-	plugin_nfs="yes"
-	plugin_processes="yes"
-	plugin_uptime="yes"
-	plugin_zfs_arc="yes"
-	plugin_zone="yes"
+if test "x$with_kstat" = "xyes"; then
+  plugin_nfs="yes"
+  plugin_processes="yes"
+  plugin_uptime="yes"
+  plugin_zfs_arc="yes"
+  plugin_zone="yes"
 fi
 
-if test "x$with_devinfo$with_kstat" = "xyesyes"
-then
-	plugin_cpu="yes"
-	plugin_disk="yes"
-	plugin_interface="yes"
-	plugin_memory="yes"
-	plugin_tape="yes"
+if test "x$with_devinfo" = "xyes" && test "x$with_kstat" = "xyes"; then
+  plugin_cpu="yes"
+  plugin_disk="yes"
+  plugin_interface="yes"
+  plugin_memory="yes"
+  plugin_tape="yes"
 fi
 
-# libi2c-dev
-if test "x$ac_system" = "xLinux"
-then
-AC_CHECK_DECL(i2c_smbus_read_i2c_block_data,
-	[with_libi2c="yes"],
-	[with_libi2c="no (symbol i2c_smbus_read_i2c_block_data not found - have you installed libi2c-dev ?)"],
-	[[#include <stdlib.h>
-	#include <linux/i2c-dev.h>]])
-else
-	with_libi2c="no (Linux only)"
-fi
-
-if test "x$with_libi2c" = "xyes"
-then
-	plugin_barometer="yes"
+if test "x$with_libi2c" = "xyes"; then
+  plugin_barometer="yes"
 fi
 
 
 # libstatgrab
-if test "x$with_libstatgrab" = "xyes"
-then
-	plugin_cpu="yes"
-	plugin_disk="yes"
-	plugin_interface="yes"
-	plugin_load="yes"
-	plugin_memory="yes"
-	plugin_swap="yes"
-	plugin_users="yes"
+if test "x$with_libstatgrab" = "xyes"; then
+  plugin_cpu="yes"
+  plugin_disk="yes"
+  plugin_interface="yes"
+  plugin_load="yes"
+  plugin_memory="yes"
+  plugin_swap="yes"
+  plugin_users="yes"
 fi
 
-if test "x$with_libcurl" = "xyes" && test "x$with_libxml2" = "xyes"
-then
-	plugin_ascent="yes"
-	if test "x$have_strptime" = "xyes"
-	then
-		plugin_bind="yes"
-	fi
+if test "x$with_libcurl" = "xyes" && test "x$with_libxml2" = "xyes"; then
+  plugin_ascent="yes"
+  if test "x$have_strptime" = "xyes"; then
+    plugin_bind="yes"
+  fi
 fi
 
-if test "x$with_libopenipmipthread" = "xyes"
-then
-	plugin_ipmi="yes"
+if test "x$with_libopenipmipthread" = "xyes"; then
+  plugin_ipmi="yes"
 fi
 
-if test "x$with_libcurl" = "xyes" && test "x$with_libyajl" = "xyes"
-then
-	plugin_curl_json="yes"
+if test "x$with_libcurl" = "xyes" && test "x$with_libyajl" = "xyes"; then
+  plugin_curl_json="yes"
 fi
 
-if test "x$with_libcurl" = "xyes" && test "x$with_libxml2" = "xyes"
-then
-	plugin_curl_xml="yes"
+if test "x$with_libcurl" = "xyes" && test "x$with_libxml2" = "xyes"; then
+  plugin_curl_xml="yes"
 fi
 
-if test "x$with_libyajl" = "xyes"
-then
-	plugin_ceph="yes"
+if test "x$with_libyajl" = "xyes"; then
+  plugin_ceph="yes"
 fi
 
-if test "x$have_processor_info" = "xyes"
-then
-	plugin_cpu="yes"
-fi
-if test "x$have_sysctl" = "xyes"
-then
-	plugin_cpu="yes"
-	plugin_memory="yes"
-	plugin_uptime="yes"
-	if test "x$ac_system" = "xDarwin"
-	then
-		plugin_swap="yes"
-	fi
-fi
-if test "x$have_sysctlbyname" = "xyes"
-then
-	plugin_contextswitch="yes"
-	plugin_cpu="yes"
-	plugin_memory="yes"
-	plugin_tcpconns="yes"
+if test "x$have_processor_info" = "xyes"; then
+  plugin_cpu="yes"
 fi
 
-# Df plugin: Check if we know how to determine mount points first.
-#if test "x$have_listmntent" = "xyes"; then
-#	plugin_df="yes"
-#fi
-if test "x$have_getvfsstat" = "xyes" || test "x$have_getfsstat" = "xyes"
-then
-	plugin_df="yes"
+if test "x$have_sysctl" = "xyes"; then
+  plugin_cpu="yes"
+  plugin_memory="yes"
+  plugin_uptime="yes"
+  if test "x$ac_system" = "xDarwin"; then
+    plugin_swap="yes"
+  fi
 fi
-if test "x$c_cv_have_two_getmntent" = "xyes" || test "x$have_getmntent" = "xgen" || test "x$have_getmntent" = "xsun"
-then
-	plugin_df="yes"
-fi
-#if test "x$have_getmntent" = "xseq"
-#then
-#	plugin_df="yes"
-#fi
-if test "x$c_cv_have_one_getmntent" = "xyes"
-then
-	plugin_df="yes"
+if test "x$have_sysctlbyname" = "xyes"; then
+  plugin_contextswitch="yes"
+  plugin_cpu="yes"
+  plugin_memory="yes"
+  plugin_tcpconns="yes"
 fi
 
-if test "x$c_cv_have_getmntent_r" = "xyes"
-then
-	plugin_df="yes"
+if test "x$have_getvfsstat" = "xyes" || test "x$have_getfsstat" = "xyes"; then
+  plugin_df="yes"
 fi
 
-# Df plugin: Check if we have either `statfs' or `statvfs' second.
-if test "x$plugin_df" = "xyes"
-then
-	plugin_df="no"
-	if test "x$have_statfs" = "xyes"
-	then
-		plugin_df="yes"
-	fi
-	if test "x$have_statvfs" = "xyes"
-	then
-		plugin_df="yes"
-	fi
+if test "x$c_cv_have_two_getmntent" = "xyes" || test "x$have_getmntent" = "xgen" || test "x$have_getmntent" = "xsun"; then
+  plugin_df="yes"
 fi
 
-if test "x$have_linux_sockios_h$have_linux_ethtool_h" = "xyesyes"
-then
-	plugin_ethstat="yes"
+if test "x$c_cv_have_one_getmntent" = "xyes"; then
+  plugin_df="yes"
 fi
 
-if test "x$with_libgrpcpp" = "xyes" && test "x$with_libprotobuf" = "xyes" && test "x$have_protoc3" = "xyes" && test "x$GRPC_CPP_PLUGIN" != "x"
-then
-	plugin_grpc="yes"
+if test "x$c_cv_have_getmntent_r" = "xyes"; then
+  plugin_df="yes"
 fi
 
-if test "x$have_getifaddrs" = "xyes"
-then
-	plugin_interface="yes"
+if test "x$plugin_df" = "xyes"; then
+  plugin_df="no"
+  if test "x$have_statfs" = "xyes"; then
+    plugin_df="yes"
+  fi
+
+  if test "x$have_statvfs" = "xyes"; then
+    plugin_df="yes"
+  fi
 fi
 
-if test "x$with_libgps" = "xyes"
-then
-	plugin_gps="yes"
+if test "x$have_linux_sockios_h" = "xyes" && test "x$have_linux_ethtool_h" = "xyes"; then
+  plugin_ethstat="yes"
 fi
 
-if test "x$have_getloadavg" = "xyes"
-then
-	plugin_load="yes"
+if test "x$with_libgps" = "xyes"; then
+  plugin_gps="yes"
 fi
 
-if test "x$with_libyajl" = "xyes"
-then
-	plugin_log_logstash="yes"
+if test "x$with_libgrpcpp" = "xyes" && test "x$with_libprotobuf" = "xyes" && test "x$have_protoc3" = "xyes" && test "x$GRPC_CPP_PLUGIN" != "x"; then
+  plugin_grpc="yes"
 fi
 
-if test "x$c_cv_have_libperl$c_cv_have_perl_ithreads" = "xyesyes"
-then
-	plugin_perl="yes"
+if test "x$have_getifaddrs" = "xyes"; then
+  plugin_interface="yes"
 fi
 
-if test "x$have_protoc_c" = "xyes" && test "x$with_libprotobuf_c" = "xyes"
-then
-	plugin_pinba="yes"
-	if test "x$with_libmicrohttpd" = "xyes"
-	then
-		plugin_write_prometheus="yes"
-	fi
+if test "x$have_getloadavg" = "xyes"; then
+  plugin_load="yes"
+fi
+
+if test "x$with_libyajl" = "xyes"; then
+  plugin_log_logstash="yes"
+fi
+
+if test "x$with_libperl" = "xyes" && test "x$c_cv_have_perl_ithreads" = "xyes"; then
+  plugin_perl="yes"
+fi
+
+if test "x$have_protoc_c" = "xyes" && test "x$with_libprotobuf_c" = "xyes"; then
+  plugin_pinba="yes"
+  if test "x$with_libmicrohttpd" = "xyes"; then
+    plugin_write_prometheus="yes"
+  fi
 fi
 
 # Mac OS X memory interface
-if test "x$have_host_statistics" = "xyes"
-then
-	plugin_memory="yes"
+if test "x$have_host_statistics" = "xyes"; then
+  plugin_memory="yes"
 fi
 
-if test "x$have_termios_h" = "xyes"
-then
-	if test "x$ac_system" != "xAIX"
-	then
-		plugin_multimeter="yes"
-	fi
-	plugin_ted="yes"
+if test "x$have_termios_h" = "xyes"; then
+  if test "x$ac_system" != "xAIX"; then
+    plugin_multimeter="yes"
+  fi
+  plugin_ted="yes"
 fi
 
-if test "x$have_thread_info" = "xyes"
-then
-	plugin_processes="yes"
+if test "x$have_thread_info" = "xyes"; then
+  plugin_processes="yes"
 fi
 
-if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_freebsd" = "xyes"
-then
-	plugin_processes="yes"
+if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_freebsd" = "xyes"; then
+  plugin_processes="yes"
 fi
 
-if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_openbsd" = "xyes"
-then
-	plugin_processes="yes"
+if test "x$with_kvm_getprocs" = "xyes" && test "x$have_struct_kinfo_proc_openbsd" = "xyes"; then
+  plugin_processes="yes"
 fi
 
-if test "x$with_libpython" != "xno"
-then
-	plugin_python="yes"
+if test "x$with_libpython" != "xno"; then
+  plugin_python="yes"
 fi
 
-if test "x$with_libatasmart" = "xyes" && test "x$with_libudev" = "xyes"
-then
-	plugin_smart="yes"
+if test "x$with_libatasmart" = "xyes" && test "x$with_libudev" = "xyes"; then
+  plugin_smart="yes"
 fi
 
-if test "x$with_kvm_getswapinfo" = "xyes"
-then
-	plugin_swap="yes"
+if test "x$with_kvm_getswapinfo" = "xyes"; then
+  plugin_swap="yes"
 fi
 
-if test "x$have_swapctl" = "xyes" && test "x$c_cv_have_swapctl_two_args" = "xyes"
-then
-	plugin_swap="yes"
+if test "x$have_swapctl" = "xyes" && test "x$c_cv_have_swapctl_two_args" = "xyes"; then
+  plugin_swap="yes"
 fi
 
-if test "x$have_swapctl" = "xyes" && test "x$c_cv_have_swapctl_three_args" = "xyes"
-then
-	plugin_swap="yes"
+if test "x$have_swapctl" = "xyes" && test "x$c_cv_have_swapctl_three_args" = "xyes"; then
+  plugin_swap="yes"
 fi
 
-if test "x$with_kvm_openfiles$with_kvm_nlist" = "xyesyes"
-then
-	plugin_tcpconns="yes"
+if test "x$with_kvm_openfiles = "xyes" && $with_kvm_nlist" = "xyes"; then
+  plugin_tcpconns="yes"
 fi
 
-if test "x$have_getutent" = "xyes"
-then
-	plugin_users="yes"
-fi
-if test "x$have_getutxent" = "xyes"
-then
-	plugin_users="yes"
+if test "x$have_getutent" = "xyes"; then
+  plugin_users="yes"
 fi
 
-if test "x$with_libxml2" = "xyes" && test "x$with_libvirt" = "xyes"
-then
-	plugin_virt="yes"
+if test "x$have_getutxent" = "xyes"; then
+  plugin_users="yes"
 fi
 
-if test "x$with_libxenctrl" = "xyes"
-then
+if test "x$with_libxml2" = "xyes" && test "x$with_libvirt" = "xyes"; then
+  plugin_virt="yes"
+fi
+
+if test "x$with_libxenctrl" = "xyes"; then
   plugin_xencpu="yes"
 fi
 
@@ -6328,19 +6250,18 @@ m4_divert_once([HELP_ENABLE], [
 collectd plugins:])
 
 AC_ARG_ENABLE([all-plugins],
-		AS_HELP_STRING([--enable-all-plugins],[enable all plugins (auto by def)]),
-		[
-		 if test "x$enableval" = "xyes"
-		 then
-			 enable_all_plugins="yes"
-		 else if test "x$enableval" = "xauto"
-		 then
-			 enable_all_plugins="auto"
-		 else
-			 enable_all_plugins="no"
-		 fi; fi
-		],
-		[enable_all_plugins="auto"])
+  [AS_HELP_STRING([--enable-all-plugins], [enable all plugins @<:@default=yes@:>@])],
+  [
+     if test "x$enableval" = "xyes"; then
+       enable_all_plugins="yes"
+     else if test "x$enableval" = "xauto"; then
+       enable_all_plugins="auto"
+     else
+       enable_all_plugins="no"
+     fi; fi
+  ],
+  [enable_all_plugins="auto"]
+)
 
 m4_divert_once([HELP_ENABLE], [])
 
@@ -6501,45 +6422,41 @@ LOAD_PLUGIN_LOG_LOGSTASH=""
 
 AC_MSG_CHECKING([which default log plugin to load])
 default_log_plugin="none"
-if test "x$enable_syslog" = "xyes"
-then
-	default_log_plugin="syslog"
+if test "x$enable_syslog" = "xyes"; then
+  default_log_plugin="syslog"
 else
-	LOAD_PLUGIN_SYSLOG="##"
+  LOAD_PLUGIN_SYSLOG="##"
 fi
 
-if test "x$enable_logfile" = "xyes"
-then
-	if test "x$default_log_plugin" = "xnone"
-	then
-		default_log_plugin="logfile"
-	else
-		LOAD_PLUGIN_LOGFILE="#"
-	fi
+if test "x$enable_logfile" = "xyes"; then
+  if test "x$default_log_plugin" = "xnone"; then
+    default_log_plugin="logfile"
+  else
+    LOAD_PLUGIN_LOGFILE="#"
+  fi
 else
-	LOAD_PLUGIN_LOGFILE="##"
+  LOAD_PLUGIN_LOGFILE="##"
 fi
 
-if test "x$enable_log_logstash" = "xyes"
-then
+if test "x$enable_log_logstash" = "xyes"; then
   LOAD_PLUGIN_LOG_LOGSTASH="#"
 else
   LOAD_PLUGIN_LOG_LOGSTASH="##"
 fi
 
-
 AC_MSG_RESULT([$default_log_plugin])
 
-AC_SUBST(LOAD_PLUGIN_SYSLOG)
-AC_SUBST(LOAD_PLUGIN_LOGFILE)
-AC_SUBST(LOAD_PLUGIN_LOG_LOGSTASH)
+AC_SUBST([LOAD_PLUGIN_SYSLOG])
+AC_SUBST([LOAD_PLUGIN_LOGFILE])
+AC_SUBST([LOAD_PLUGIN_LOG_LOGSTASH])
 
-DEFAULT_LOG_LEVEL="info"
 if test "x$enable_debug" = "xyes"
 then
-	DEFAULT_LOG_LEVEL="debug"
+  DEFAULT_LOG_LEVEL="debug"
+else
+  DEFAULT_LOG_LEVEL="info"
 fi
-AC_SUBST(DEFAULT_LOG_LEVEL)
+AC_SUBST([DEFAULT_LOG_LEVEL])
 
 # Load only one of rrdtool, network, csv in the default config.
 LOAD_PLUGIN_RRDTOOL=""
@@ -6548,73 +6465,65 @@ LOAD_PLUGIN_CSV=""
 
 AC_MSG_CHECKING([which default write plugin to load])
 default_write_plugin="none"
-if test "x$enable_rrdtool" = "xyes"
-then
-	default_write_plugin="rrdtool"
+if test "x$enable_rrdtool" = "xyes"; then
+  default_write_plugin="rrdtool"
 else
-	LOAD_PLUGIN_RRDTOOL="##"
+  LOAD_PLUGIN_RRDTOOL="##"
 fi
 
-if test "x$enable_network" = "xyes"
-then
-	if test "x$default_write_plugin" = "xnone"
-	then
-		default_write_plugin="network"
-	else
-		LOAD_PLUGIN_NETWORK="#"
-	fi
+if test "x$enable_network" = "xyes"; then
+  if test "x$default_write_plugin" = "xnone"; then
+    default_write_plugin="network"
+  else
+    LOAD_PLUGIN_NETWORK="#"
+  fi
 else
-	LOAD_PLUGIN_NETWORK="##"
+  LOAD_PLUGIN_NETWORK="##"
 fi
 
-if test "x$enable_csv" = "xyes"
-then
-	if test "x$default_write_plugin" = "xnone"
-	then
-		default_write_plugin="csv"
-	else
-		LOAD_PLUGIN_CSV="#"
-	fi
+if test "x$enable_csv" = "xyes"; then
+  if test "x$default_write_plugin" = "xnone"; then
+    default_write_plugin="csv"
+  else
+    LOAD_PLUGIN_CSV="#"
+  fi
 else
-	LOAD_PLUGIN_CSV="##"
+  LOAD_PLUGIN_CSV="##"
 fi
 AC_MSG_RESULT([$default_write_plugin])
 
-AC_SUBST(LOAD_PLUGIN_RRDTOOL)
-AC_SUBST(LOAD_PLUGIN_NETWORK)
-AC_SUBST(LOAD_PLUGIN_CSV)
+AC_SUBST([LOAD_PLUGIN_RRDTOOL])
+AC_SUBST([LOAD_PLUGIN_NETWORK])
+AC_SUBST([LOAD_PLUGIN_CSV])
 
 dnl ip_vs.h
-if test "x$ac_system" = "xLinux" \
-	&& test "x$have_linux_ip_vs_h$have_net_ip_vs_h$have_ip_vs_h" = "xnonono"
-then
-	enable_ipvs="$enable_ipvs (ip_vs.h not found)"
+if test "x$ac_system" = "xLinux" && test "x$have_linux_ip_vs_h" = "xno" && "x$have_net_ip_vs_h" = "xno" && "x$have_ip_vs_h" = "xno"; then
+  enable_ipvs="$enable_ipvs (ip_vs.h not found)"
 fi
 
-if test "x$ip_vs_h_needs_kernel_cflags" = "xyes"
-then
-	enable_ipvs="$enable_ipvs (needs $KERNEL_CFLAGS)"
+if test "x$ip_vs_h_needs_kernel_cflags" = "xyes"; then
+  enable_ipvs="$enable_ipvs (needs $KERNEL_CFLAGS)"
 fi
 
 dnl Perl bindings
 PERL_BINDINGS_OPTIONS="PREFIX=${prefix}"
 AC_ARG_WITH(perl-bindings, [AS_HELP_STRING([--with-perl-bindings@<:@=OPTIONS@:>@], [Options passed to "perl Makefile.PL".])],
 [
-	if test "x$withval" != "xno" && test "x$withval" != "xyes"
-	then
-		PERL_BINDINGS_OPTIONS="$withval"
-		with_perl_bindings="yes"
-	else
-		with_perl_bindings="$withval"
-	fi
+  if test "x$withval" != "xno" && test "x$withval" != "xyes"
+  then
+    PERL_BINDINGS_OPTIONS="$withval"
+    with_perl_bindings="yes"
+  else
+    with_perl_bindings="$withval"
+  fi
 ],
 [
-	if test -n "$perl_interpreter"
-	then
-		with_perl_bindings="yes"
-	else
-		with_perl_bindings="no (no perl interpreter found)"
-	fi
+  if test "x$PERL" != "x"
+  then
+    with_perl_bindings="yes"
+  else
+    with_perl_bindings="no (no perl interpreter found)"
+  fi
 ])
 
 if test "x$with_perl_bindings" = "xyes"
@@ -6630,12 +6539,13 @@ fi
 
 if test "x$with_perl_bindings" = "xyes"
 then
-	PERL_BINDINGS="perl"
+  PERL_BINDINGS="perl"
 else
-	PERL_BINDINGS=""
+  PERL_BINDINGS=""
 fi
-AC_SUBST(PERL_BINDINGS)
-AC_SUBST(PERL_BINDINGS_OPTIONS)
+
+AC_SUBST([PERL_BINDINGS])
+AC_SUBST([PERL_BINDINGS_OPTIONS])
 
 dnl libcollectdclient
 LCC_VERSION_MAJOR=`echo $PACKAGE_VERSION | cut -d'.' -f1`
@@ -6646,49 +6556,55 @@ LCC_VERSION_EXTRA=`echo $PACKAGE_VERSION | cut -d'.' -f4-`
 
 LCC_VERSION_STRING="$LCC_VERSION_MAJOR.$LCC_VERSION_MINOR.$LCC_VERSION_PATCH"
 
-AC_SUBST(LCC_VERSION_MAJOR)
-AC_SUBST(LCC_VERSION_MINOR)
-AC_SUBST(LCC_VERSION_PATCH)
-AC_SUBST(LCC_VERSION_EXTRA)
-AC_SUBST(LCC_VERSION_STRING)
+AC_SUBST([LCC_VERSION_MAJOR])
+AC_SUBST([LCC_VERSION_MINOR])
+AC_SUBST([LCC_VERSION_PATCH])
+AC_SUBST([LCC_VERSION_EXTRA])
+AC_SUBST([LCC_VERSION_STRING])
 
-AC_CONFIG_FILES(src/libcollectdclient/collectd/lcc_features.h)
+AC_CONFIG_FILES([src/libcollectdclient/collectd/lcc_features.h])
 
 AM_CFLAGS="-Wall"
 AM_CXXFLAGS="-Wall"
-if test "x$enable_werror" != "xno"
-then
-        AM_CFLAGS="$AM_CFLAGS -Werror"
-        AM_CXXFLAGS="$AM_CXXFLAGS -Werror"
+if test "x$enable_werror" != "xno"; then
+  AM_CFLAGS="$AM_CFLAGS -Werror"
+  AM_CXXFLAGS="$AM_CXXFLAGS -Werror"
 fi
+
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CXXFLAGS])
 
-AC_CONFIG_FILES([Makefile proto/Makefile src/Makefile src/daemon/Makefile src/collectd.conf src/libcollectdclient/Makefile src/libcollectdclient/libcollectdclient.pc src/liboconfig/Makefile bindings/Makefile bindings/java/Makefile])
+AC_CONFIG_FILES([ \
+  Makefile \
+  bindings/Makefile \
+  bindings/java/Makefile \
+  proto/Makefile \
+  src/Makefile \
+  src/collectd.conf \
+  src/daemon/Makefile \
+  src/libcollectdclient/Makefile \
+  src/libcollectdclient/libcollectdclient.pc \
+  src/liboconfig/Makefile \
+])
+
 AC_OUTPUT
 
-if test "x$with_librrd" = "xyes" \
-	&& test "x$librrd_threadsafe" != "xyes"
-then
-	with_librrd="yes (warning: librrd is not thread-safe)"
+if test "x$with_librrd" = "xyes" && test "x$librrd_threadsafe" != "xyes"; then
+  with_librrd="yes (warning: librrd is not thread-safe)"
 fi
 
-if test "x$with_libperl" = "xyes"
-then
-	with_libperl="yes (version `$perl_interpreter -MConfig -e 'print $Config{version};'`)"
+if test "x$with_libperl" = "xyes"; then
+  with_libperl="yes (version `$PERL -MConfig -e 'print $Config{version};'`)"
 else
-	enable_perl="no (needs libperl)"
+  enable_perl="no (needs libperl)"
 fi
 
-if test "x$enable_perl" = "xno" && test "x$c_cv_have_perl_ithreads" = "xno"
-then
-	enable_perl="no (libperl doesn't support ithreads)"
+if test "x$enable_perl" = "xno" && test "x$c_cv_have_perl_ithreads" = "xno"; then
+  enable_perl="no (libperl doesn't support ithreads)"
 fi
 
-if test "x$with_perl_bindings" = "xyes" \
-	&& test "x$PERL_BINDINGS_OPTIONS" != "x"
-then
-	with_perl_bindings="yes ($PERL_BINDINGS_OPTIONS)"
+if test "x$with_perl_bindings" = "xyes" && test "x$PERL_BINDINGS_OPTIONS" != "x"; then
+  with_perl_bindings="yes ($PERL_BINDINGS_OPTIONS)"
 fi
 
 AC_MSG_RESULT()
@@ -6740,7 +6656,6 @@ AC_MSG_RESULT([    libmysql  . . . . . . $with_libmysql])
 AC_MSG_RESULT([    libnetapp . . . . . . $with_libnetapp])
 AC_MSG_RESULT([    libnetsnmp  . . . . . $with_libnetsnmp])
 AC_MSG_RESULT([    libnotify . . . . . . $with_libnotify])
-AC_MSG_RESULT([    liboconfig  . . . . . $with_liboconfig])
 AC_MSG_RESULT([    libopenipmi . . . . . $with_libopenipmipthread])
 AC_MSG_RESULT([    liboping  . . . . . . $with_liboping])
 AC_MSG_RESULT([    libowcapi . . . . . . $with_libowcapi])
@@ -6931,11 +6846,11 @@ AC_MSG_RESULT([    zookeeper . . . . . . $enable_zookeeper])
 AC_MSG_RESULT()
 
 if test "x$dependency_error" = "xyes"; then
-	AC_MSG_ERROR("Some plugins are missing dependencies - see the summary above for details")
+  AC_MSG_ERROR("Some plugins are missing dependencies - see the summary above for details")
 fi
 
 if test "x$dependency_warning" = "xyes"; then
-	AC_MSG_WARN("Some plugins seem to have missing dependencies but have been enabled forcibly - see the summary above for details")
+  AC_MSG_WARN("Some plugins seem to have missing dependencies but have been enabled forcibly - see the summary above for details")
 fi
 
-# vim: set fdm=marker :
+# vim: set fdm=marker sw=2 sts=2 ts=2 et :

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,4 @@
-SUBDIRS = libcollectdclient
-if BUILD_WITH_OWN_LIBOCONFIG
-SUBDIRS += liboconfig
-endif
-SUBDIRS += daemon
+SUBDIRS = libcollectdclient liboconfig daemon
 
 PLUGIN_LDFLAGS = -module -avoid-version -export-symbols-regex '\<module_register\>'
 
@@ -381,6 +377,7 @@ if BUILD_PLUGIN_DISK
 pkglib_LTLIBRARIES += disk.la
 disk_la_SOURCES = disk.c
 disk_la_CFLAGS = $(AM_CFLAGS)
+disk_la_CPPFLAGS = $(AM_CPPFLAGS)
 disk_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 disk_la_LIBADD =
 if BUILD_WITH_LIBKSTAT
@@ -397,7 +394,7 @@ disk_la_CFLAGS += $(BUILD_WITH_LIBSTATGRAB_CFLAGS)
 disk_la_LIBADD += $(BUILD_WITH_LIBSTATGRAB_LDFLAGS)
 endif
 if BUILD_WITH_LIBUDEV
-disk_la_CFLAGS += $(BUILD_WITH_LIBUDEV_CFLAGS)
+disk_la_CPPFLAGS += $(BUILD_WITH_LIBUDEV_CPPFLAGS)
 disk_la_LDFLAGS += $(BUILD_WITH_LIBUDEV_LDFLAGS)
 disk_la_LIBADD += $(BUILD_WITH_LIBUDEV_LIBS)
 endif
@@ -412,8 +409,9 @@ endif
 if BUILD_PLUGIN_DNS
 pkglib_LTLIBRARIES += dns.la
 dns_la_SOURCES = dns.c utils_dns.c utils_dns.h
-dns_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-dns_la_LIBADD = -lpcap
+dns_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBPCAP_CPPFLAGS)
+dns_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBPCAP_LDFLAGS)
+dns_la_LIBADD = $(BUILD_WITH_LIBPCAP_LIBS)
 endif
 
 if BUILD_PLUGIN_DPDKSTAT
@@ -728,9 +726,9 @@ endif
 if BUILD_PLUGIN_MIC
 pkglib_LTLIBRARIES += mic.la
 mic_la_SOURCES = mic.c
-mic_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_MIC_LIBPATH)
-mic_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_MIC_CPPFLAGS)
-mic_la_LIBADD = $(BUILD_WITH_MIC_LDADD)
+mic_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_MIC_CPPFLAGS)
+mic_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_MIC_LDFLAGS)
+mic_la_LIBADD = $(BUILD_WITH_MIC_LIBS)
 endif
 
 if BUILD_PLUGIN_MODBUS
@@ -827,8 +825,9 @@ endif
 if BUILD_PLUGIN_NOTIFY_EMAIL
 pkglib_LTLIBRARIES += notify_email.la
 notify_email_la_SOURCES = notify_email.c
-notify_email_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-notify_email_la_LIBADD = -lesmtp -lssl -lcrypto
+notify_email_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBESMTP_CPPFLAGS)
+notify_email_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBESMTP_LDFLAGS)
+notify_email_la_LIBADD = $(BUILD_WITH_LIBESMTP_LIBS)
 endif
 
 if BUILD_PLUGIN_NOTIFY_NAGIOS
@@ -915,11 +914,6 @@ perl_la_CPPFLAGS += -D_GNU_SOURCE
 perl_la_CFLAGS  = $(AM_CFLAGS) \
 		$(PERL_CFLAGS) \
 		-DXS_VERSION=\"$(VERSION)\" -DVERSION=\"$(VERSION)\"
-# Work-around for issues #41 and #42 - Perl 5.10 incorrectly introduced
-# __attribute__nonnull__(3) for Perl_load_module().
-if HAVE_BROKEN_PERL_LOAD_MODULE
-perl_la_CFLAGS += -Wno-nonnull
-endif
 perl_la_LDFLAGS = $(PLUGIN_LDFLAGS) \
 		$(PERL_LDFLAGS)
 perl_la_LIBADD = $(PERL_LIBS)
@@ -955,7 +949,7 @@ postgresql_la_SOURCES = postgresql.c \
 postgresql_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBPQ_CPPFLAGS)
 postgresql_la_LDFLAGS = $(PLUGIN_LDFLAGS) \
 		$(BUILD_WITH_LIBPQ_LDFLAGS)
-postgresql_la_LIBADD = -lpq
+postgresql_la_LIBADD = $(BUILD_WITH_LIBPQ_LIBS)
 endif
 
 if BUILD_PLUGIN_POWERDNS
@@ -1033,9 +1027,9 @@ endif
 if BUILD_PLUGIN_SENSORS
 pkglib_LTLIBRARIES += sensors.la
 sensors_la_SOURCES = sensors.c
-sensors_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBSENSORS_CFLAGS)
+sensors_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBSENSORS_CPPFLAGS)
 sensors_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBSENSORS_LDFLAGS)
-sensors_la_LIBADD = -lsensors
+sensors_la_LIBADD = $(BUILD_WITH_LIBSENSORS_LIBS)
 endif
 
 if BUILD_PLUGIN_SERIAL
@@ -1056,7 +1050,7 @@ if BUILD_PLUGIN_SMART
 if BUILD_WITH_LIBUDEV
 pkglib_LTLIBRARIES += smart.la
 smart_la_SOURCES = smart.c
-smart_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBATASMART_CPPFLAGS) $(BUILD_WITH_LIBUDEV_CFLAGS)
+smart_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBATASMART_CPPFLAGS) $(BUILD_WITH_LIBUDEV_CPPFLAGS)
 smart_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBATASMART_LDFLAGS) $(BUILD_WITH_LIBUDEV_LDFLAGS)
 smart_la_LIBADD = $(BUILD_WITH_LIBATASMART_LIBS) $(BUILD_WITH_LIBUDEV_LIBS)
 endif

--- a/src/apple_sensors.c
+++ b/src/apple_sensors.c
@@ -29,10 +29,6 @@
 #include "common.h"
 #include "plugin.h"
 
-#if HAVE_CTYPE_H
-#include <ctype.h>
-#endif
-
 #if HAVE_MACH_MACH_TYPES_H
 #include <mach/mach_types.h>
 #endif

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -23,9 +23,6 @@ endif
 if BUILD_WITH_LIBSOCKET
 COMMON_LIBS += -lsocket
 endif
-if BUILD_WITH_LIBRESOLV
-COMMON_LIBS += -lresolv
-endif
 if BUILD_WITH_LIBKSTAT
 COMMON_LIBS += -lkstat
 endif
@@ -81,12 +78,8 @@ collectd_CFLAGS += $(BUILD_WITH_LIBSTATGRAB_CFLAGS)
 collectd_LDADD += $(BUILD_WITH_LIBSTATGRAB_LDFLAGS)
 endif
 
-if BUILD_WITH_OWN_LIBOCONFIG
 collectd_LDADD += $(top_builddir)/src/liboconfig/liboconfig.la
 collectd_DEPENDENCIES += $(top_builddir)/src/liboconfig/liboconfig.la
-else
-collectd_LDADD += -loconfig
-endif
 
 LOG_COMPILER = env VALGRIND="@VALGRIND@" $(abs_top_srcdir)/testwrapper.sh
 

--- a/src/daemon/collectd.h
+++ b/src/daemon/collectd.h
@@ -31,35 +31,26 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#if STDC_HEADERS
-#include <stddef.h>
-#include <stdlib.h>
-#else
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#endif
-#if HAVE_STRING_H
-#if !STDC_HEADERS && HAVE_MEMORY_H
-#include <memory.h>
-#endif
-#include <string.h>
-#endif
 #if HAVE_STRINGS_H
 #include <strings.h>
-#endif
-#if HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
-#if HAVE_STDINT_H
-#include <stdint.h>
 #endif
 #if HAVE_UNISTD_H
 #include <unistd.h>
@@ -73,17 +64,8 @@
 #ifndef WIFEXITED
 #define WIFEXITED(stat_val) (((stat_val)&255) == 0)
 #endif
-#if HAVE_SIGNAL_H
-#include <signal.h>
-#endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>
-#endif
-#if HAVE_ERRNO_H
-#include <errno.h>
-#endif
-#if HAVE_LIMITS_H
-#include <limits.h>
 #endif
 #if TIME_WITH_SYS_TIME
 #include <sys/time.h>
@@ -97,18 +79,6 @@
 #endif
 #if HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif
-
-#if HAVE_ASSERT_H
-#include <assert.h>
-#else
-#define assert(...) /* nop */
-#endif
-
-#if !defined(HAVE__BOOL) || !HAVE__BOOL
-typedef int _Bool;
-#undef HAVE__BOOL
-#define HAVE__BOOL 1
 #endif
 
 #if NAN_STATIC_DEFAULT
@@ -212,12 +182,6 @@ typedef int _Bool;
 #endif
 #endif
 
-#if HAVE_STDARG_H
-#include <stdarg.h>
-#endif
-#if HAVE_CTYPE_H
-#include <ctype.h>
-#endif
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -37,10 +37,6 @@
 #include "plugin.h"
 #include "utils_cache.h"
 
-#ifdef HAVE_MATH_H
-#include <math.h>
-#endif
-
 /* for getaddrinfo */
 #include <netdb.h>
 #include <sys/types.h>

--- a/src/disk.c
+++ b/src/disk.c
@@ -139,7 +139,7 @@ static int pnumdisk;
 #error "No applicable input method."
 #endif
 
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
 #include <libudev.h>
 
 static char *conf_udev_name_attr = NULL;
@@ -173,7 +173,7 @@ static int disk_config(const char *key, const char *value) {
             "on Mach / Mac OS X and will be ignored.");
 #endif
   } else if (strcasecmp("UdevNameAttr", key) == 0) {
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
     if (conf_udev_name_attr != NULL) {
       free(conf_udev_name_attr);
       conf_udev_name_attr = NULL;
@@ -209,7 +209,7 @@ static int disk_init(void) {
 /* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_LINUX
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
   if (conf_udev_name_attr != NULL) {
     handle_udev = udev_new();
     if (handle_udev == NULL) {
@@ -217,7 +217,7 @@ static int disk_init(void) {
       return (-1);
     }
   }
-#endif /* HAVE_LIBUDEV */
+#endif /* HAVE_UDEV_H */
 /* #endif KERNEL_LINUX */
 
 #elif KERNEL_FREEBSD
@@ -260,10 +260,10 @@ static int disk_init(void) {
 
 static int disk_shutdown(void) {
 #if KERNEL_LINUX
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
   if (handle_udev != NULL)
     udev_unref(handle_udev);
-#endif /* HAVE_LIBUDEV */
+#endif /* HAVE_UDEV_H */
 #endif /* KERNEL_LINUX */
   return (0);
 } /* int disk_shutdown */
@@ -325,7 +325,7 @@ static counter_t disk_calc_time_incr(counter_t delta_time,
 }
 #endif
 
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
 /**
  * Attempt to provide an rename disk instance from an assigned udev attribute.
  *
@@ -842,7 +842,7 @@ static int disk_read(void) {
 
     output_name = disk_name;
 
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
     char *alt_name = NULL;
     if (conf_udev_name_attr != NULL) {
       alt_name =
@@ -853,7 +853,7 @@ static int disk_read(void) {
 #endif
 
     if (ignorelist_match(ignorelist, output_name) != 0) {
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
       /* release udev-based alternate name, if allocated */
       sfree(alt_name);
 #endif
@@ -879,7 +879,7 @@ static int disk_read(void) {
         submit_io_time(output_name, io_time, weighted_time);
     } /* if (is_disk) */
 
-#if HAVE_LIBUDEV
+#if HAVE_UDEV_H
     /* release udev-based alternate name, if allocated */
     sfree(alt_name);
 #endif

--- a/src/libcollectdclient/collectd/client.h
+++ b/src/libcollectdclient/collectd/client.h
@@ -39,9 +39,7 @@
 /*
  * Includes (for data types)
  */
-#if HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <inttypes.h>
 #include <time.h>
 

--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -35,7 +35,7 @@
 
 #include <pthread.h>
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 #if defined __APPLE__
 /* default xcode compiler throws warnings even when deprecated functionality
  * is not used. -Werror breaks the build because of erroneous warnings.
@@ -106,7 +106,7 @@ struct lcc_network_buffer_s {
   char *username;
   char *password;
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   gcry_cipher_hd_t encr_cypher;
   size_t encr_header_len;
   char encr_iv[16];
@@ -131,7 +131,7 @@ static _Bool have_gcrypt(void) /* {{{ */
     return (result);
   need_init = 0;
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 #if GCRYPT_VERSION_NUMBER < 0x010600
   if (gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread))
     return (0);
@@ -475,7 +475,7 @@ static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
   return (0);
 } /* }}} int nb_add_value_list */
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 static int nb_add_signature(lcc_network_buffer_t *nb) /* {{{ */
 {
   char *buffer;
@@ -688,7 +688,7 @@ int lcc_network_buffer_initialize(lcc_network_buffer_t *nb) /* {{{ */
   nb->ptr = nb->buffer;
   nb->free = nb->size;
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   if (nb->seclevel == SIGN) {
     size_t username_len;
     uint16_t pkg_type = htons(TYPE_SIGN_SHA256);
@@ -739,7 +739,7 @@ int lcc_network_buffer_finalize(lcc_network_buffer_t *nb) /* {{{ */
   if (nb == NULL)
     return (EINVAL);
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   if (nb->seclevel == SIGN)
     return nb_add_signature(nb);
   else if (nb->seclevel == ENCRYPT)

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -27,8 +27,7 @@
 #include "common.h"
 #include "plugin.h"
 
-#if HAVE_TERMIOS_H && HAVE_SYS_IOCTL_H && HAVE_MATH_H
-#include <math.h>
+#if HAVE_TERMIOS_H && HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #include <termios.h>
 #else

--- a/src/network.c
+++ b/src/network.c
@@ -51,7 +51,7 @@
 #include <net/if.h>
 #endif
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 #if defined __APPLE__
 /* default xcode compiler throws warnings even when deprecated functionality
  * is not used. -Werror breaks the build because of erroneous warnings.
@@ -96,7 +96,7 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
  * Private data types
  */
 #define SECURITY_LEVEL_NONE 0
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 #define SECURITY_LEVEL_SIGN 1
 #define SECURITY_LEVEL_ENCRYPT 2
 #endif
@@ -104,7 +104,7 @@ struct sockent_client {
   int fd;
   struct sockaddr_storage *addr;
   socklen_t addrlen;
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   int security_level;
   char *username;
   char *password;
@@ -118,7 +118,7 @@ struct sockent_client {
 struct sockent_server {
   int *fd;
   size_t fd_num;
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   int security_level;
   char *auth_file;
   fbhash_t *userdb;
@@ -468,7 +468,7 @@ static int network_dispatch_notification(notification_t *n) /* {{{ */
   return (status);
 } /* }}} int network_dispatch_notification */
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 static int network_init_gcrypt(void) /* {{{ */
 {
   gcry_error_t err;
@@ -570,7 +570,7 @@ static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
 
   return (*cyper_ptr);
 } /* }}} int network_get_aes256_cypher */
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
 static int write_part_values(char **ret_buffer, size_t *ret_buffer_len,
                              const data_set_t *ds, const value_list_t *vl) {
@@ -978,7 +978,7 @@ static int parse_packet(sockent_t *se, void *buffer, size_t buffer_size,
     buffer_offset += (s);                                                      \
   } while (0)
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
                                   void **ret_buffer, size_t *ret_buffer_len,
                                   int flags) {
@@ -1103,9 +1103,9 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
 
   return (0);
 } /* }}} int parse_part_sign_sha256 */
-/* #endif HAVE_LIBGCRYPT */
+/* #endif HAVE_GCRYPT_H */
 
-#else  /* if !HAVE_LIBGCRYPT */
+#else  /* if !HAVE_GCRYPT_H */
 static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
                                   void **ret_buffer, size_t *ret_buffer_size,
                                   int flags) {
@@ -1147,9 +1147,9 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
 
   return (0);
 } /* }}} int parse_part_sign_sha256 */
-#endif /* !HAVE_LIBGCRYPT */
+#endif /* !HAVE_GCRYPT_H */
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
                                   void **ret_buffer, size_t *ret_buffer_len,
                                   int flags) {
@@ -1260,9 +1260,9 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
 
   return (0);
 } /* }}} int parse_part_encr_aes256 */
-/* #endif HAVE_LIBGCRYPT */
+/* #endif HAVE_GCRYPT_H */
 
-#else  /* if !HAVE_LIBGCRYPT */
+#else  /* if !HAVE_GCRYPT_H */
 static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
                                   void **ret_buffer, size_t *ret_buffer_size,
                                   int flags) {
@@ -1304,7 +1304,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
 
   return (0);
 } /* }}} int parse_part_encr_aes256 */
-#endif /* !HAVE_LIBGCRYPT */
+#endif /* !HAVE_GCRYPT_H */
 
 #undef BUFFER_READ
 
@@ -1316,11 +1316,11 @@ static int parse_packet(sockent_t *se, /* {{{ */
   value_list_t vl = VALUE_LIST_INIT;
   notification_t n = {0};
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   int packet_was_signed = (flags & PP_SIGNED);
   int packet_was_encrypted = (flags & PP_ENCRYPTED);
   int printed_ignore_warning = 0;
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
   memset(&vl, '\0', sizeof(vl));
   status = 0;
@@ -1353,7 +1353,7 @@ static int parse_packet(sockent_t *se, /* {{{ */
         break;
       }
     }
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     else if ((se->data.server.security_level == SECURITY_LEVEL_ENCRYPT) &&
              (packet_was_encrypted == 0)) {
       if (printed_ignore_warning == 0) {
@@ -1365,7 +1365,7 @@ static int parse_packet(sockent_t *se, /* {{{ */
       buffer_size -= (size_t)pkg_length;
       continue;
     }
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
     else if (pkg_type == TYPE_SIGN_SHA256) {
       status = parse_part_sign_sha256(se, &buffer, &buffer_size, flags);
       if (status != 0) {
@@ -1376,7 +1376,7 @@ static int parse_packet(sockent_t *se, /* {{{ */
         break;
       }
     }
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     else if ((se->data.server.security_level == SECURITY_LEVEL_SIGN) &&
              (packet_was_encrypted == 0) && (packet_was_signed == 0)) {
       if (printed_ignore_warning == 0) {
@@ -1388,7 +1388,7 @@ static int parse_packet(sockent_t *se, /* {{{ */
       buffer_size -= (size_t)pkg_length;
       continue;
     }
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
     else if (pkg_type == TYPE_VALUES) {
       status =
           parse_part_values(&buffer, &buffer_size, &vl.values, &vl.values_len);
@@ -1499,7 +1499,7 @@ static void free_sockent_client(struct sockent_client *sec) /* {{{ */
     sec->fd = -1;
   }
   sfree(sec->addr);
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   sfree(sec->username);
   sfree(sec->password);
   if (sec->cypher != NULL)
@@ -1517,7 +1517,7 @@ static void free_sockent_server(struct sockent_server *ses) /* {{{ */
   }
 
   sfree(ses->fd);
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   sfree(ses->auth_file);
   fbh_destroy(ses->userdb);
   if (ses->cypher != NULL)
@@ -1846,7 +1846,7 @@ static sockent_t *sockent_create(int type) /* {{{ */
   if (type == SOCKENT_TYPE_SERVER) {
     se->data.server.fd = NULL;
     se->data.server.fd_num = 0;
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     se->data.server.security_level = SECURITY_LEVEL_NONE;
     se->data.server.auth_file = NULL;
     se->data.server.userdb = NULL;
@@ -1857,7 +1857,7 @@ static sockent_t *sockent_create(int type) /* {{{ */
     se->data.client.addr = NULL;
     se->data.client.resolve_interval = 0;
     se->data.client.next_resolve_reconnect = 0;
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     se->data.client.security_level = SECURITY_LEVEL_NONE;
     se->data.client.username = NULL;
     se->data.client.password = NULL;
@@ -1870,7 +1870,7 @@ static sockent_t *sockent_create(int type) /* {{{ */
 
 static int sockent_init_crypto(sockent_t *se) /* {{{ */
 {
-#if HAVE_LIBGCRYPT /* {{{ */
+#if HAVE_GCRYPT_H /* {{{ */
   if (se->type == SOCKENT_TYPE_CLIENT) {
     if (se->data.client.security_level > SECURITY_LEVEL_NONE) {
       if (network_init_gcrypt() < 0) {
@@ -1913,7 +1913,7 @@ static int sockent_init_crypto(sockent_t *se) /* {{{ */
       }
     }
   }
-#endif /* }}} HAVE_LIBGCRYPT */
+#endif /* }}} HAVE_GCRYPT_H */
 
   return (0);
 } /* }}} int sockent_init_crypto */
@@ -2375,7 +2375,7 @@ static void network_send_buffer_plain(sockent_t *se, /* {{{ */
   } /* while (42) */
 } /* }}} void network_send_buffer_plain */
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 #define BUFFER_ADD(p, s)                                                       \
   do {                                                                         \
     memcpy(buffer + buffer_offset, (p), (s));                                  \
@@ -2525,20 +2525,20 @@ static void network_send_buffer_encrypted(sockent_t *se, /* {{{ */
   network_send_buffer_plain(se, buffer, buffer_size);
 } /* }}} void network_send_buffer_encrypted */
 #undef BUFFER_ADD
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
 static void network_send_buffer(char *buffer, size_t buffer_len) /* {{{ */
 {
   DEBUG("network plugin: network_send_buffer: buffer_len = %zu", buffer_len);
 
   for (sockent_t *se = sending_sockets; se != NULL; se = se->next) {
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     if (se->data.client.security_level == SECURITY_LEVEL_ENCRYPT)
       network_send_buffer_encrypted(se, buffer, buffer_len);
     else if (se->data.client.security_level == SECURITY_LEVEL_SIGN)
       network_send_buffer_signed(se, buffer, buffer_len);
     else /* if (se->data.client.security_level == SECURITY_LEVEL_NONE) */
-#endif   /* HAVE_LIBGCRYPT */
+#endif   /* HAVE_GCRYPT_H */
       network_send_buffer_plain(se, buffer, buffer_len);
   } /* for (sending_sockets) */
 } /* }}} void network_send_buffer */
@@ -2731,7 +2731,7 @@ static int network_config_set_buffer_size(const oconfig_item_t *ci) /* {{{ */
   return (0);
 } /* }}} int network_config_set_buffer_size */
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
 static int network_config_set_security_level(oconfig_item_t *ci, /* {{{ */
                                              int *retval) {
   char *str;
@@ -2755,7 +2755,7 @@ static int network_config_set_security_level(oconfig_item_t *ci, /* {{{ */
 
   return (0);
 } /* }}} int network_config_set_security_level */
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
 static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
 {
@@ -2784,13 +2784,13 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     if (strcasecmp("AuthFile", child->key) == 0)
       cf_util_get_string(child, &se->data.server.auth_file);
     else if (strcasecmp("SecurityLevel", child->key) == 0)
       network_config_set_security_level(child, &se->data.server.security_level);
     else
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
         if (strcasecmp("Interface", child->key) == 0)
       network_config_set_interface(child, &se->interface);
     else {
@@ -2798,7 +2798,7 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
     }
   }
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   if ((se->data.server.security_level > SECURITY_LEVEL_NONE) &&
       (se->data.server.auth_file == NULL)) {
     ERROR("network plugin: A security level higher than `none' was "
@@ -2807,7 +2807,7 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
     sockent_destroy(se);
     return (-1);
   }
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
   status = sockent_init_crypto(se);
   if (status != 0) {
@@ -2862,7 +2862,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
     if (strcasecmp("Username", child->key) == 0)
       cf_util_get_string(child, &se->data.client.username);
     else if (strcasecmp("Password", child->key) == 0)
@@ -2870,7 +2870,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("SecurityLevel", child->key) == 0)
       network_config_set_security_level(child, &se->data.client.security_level);
     else
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
         if (strcasecmp("Interface", child->key) == 0)
       network_config_set_interface(child, &se->interface);
     else if (strcasecmp("ResolveInterval", child->key) == 0)
@@ -2880,7 +2880,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
     }
   }
 
-#if HAVE_LIBGCRYPT
+#if HAVE_GCRYPT_H
   if ((se->data.client.security_level > SECURITY_LEVEL_NONE) &&
       ((se->data.client.username == NULL) ||
        (se->data.client.password == NULL))) {
@@ -2890,7 +2890,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
     sockent_destroy(se);
     return (-1);
   }
-#endif /* HAVE_LIBGCRYPT */
+#endif /* HAVE_GCRYPT_H */
 
   status = sockent_init_crypto(se);
   if (status != 0) {

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -32,9 +32,6 @@
 #include "common.h"
 #include "plugin.h"
 
-#if HAVE_STDINT_H
-#include <stdint.h>
-#endif
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif

--- a/src/ted.c
+++ b/src/ted.c
@@ -39,8 +39,7 @@
 #include "common.h"
 #include "plugin.h"
 
-#if HAVE_TERMIOS_H && HAVE_SYS_IOCTL_H && HAVE_MATH_H
-#include <math.h>
+#if HAVE_TERMIOS_H && HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #include <termios.h>
 #else

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -34,11 +34,7 @@
 #include "plugin.h"
 #include "utils_cache.h"
 
-#if HAVE_STDINT_H
 #define MONGO_HAVE_STDINT 1
-#else
-#define MONGO_USE_LONG_LONG_INT 1
-#endif
 #include <mongo.h>
 
 #if (MONGO_MAJOR == 0) && (MONGO_MINOR < 8)


### PR DESCRIPTION
This fixes a lot of stuff in configure.ac, mainly:
- Quote m4 macros consistently
- 2 space indents
- Indent all the macros in the same way
- Remove redundant checks
- Limit certain checks to only run on certain platforms
- Remove a lot of unused AC_DEFINE and AM_CONDITIONAL calls
- Order some stuff around
- Fixes some checks that didn't actually check anything, i.e. libesmtp.
- Removed some checks for headers that are in std C89/99

Still to do is to remove all calls to $PKG_CONFIG --exists with PKG_CHECK_MODULES macros, but I think this patch set is big enough as it is.
