### PR TITLE
Add RFC3339 Zulu time functions

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5726,7 +5726,7 @@ values are made available through those parameters:
 
 =item B<$1>
 
-The timestamp of the queried value as a floating point number.
+The timestamp of the queried value as an RFC 3339-formatted local time.
 
 =item B<$2>
 

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -128,7 +128,6 @@ static int get_local_time (cdtime_t t, struct tm *t_tm, long *nsec) /* {{{ */
  Formatting functions
 ***********************************************************************/
 
-static const char utc_zone[] = "+00:00";
 static const char zulu_zone[] = "Z";
 
 /* format_zone reads time zone information from "extern long timezone", exported
@@ -186,22 +185,22 @@ int format_rfc3339 (char *buffer, size_t buffer_size, struct tm const *t_tm, lon
   return 0;
 } /* }}} int format_rfc3339 */
 
-int format_rfc3339_utc (char *buffer, size_t buffer_size, cdtime_t t, _Bool print_nano, char const *zone) /* {{{ */
+int format_rfc3339_utc (char *buffer, size_t buffer_size, cdtime_t t, _Bool print_nano) /* {{{ */
 {
   struct tm t_tm;
-  long nsec;
+  long nsec = 0;
   int status;
 
   if ((status = get_utc_time (t, &t_tm, &nsec)) != 0)
     return status;  /* The error should have already be reported. */
 
-  return format_rfc3339 (buffer, buffer_size, &t_tm, nsec, print_nano, zone);
+  return format_rfc3339 (buffer, buffer_size, &t_tm, nsec, print_nano, zulu_zone);
 } /* }}} int format_rfc3339_utc */
 
 int format_rfc3339_local (char *buffer, size_t buffer_size, cdtime_t t, _Bool print_nano) /* {{{ */
 {
   struct tm t_tm;
-  long nsec;
+  long nsec = 0;
   int status;
   char zone[7];  /* +00:00 */
 
@@ -223,7 +222,7 @@ int rfc3339 (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
   if (buffer_size < RFC3339_SIZE)
     return ENOMEM;
 
-  return format_rfc3339_utc (buffer, buffer_size, t, 0, utc_zone);
+  return format_rfc3339_utc (buffer, buffer_size, t, 0);
 } /* }}} int rfc3339 */
 
 int rfc3339nano (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
@@ -231,24 +230,8 @@ int rfc3339nano (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
   if (buffer_size < RFC3339NANO_SIZE)
     return ENOMEM;
 
-  return format_rfc3339_utc (buffer, buffer_size, t, 1, utc_zone);
+  return format_rfc3339_utc (buffer, buffer_size, t, 1);
 } /* }}} int rfc3339nano */
-
-int rfc3339_zulu (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
-{
-  if (buffer_size < RFC3339_ZULU_SIZE)
-    return ENOMEM;
-
-  return format_rfc3339_utc (buffer, buffer_size, t, 0, zulu_zone);
-} /* }}} int rfc3339_zulu */
-
-int rfc3339nano_zulu (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
-{
-  if (buffer_size < RFC3339NANO_ZULU_SIZE)
-    return ENOMEM;
-
-  return format_rfc3339_utc (buffer, buffer_size, t, 1, zulu_zone);
-} /* }}} int rfc3339nano_zulu */
 
 int rfc3339_local (char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
 {

--- a/src/daemon/utils_time.h
+++ b/src/daemon/utils_time.h
@@ -82,26 +82,35 @@ extern cdtime_t cdtime_mock;
 
 cdtime_t cdtime (void);
 
-#define RFC3339_SIZE     26
-#define RFC3339NANO_SIZE 36
+#define RFC3339_SIZE     26  /* 2006-01-02T15:04:05+00:00 */
+#define RFC3339NANO_SIZE 36  /* 2006-01-02T15:04:05.999999999+00:00 */
 
-#define RFC3339_ZULU_SIZE     21
-#define RFC3339NANO_ZULU_SIZE 31
+#define RFC3339_ZULU_SIZE     21  /* 2006-01-02T15:04:05Z */
+#define RFC3339NANO_ZULU_SIZE 31  /* 2006-01-02T15:04:05.999999999Z */
 
-/* rfc3339 formats a cdtime_t time in RFC 3339 format with second precision. */
+/* rfc3339 formats a cdtime_t time as UTC in RFC 3339 format with second
+ * precision. */
 int rfc3339 (char *buffer, size_t buffer_size, cdtime_t t);
 
-/* rfc3339nano formats a cdtime_t time in RFC 3339 format with nanosecond
- * precision. */
+/* rfc3339nano formats a cdtime_t as UTC time in RFC 3339 format with
+ * nanosecond precision. */
 int rfc3339nano (char *buffer, size_t buffer_size, cdtime_t t);
 
-/* rfc3339 formats a cdtime_t time in RFC 3339 zulu format with second
+/* rfc3339 formats a cdtime_t time as UTC in RFC 3339 zulu format with second
  * precision. */
 int rfc3339_zulu (char *buffer, size_t buffer_size, cdtime_t t);
 
-/* rfc3339nano formats a cdtime_t time in RFC 3339 zulu format with nanosecond
- * precision. */
+/* rfc3339nano formats a cdtime_t time as UTC in RFC 3339 zulu format with
+ * nanosecond precision. */
 int rfc3339nano_zulu (char *buffer, size_t buffer_size, cdtime_t t);
+
+/* rfc3339 formats a cdtime_t time as local in RFC 3339 format with second
+ * precision. */
+int rfc3339_local (char *buffer, size_t buffer_size, cdtime_t t);
+
+/* rfc3339nano formats a cdtime_t time as local in RFC 3339 format with
+ * nanosecond precision. */
+int rfc3339nano_local (char *buffer, size_t buffer_size, cdtime_t t);
 
 #endif /* UTILS_TIME_H */
 /* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_time.h
+++ b/src/daemon/utils_time.h
@@ -85,31 +85,20 @@ cdtime_t cdtime (void);
 #define RFC3339_SIZE     26  /* 2006-01-02T15:04:05+00:00 */
 #define RFC3339NANO_SIZE 36  /* 2006-01-02T15:04:05.999999999+00:00 */
 
-#define RFC3339_ZULU_SIZE     21  /* 2006-01-02T15:04:05Z */
-#define RFC3339NANO_ZULU_SIZE 31  /* 2006-01-02T15:04:05.999999999Z */
-
-/* rfc3339 formats a cdtime_t time as UTC in RFC 3339 format with second
- * precision. */
+/* rfc3339 formats a cdtime_t time as UTC in RFC 3339 zulu format with second
+ * precision, e.g., "2006-01-02T15:04:05Z". */
 int rfc3339 (char *buffer, size_t buffer_size, cdtime_t t);
 
-/* rfc3339nano formats a cdtime_t as UTC time in RFC 3339 format with
- * nanosecond precision. */
+/* rfc3339nano formats a cdtime_t as UTC time in RFC 3339 zulu format with
+ * nanosecond precision, e.g., "2006-01-02T15:04:05.999999999Z". */
 int rfc3339nano (char *buffer, size_t buffer_size, cdtime_t t);
 
-/* rfc3339 formats a cdtime_t time as UTC in RFC 3339 zulu format with second
- * precision. */
-int rfc3339_zulu (char *buffer, size_t buffer_size, cdtime_t t);
-
-/* rfc3339nano formats a cdtime_t time as UTC in RFC 3339 zulu format with
- * nanosecond precision. */
-int rfc3339nano_zulu (char *buffer, size_t buffer_size, cdtime_t t);
-
 /* rfc3339 formats a cdtime_t time as local in RFC 3339 format with second
- * precision. */
+ * precision, e.g., "2006-01-02T15:04:05+00:00". */
 int rfc3339_local (char *buffer, size_t buffer_size, cdtime_t t);
 
 /* rfc3339nano formats a cdtime_t time as local in RFC 3339 format with
- * nanosecond precision. */
+ * nanosecond precision, e.g., "2006-01-02T15:04:05.999999999+00:00". */
 int rfc3339nano_local (char *buffer, size_t buffer_size, cdtime_t t);
 
 #endif /* UTILS_TIME_H */

--- a/src/daemon/utils_time.h
+++ b/src/daemon/utils_time.h
@@ -85,12 +85,23 @@ cdtime_t cdtime (void);
 #define RFC3339_SIZE     26
 #define RFC3339NANO_SIZE 36
 
+#define RFC3339_ZULU_SIZE     21
+#define RFC3339NANO_ZULU_SIZE 31
+
 /* rfc3339 formats a cdtime_t time in RFC 3339 format with second precision. */
 int rfc3339 (char *buffer, size_t buffer_size, cdtime_t t);
 
 /* rfc3339nano formats a cdtime_t time in RFC 3339 format with nanosecond
  * precision. */
 int rfc3339nano (char *buffer, size_t buffer_size, cdtime_t t);
+
+/* rfc3339 formats a cdtime_t time in RFC 3339 zulu format with second
+ * precision. */
+int rfc3339_zulu (char *buffer, size_t buffer_size, cdtime_t t);
+
+/* rfc3339nano formats a cdtime_t time in RFC 3339 zulu format with nanosecond
+ * precision. */
+int rfc3339nano_zulu (char *buffer, size_t buffer_size, cdtime_t t);
 
 #endif /* UTILS_TIME_H */
 /* vim: set sw=2 sts=2 et : */

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -833,8 +833,7 @@ static int c_psql_write (const data_set_t *ds, const value_list_t *vl,
 	assert (db->database != NULL);
 	assert (db->writers != NULL);
 
-	/* TODO: Should this be rfc3339nano_local()? */
-	if (rfc3339nano (time_str, sizeof (time_str), vl->time) != 0) {
+	if (rfc3339nano_local (time_str, sizeof (time_str), vl->time) != 0) {
 		log_err ("c_psql_write: Failed to convert time to RFC 3339 format");
 		return -1;
 	}

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -833,6 +833,7 @@ static int c_psql_write (const data_set_t *ds, const value_list_t *vl,
 	assert (db->database != NULL);
 	assert (db->writers != NULL);
 
+	/* TODO: Should this be rfc3339nano_local()? */
 	if (rfc3339nano (time_str, sizeof (time_str), vl->time) != 0) {
 		log_err ("c_psql_write: Failed to convert time to RFC 3339 format");
 		return -1;


### PR DESCRIPTION
"Zulu" time is always in UTC and the timezone part is just a 'Z'.  This is a pretty common form, and it is a requirement of the Google Stackdriver metric ingestion API.

This PR adds a couple of functions alongside the existing RFC3339 ones (the latter use local time instead of UTC and give the timezone in the +hh:mm form).

thanks