### PR TITLE
write_graphite plugin: add option DropDuplicateFields

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1415,6 +1415,7 @@
 #    StoreRates true
 #    AlwaysAppendDS false
 #    EscapeCharacter "_"
+#    DropDuplicateFields false
 #  </Node>
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7818,6 +7818,12 @@ If set to B<true>, append the name of the I<Data Source> (DS) to the "metric"
 identifier. If set to B<false> (the default), this is only done when there is
 more than one DS.
 
+=item B<DropDuplicateFields> B<false>|B<true>
+
+If set to B<true>, detect and remove duplicate components in Graphite metric
+names. For example, the metric name  C<host.load.load.shortterm> will
+be shortened to C<host.load.shortterm>.
+
 =back
 
 =head2 Plugin C<write_tsdb>

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -150,33 +150,28 @@ static int gr_format_name (char *ret, int ret_len,
         sstrncpy (tmp_plugin, n_plugin, sizeof (tmp_plugin));
 
     if (n_type_instance[0] != '\0')
+    {
         if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
-        {
             sstrncpy (tmp_type, n_type_instance, sizeof (tmp_type));
-        }
         else
-        {
             ssnprintf (tmp_type, sizeof (tmp_type), "%s%c%s",
                 n_type,
                 (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
                 n_type_instance);
-        }
+    }
     else
         sstrncpy (tmp_type, n_type, sizeof (tmp_type));
-
     /* Assert always_append_ds -> ds_name */
     assert (!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
     if (ds_name != NULL)
+    {
         if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(tmp_plugin, tmp_type) == 0)
-        {
             ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
                 prefix, n_host, postfix, tmp_plugin, ds_name);
-        }
         else
-        {
             ssnprintf (ret, ret_len, "%s%s%s.%s.%s.%s",
                 prefix, n_host, postfix, tmp_plugin, tmp_type, ds_name);
-        }
+    }
     else
         ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
             prefix, n_host, postfix, tmp_plugin, tmp_type);

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -161,6 +161,7 @@ static int gr_format_name (char *ret, int ret_len,
     }
     else
         sstrncpy (tmp_type, n_type, sizeof (tmp_type));
+
     /* Assert always_append_ds -> ds_name */
     assert (!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
     if (ds_name != NULL)

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -150,18 +150,25 @@ static int gr_format_name (char *ret, int ret_len,
         sstrncpy (tmp_plugin, n_plugin, sizeof (tmp_plugin));
 
     if (n_type_instance[0] != '\0')
-        ssnprintf (tmp_type, sizeof (tmp_type), "%s%c%s",
-            n_type,
-            (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
-            n_type_instance);
+        if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
+            sstrncpy (tmp_type, n_type_instance, sizeof (tmp_type));
+        else
+            ssnprintf (tmp_type, sizeof (tmp_type), "%s%c%s",
+                n_type,
+                (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
+                n_type_instance);
     else
         sstrncpy (tmp_type, n_type, sizeof (tmp_type));
 
     /* Assert always_append_ds -> ds_name */
     assert (!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
     if (ds_name != NULL)
-        ssnprintf (ret, ret_len, "%s%s%s.%s.%s.%s",
-            prefix, n_host, postfix, tmp_plugin, tmp_type, ds_name);
+        if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(tmp_plugin, tmp_type) == 0)
+            ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
+                prefix, n_host, postfix, tmp_plugin, ds_name);
+        else
+            ssnprintf (ret, ret_len, "%s%s%s.%s.%s.%s",
+                prefix, n_host, postfix, tmp_plugin, tmp_type, ds_name);
     else
         ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
             prefix, n_host, postfix, tmp_plugin, tmp_type);

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -151,12 +151,16 @@ static int gr_format_name (char *ret, int ret_len,
 
     if (n_type_instance[0] != '\0')
         if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
+        {
             sstrncpy (tmp_type, n_type_instance, sizeof (tmp_type));
+        }
         else
+        {
             ssnprintf (tmp_type, sizeof (tmp_type), "%s%c%s",
                 n_type,
                 (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
                 n_type_instance);
+        }
     else
         sstrncpy (tmp_type, n_type, sizeof (tmp_type));
 
@@ -164,11 +168,15 @@ static int gr_format_name (char *ret, int ret_len,
     assert (!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
     if (ds_name != NULL)
         if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(tmp_plugin, tmp_type) == 0)
+        {
             ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
                 prefix, n_host, postfix, tmp_plugin, ds_name);
+        }
         else
+        {
             ssnprintf (ret, ret_len, "%s%s%s.%s.%s.%s",
                 prefix, n_host, postfix, tmp_plugin, tmp_type, ds_name);
+        }
     else
         ssnprintf (ret, ret_len, "%s%s%s.%s.%s",
             prefix, n_host, postfix, tmp_plugin, tmp_type);

--- a/src/utils_format_graphite.h
+++ b/src/utils_format_graphite.h
@@ -29,6 +29,7 @@
 #define GRAPHITE_STORE_RATES        0x01
 #define GRAPHITE_SEPARATE_INSTANCES 0x02
 #define GRAPHITE_ALWAYS_APPEND_DS   0x04
+#define GRAPHITE_DROP_DUPE_FIELDS   0x08
 
 int format_graphite (char *buffer,
     size_t buffer_size, const data_set_t *ds,

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -548,6 +548,9 @@ static int wg_config_node (oconfig_item_t *ci)
         else if (strcasecmp ("AlwaysAppendDS", child->key) == 0)
             cf_util_get_flag (child, &cb->format_flags,
                     GRAPHITE_ALWAYS_APPEND_DS);
+        else if (strcasecmp ("DropDuplicateFields", child->key) == 0)
+            cf_util_get_flag (child, &cb->format_flags,
+                    GRAPHITE_DROP_DUPE_FIELDS);
         else if (strcasecmp ("EscapeCharacter", child->key) == 0)
             config_set_char (&cb->escape_char, child);
         else


### PR DESCRIPTION
The Collectd naming hierarchy often contains multiple levels with duplicate naming. For example, the CPU plugin uses the string "cpu" for both plugin and type (when `ValuesPercentage false`), leading to Graphite metrics with redundant components:
`example_host.cpu.0.cpu.idle`

Other examples include both the Load plugin and Memory plugin which use the same plugin and type name:
`example_host.load.load.shortterm`
`example_host.memory.memory.cached`

This new option drops the latter of these fields when it duplicates a previous metric component.