### PR TITLE
Tree wide: Use user_data_t compound literal where appropriate.

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -1070,11 +1070,13 @@ static int camqp_config_connection (oconfig_item_t *ci, /* {{{ */
     if (publish)
     {
         char cbname[128];
-        user_data_t ud = { conf, camqp_config_free };
-
         ssnprintf (cbname, sizeof (cbname), "amqp/%s", conf->name);
 
-        status = plugin_register_write (cbname, camqp_write, &ud);
+        status = plugin_register_write (cbname, camqp_write,
+                &(user_data_t) {
+                    .data = conf,
+                    .free_func = camqp_config_free,
+                });
         if (status != 0)
         {
             camqp_config_free (conf);

--- a/src/apache.c
+++ b/src/apache.c
@@ -250,7 +250,7 @@ static int config_add (oconfig_item_t *ci)
 				/* name      = */ callback_name,
 				/* callback  = */ apache_read_host,
 				/* interval  = */ 0,
-				/* user_data = */ &(user_data_t) {
+				&(user_data_t) {
 					.data = st,
 					.free_func = apache_free,
 				});

--- a/src/apache.c
+++ b/src/apache.c
@@ -239,11 +239,6 @@ static int config_add (oconfig_item_t *ci)
 
 	if (status == 0)
 	{
-		user_data_t ud = {
-			.data = st,
-			.free_func = apache_free
-		};
-
 		char callback_name[3*DATA_MAX_NAME_LEN];
 
 		ssnprintf (callback_name, sizeof (callback_name),
@@ -255,7 +250,11 @@ static int config_add (oconfig_item_t *ci)
 				/* name      = */ callback_name,
 				/* callback  = */ apache_read_host,
 				/* interval  = */ 0,
-				/* user_data = */ &ud);
+				/* user_data = */ &(user_data_t) {
+					.data = st,
+					.free_func = apache_free,
+				});
+
 	}
 
 	if (status != 0)

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -769,14 +769,12 @@ static int cj_config_add_url (oconfig_item_t *ci) /* {{{ */
     cb_name = ssnprintf_alloc ("curl_json-%s-%s",
                db->instance, db->url ? db->url : db->sock);
 
-    user_data_t ud = {
-      .data = db,
-      .free_func = cj_free
-    };
-
     plugin_register_complex_read (/* group = */ NULL, cb_name, cj_read,
                                   /* interval = */ db->interval,
-                                  &ud);
+                                  &(user_data_t) {
+                                    .data = db,
+                                    .free_func = cj_free,
+                                  });
     sfree (cb_name);
   }
   else

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -1026,13 +1026,12 @@ static int cx_config_add_url (oconfig_item_t *ci) /* {{{ */
 
     cb_name = ssnprintf_alloc ("curl_xml-%s-%s", db->instance, db->url);
 
-    user_data_t ud = {
-      .data = db,
-      .free_func = cx_free
-    };
-
     plugin_register_complex_read (/* group = */ "curl_xml", cb_name, cx_read,
-                                  /* interval = */ 0, &ud);
+        /* interval = */ 0,
+        &(user_data_t) {
+          .data = db,
+          .free_func = cx_free,
+        });
     sfree (cb_name);
   }
   else

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -399,7 +399,7 @@ static int cdbi_config_add_database (oconfig_item_t *ci) /* {{{ */
           /* name = */ name ? name : db->name,
           /* callback = */ cdbi_read_database,
           /* interval = */ (db->interval > 0) ? db->interval : 0,
-          /* user_data = */ &(user_data_t) {
+          &(user_data_t) {
             .data = db,
 	  });
       sfree (name);

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -390,24 +390,19 @@ static int cdbi_config_add_database (oconfig_item_t *ci) /* {{{ */
     }
     else
     {
-      char *name = NULL;
-
       databases = temp;
       databases[databases_num] = db;
       databases_num++;
 
-      name = ssnprintf_alloc("dbi:%s", db->name);
-
-      user_data_t ud = {
-        .data = db
-      };
-
+      char *name = ssnprintf_alloc("dbi:%s", db->name);
       plugin_register_complex_read (/* group = */ NULL,
           /* name = */ name ? name : db->name,
           /* callback = */ cdbi_read_database,
           /* interval = */ (db->interval > 0) ? db->interval : 0,
-          /* user_data = */ &ud);
-      free (name);
+          /* user_data = */ &(user_data_t) {
+            .data = db,
+	  });
+      sfree (name);
     }
   }
 

