### PR TITLE
Work around Solaris 10 defining label_t

### DIFF
--- a/src/utils_format_json_test.c
+++ b/src/utils_format_json_test.c
@@ -24,6 +24,16 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
+/* Workaround for Solaris 10 defining label_t
+ * Issue #1301
+ */
+#if KERNEL_SOLARIS
+# ifndef _POSIX_C_SOURCE
+#  define _POSIX_C_SOURCE 200112L
+# endif
+# undef __EXTENSIONS__
+#endif
+
 #include "collectd.h"
 
 #include "testing.h"


### PR DESCRIPTION
Solaris 10 defines label_t in /usr/include/sys/machtypes.h,
unless POSIX_C_SOURCE is defined, or when __EXTENSIONS__ is defined.

Fixes #1301