### PR TITLE
grpc plugin: Rename "DispatchValues" to "PutValues".

### DIFF
--- a/proto/collectd.proto
+++ b/proto/collectd.proto
@@ -30,25 +30,25 @@ option go_package = "collectd.org/rpc/proto";
 import "types.proto";
 
 service Collectd {
-  // DispatchValues reads the value lists from the DispatchValuesRequest stream.
+  // PutValues reads the value lists from the PutValuesRequest stream.
   // The gRPC server embedded into collectd will inject them into the system
   // just like the network plugin.
-  rpc DispatchValues(stream DispatchValuesRequest)
-      returns (DispatchValuesResponse);
+  rpc PutValues(stream PutValuesRequest)
+      returns (PutValuesResponse);
 
   // QueryValues returns a stream of matching value lists from collectd's
   // internal cache.
   rpc QueryValues(QueryValuesRequest) returns (stream QueryValuesResponse);
 }
 
-// The arguments to DispatchValues.
-message DispatchValuesRequest {
+// The arguments to PutValues.
+message PutValuesRequest {
   // value_list is the metric to be sent to the server.
   collectd.types.ValueList value_list = 1;
 }
 
-// The response from DispatchValues.
-message DispatchValuesResponse {}
+// The response from PutValues.
+message PutValuesResponse {}
 
 // The arguments to QueryValues.
 message QueryValuesRequest {


### PR DESCRIPTION
This is done to use a naming closer to that of the *unixsock* and *exec plugins*.