--- a/src/java.c
+++ b/src/java.c
@@ -1425,13 +1425,11 @@ static jint JNICALL cjni_api_register_read (JNIEnv *jvm_env, /* {{{ */
 
   DEBUG ("java plugin: Registering new read callback: %s", cbi->name);
 
-  user_data_t ud = {
-    .data = cbi,
-    .free_func = cjni_callback_info_destroy
-  };
-
   plugin_register_complex_read (/* group = */ NULL, cbi->name, cjni_read,
-      /* interval = */ 0, &ud);
+      /* interval = */ 0, &(user_data_t) {
+        .data = cbi,
+        .free_func = cjni_callback_info_destroy,
+      });
 
   (*jvm_env)->DeleteLocalRef (jvm_env, o_read);
 
@@ -1449,12 +1447,10 @@ static jint JNICALL cjni_api_register_write (JNIEnv *jvm_env, /* {{{ */
 
   DEBUG ("java plugin: Registering new write callback: %s", cbi->name);
 
-  user_data_t ud = {
-    .data = cbi,
-    .free_func = cjni_callback_info_destroy
-  };
-
-  plugin_register_write (cbi->name, cjni_write, &ud);
+  plugin_register_write (cbi->name, cjni_write, &(user_data_t) {
+        .data = cbi,
+        .free_func = cjni_callback_info_destroy,
+      });
 
   (*jvm_env)->DeleteLocalRef (jvm_env, o_write);
 
@@ -1472,12 +1468,10 @@ static jint JNICALL cjni_api_register_flush (JNIEnv *jvm_env, /* {{{ */
 
   DEBUG ("java plugin: Registering new flush callback: %s", cbi->name);
 
-  user_data_t ud = {
-    .data = cbi,
-    .free_func = cjni_callback_info_destroy
-  };
-
-  plugin_register_flush (cbi->name, cjni_flush, &ud);
+  plugin_register_flush (cbi->name, cjni_flush, &(user_data_t) {
+        .data = cbi,
+        .free_func = cjni_callback_info_destroy,
+      });
 
   (*jvm_env)->DeleteLocalRef (jvm_env, o_flush);
 
@@ -1502,12 +1496,10 @@ static jint JNICALL cjni_api_register_log (JNIEnv *jvm_env, /* {{{ */
 
   DEBUG ("java plugin: Registering new log callback: %s", cbi->name);
 
-  user_data_t ud = {
-    .data = cbi,
-    .free_func = cjni_callback_info_destroy
-  };
-
-  plugin_register_log (cbi->name, cjni_log, &ud);
+  plugin_register_log (cbi->name, cjni_log, &(user_data_t) {
+        .data = cbi,
+        .free_func = cjni_callback_info_destroy,
+      });
 
   (*jvm_env)->DeleteLocalRef (jvm_env, o_log);
 
@@ -1526,12 +1518,10 @@ static jint JNICALL cjni_api_register_notification (JNIEnv *jvm_env, /* {{{ */
 
   DEBUG ("java plugin: Registering new notification callback: %s", cbi->name);
 
-  user_data_t ud = {
-    .data = cbi,
-    .free_func = cjni_callback_info_destroy
-  };
-
-  plugin_register_notification (cbi->name, cjni_notification, &ud);
+  plugin_register_notification (cbi->name, cjni_notification, &(user_data_t) {
+        .data = cbi,
+        .free_func = cjni_callback_info_destroy,
+      });
 
   (*jvm_env)->DeleteLocalRef (jvm_env, o_notification);
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -303,15 +303,13 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
   cb->lua_function_name = strdup(function_name);
   pthread_mutex_init(&cb->lock, NULL);
 
-  user_data_t ud = {
-    .data = cb
-  };
-
   int status = plugin_register_complex_read(/* group = */ "lua",
                                             /* name      = */ function_name,
                                             /* callback  = */ clua_read,
                                             /* interval  = */ 0,
-                                            /* user_data = */ &ud);
+                                            /* user_data = */ &(user_data_t) {
+                                              .data = cb,
+                                            });
 
   if (status != 0)
     return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -349,13 +347,11 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
   cb->lua_function_name = strdup(function_name);
   pthread_mutex_init(&cb->lock, NULL);
 
-  user_data_t ud = {
-    .data = cb
-  };
-
   int status = plugin_register_write(/* name = */ function_name,
                                     /* callback  = */ clua_write,
-                                    /* user_data = */ &ud);
+                                    /* user_data = */ &(user_data_t) {
+                                      .data = cb,
+                                    });
 
   if (status != 0)
     return luaL_error(L, "%s", "plugin_register_write failed");

--- a/src/lua.c
+++ b/src/lua.c
@@ -307,7 +307,7 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
                                             /* name      = */ function_name,
                                             /* callback  = */ clua_read,
                                             /* interval  = */ 0,
-                                            /* user_data = */ &(user_data_t) {
+                                            &(user_data_t) {
                                               .data = cb,
                                             });
 
@@ -349,7 +349,7 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
 
   int status = plugin_register_write(/* name = */ function_name,
                                     /* callback  = */ clua_write,
-                                    /* user_data = */ &(user_data_t) {
+                                    &(user_data_t) {
                                       .data = cb,
                                     });
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -554,16 +554,15 @@ static int memcached_add_read_callback (memcached_t *st)
   assert (st->name != NULL);
   ssnprintf (callback_name, sizeof (callback_name), "memcached/%s", st->name);
 
-  user_data_t ud = {
-    .data = st,
-    .free_func = memcached_free
-  };
-
   status = plugin_register_complex_read (/* group = */ "memcached",
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
       /* interval  = */ 0,
-      /* user_data = */ &ud);
+      /* user_data = */ &(user_data_t) {
+        .data = st,
+        .free_func = memcached_free,
+      });
+
   return (status);
 } /* int memcached_add_read_callback */
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -558,7 +558,7 @@ static int memcached_add_read_callback (memcached_t *st)
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
       /* interval  = */ 0,
-      /* user_data = */ &(user_data_t) {
+      &(user_data_t) {
         .data = st,
         .free_func = memcached_free,
       });

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1003,18 +1003,17 @@ static int mb_config_add_host (oconfig_item_t *ci) /* {{{ */
 
   if (status == 0)
   {
-    user_data_t ud;
     char name[1024];
-
-    ud.data = host;
-    ud.free_func = host_free;
 
     ssnprintf (name, sizeof (name), "modbus-%s", host->host);
 
     plugin_register_complex_read (/* group = */ NULL, name,
         /* callback = */ mb_read,
         /* interval = */ host->interval,
-        &ud);
+        &(user_data_t) {
+          .data = host,
+          .free_func = host_free,
+        });
   }
   else
   {

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -631,11 +631,9 @@ static int mqtt_config_publisher (oconfig_item_t *ci)
     }
 
     ssnprintf (cb_name, sizeof (cb_name), "mqtt/%s", conf->name);
