### PR TITLE
hugepages plugin: Implement the Values{Pages,Bytes,Percentage} options and refactoring.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -597,8 +597,11 @@
 #</Plugin>
 
 #<Plugin hugepages>
-#    ReportPerNodeHP "true"
-#    ReportRootHP "true"
+#    ReportPerNodeHP  true
+#    ReportRootHP     true
+#    ValuesPages      true
+#    ValuesBytes      false
+#    ValuesPercentage false
 #</Plugin>
 
 #<Plugin interface>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2836,19 +2836,34 @@ options (default is enabled).
 
 =over 4
 
-=item B<ReportPerNodeHP> I<true>|I<false>
+=item B<ReportPerNodeHP> B<true>|B<false>
 
 If enabled, information will be collected from the hugepage
 counters in "/sys/devices/system/node/*/hugepages".
 This is used to check the per-node hugepage statistics on
 a NUMA system.
 
-=item B<ReportRootHP> I<true>|I<false>
+=item B<ReportRootHP> B<true>|B<false>
 
 If enabled, information will be collected from the hugepage
 counters in "/sys/kernel/mm/hugepages".
 This can be used on both NUMA and non-NUMA systems to check
 the overall hugepage statistics.
+
+=item B<ValuesPages> B<true>|B<false>
+
+Whether to report hugepages metrics in number of pages.
+Defaults to B<true>.
+
+=item B<ValuesBytes> B<false>|B<true>
+
+Whether to report hugepages metrics in bytes.
+Defaults to B<false>.
+
+=item B<ValuesPercentage> B<false>|B<true>
+
+Whether to report hugepages metrics as percentage.
+Defaults to B<false>.
 
 =back
 

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -38,9 +38,9 @@ static const char g_plugin_name[] = "hugepages";
 static _Bool g_flag_rpt_numa = 1;
 static _Bool g_flag_rpt_mm = 1;
 
-static _Bool values_pages = 1;
-static _Bool values_bytes = 0;
-static _Bool values_percent = 0;
+static _Bool g_values_pages = 1;
+static _Bool g_values_bytes = 0;
+static _Bool g_values_percent = 0;
 
 #define HP_HAVE_NR 0x01
 #define HP_HAVE_SURPLUS 0x02
