### PR TITLE
Add missing option to write_graphite example config

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1415,6 +1415,7 @@
 #    StoreRates true
 #    AlwaysAppendDS false
 #    EscapeCharacter "_"
+#    SeparateInstances false
 #  </Node>
 #</Plugin>
 


### PR DESCRIPTION
The example config for write_graphite included in the shipped collectd.conf is missing one option: SeparateInstances

This option is present [in the wiki](https://collectd.org/wiki/index.php/Plugin:Write_Graphite) and is valid [in the current version](https://github.com/collectd/collectd/blob/collectd-5.5.2/src/write_graphite.c#L541-L543)