-    user_data_t user_data = {
-        .data = conf
-    };
-
-    plugin_register_write (cb_name, mqtt_write, &user_data);
+    plugin_register_write (cb_name, mqtt_write, &(user_data_t) {
+                .data = conf,
+            });
     return (0);
 } /* mqtt_config_publisher */
 

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -233,14 +233,11 @@ static int mysql_config_database (oconfig_item_t *ci) /* {{{ */
 		else
 			sstrncpy (cb_name, "mysql", sizeof (cb_name));
 
-		user_data_t ud = {
-			.data = db,
-			.free_func = mysql_database_free
-		};
-
 		plugin_register_complex_read (/* group = */ NULL, cb_name,
-					      mysql_read,
-					      /* interval = */ 0, &ud);
+				mysql_read, /* interval = */ 0, &(user_data_t) {
+					.data = db,
+					.free_func = mysql_database_free,
+				});
 	}
 	else
 	{

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -2882,7 +2882,7 @@ static int cna_register_host (host_config_t *host) /* {{{ */
 	plugin_register_complex_read (/* group = */ NULL, cb_name,
 			/* callback  = */ cna_read,
 			/* interval  = */ host->interval,
-			/* user data = */ &(user_data_t) {
+			&(user_data_t) {
 				.data = host,
 				.free_func = (void *) free_host_config,
 			});

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -2879,15 +2879,13 @@ static int cna_register_host (host_config_t *host) /* {{{ */
 	else
 		ssnprintf (cb_name, sizeof (cb_name), "netapp-%s", host->name);
 
-	user_data_t ud = {
-		.data = host,
-		.free_func = (void (*) (void *)) free_host_config
-	};
-
 	plugin_register_complex_read (/* group = */ NULL, cb_name,
 			/* callback  = */ cna_read,
 			/* interval  = */ host->interval,
-			/* user data = */ &ud);
+			/* user data = */ &(user_data_t) {
+				.data = host,
+				.free_func = (void *) free_host_config,
+			});
 
 	return (0);
 } /* }}} int cna_register_host */

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -663,15 +663,13 @@ static int cldap_config_add (oconfig_item_t *ci) /* {{{ */
 					(st->host != NULL) ? st->host : hostname_g,
 					(st->name != NULL) ? st->name : "default");
 
