### PR TITLE
5.5: Fix compilation against >=xfsprogs-4.7.0

### DIFF
--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -24,15 +24,16 @@
 # include "config.h"
 #endif
 
+#define _GNU_SOURCE
+
+#include "collectd.h"
+#include "utils_mount.h"
+
 #if HAVE_XFS_XQM_H
-# define _GNU_SOURCE
 # include <xfs/xqm.h>
 #define XFS_SUPER_MAGIC_STR "XFSB"
 #define XFS_SUPER_MAGIC2_STR "BSFX"
 #endif
-
-#include "collectd.h"
-#include "utils_mount.h"
 
 #include "common.h" /* sstrncpy() et alii */
 #include "plugin.h" /* ERROR() macro */


### PR DESCRIPTION
backport of commit 225ee7bb45152c51c1c9508b2e776cef36d2682d for collect-5.5 branch.
