### PR TITLE
Set _GNU_SOURCE globally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -950,70 +950,7 @@ AC_CHECK_FUNCS(getloadavg, [have_getloadavg="yes"], [have_getloadavg="no"])
 AC_CHECK_FUNCS(syslog, [have_syslog="yes"], [have_syslog="no"])
 AC_CHECK_FUNCS(getutent, [have_getutent="yes"], [have_getutent="no"])
 AC_CHECK_FUNCS(getutxent, [have_getutxent="yes"], [have_getutxent="no"])
-
-# Check for strptime {{{
-if test "x$GCC" = "xyes"
-then
-	SAVE_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS -Wall -Wextra -Werror"
-fi
-
 AC_CHECK_FUNCS(strptime, [have_strptime="yes"], [have_strptime="no"])
-if test "x$have_strptime" = "xyes"
-then
-	AC_CACHE_CHECK([whether strptime is exported by default],
-		       [c_cv_have_strptime_default],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#include <time.h>
-]]],
-[[[
- struct tm stm;
- (void) strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
-]]]
-		       )],
-		       [c_cv_have_strptime_default="yes"],
-		       [c_cv_have_strptime_default="no"]))
-fi
-if test "x$have_strptime" = "xyes" && test "x$c_cv_have_strptime_default" = "xno"
-then
-	AC_CACHE_CHECK([whether strptime needs standards mode],
-		       [c_cv_have_strptime_standards],
-		       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[[
-#ifndef _ISOC99_SOURCE
-# define _ISOC99_SOURCE 1
-#endif
-#ifndef _POSIX_C_SOURCE
-# define _POSIX_C_SOURCE 200112L
-#endif
-#ifndef _XOPEN_SOURCE
-# define _XOPEN_SOURCE 500
-#endif
-#include <time.h>
-]]],
-[[[
- struct tm stm;
- (void) strptime ("2010-12-30%13:42:42", "%Y-%m-%dT%T", &stm);
-]]]
-		       )],
-		       [c_cv_have_strptime_standards="yes"],
-		       [c_cv_have_strptime_standards="no"]))
-
-	if test "x$c_cv_have_strptime_standards" = "xyes"
-	then
-		AC_DEFINE([STRPTIME_NEEDS_STANDARDS], 1, [Set to true if strptime is only exported in X/Open mode (GNU libc).])
-	else
-		have_strptime="no"
-	fi
-fi
-
-if test "x$GCC" = "xyes"
-then
-	CFLAGS="$SAVE_CFLAGS"
-fi
-# }}} Check for strptime
-
 AC_CHECK_FUNCS(swapctl, [have_swapctl="yes"], [have_swapctl="no"])
 if test "x$have_swapctl" = "xyes"; then
         AC_CACHE_CHECK([whether swapctl takes two arguments],

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,12 @@ AC_LANG(C)
 
 AC_PREFIX_DEFAULT("/opt/collectd")
 
+AH_VERBATIM([_GNU_SOURCE], [/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif]
+)
+
 AC_SYS_LARGEFILE
 
 #
@@ -683,10 +689,7 @@ AC_CHECK_HEADERS([ \
   wordexp.h \
 ])
 
-AC_CHECK_HEADERS([xfs/xqm.h], [], [],
-[
-#define _GNU_SOURCE
-])
+AC_CHECK_HEADERS([xfs/xqm.h])
 
 # For the dns plugin
 AC_CHECK_HEADERS(arpa/nameser.h)
@@ -1580,9 +1583,7 @@ AC_CHECK_MEMBERS([struct kinfo_proc2.p_pid, struct kinfo_proc2.p_uru_maxrss],
 
 
 AC_CHECK_MEMBERS([struct udphdr.uh_dport, struct udphdr.uh_sport], [], [],
-[#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#if HAVE_STDINT_H
+[#if HAVE_STDINT_H
 # include <stdint.h>
 #endif
 #if HAVE_SYS_TYPES_H
@@ -1602,9 +1603,7 @@ AC_CHECK_MEMBERS([struct udphdr.uh_dport, struct udphdr.uh_sport], [], [],
 #endif
 ])
 AC_CHECK_MEMBERS([struct udphdr.dest, struct udphdr.source], [], [],
-[#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#if HAVE_STDINT_H
+[#if HAVE_STDINT_H
 # include <stdint.h>
 #endif
 #if HAVE_SYS_TYPES_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -856,10 +856,6 @@ perl_la_SOURCES = perl.c
 # Despite C99 providing the "bool" type thru stdbool.h, Perl defines its own
 # version of that type if HAS_BOOL is not defined... *sigh*
 perl_la_CPPFLAGS = $(AM_CPPFLAGS) -DHAS_BOOL=1
-# Despite off_t being 64 bit wide on 64 bit platforms, Perl insist on using
-# off64_t which is only exposed when _LARGEFILE64_SOURCE is defined... *sigh*
-# On older platforms we also need _REENTRANT. _GNU_SOURCE sets both of these.
-perl_la_CPPFLAGS += -D_GNU_SOURCE
 perl_la_CFLAGS  = $(AM_CFLAGS) \
 		$(PERL_CFLAGS) \
 		-DXS_VERSION=\"$(VERSION)\" -DVERSION=\"$(VERSION)\"

--- a/src/bind.c
+++ b/src/bind.c
@@ -23,18 +23,6 @@
 
 #include "config.h"
 
-#if STRPTIME_NEEDS_STANDARDS
-# ifndef _ISOC99_SOURCE
-#  define _ISOC99_SOURCE 1
-# endif
-# ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 200112L
-# endif
-# ifndef _XOPEN_SOURCE
-#  define _XOPEN_SOURCE 500
-# endif
-#endif /* STRPTIME_NEEDS_STANDARDS */
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -23,9 +23,6 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/dns.c
+++ b/src/dns.c
@@ -21,9 +21,6 @@
  *   Mirko Buffoni <briareos at eswat.org>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/exec.c
+++ b/src/exec.c
@@ -23,9 +23,6 @@
  *   Peter Holik <peter at holik.at>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE /* For setgroups */
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -33,9 +33,6 @@
 #include "configfile.h"
 
 #if KERNEL_LINUX
-  /* _GNU_SOURCE is needed for struct shm_info.used_ids on musl libc */
-# define _GNU_SOURCE
-
   /* X/OPEN tells us to use <sys/{types,ipc,sem}.h> for semctl() */
   /* X/OPEN tells us to use <sys/{types,ipc,msg}.h> for msgctl() */
   /* X/OPEN tells us to use <sys/{types,ipc,shm}.h> for shmctl() */

--- a/src/load.c
+++ b/src/load.c
@@ -23,9 +23,6 @@
  *   Vedran Bartonicek <vbartoni at gmail.com>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/network.c
+++ b/src/network.c
@@ -22,9 +22,6 @@
  *   Aman Gupta <aman at tmm1.net>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE /* For struct ip_mreq */
-
 #include "collectd.h"
 
 #include "plugin.h"

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -24,9 +24,6 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE /* For NI_MAXHOST */
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -24,17 +24,6 @@
  * Ported to collectd by Vincent Brillault <git@lerya.net>
  */
 
-/*
- * _GNU_SOURCE is required because of the following functions:
- * - CPU_ISSET_S
- * - CPU_ZERO_S
- * - CPU_SET_S
- * - CPU_FREE
- * - CPU_ALLOC
- * - CPU_ALLOC_SIZE
- */
-#define _GNU_SOURCE
-
 #include "collectd.h"
 
 #include "common.h"

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -33,9 +33,6 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#define _DEFAULT_SOURCE
-#define _BSD_SOURCE
-
 #include "collectd.h"
 
 #include "plugin.h"

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -24,13 +24,6 @@
 # include "config.h"
 #endif
 
-#if HAVE_XFS_XQM_H
-# define _GNU_SOURCE
-# include <xfs/xqm.h>
-#define XFS_SUPER_MAGIC_STR "XFSB"
-#define XFS_SUPER_MAGIC2_STR "BSFX"
-#endif
-
 #include "collectd.h"
 
 #include "utils_mount.h"
@@ -69,6 +62,12 @@
 
 #if HAVE_PATHS_H
 #  include <paths.h>
+#endif
+
+#if HAVE_XFS_XQM_H
+# include <xfs/xqm.h>
+#define XFS_SUPER_MAGIC_STR "XFSB"
+#define XFS_SUPER_MAGIC2_STR "BSFX"
 #endif
 
 #ifdef COLLECTD_MNTTAB

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -24,8 +24,6 @@
  *   Fabrice A. Marie <fabrice at kibinlabs.com>
  */
 
-#define _GNU_SOURCE
-
 #include "collectd.h"
 
 #include "plugin.h"


### PR DESCRIPTION
One minor issue is that Python.h unconditionally defines
_GNU_SOURCE (https://bugs.python.org/issue1045893) so we
need to use AH_VERBATIM instead of AC_DEFINE.