-			user_data_t ud = {
-				.data = st
-			};
-
 			status = plugin_register_complex_read (/* group = */ NULL,
 					/* name      = */ callback_name,
 					/* callback  = */ cldap_read_host,
 					/* interval  = */ 0,
-					/* user_data = */ &ud);
+					/* user_data = */ &(user_data_t) {
+						.data = st,
+					});
 		}
 	}
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -667,7 +667,7 @@ static int cldap_config_add (oconfig_item_t *ci) /* {{{ */
 					/* name      = */ callback_name,
 					/* callback  = */ cldap_read_host,
 					/* interval  = */ 0,
-					/* user_data = */ &(user_data_t) {
+					&(user_data_t) {
 						.data = st,
 					});
 		}

--- a/src/python.c
+++ b/src/python.c
@@ -665,12 +665,11 @@ static PyObject *cpy_register_generic_userdata(void *reg, void *handler, PyObjec
 	c->data = data;
 	c->next = NULL;
 
-	user_data_t user_data = {
-		.data = c,
-		.free_func = cpy_destroy_user_data
-	};
+	register_function(buf, handler, &(user_data_t) {
+				.data = c,
+				.free_func = cpy_destroy_user_data,
+			});
 
-	register_function(buf, handler, &user_data);
 	++cpy_num_callbacks;
 	return cpy_string_to_unicode_or_bytes(buf);
 }
@@ -704,13 +703,12 @@ static PyObject *cpy_register_read(PyObject *self, PyObject *args, PyObject *kwd
 	c->data = data;
 	c->next = NULL;
 
-	user_data_t user_data = {
-		.data = c,
-		.free_func = cpy_destroy_user_data
-	};
-
 	plugin_register_complex_read(/* group = */ "python", buf,
-			cpy_read_callback, DOUBLE_TO_CDTIME_T (interval), &user_data);
+			cpy_read_callback, DOUBLE_TO_CDTIME_T (interval),
+			&(user_data_t) {
+				.data = c,
+				.free_func = cpy_destroy_user_data,
+			});
 	++cpy_num_callbacks;
 	return cpy_string_to_unicode_or_bytes(buf);
 }

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -325,7 +325,6 @@ static int cr_config_router (oconfig_item_t *ci) /* {{{ */
 {
   cr_data_t *router_data;
   char read_name[128];
-  user_data_t user_data;
   int status;
 
   router_data = calloc (1, sizeof (*router_data));
@@ -409,11 +408,12 @@ static int cr_config_router (oconfig_item_t *ci) /* {{{ */
   }
 
   ssnprintf (read_name, sizeof (read_name), "routeros/%s", router_data->node);
