### PR TITLE
utils_dns.c: fix compiler warning

### DIFF
--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -527,7 +527,7 @@ handle_ip(const struct ip *ip, int len)
 	    return (0);
     if (IPPROTO_UDP != ip->ip_p)
 	return 0;
-    memcpy(buf, (void *) ip + offset, len - offset);
+    memcpy(buf, ((char *)ip) + offset, len - offset);
     if (0 == handle_udp((struct udphdr *) buf, len - offset))
 	return 0;
     return 1;


### PR DESCRIPTION
utils_dns.c: In function ‘handle_ip’:
utils_dns.c:531:29: warning: pointer of type ‘void *’ used in arithmetic
[-Wpointer-arith]
     memcpy(buf, (void *) ip + offset, len - offset);
                             ^