### PR TITLE
Making /proc and /sys path configurable

### DIFF
--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -91,9 +91,15 @@ static int cs_read (void)
 	derive_t result = 0;
 	int status = -2;
 
-	fh = fopen ("/proc/stat", "r");
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/stat";
+	char statfile[strlen(prefix) + strlen(path) + 1];
+
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	fh = fopen (statfile, "r");
 	if (fh == NULL) {
-		ERROR ("contextswitch plugin: unable to open /proc/stat: %s",
+		ERROR ("contextswitch plugin: unable to open %s: %s",
+				statfile,
 				sstrerror (errno, buffer, sizeof (buffer)));
 		return (-1);
 	}

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -600,10 +600,16 @@ static int cpu_read (void)
 	char *fields[9];
 	int numfields;
 
-	if ((fh = fopen ("/proc/stat", "r")) == NULL)
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/stat";
+	char statfile[strlen(prefix) + strlen(path) + 1];
+
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	if ((fh = fopen (statfile, "r")) == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("cpu plugin: fopen (/proc/stat) failed: %s",
+		ERROR ("cpu plugin: fopen (%s) failed: %s",
+				statfile,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -123,7 +123,8 @@ static cf_global_option_t cf_global_options[] =
 	{"CollectInternalStats", NULL, 0, "false"},
 	{"PreCacheChain",        NULL, 0, "PreCache"},
 	{"PostCacheChain",       NULL, 0, "PostCache"},
-	{"MaxReadInterval",      NULL, 0, "86400"}
+	{"MaxReadInterval",      NULL, 0, "86400"},
+	{"PseudoFSPrefix",       NULL, 0, ""}
 };
 static int cf_global_options_num = STATIC_ARRAY_SIZE (cf_global_options);
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -698,12 +698,22 @@ static int disk_read (void)
 
 	diskstats_t *ds, *pre_ds;
 
-	if ((fh = fopen ("/proc/diskstats", "r")) == NULL)
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *diskstats_path = "/proc/diskstats";
+	const char *partitions_path = "/proc/partitions";
+	char proc_diskstats[strlen(prefix) + strlen(diskstats_path) + 1];
+	char proc_partitions[strlen(prefix) + strlen(partitions_path) + 1];
+
+	ssnprintf(proc_diskstats, sizeof(proc_diskstats), "%s%s", prefix, diskstats_path);
+	ssnprintf(proc_partitions, sizeof(proc_partitions), "%s%s", prefix, partitions_path);
+
+	if ((fh = fopen (proc_diskstats, "r")) == NULL)
 	{
-		fh = fopen ("/proc/partitions", "r");
+		fh = fopen (proc_partitions, "r");
 		if (fh == NULL)
 		{
-			ERROR ("disk plugin: fopen (/proc/{diskstats,partitions}) failed.");
+			ERROR ("disk plugin: fopen (%s/proc/{diskstats,partitions}) failed.",
+					prefix);
 			return (-1);
 		}
 

--- a/src/fhcount.c
+++ b/src/fhcount.c
@@ -91,8 +91,13 @@ static int fhcount_read(void) {
   char errbuf[1024];
   FILE *fp;
 
+  const char *prefix = global_option_get("PseudoFSPrefix");
+  const char *path   = "/proc/sys/fs/file-nr";
+  char statfile[strlen(prefix) + strlen(path) + 1];
+
   // Open file
-  fp = fopen("/proc/sys/fs/file-nr" , "r");
+  ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+  fp = fopen(statfile, "r");
   if (fp == NULL) {
     ERROR("fhcount: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
     return(EXIT_FAILURE);

--- a/src/interface.c
+++ b/src/interface.c
@@ -254,11 +254,16 @@ static int interface_read (void)
 	char *fields[16];
 	int numfields;
 
-	if ((fh = fopen ("/proc/net/dev", "r")) == NULL)
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/net/dev";
+	char statfile[strlen(prefix) + strlen(path) + 1];
+
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	if ((fh = fopen (statfile, "r")) == NULL)
 	{
 		char errbuf[1024];
-		WARNING ("interface plugin: fopen: %s",
-				sstrerror (errno, errbuf, sizeof (errbuf)));
+		WARNING ("interface plugin: fopen(%s): %s",
+				statfile, sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
 

--- a/src/load.c
+++ b/src/load.c
@@ -139,10 +139,16 @@ static int load_read (void)
 	char *fields[8];
 	int numfields;
 
-	if ((loadavg = fopen ("/proc/loadavg", "r")) == NULL)
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/loadavg";
+	char statfile[strlen(prefix) + strlen(path) + 1];
+
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	if ((loadavg = fopen (statfile, "r")) == NULL)
 	{
 		char errbuf[1024];
-		WARNING ("load: fopen: %s",
+		WARNING ("load: fopen(%s): %s",
+				statfile,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}

--- a/src/memory.c
+++ b/src/memory.c
@@ -296,10 +296,16 @@ static int memory_read_internal (value_list_t *vl)
 	gauge_t mem_slab_reclaimable = 0;
 	gauge_t mem_slab_unreclaimable = 0;
 
-	if ((fh = fopen ("/proc/meminfo", "r")) == NULL)
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/meminfo";
+	char statfile[strlen(prefix) + strlen(path) + 1];
+
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	if ((fh = fopen (statfile, "r")) == NULL)
 	{
 		char errbuf[1024];
-		WARNING ("memory: fopen: %s",
+		ERROR ("memory plugin: fopen (%s) failed: %s",
+				statfile,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}

--- a/src/processes.c
+++ b/src/processes.c
@@ -806,10 +806,11 @@ static void ps_submit_fork_rate (derive_t value)
 #if KERNEL_LINUX
 static procstat_t *ps_read_tasks_status (long pid, procstat_t *ps)
 {
-	char           dirname[64];
 	DIR           *dh;
-	char           filename[64];
 	FILE          *fh;
+	const char    *prefix = global_option_get("PseudoFSPrefix");
+	char           filename[strlen(prefix) + 64];
+	char           dirname[strlen(prefix) + 64];
 	struct dirent *ent;
 	derive_t cswitch_vol = 0;
 	derive_t cswitch_invol = 0;
@@ -817,7 +818,8 @@ static procstat_t *ps_read_tasks_status (long pid, procstat_t *ps)
 	char *fields[8];
 	int numfields;
 
-	ssnprintf (dirname, sizeof (dirname), "/proc/%li/task", pid);
+
+	ssnprintf (dirname, sizeof (dirname), "%s/proc/%li/task", prefix, pid);
 
 	if ((dh = opendir (dirname)) == NULL)
 	{
@@ -834,7 +836,7 @@ static procstat_t *ps_read_tasks_status (long pid, procstat_t *ps)
 
 		tpid = ent->d_name;
 
-		ssnprintf (filename, sizeof (filename), "/proc/%li/task/%s/status", pid, tpid);
+		ssnprintf (filename, sizeof (filename), "%s/proc/%li/task/%s/status", prefix, pid, tpid);
 		if ((fh = fopen (filename, "r")) == NULL)
 		{
 			DEBUG ("Failed to open file `%s'", filename);
@@ -892,7 +894,8 @@ static procstat_t *ps_read_status (long pid, procstat_t *ps)
 {
 	FILE *fh;
 	char buffer[1024];
-	char filename[64];
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char filename[strlen(prefix) + 64];
 	unsigned long lib = 0;
 	unsigned long exe = 0;
 	unsigned long data = 0;
@@ -900,7 +903,7 @@ static procstat_t *ps_read_status (long pid, procstat_t *ps)
 	char *fields[8];
 	int numfields;
 
-	ssnprintf (filename, sizeof (filename), "/proc/%li/status", pid);
+	ssnprintf (filename, sizeof (filename), "%s/proc/%li/status", prefix, pid);
 	if ((fh = fopen (filename, "r")) == NULL)
 		return (NULL);
 
@@ -962,12 +965,13 @@ static procstat_t *ps_read_io (long pid, procstat_t *ps)
 {
 	FILE *fh;
 	char buffer[1024];
-	char filename[64];
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char filename[strlen(prefix) + 64];
 
 	char *fields[8];
 	int numfields;
 
-	ssnprintf (filename, sizeof (filename), "/proc/%li/io", pid);
+	ssnprintf (filename, sizeof (filename), "%s/proc/%li/io", prefix, pid);
 	if ((fh = fopen (filename, "r")) == NULL)
 		return (NULL);
 
@@ -1015,7 +1019,8 @@ static procstat_t *ps_read_io (long pid, procstat_t *ps)
 
 static int ps_read_process (long pid, procstat_t *ps, char *state)
 {
-	char  filename[64];
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char  filename[strlen(prefix) + 64];
 	char  buffer[1024];
 
 	char *fields[64];
@@ -1038,7 +1043,7 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 
 	memset (ps, 0, sizeof (procstat_t));
 
-	ssnprintf (filename, sizeof (filename), "/proc/%li/stat", pid);
+	ssnprintf (filename, sizeof (filename), "%s/proc/%li/stat", prefix, pid);
 
 	status = read_file_contents (filename, buffer, sizeof(buffer) - 1);
 	if (status <= 0)
@@ -1176,7 +1181,8 @@ static char *ps_get_cmdline (long pid, char *name, char *buf, size_t buf_len)
 	char  *buf_ptr;
 	size_t len;
 
-	char file[PATH_MAX];
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char file[strlen(prefix) + 64];
 	int  fd;
 
 	size_t n;
@@ -1184,7 +1190,7 @@ static char *ps_get_cmdline (long pid, char *name, char *buf, size_t buf_len)
 	if ((pid < 1) || (NULL == buf) || (buf_len < 2))
 		return NULL;
 
-	ssnprintf (file, sizeof (file), "/proc/%li/cmdline", pid);
+	ssnprintf (file, sizeof (file), "%s/proc/%li/cmdline", prefix, pid);
 
 	errno = 0;
 	fd = open (file, O_RDONLY);
@@ -1271,12 +1277,17 @@ static int read_fork_rate (void)
 	char buffer[1024];
 	value_t value;
 	_Bool value_valid = 0;
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	const char *path   = "/proc/stat";
+	char statfile[strlen(prefix) + strlen(path) + 1];
 
-	proc_stat = fopen ("/proc/stat", "r");
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+	proc_stat = fopen (statfile, "r");
 	if (proc_stat == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("processes plugin: fopen (/proc/stat) failed: %s",
+		ERROR ("processes plugin: fopen (%s) failed: %s",
+				statfile,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (-1);
 	}
@@ -1318,8 +1329,9 @@ static char *ps_get_cmdline (long pid, char *name __attribute__((unused)), /* {{
 	char path[PATH_MAX];
 	psinfo_t info;
 	ssize_t status;
+	const char *prefix = global_option_get("PseudoFSPrefix");
 
-	snprintf(path, sizeof (path), "/proc/%li/psinfo", pid);
+	snprintf(path, sizeof (path), "%s/proc/%li/psinfo", prefix, pid);
 
 	status = read_file_contents (path, (void *) &info, sizeof (info));
 	if ((status < 0) || (((size_t) status) != sizeof (info)))
@@ -1348,14 +1360,15 @@ static int ps_read_process(long pid, procstat_t *ps, char *state)
 	char filename[64];
 	char f_psinfo[64], f_usage[64];
 	char *buffer;
+	const char *prefix = global_option_get("PseudoFSPrefix");
 
 	pstatus_t *myStatus;
 	psinfo_t *myInfo;
 	prusage_t *myUsage;
 
-	snprintf(filename, sizeof (filename), "/proc/%li/status", pid);
-	snprintf(f_psinfo, sizeof (f_psinfo), "/proc/%li/psinfo", pid);
-	snprintf(f_usage, sizeof (f_usage), "/proc/%li/usage", pid);
+	snprintf(filename, sizeof (filename), "%s/proc/%li/status", prefix, pid);
+	snprintf(f_psinfo, sizeof (f_psinfo), "%s/proc/%li/psinfo", prefix, pid);
+	snprintf(f_usage, sizeof (f_usage), "%s/proc/%li/usage", prefix, pid);
 
 
 	buffer = calloc(1, sizeof (pstatus_t));

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -200,11 +200,17 @@ static int protocols_read (void)
   int status;
   int success = 0;
 
-  status = read_file (SNMP_FILE);
+  const char *prefix = global_option_get("PseudoFSPrefix");
+  char snmp_file[strlen(prefix) + strlen(SNMP_FILE) + 1];
+  char netstat_file[strlen(prefix) + strlen(NETSTAT_FILE) + 1];
+
+  ssnprintf(snmp_file, sizeof(snmp_file), "%s%s", prefix, SNMP_FILE);
+  status = read_file (snmp_file);
   if (status == 0)
     success++;
 
-  status = read_file (NETSTAT_FILE);
+  ssnprintf(netstat_file, sizeof(netstat_file), "%s%s", prefix, NETSTAT_FILE);
+  status = read_file (netstat_file);
   if (status == 0)
     success++;
 

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -94,9 +94,13 @@ static int uptime_init (void) /* {{{ */
 	int ret;
 	FILE *fh;
 
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char statfile[strlen(prefix) + strlen(STAT_FILE) + 1];
+
 	ret = 0;
 
-	fh = fopen (STAT_FILE, "r");
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, STAT_FILE);
+	fh = fopen (statfile, "r");
 
 	if (fh == NULL)
 	{

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -218,12 +218,18 @@ uuidcache_init(void)
 	char device[110];
 	int handleOnFirst;
 
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char statfile[strlen(prefix) + strlen(PROC_PARTITIONS) + 1];
+
 	if(uuidCache) {
 		return;
 	}
 
-	procpt = fopen(PROC_PARTITIONS, "r");
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, PROC_PARTITIONS);
+	procpt = fopen(statfile, "r");
 	if(procpt == NULL) {
+		ERROR ("utils_mount: fopen (%s) failed.",
+				statfile);
 		return;
 	}
 
@@ -576,16 +582,21 @@ static cu_mount_t *cu_mount_getmntent (void)
 	struct mntent me;
 	char mntbuf[1024];
 
+	const char *prefix = global_option_get("PseudoFSPrefix");
+	char statfile[strlen(prefix) + strlen(COLLECTD_MNTTAB) + 1];
+
 	cu_mount_t *first = NULL;
 	cu_mount_t *last  = NULL;
 	cu_mount_t *new   = NULL;
 
-	DEBUG ("utils_mount: (void); COLLECTD_MNTTAB = %s", COLLECTD_MNTTAB);
+	ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, COLLECTD_MNTTAB);
 
-	if ((fp = setmntent (COLLECTD_MNTTAB, "r")) == NULL)
+	DEBUG ("utils_mount: (void); COLLECTD_MNTTAB = %s", statfile);
+
+	if ((fp = setmntent (statfile, "r")) == NULL)
 	{
 		char errbuf[1024];
-		ERROR ("setmntent (%s): %s", COLLECTD_MNTTAB,
+		ERROR ("setmntent (%s): %s", statfile,
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 		return (NULL);
 	}

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -114,11 +114,17 @@ static int vmem_read (void)
   FILE *fh;
   char buffer[1024];
 
-  fh = fopen ("/proc/vmstat", "r");
+  const char *prefix = global_option_get("PseudoFSPrefix");
+  const char *path   = "/proc/vmstat";
+  char statfile[strlen(prefix) + strlen(path) + 1];
+
+  ssnprintf(statfile, sizeof(statfile), "%s%s", prefix, path);
+  fh = fopen (statfile, "r");
   if (fh == NULL)
   {
     char errbuf[1024];
-    ERROR ("vmem plugin: fopen (/proc/vmstat) failed: %s",
+    ERROR ("vmem plugin: fopen (%s) failed: %s",
+        statfile,
 	sstrerror (errno, errbuf, sizeof (errbuf)));
     return (-1);
   }


### PR DESCRIPTION
This is a work in progress I wanted to submit for review before finishing it up. The use-case is detailed in #1169.

Basically, set `PseudoFSPrefix "/foo"` in the configuration file, and the plugins will read from `/foo/proc/...` and `/foo/sys/...`.

As this touches a ton of plugins, I tried to make the patch as un-invasive as possible. My main concern now is that the string concatenation gets executed at each iteration, rather than once at plugin initialization time. But I'm not sure how to do this better without global variables or altering a lot of function prototypes. This also adds a lot of mostly duplicate code, but I'm not sure how to isolate that in a function (still not very confortable with passing strings around in C...)

There are a few more plugins that need to be converted, and the doc bits are missing, so this is definetely not ready to be merged.