@@ -66,11 +66,11 @@ static int hp_config(oconfig_item_t *ci) {
     else if (strcasecmp("ReportRootHP", child->key) == 0)
       cf_util_get_boolean(child, &g_flag_rpt_mm);
     else if (strcasecmp("ValuesPages", child->key) == 0)
-      cf_util_get_boolean(child, &values_pages);
+      cf_util_get_boolean(child, &g_values_pages);
     else if (strcasecmp("ValuesBytes", child->key) == 0)
-      cf_util_get_boolean(child, &values_bytes);
+      cf_util_get_boolean(child, &g_values_bytes);
     else if (strcasecmp("ValuesPercentage", child->key) == 0)
-      cf_util_get_boolean(child, &values_percent);
+      cf_util_get_boolean(child, &g_values_percent);
     else
       ERROR("%s: Invalid configuration option: \"%s\".", g_plugin_name,
             child->key);
@@ -101,19 +101,19 @@ static void submit_hp(const struct entry_info *info) {
   gauge_t free = info->free;
   gauge_t used = (info->nr + info->surplus) - info->free;
 
-  if (values_pages) {
+  if (g_values_pages) {
     sstrncpy(vl.type, "vmpage_number", sizeof(vl.type));
     plugin_dispatch_multivalue(&vl, /* store_percentage = */ 0, DS_TYPE_GAUGE,
                                "free", free, "used", used, NULL);
   }
-  if (values_bytes) {
+  if (g_values_bytes) {
     gauge_t page_size = (gauge_t)(1024 * info->page_size_kb);
     sstrncpy(vl.type, "memory", sizeof(vl.type));
     plugin_dispatch_multivalue(&vl, /* store_percentage = */ 0, DS_TYPE_GAUGE,
                                "free", free * page_size, "used",
                                used * page_size, NULL);
   }
-  if (values_percent) {
+  if (g_values_percent) {
     sstrncpy(vl.type, "percent", sizeof(vl.type));
     plugin_dispatch_multivalue(&vl, /* store_percentage = */ 1, DS_TYPE_GAUGE,
                                "free", free, "used", used, NULL);

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -160,24 +160,11 @@ static int read_syshugepages(const char *path, const char *node) {
   struct dirent *result;
   char path2[PATH_MAX];
   struct entry_info e_info;
-  long lim;
 
   dir = opendir(path);
   if (dir == NULL) {
     ERROR("%s: cannot open directory %s", g_plugin_name, path);
     return -1;
-  }
-
-  errno = 0;
-  if ((lim = pathconf(path, _PC_NAME_MAX)) == -1) {
-    /* Limit not defined if errno == 0, otherwise error */
-    if (errno != 0) {
-      ERROR("%s: pathconf failed", g_plugin_name);
-      closedir(dir);
-      return -1;
-    } else {
-      lim = PATH_MAX;
-    }
   }
 
   /* read "hugepages-XXXXXkB" entries */
@@ -189,7 +176,7 @@ static int read_syshugepages(const char *path, const char *node) {
     }
 
     /* /sys/devices/system/node/node?/hugepages/ */
-    ssnprintf(path2, (size_t)lim, "%s/%s", path, result->d_name);
+    ssnprintf(path2, sizeof(path2), "%s/%s", path, result->d_name);
 
     e_info.d_name = result->d_name;
     e_info.node = node;
@@ -216,24 +203,11 @@ static int read_nodes(void) {
   DIR *dir;
   struct dirent *result;
   char path[PATH_MAX];
-  long lim;
 
   dir = opendir(sys_node);
   if (dir == NULL) {
     ERROR("%s: cannot open directory %s", g_plugin_name, sys_node);
     return -1;
-  }
-
-  errno = 0;
-  if ((lim = pathconf(sys_node, _PC_NAME_MAX)) == -1) {
-    /* Limit not defined if errno == 0, otherwise error */
-    if (errno != 0) {
-      ERROR("%s: pathconf failed", g_plugin_name);
-      closedir(dir);
-      return -1;
-    } else {
-      lim = PATH_MAX;
-    }
   }
 
   while ((result = readdir(dir)) != NULL) {
@@ -243,7 +217,7 @@ static int read_nodes(void) {
       continue;
     }
 
-    ssnprintf(path, (size_t)lim, sys_node_hugepages, result->d_name);
+    ssnprintf(path, sizeof(path), sys_node_hugepages, result->d_name);
     read_syshugepages(path, result->d_name);
     errno = 0;
   }

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -121,7 +121,6 @@ static void submit_hp(const struct entry_info *info) {
 static int read_hugepage_entry(const char *path, const char *entry,
                                void *e_info) {
   char path2[PATH_MAX];
-  char type_instance[PATH_MAX];
   struct entry_info *info = e_info;
   double value;
 
@@ -155,8 +154,6 @@ static int read_hugepage_entry(const char *path, const char *entry,
     return 0;
   }
 
-  ssnprintf(type_instance, sizeof(type_instance), "free_used-%zukB",
-            info->page_size_kb);
   submit_hp(info);
 
   /* Reset flags so subsequent calls don't submit again. */

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -4,15 +4,15 @@
  *
  * Copyright(c) 2016 Intel Corporation. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
- * so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -36,8 +36,7 @@ static const char g_cfg_rpt_numa[] = "ReportPerNodeHP";
 static const char g_cfg_rpt_mm[] = "ReportRootHP";
 
 static const char *g_config_keys[] = {
-  g_cfg_rpt_numa,
-  g_cfg_rpt_mm,
+    g_cfg_rpt_numa, g_cfg_rpt_mm,
 };
 static size_t g_config_keys_num = STATIC_ARRAY_SIZE(g_config_keys);
 static int g_flag_rpt_numa = 1;
@@ -48,8 +47,7 @@ struct entry_info {
   const char *node;
 };
 
-static int huge_config_callback(const char *key, const char *val)
-{
+static int huge_config_callback(const char *key, const char *val) {
   DEBUG("%s: HugePages config key='%s', val='%s'", g_plugin_name, key, val);
 
   if (strcasecmp(key, g_cfg_rpt_numa) == 0) {
@@ -65,8 +63,8 @@ static int huge_config_callback(const char *key, const char *val)
 }
 
 static void submit_hp(const char *plug_inst, const char *type,
-  const char *type_instance, gauge_t free_value, gauge_t used_value)
-{
+                      const char *type_instance, gauge_t free_value,
+                      gauge_t used_value) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
     { .gauge = free_value },
@@ -75,24 +73,23 @@ static void submit_hp(const char *plug_inst, const char *type,
 
   vl.values = values;
   vl.values_len = STATIC_ARRAY_SIZE (values);
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-  sstrncpy (vl.plugin, g_plugin_name, sizeof (vl.plugin));
-  sstrncpy (vl.plugin_instance, plug_inst, sizeof (vl.plugin_instance));
-  sstrncpy (vl.type, type, sizeof (vl.type));
+  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
+  sstrncpy(vl.plugin, g_plugin_name, sizeof(vl.plugin));
+  sstrncpy(vl.plugin_instance, plug_inst, sizeof(vl.plugin_instance));
+  sstrncpy(vl.type, type, sizeof(vl.type));
 
   if (type_instance != NULL) {
-    sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
+    sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
   }
 
   DEBUG("submit_hp pl_inst:%s, inst_type %s, type %s, free=%lf, used=%lf",
-      plug_inst, type_instance, type, free_value, used_value);
+        plug_inst, type_instance, type, free_value, used_value);
 
-  plugin_dispatch_values (&vl);
+  plugin_dispatch_values(&vl);
 }
 
 static int read_hugepage_entry(const char *path, const char *entry,
-    void *e_info)
-{
+                               void *e_info) {
   char path2[PATH_MAX];
   static const char type[] = "hugepages";
   static const char partial_type_inst[] = "free_used";
@@ -112,7 +109,7 @@ static int read_hugepage_entry(const char *path, const char *entry,
     return -1;
   }
 
-  if (fscanf(fh, "%lf", &value) !=1) {
+  if (fscanf(fh, "%lf", &value) != 1) {
     ERROR("%s: cannot parse file %s", g_plugin_name, path2);
     fclose(fh);
     return -1;
@@ -139,10 +136,11 @@ static int read_hugepage_entry(const char *path, const char *entry,
      */
     strin = strchr(hpsize_plinst->d_name, 0x2D);
     if (strin != NULL) {
-      ssnprintf(type_instance, sizeof(type_instance), "%s%s", partial_type_inst, strin);
+      ssnprintf(type_instance, sizeof(type_instance), "%s%s", partial_type_inst,
+                strin);
     } else {
       ssnprintf(type_instance, sizeof(type_instance), "%s%s", partial_type_inst,
-          hpsize_plinst->d_name);
+                hpsize_plinst->d_name);
     }
     submit_hp(hpsize_plinst->node, type, type_instance, free_hp, used_hp);
 
@@ -156,8 +154,7 @@ static int read_hugepage_entry(const char *path, const char *entry,
   return 0;
 }
 
-static int read_syshugepages(const char* path, const char* node)
-{
+static int read_syshugepages(const char *path, const char *node) {
   static const char hugepages_dir[] = "hugepages";
   DIR *dir;
   struct dirent *result;
@@ -185,14 +182,14 @@ static int read_syshugepages(const char* path, const char* node)
 
   /* read "hugepages-XXXXXkB" entries */
   while ((result = readdir(dir)) != NULL) {
-    if (strncmp(result->d_name, hugepages_dir, sizeof(hugepages_dir)-1)) {
+    if (strncmp(result->d_name, hugepages_dir, sizeof(hugepages_dir) - 1)) {
       /* not node dir */
       errno = 0;
       continue;
     }
 
     /* /sys/devices/system/node/node?/hugepages/ */
-    ssnprintf(path2, (size_t) lim, "%s/%s", path, result->d_name);
+    ssnprintf(path2, (size_t)lim, "%s/%s", path, result->d_name);
 
     e_info.d_name = result->d_name;
     e_info.node = node;
@@ -202,20 +199,20 @@ static int read_syshugepages(const char* path, const char* node)
 
   /* Check if NULL return from readdir() was an error */
   if (errno != 0) {
-      ERROR("%s: readdir failed", g_plugin_name);
-      closedir(dir);
-      return -1;
+    ERROR("%s: readdir failed", g_plugin_name);
+    closedir(dir);
+    return -1;
   }
 
   closedir(dir);
   return 0;
 }
 
-static int read_nodes(void)
-{
+static int read_nodes(void) {
   static const char sys_node[] = "/sys/devices/system/node";
   static const char node_string[] = "node";
-  static const char sys_node_hugepages[] = "/sys/devices/system/node/%s/hugepages";
+  static const char sys_node_hugepages[] =
+      "/sys/devices/system/node/%s/hugepages";
   DIR *dir;
   struct dirent *result;
   char path[PATH_MAX];
@@ -240,31 +237,29 @@ static int read_nodes(void)
   }
 
   while ((result = readdir(dir)) != NULL) {
-    if (strncmp(result->d_name, node_string, sizeof(node_string)-1)) {
+    if (strncmp(result->d_name, node_string, sizeof(node_string) - 1)) {
       /* not node dir */
       errno = 0;
       continue;
     }
 
-    ssnprintf(path, (size_t) lim, sys_node_hugepages, result->d_name);
+    ssnprintf(path, (size_t)lim, sys_node_hugepages, result->d_name);
     read_syshugepages(path, result->d_name);
     errno = 0;
   }
 
   /* Check if NULL return from readdir() was an error */
   if (errno != 0) {
-      ERROR("%s: readdir failed", g_plugin_name);
-      closedir(dir);
-      return -1;
+    ERROR("%s: readdir failed", g_plugin_name);
+    closedir(dir);
+    return -1;
   }
 
   closedir(dir);
   return 0;
 }
 
-
-static int huge_read(void)
-{
+static int huge_read(void) {
   static const char sys_mm_hugepages[] = "/sys/kernel/mm/hugepages";
 
   if (g_flag_rpt_mm) {
@@ -281,10 +276,8 @@ static int huge_read(void)
   return 0;
 }
 
-void module_register(void)
-{
+void module_register(void) {
   plugin_register_config(g_plugin_name, huge_config_callback, g_config_keys,
-      g_config_keys_num);
+                         g_config_keys_num);
   plugin_register_read(g_plugin_name, huge_read);
 }
-

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -25,9 +25,11 @@
  * Authors:
  *   Jaroslav Safka <jaroslavx.safka@intel.com>
  *   Kim-Marie Jones <kim-marie.jones@intel.com>
+ *   Florian Forster <octo at collectd.org>
  */
 
 #include "collectd.h"
+
 #include "common.h" /* auxiliary functions */
 #include "plugin.h" /* plugin_register_*, plugin_dispatch_values */
 

--- a/src/types.db
+++ b/src/types.db
@@ -94,7 +94,6 @@ hash_collisions         value:DERIVE:0:U
 http_request_methods    value:DERIVE:0:U
 http_requests           value:DERIVE:0:U
 http_response_codes     value:DERIVE:0:U
-hugepages               free:GAUGE:0:4294967295, used:GAUGE:0:4294967295
 humidity                value:GAUGE:0:100
 if_collisions           value:DERIVE:0:U
 if_dropped              rx:DERIVE:0:U, tx:DERIVE:0:U


### PR DESCRIPTION
This PR implements three new options for the *hugepages plugin*:

*  `ValuesPages` (enabled by default) reports the number of used and free *pages* as `vmpage_number`.
*  `ValuesBytes` (disabled by default) reports the number of used and free *bytes* in hugepages as `memory`.
*  `ValuesPercentage` (disabled by default) reports the *percentage* of used and free hugepages as `percentage`.

All options can be enabled / disabled independently from each other so users can gather the metrics in the form(s) they need.

This PR also does a fair bit of refactoring that the actual feature implementation depends on. Sorry about that.