### PR TITLE
Fix compilation against >=xfsprogs-4.7.0

### DIFF
--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -24,16 +24,16 @@
 # include "config.h"
 #endif
 
+#define _GNU_SOURCE
+
+#include "collectd.h"
+#include "utils_mount.h"
+
 #if HAVE_XFS_XQM_H
-# define _GNU_SOURCE
 # include <xfs/xqm.h>
 #define XFS_SUPER_MAGIC_STR "XFSB"
 #define XFS_SUPER_MAGIC2_STR "BSFX"
 #endif
-
-#include "collectd.h"
-
-#include "utils_mount.h"
 
 #include "common.h" /* sstrncpy() et alii */
 #include "plugin.h" /* ERROR() macro */


### PR DESCRIPTION
Fixes: https://github.com/collectd/collectd/issues/1877

Confirmed that this is still needed:
I tried current git master (9e2c04a0c5b1b0f4bd2269c29c27fe1f3b1115de), i.e. I run `build.sh && ./configure && make` which failed with
```
  CC       utils_mount.lo
In file included from /usr/include/xfs/linux.h:35:0,
                 from /usr/include/xfs/xfs.h:37,
                 from /usr/include/xfs/xqm.h:21,
                 from utils_mount.c:29:
/usr/include/sys/mount.h:35:3: error: expected identifier before numeric constant
   MS_RDONLY = 1,  /* Mount read-only.  */
   ^
```
I am able to build current git master when this commit is applied.