-  user_data.data = router_data;
-  user_data.free_func = (void *) cr_free_data;
   if (status == 0)
     status = plugin_register_complex_read (/* group = */ NULL, read_name,
-	cr_read, /* interval = */ 0, &user_data);
+        cr_read, /* interval = */ 0, &(user_data_t) {
+          .data = router_data,
+          .free_func = (void *) cr_free_data,
+        });
 
   if (status != 0)
     cr_free_data (router_data);

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -764,13 +764,11 @@ static int csnmp_config_add_host (oconfig_item_t *ci)
 
   ssnprintf (cb_name, sizeof (cb_name), "snmp-%s", hd->name);
 
-  user_data_t ud = {
-    .data = hd,
-    .free_func = csnmp_host_definition_destroy
-  };
-
   status = plugin_register_complex_read (/* group = */ NULL, cb_name,
-      csnmp_read_host, hd->interval, /* user_data = */ &ud);
+      csnmp_read_host, hd->interval, &(user_data_t) {
+        .data = hd,
+        .free_func = csnmp_host_definition_destroy,
+      });
   if (status != 0)
   {
     ERROR ("snmp plugin: Registering complex read function failed.");

--- a/src/tail.c
+++ b/src/tail.c
@@ -339,11 +339,10 @@ static int ctail_init (void)
   {
     ssnprintf(str, sizeof(str), "tail-%zu", i);
 
-    user_data_t ud = {
-     .data = tail_match_list[i]
-    };
-
-    plugin_register_complex_read (NULL, str, ctail_read, tail_match_list_intervals[i], &ud);
+    plugin_register_complex_read (NULL, str, ctail_read, tail_match_list_intervals[i],
+        &(user_data_t) {
+          .data = tail_match_list[i],
+        });
   }
 
   return (0);

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -482,13 +482,11 @@ static int tcsv_config_add_file(oconfig_item_t *ci)
 
     ssnprintf (cb_name, sizeof (cb_name), "tail_csv/%s", id->path);
 
-    user_data_t ud = {
-        .data = id,
-        .free_func = tcsv_instance_definition_destroy
-    };
-
-    status = plugin_register_complex_read(NULL, cb_name, tcsv_read, id->interval, &ud);
-
+    status = plugin_register_complex_read(NULL, cb_name, tcsv_read, id->interval,
+            &(user_data_t) {
+                .data = id,
+                .free_func = tcsv_instance_definition_destroy,
+            });
     if (status != 0){
         ERROR("tail_csv plugin: Registering complex read function failed.");
         tcsv_instance_definition_destroy(id);

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -1134,8 +1134,8 @@ static int varnish_config_instance (const oconfig_item_t *ci) /* {{{ */
 			/* callback  = */ varnish_read,
 			/* interval  = */ 0,
 			&(user_data_t) {
-				ud.data = conf,
-				ud.free_func = varnish_config_free,
+				.data = conf,
+				.free_func = varnish_config_free,
 			});
 
 	have_instance = 1;

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -951,16 +951,14 @@ static int varnish_init (void) /* {{{ */
 
 	varnish_config_apply_default (conf);
 
-	user_data_t ud = {
-		.data = conf,
-		.free_func = varnish_config_free
-	};
-
 	plugin_register_complex_read (/* group = */ "varnish",
 			/* name      = */ "varnish/localhost",
 			/* callback  = */ varnish_read,
 			/* interval  = */ 0,
-			/* user data = */ &ud);
+			/* user data = */ &(user_data_t) {
+				.data = conf,
+				.free_func = varnish_config_free,
+			});
 
 	return (0);
 } /* }}} int varnish_init */
