### PR TITLE
pgsql plugin: avoid parsing error from query_plans

### DIFF
--- a/src/postgresql_default.conf
+++ b/src/postgresql_default.conf
@@ -159,10 +159,10 @@
 </Query>
 
 <Query query_plans>
-	Statement "SELECT sum(seq_scan) AS seq, \
-			sum(seq_tup_read) AS seq_tup_read, \
-			sum(idx_scan) AS idx, \
-			sum(idx_tup_fetch) AS idx_tup_fetch \
+	Statement "SELECT coalesce(sum(seq_scan), 0) AS seq, \
+			  coalesce(sum(seq_tup_read), 0) AS seq_tup_read, \
+			  coalesce(sum(idx_scan), 0) AS idx, \
+			  coalesce(sum(idx_tup_fetch), 0) AS idx_tup_fetch \
 		FROM pg_stat_user_tables;"
 
 	<Result>

--- a/src/postgresql_default.conf
+++ b/src/postgresql_default.conf
@@ -207,10 +207,10 @@
 
 <Query query_plans_by_table>
 	Statement "SELECT schemaname, relname, \
-			seq_scan AS seq, \
-			seq_tup_read AS seq_tup_read, \
-			idx_scan AS idx, \
-			idx_tup_fetch AS idx_tup_fetch \
+			coalesce(seq_scan, 0) AS seq, \
+			coalesce(seq_tup_read, 0) AS seq_tup_read, \
+			coalesce(idx_scan, 0) AS idx, \
+			coalesce(idx_tup_fetch, 0) AS idx_tup_fetch \
 		FROM pg_stat_user_tables;"
 
 	<Result>


### PR DESCRIPTION
idx_scan/idx_tup_fetch can be NULL, avoid trying to parse that into a number.

This should fix #1905.