### PR TITLE
support older versions of riemann-c-client

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5478,7 +5478,7 @@ PKG_CHECK_MODULES([LIBNOTIFY], [libnotify],
 		[with_libnotify="no (pkg-config doesn't know libnotify)"]
 )
 
-PKG_CHECK_MODULES([LIBRIEMANN_CLIENT], [riemann-client >= 1.8.0],
+PKG_CHECK_MODULES([LIBRIEMANN_CLIENT], [riemann-client >= 1.6.0],
  [with_libriemann_client="yes"],
  [with_libriemann_client="no (pkg-config doesn't know libriemann-client)"])
 

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -101,6 +101,7 @@ static int wrr_connect(struct riemann_host *host) /* {{{ */
                node, port);
     return -1;
   }
+#if RCC_VERSION_NUMBER >= 0x010800
   if (host->timeout.tv_sec != 0) {
     if (riemann_client_set_timeout(host->client, &host->timeout) != 0) {
       riemann_client_free(host->client);
@@ -111,6 +112,7 @@ static int wrr_connect(struct riemann_host *host) /* {{{ */
       return -1;
     }
   }
+#endif
 
   set_sock_opts(riemann_client_get_fd(host->client));
 
@@ -681,9 +683,13 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
       if (status != 0)
         break;
     } else if (strcasecmp("Timeout", child->key) == 0) {
+#if RCC_VERSION_NUMBER >= 0x010800
       status = cf_util_get_int(child, (int *)&host->timeout.tv_sec);
       if (status != 0)
         break;
+#else
+      WARNING("write_riemann plugin: The Timeout option is not supported. Please upgrade the Riemann client to at least 1.8.0.");
+#endif
     } else if (strcasecmp("Port", child->key) == 0) {
       host->port = cf_util_get_port_number(child);
       if (host->port == -1) {


### PR DESCRIPTION
riemann_client_set_timeout() was added in 1.8.0, but this
version hasn't landed in all distro's yet.

Fixes #986