@@ -968,7 +966,6 @@ static int varnish_init (void) /* {{{ */
 static int varnish_config_instance (const oconfig_item_t *ci) /* {{{ */
 {
 	user_config_t *conf;
-	user_data_t ud;
 	char callback_name[DATA_MAX_NAME_LEN];
 
 	conf = calloc (1, sizeof (*conf));
@@ -1132,14 +1129,14 @@ static int varnish_config_instance (const oconfig_item_t *ci) /* {{{ */
 	ssnprintf (callback_name, sizeof (callback_name), "varnish/%s",
 			(conf->instance == NULL) ? "localhost" : conf->instance);
 
-	ud.data = conf;
-	ud.free_func = varnish_config_free;
-
 	plugin_register_complex_read (/* group = */ "varnish",
 			/* name      = */ callback_name,
 			/* callback  = */ varnish_read,
 			/* interval  = */ 0,
-			/* user data = */ &ud);
+			/* user data = */ &(user_data_t) {
+				ud.data = conf,
+				ud.free_func = varnish_config_free,
+			});
 
 	have_instance = 1;
 

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -955,7 +955,7 @@ static int varnish_init (void) /* {{{ */
 			/* name      = */ "varnish/localhost",
 			/* callback  = */ varnish_read,
 			/* interval  = */ 0,
-			/* user data = */ &(user_data_t) {
+			&(user_data_t) {
 				.data = conf,
 				.free_func = varnish_config_free,
 			});
@@ -1133,7 +1133,7 @@ static int varnish_config_instance (const oconfig_item_t *ci) /* {{{ */
 			/* name      = */ callback_name,
 			/* callback  = */ varnish_read,
 			/* interval  = */ 0,
-			/* user data = */ &(user_data_t) {
+			&(user_data_t) {
 				ud.data = conf,
 				ud.free_func = varnish_config_free,
 			});

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -575,15 +575,13 @@ static int wg_config_node (oconfig_item_t *ci)
         ssnprintf (callback_name, sizeof (callback_name), "write_graphite/%s",
                 cb->name);
 
-    user_data_t ud = {
-        .data = cb,
-        .free_func = wg_callback_free
-    };
+    plugin_register_write (callback_name, wg_write,
+            &(user_data_t) {
+                .data = cb,
+                .free_func = wg_callback_free,
+            });
 
-    plugin_register_write (callback_name, wg_write, &ud);
-
-    ud.free_func = NULL;
-    plugin_register_flush (callback_name, wg_flush, &ud);
+    plugin_register_flush (callback_name, wg_flush, &(user_data_t) { .data = cb });
 
     return (0);
 }

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -383,12 +383,11 @@ static void kafka_config_topic(rd_kafka_conf_t *conf, oconfig_item_t *ci) /* {{{
     ssnprintf(callback_name, sizeof(callback_name),
               "write_kafka/%s", tctx->topic_name);
 
-    user_data_t ud = {
-        .data = tctx,
-        .free_func = kafka_topic_context_free
-    };
-
-    status = plugin_register_write (callback_name, kafka_write, &ud);
+    status = plugin_register_write (callback_name, kafka_write,
+            &(user_data_t) {
+                .data = tctx,
+                .free_func = kafka_topic_context_free,
+            });
     if (status != 0) {
         WARNING ("write_kafka plugin: plugin_register_write (\"%s\") "
                 "failed with status %i.",

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -339,12 +339,11 @@ static int wm_config_node (oconfig_item_t *ci) /* {{{ */
 
     ssnprintf (cb_name, sizeof (cb_name), "write_mongodb/%s", node->name);
 
-    user_data_t ud = {
-      .data = node,
-      .free_func = wm_config_free
-    };
-
-    status = plugin_register_write (cb_name, wm_write, &ud);
+    status = plugin_register_write (cb_name, wm_write,
+		    &(user_data_t) {
+			    .data = node,
+			    .free_func = wm_config_free,
+		    });
     INFO ("write_mongodb plugin: registered write plugin %s %d",cb_name,status);
   }
 

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -234,12 +234,11 @@ static int wr_config_node (oconfig_item_t *ci) /* {{{ */
 
     ssnprintf (cb_name, sizeof (cb_name), "write_redis/%s", node->name);
 
-    user_data_t ud = {
-      .data = node,
-      .free_func = wr_config_free
-    };
-
-    status = plugin_register_write (cb_name, wr_write, &ud);
+    status = plugin_register_write (cb_name, wr_write,
+        &(user_data_t) {
+          .data = node,
+          .free_func = wr_config_free,
+        });
   }
 
   if (status != 0)


### PR DESCRIPTION
`user_data_t` is one of those structs where we used to create a variable just for a single function call. This patch inlines these cases into the function call using a compound literal.