### PR TITLE
Allow Target:Set to delete metadata and interpolate field values.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9419,9 +9419,37 @@ Available options:
 
 =item B<MetaData> I<String> I<String>
 
-Set the appropriate field to the given string. The strings for plugin instance
-and type instance may be empty, the strings for host and plugin may not be
-empty. It's currently not possible to set the type of a value this way.
+Set the appropriate field to the given string. The strings for plugin instance,
+type instance, and meta data may be empty, the strings for host and plugin may
+not be empty. It's currently not possible to set the type of a value this way.
+
+The following placeholders will be replaced by an appropriate value:
+
+=over 4
+
+=item B<%{host}>
+
+=item B<%{plugin}>
+
+=item B<%{plugin_instance}>
+
+=item B<%{type}>
+
+=item B<%{type_instance}>
+
+These placeholders are replaced by the identifier field of the same name.
+
+=item B<%{meta:>I<name>B<}>
+
+These placeholders are replaced by the meta data value with the given name.
+
+=back
+
+Please note that these placeholders are B<case sensitive>!
+
+=item B<DeleteMetaData> I<String>
+
+Delete the named meta data field.
 
 =back
 

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -739,6 +739,7 @@ int meta_data_as_string (meta_data_t *md, /* {{{ */
   char *actual;
   char buffer[MD_MAX_NONSTRING_CHARS];  /* For non-string types. */
   char *temp;
+  int type;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
     return (-EINVAL);
@@ -752,7 +753,9 @@ int meta_data_as_string (meta_data_t *md, /* {{{ */
     return (-ENOENT);
   }
 
-  switch (e->type)
+  type = e->type;
+
+  switch (type)
   {
     case MD_TYPE_STRING:
       actual = e->value.mv_string;
@@ -774,20 +777,19 @@ int meta_data_as_string (meta_data_t *md, /* {{{ */
       break;
     default:
       pthread_mutex_unlock (&md->lock);
-      ERROR ("meta_data_as_string: unknown type %d for key `%s'",
-          e->type, e->key);
+      ERROR ("meta_data_as_string: unknown type %d for key `%s'", type, key);
       return (-ENOENT);
   }
+
+  pthread_mutex_unlock (&md->lock);
 
   temp = md_strdup (actual);
   if (temp == NULL)
   {
     pthread_mutex_unlock (&md->lock);
-    ERROR ("meta_data_as_string: md_strdup failed for key `%s'.", e->key);
+    ERROR ("meta_data_as_string: md_strdup failed for key `%s'.", key);
     return (-ENOMEM);
   }
-
-  pthread_mutex_unlock (&md->lock);
 
   *value = temp;
 

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -26,8 +26,11 @@
 
 #include "collectd.h"
 
+#include "common.h"
 #include "plugin.h"
 #include "meta_data.h"
+
+#define MD_MAX_NONSTRING_CHARS 128
 
 /*
  * Data types
@@ -728,5 +731,67 @@ int meta_data_get_boolean (meta_data_t *md, /* {{{ */
   pthread_mutex_unlock (&md->lock);
   return (0);
 } /* }}} int meta_data_get_boolean */
+
+int meta_data_as_string (meta_data_t *md, /* {{{ */
+    const char *key, char **value)
+{
+  meta_entry_t *e;
+  char *actual;
+  char buffer[MD_MAX_NONSTRING_CHARS];  /* For non-string types. */
+  char *temp;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return (-EINVAL);
+
+  pthread_mutex_lock (&md->lock);
+
+  e = md_entry_lookup (md, key);
+  if (e == NULL)
+  {
+    pthread_mutex_unlock (&md->lock);
+    return (-ENOENT);
+  }
+
+  switch (e->type)
+  {
+    case MD_TYPE_STRING:
+      actual = e->value.mv_string;
+      break;
+    case MD_TYPE_SIGNED_INT:
+      ssnprintf (buffer, sizeof (buffer), "%"PRIi64, e->value.mv_signed_int);
+      actual = buffer;
+      break;
+    case MD_TYPE_UNSIGNED_INT:
+      ssnprintf (buffer, sizeof (buffer), "%"PRIu64, e->value.mv_unsigned_int);
+      actual = buffer;
+      break;
+    case MD_TYPE_DOUBLE:
+      ssnprintf (buffer, sizeof (buffer), GAUGE_FORMAT, e->value.mv_double);
+      actual = buffer;
+      break;
+    case MD_TYPE_BOOLEAN:
+      actual = e->value.mv_boolean ? "true" : "false";
+      break;
+    default:
+      pthread_mutex_unlock (&md->lock);
+      ERROR ("meta_data_as_string: unknown type %d for key `%s'",
+          e->type, e->key);
+      return (-ENOENT);
+  }
+
+  temp = md_strdup (actual);
+  if (temp == NULL)
+  {
+    pthread_mutex_unlock (&md->lock);
+    ERROR ("meta_data_as_string: md_strdup failed for key `%s'.", e->key);
+    return (-ENOMEM);
+  }
+
+  pthread_mutex_unlock (&md->lock);
+
+  *value = temp;
+
+  return (0);
+} /* }}} int meta_data_as_string */
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/meta_data.h
+++ b/src/daemon/meta_data.h
@@ -84,5 +84,10 @@ int meta_data_get_boolean (meta_data_t *md,
     const char *key,
     _Bool *value);
 
+/* Returns the value as a string, regardless of the type. */
+int meta_data_as_string (meta_data_t *md,
+    const char *key,
+    char **value);
+
 #endif /* META_DATA_H */
 /* vim: set sw=2 sts=2 et : */

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -43,12 +43,12 @@ static void ts_key_list_free (ts_key_list_t *l) /* {{{ */
   if (l == NULL)
     return;
 
-  free (l->key);
+  sfree (l->key);
 
   if (l->next != NULL)
     ts_key_list_free (l->next);
 
-  free (l);
+  sfree (l);
 } /* }}} void ts_name_list_free */
 
 struct ts_data_s
@@ -153,13 +153,16 @@ static int ts_config_add_meta_delete (ts_key_list_t **dest, /* {{{ */
   }
 
   if (cf_util_get_string (ci, &entry->key) != 0)
+  {
+    ts_key_list_free (entry);
     return (-1);  /* An error has already been reported. */
+  }
 
   if (strlen (entry->key) == 0)
   {
     ERROR ("Target `set': The `%s' option does not accept empty string as "
         "first argument.", ci->key);
-    sfree (entry->key);
+    ts_key_list_free (entry);
     return (-1);
   }
 


### PR DESCRIPTION
This uses the syntax from Target:Notification to allow interpolating field and metadata values via Target:Set. It also adds a new DeleteMetaData option to allow deleting metadata keys.