### PR TITLE
Drop support for libtool version 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Makefile.in
 /aclocal.m4
 /autom4te.cache
 /autom4te.cache
+/build-aux/
 /compile
 /config.guess
 /config.sub
@@ -12,8 +13,15 @@ Makefile.in
 /install-sh
 /libltdl/
 /ltmain.sh
+/m4/libtool.m4
+/m4/ltargz.m4
+/m4/ltdl.m4
+/m4/lt~obsolete.m4
+/m4/ltoptions.m4
+/m4/ltsugar.m4
+/m4/ltversion.m4
 /missing
-src/config.h.in
+/src/config.h.in
 
 # configure stuff:
 Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-ACLOCAL_AMFLAGS = -I libltdl/m4
+ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS =
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,25 +10,9 @@ dnl we don't really need the 'u' even in older toolchains.  Then there is
 dnl older libtool, which spelled it AR_FLAGS
 m4_divert_text([DEFAULTS], [: "${ARFLAGS=cr} ${AR_FLAGS=cr}"])
 
-m4_ifdef([LT_PACKAGE_VERSION],
-	# libtool >= 2.2
-	[
-	 LT_CONFIG_LTDL_DIR([libltdl])
-	 LT_INIT([dlopen])
-	 LTDL_INIT([convenience])
-	 AC_DEFINE(LIBTOOL_VERSION, 2, [Define to used libtool version.])
-	]
-,
-	# libtool <= 1.5
-	[
-	 AC_LIBLTDL_CONVENIENCE
-	 AC_SUBST(LTDLINCL)
-	 AC_SUBST(LIBLTDL)
-	 AC_LIBTOOL_DLOPEN
-	 AC_CONFIG_SUBDIRS(libltdl)
-	 AC_DEFINE(LIBTOOL_VERSION, 1, [Define to used libtool version.])
-	]
-)
+LT_CONFIG_LTDL_DIR([libltdl])
+LT_INIT([dlopen])
+LTDL_INIT([convenience])
 
 AM_CONDITIONAL([BUILD_INCLUDED_LTDL], [test "x$LTDLDEPS" != "x"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,8 @@ AC_PREREQ([2.60])
 AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
 AC_CONFIG_SRCDIR(src/target_set.c)
 AC_CONFIG_HEADERS(src/config.h)
-AC_CONFIG_AUX_DIR([libltdl/config])
+AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_MACRO_DIR([m4])
 
 dnl older automake's default of ARFLAGS=cru is noisy on newer binutils;
 dnl we don't really need the 'u' even in older toolchains.  Then there is

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -426,7 +426,6 @@ static int plugin_load_file (char *file, uint32_t flags)
 	lt_dlinit ();
 	lt_dlerror (); /* clear errors */
 
-#if LIBTOOL_VERSION == 2
 	if (flags & PLUGIN_FLAGS_GLOBAL) {
 		lt_dladvise advise;
 		lt_dladvise_init(&advise);
@@ -436,12 +435,6 @@ static int plugin_load_file (char *file, uint32_t flags)
 	} else {
 		dlh = lt_dlopen (file);
 	}
-#else /* if LIBTOOL_VERSION == 1 */
-	if (flags & PLUGIN_FLAGS_GLOBAL)
-		WARNING ("plugin_load_file: The global flag is not supported, "
-				"libtool 2 is required for this.");
-	dlh = lt_dlopen (file);
-#endif
 
 	if (dlh == NULL)
 	{


### PR DESCRIPTION
The only distro that we still support that uses libtool version 1
is RHEL5, but that will be EOL in a few months.