### PR TITLE
curl_json: fix segfault with unexpected number instead of map

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -232,7 +232,7 @@ static int cj_cb_number (void *ctx,
               " a map.", buffer);
     cj_cb_inc_array_index (ctx, /* update_key = */ 1);
     key = db->state[db->depth].key;
-    if (key == NULL) {
+    if (key == NULL || !CJ_IS_KEY (key)) {
       return (CJ_CB_CONTINUE);
     }
   }


### PR DESCRIPTION
I am totally unsure of this fix! The code in `src/curl_json.c` seems arcane black magic to me.

When using a configuration like this:

```
LoadPlugin curl_json
<Plugin curl_json >
  <URL "http://api.facebook.com/method/fql.query?format=json&query=select+fan_count+from+page+where+page_id=280922605253831" >
    Instance "facebook"
    <Key "*/fan_count">
      Type "gauge"
    </Key>
  </URL>
</Plugin>
```

collectd segfaults in `src/curl_json.c` in `cj_cb_number`.

    >>> bt
    #0  __strcmp_sse2_unaligned () at ../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S:31
    #1  0x0000000000414da2 in search (t=0x2304a80, t=0x2304a80, key=0x1) at ../../../src/daemon/utils_avltree.c:119
    #2  c_avl_get (t=0x2304a80, key=key@entry=0x1, value=value@entry=0x7f01184f2ab8) at ../../../src/daemon/utils_avltree.c:599
    #3  0x000000000040cbd1 in plugin_get_ds (name=0x1 <error: Cannot access memory at address 0x1>) at ../../../src/daemon/plugin.c:2559
    #4  0x00007f011f93b7ef in cj_get_type (key=0x23324f0) at ../../src/curl_json.c:147
    #5  cj_cb_number (ctx=0x231f2f0, number=<optimized out>, number_len=2) at ../../src/curl_json.c:244
    #6  0x00007f011f4b7874 in yajl_do_parse (hand=0x7f01100008e0, jsonText=jsonText@entry=0x234f990 "{\"error_code\":12,\"error_msg\":\"REST API is deprecated for versions v2.1 and higher (12)\",\"request_args\":[{\"key\":\"method\",\"value\":\"fql.query\"},{\"key\":\"format\",\"value\":\"json\"},{\"key\":\"query\",\"value\":\"sel"..., jsonTextLen=jsonTextLen@entry=257) at /tmp/buildd/yajl-2.1.0/src/yajl_parser.c:307

In fact, `db->state[db->depth].key` is not a key (it's a tree). This is
correctly detected at the beginning, but despite that, there is a call
to `cj_cb_inc_array_index()` (without effect, not in an array) and `key`
is set again to `db->state[db->depth].key` which is still not a key.

In a previous call to `cj_cb_map_key()` where the corresponding value is
set, `(c_avl_get (tree, CJ_ANY, (void *) &value) == 0)` is true but
`(CJ_IS_KEY((cj_key_t*)value))` is false. Therefore, this confirms this
a tree which is stored in this node, not a key.

This is a tentative fix to ignore the value if we are expecting a map,
but didn't get one and aren't in an inhomogeneous array.