### PR TITLE
Tree wide: Use compound literals when dealing with value_t.

### DIFF
--- a/contrib/examples/myplugin.c
+++ b/contrib/examples/myplugin.c
@@ -85,36 +85,50 @@ static int my_init (void)
 } /* static int my_init (void) */
 
 /*
- * This function is called in regular intervalls to collect the data.
+ * This is a utility function used by the read callback to populate a
+ * value_list_t and pass it to plugin_dispatch_values.
  */
-static int my_read (void)
+static int my_submit (gauge_t value)
 {
-	value_t values[1]; /* the size of this list should equal the number of
-						  data sources */
 	value_list_t vl = VALUE_LIST_INIT;
 
-	/* do the magic to read the data */
-	values[0].gauge = random ();
-
-	vl.values     = values;
+	/* Convert the gauge_t to a value_t and add it to the value_list_t. */
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	vl.time       = time (NULL);
+
+	/* Only set vl.time yourself if you update multiple metrics (i.e. you
+	 * have multiple calls to plugin_dispatch_values()) and they need to all
+	 * have the same timestamp. */
+	/* vl.time = cdtime(); */
+
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "myplugin", sizeof (vl.plugin));
 
 	/* it is strongly recommended to use a type defined in the types.db file
 	 * instead of a custom type */
-	sstrncpy (vl.type, "myplugin", sizeof (vl.plugin));
+	sstrncpy (vl.type, "myplugin", sizeof (vl.type));
 	/* optionally set vl.plugin_instance and vl.type_instance to reasonable
 	 * values (default: "") */
 
 	/* dispatch the values to collectd which passes them on to all registered
 	 * write functions */
-	plugin_dispatch_values (&vl);
+	return plugin_dispatch_values (&vl);
+}
+
+/*
+ * This function is called in regular intervalls to collect the data.
+ */
+static int my_read (void)
+{
+	/* do the magic to read the data */
+	gauge_t value = random ();
+
+	if (my_submit (value) != 0)
+		WARNING ("myplugin plugin: Dispatching a random value failed.");
 
 	/* A return value != 0 indicates an error and the plugin will be skipped
 	 * for an increasing amount of time. */
-    return 0;
+	return 0;
 } /* static int my_read (void) */
 
 /*

--- a/src/apache.c
+++ b/src/apache.c
@@ -411,19 +411,15 @@ static void submit_value (const char *type, const char *type_instance,
 } /* void submit_value */
 
 static void submit_derive (const char *type, const char *type_instance,
-		derive_t c, apache_t *st)
+		derive_t d, apache_t *st)
 {
-	value_t v;
-	v.derive = c;
-	submit_value (type, type_instance, v, st);
+	submit_value (type, type_instance, (value_t) { .derive = d }, st);
 } /* void submit_derive */
 
 static void submit_gauge (const char *type, const char *type_instance,
 		gauge_t g, apache_t *st)
 {
-	value_t v;
-	v.gauge = g;
-	submit_value (type, type_instance, v, st);
+	submit_value (type, type_instance, (value_t) { .gauge = g }, st);
 } /* void submit_gauge */
 
 static void submit_scoreboard (char *buf, apache_t *st)

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -416,12 +416,9 @@ static int apcups_config (oconfig_item_t *ci)
 
 static void apc_submit_generic (const char *type, const char *type_inst, double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "apcups", sizeof (vl.plugin));

--- a/src/apple_sensors.c
+++ b/src/apple_sensors.c
@@ -83,15 +83,9 @@ static int as_init (void)
 static void as_submit (const char *type, const char *type_instance,
 		double val)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	DEBUG ("type = %s; type_instance = %s; val = %f;",
-			type, type_instance, val);
-
-	values[0].gauge = val;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = val };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "apple_sensors", sizeof (vl.plugin));

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -60,16 +60,13 @@ static void aquaero_submit (const char *type, const char *type_instance,
 		double value)
 {
 	const char *instance = conf_device?conf_device:"default";
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
 	/* Don't report undefined values. */
 	if (value == AQ5_FLOAT_UNDEF)
 		return;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -126,12 +126,9 @@ static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 static int ascent_submit_gauge (const char *plugin_instance, /* {{{ */
     const char *type, const char *type_instance, gauge_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ascent", sizeof (vl.plugin));

--- a/src/battery.c
+++ b/src/battery.c
@@ -78,12 +78,9 @@ static _Bool query_statefs = 0;
 static void battery_submit2 (char const *plugin_instance, /* {{{ */
 		char const *type, char const *type_instance, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "battery", sizeof (vl.plugin));

--- a/src/battery_statefs.c
+++ b/src/battery_statefs.c
@@ -54,12 +54,9 @@ SOFTWARE.
 
 static void battery_submit(const char *type, gauge_t value,
                            const char *type_instance) {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "battery", sizeof(vl.plugin));

--- a/src/bind.c
+++ b/src/bind.c
@@ -247,12 +247,9 @@ static int memsummary_translation_table_length =
 static void submit (time_t ts, const char *plugin_instance, /* {{{ */
     const char *type, const char *type_instance, value_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0] = value;
-
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   if (config_parse_time)
     vl.time = TIME_T_TO_CDTIME_T (ts);

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -677,12 +677,9 @@ ntohf(tFloat p_float)
 static void
 chrony_push_data(const char *p_type, const char *p_type_inst, double p_value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = p_value;    /* TODO: Check type??? (counter, gauge, derive, absolute) */
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = p_value };
   vl.values_len = 1;
 
   /* XXX: Shall g_chrony_host/g_chrony_port be reflected in the plugin's output? */

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -49,12 +49,9 @@
 
 static void cs_submit (derive_t context_switches)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = (derive_t) context_switches;
-
-	vl.values = values;
+	vl.values = &(value_t) { .derive = context_switches };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "contextswitch", sizeof (vl.plugin));

--- a/src/cpusleep.c
+++ b/src/cpusleep.c
@@ -37,12 +37,9 @@
 #include <time.h>
 
 static void cpusleep_submit(derive_t cpu_sleep) {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].derive = cpu_sleep;
-
-  vl.values = values;
+  vl.values = &(value_t) { .derive = cpu_sleep };
   vl.values_len = 1;
   sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "cpusleep", sizeof(vl.plugin));

--- a/src/curl.c
+++ b/src/curl.c
@@ -608,14 +608,11 @@ static int cc_init (void) /* {{{ */
 } /* }}} int cc_init */
 
 static void cc_submit (const web_page_t *wp, const web_match_t *wm, /* {{{ */
-    const cu_match_value_t *mv)
+    value_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0] = mv->value;
-
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
@@ -629,12 +626,9 @@ static void cc_submit (const web_page_t *wp, const web_match_t *wm, /* {{{ */
 
 static void cc_submit_response_code (const web_page_t *wp, long code) /* {{{ */
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = code;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = (gauge_t) code };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
@@ -647,12 +641,9 @@ static void cc_submit_response_code (const web_page_t *wp, long code) /* {{{ */
 static void cc_submit_response_time (const web_page_t *wp, /* {{{ */
     cdtime_t response_time)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = CDTIME_T_TO_DOUBLE (response_time);
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = CDTIME_T_TO_DOUBLE (response_time) };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
@@ -714,7 +705,7 @@ static int cc_read_page (web_page_t *wp) /* {{{ */
       continue;
     }
 
-    cc_submit (wp, wm, mv);
+    cc_submit (wp, wm, mv->value);
     match_value_reset (mv);
   } /* for (wm = wp->matches; wm != NULL; wm = wm->next) */
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -151,34 +151,28 @@ static const char *plugin_get_dir (void)
 }
 
 static void plugin_update_internal_statistics (void) { /* {{{ */
-	derive_t copy_write_queue_length;
-	value_list_t vl = VALUE_LIST_INIT;
-	value_t values[2];
 
-	copy_write_queue_length = write_queue_length;
+	gauge_t copy_write_queue_length = (gauge_t) write_queue_length;
 
 	/* Initialize `vl' */
-	vl.values = values;
-	vl.values_len = 2;
-	vl.time = 0;
+	value_list_t vl = VALUE_LIST_INIT;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "collectd", sizeof (vl.plugin));
-
-	vl.type_instance[0] = 0;
-	vl.values_len = 1;
 
 	/* Write queue */
 	sstrncpy (vl.plugin_instance, "write_queue",
 			sizeof (vl.plugin_instance));
 
 	/* Write queue : queue length */
-	vl.values[0].gauge = (gauge_t) copy_write_queue_length;
+	vl.values = &(value_t) { .gauge = copy_write_queue_length };
+	vl.values_len = 1;
 	sstrncpy (vl.type, "queue_length", sizeof (vl.type));
 	vl.type_instance[0] = 0;
 	plugin_dispatch_values (&vl);
 
 	/* Write queue : Values dropped (queue length > low limit) */
-	vl.values[0].derive = (derive_t) stats_values_dropped;
+	vl.values = &(value_t) { .gauge = (gauge_t) stats_values_dropped };
+	vl.values_len = 1;
 	sstrncpy (vl.type, "derive", sizeof (vl.type));
 	sstrncpy (vl.type_instance, "dropped", sizeof (vl.type_instance));
 	plugin_dispatch_values (&vl);
@@ -188,7 +182,8 @@ static void plugin_update_internal_statistics (void) { /* {{{ */
 			sizeof (vl.plugin_instance));
 
 	/* Cache : Nb entry in cache tree */
-	vl.values[0].gauge = (gauge_t) uc_get_size();
+	vl.values = &(value_t) { .gauge = (gauge_t) uc_get_size() };
+	vl.values_len = 1;
 	sstrncpy (vl.type, "cache_size", sizeof (vl.type));
 	vl.type_instance[0] = 0;
 	plugin_dispatch_values (&vl);

--- a/src/df.c
+++ b/src/df.c
@@ -161,12 +161,9 @@ static void df_submit_one (char *plugin_instance,
 		const char *type, const char *type_instance,
 		gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "df", sizeof (vl.plugin));

--- a/src/disk.c
+++ b/src/disk.c
@@ -297,14 +297,14 @@ static void disk_submit (const char *plugin_instance,
 		const char *type,
 		derive_t read, derive_t write)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = read;
-	values[1].derive = write;
+	value_t values[] = {
+		{ .derive = read },
+		{ .derive = write },
+	};
 
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
@@ -317,14 +317,14 @@ static void disk_submit (const char *plugin_instance,
 #if KERNEL_FREEBSD || KERNEL_LINUX
 static void submit_io_time (char const *plugin_instance, derive_t io_time, derive_t weighted_time)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = io_time;
-	values[1].derive = weighted_time;
+	value_t values[] = {
+		{ .derive = io_time },
+		{ .derive = weighted_time },
+	};
 
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));

--- a/src/disk.c
+++ b/src/disk.c
@@ -337,12 +337,9 @@ static void submit_io_time (char const *plugin_instance, derive_t io_time, deriv
 #if KERNEL_LINUX
 static void submit_in_progress (char const *disk_name, gauge_t in_progress)
 {
-	value_t v;
 	value_list_t vl = VALUE_LIST_INIT;
 
-	v.gauge = in_progress;
-
-	vl.values = &v;
+	vl.values = &(value_t) { .gauge = in_progress };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
@@ -351,7 +348,6 @@ static void submit_in_progress (char const *disk_name, gauge_t in_progress)
 
 	plugin_dispatch_values (&vl);
 }
-
 
 static counter_t disk_calc_time_incr (counter_t delta_time, counter_t delta_ops)
 {

--- a/src/dns.c
+++ b/src/dns.c
@@ -384,14 +384,14 @@ static void submit_derive (const char *type, const char *type_instance,
 
 static void submit_octets (derive_t queries, derive_t responses)
 {
-	value_t values[2];
+	value_t values[] = {
+          { .derive = queries },
+          { .derive = responses },
+        };
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = queries;
-	values[1].derive = responses;
-
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "dns", sizeof (vl.plugin));
 	sstrncpy (vl.type, "dns_octets", sizeof (vl.type));

--- a/src/dns.c
+++ b/src/dns.c
@@ -370,12 +370,9 @@ static int dns_init (void)
 static void submit_derive (const char *type, const char *type_instance,
 		derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "dns", sizeof (vl.plugin));

--- a/src/email.c
+++ b/src/email.c
@@ -653,12 +653,9 @@ static int email_shutdown (void)
 
 static void email_submit (const char *type, const char *type_instance, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "email", sizeof (vl.plugin));

--- a/src/ethstat.c
+++ b/src/ethstat.c
@@ -172,7 +172,6 @@ static void ethstat_submit_value (const char *device,
 {
   static c_complain_t complain_no_map = C_COMPLAIN_INIT_STATIC;
 
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
   value_map_t *map = NULL;
 
@@ -189,8 +188,7 @@ static void ethstat_submit_value (const char *device,
     return;
   }
 
-  values[0].derive = value;
-  vl.values = values;
+  vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
 
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/fhcount.c
+++ b/src/fhcount.c
@@ -60,13 +60,9 @@ static int fhcount_config(const char *key, const char *value) {
 
 static void fhcount_submit(
     const char *type, const char *type_instance, gauge_t value) {
-
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
 
   // Compose the metric
@@ -78,7 +74,6 @@ static void fhcount_submit(
   // Dispatch the metric
   plugin_dispatch_values(&vl);
 }
-
 
 static int fhcount_read(void) {
   int numfields = 0;

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -61,13 +61,10 @@ static size_t directories_num = 0;
 
 static void fc_submit_dir (const fc_directory_conf_t *dir)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = (gauge_t) dir->files_num;
-
-  vl.values = values;
-  vl.values_len = STATIC_ARRAY_SIZE (values);
+  vl.values = &(value_t) { .gauge = (gauge_t) dir->files_num };
+  vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "filecount", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dir->instance, sizeof (vl.plugin_instance));
@@ -75,7 +72,7 @@ static void fc_submit_dir (const fc_directory_conf_t *dir)
 
   plugin_dispatch_values (&vl);
 
-  values[0].gauge = (gauge_t) dir->files_size;
+  vl.values = &(value_t) { .gauge = (gauge_t) dir->files_size };
   sstrncpy (vl.type, "bytes", sizeof (vl.type));
 
   plugin_dispatch_values (&vl);

--- a/src/gps.c
+++ b/src/gps.c
@@ -220,12 +220,9 @@ quit:
  */
 static void cgps_submit (const char *type, gauge_t value, const char *type_instance)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "gps", sizeof (vl.plugin));

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -226,12 +226,9 @@ static int hddtemp_config (const char *key, const char *value)
 
 static void hddtemp_submit (char *type_instance, double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "hddtemp", sizeof (vl.plugin));

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -67,14 +67,14 @@ static int huge_config_callback(const char *key, const char *val)
 static void submit_hp(const char *plug_inst, const char *type,
   const char *type_instance, gauge_t free_value, gauge_t used_value)
 {
-  value_t values[2];
   value_list_t vl = VALUE_LIST_INIT;
-
-  values[0].gauge = free_value;
-  values[1].gauge = used_value;
+  value_t values[] = {
+    { .gauge = free_value },
+    { .gauge = used_value },
+  };
 
   vl.values = values;
-  vl.values_len = 2;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, g_plugin_name, sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, plug_inst, sizeof (vl.plugin_instance));

--- a/src/interface.c
+++ b/src/interface.c
@@ -168,17 +168,17 @@ static void if_submit (const char *dev, const char *type,
 		derive_t rx,
 		derive_t tx)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 
 	if (ignorelist_match (ignorelist, dev) != 0)
 		return;
 
-	values[0].derive = rx;
-	values[1].derive = tx;
-
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "interface", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -97,12 +97,9 @@ static void ipc_submit_g (const char *plugin_instance,
                           const char *type_instance,
                           gauge_t value) /* {{{ */
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ipc", sizeof (vl.plugin));

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -115,7 +115,6 @@ static void sensor_read_handler (ipmi_sensor_t *sensor,
     ipmi_states_t __attribute__((unused)) *states,
     void *user_data)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
   c_ipmi_sensor_list_t *list_item = (c_ipmi_sensor_list_t *)user_data;
@@ -214,9 +213,7 @@ static void sensor_read_handler (ipmi_sensor_t *sensor,
     return;
   }
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
 
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -242,7 +242,6 @@ static int submit6_match (const struct ip6t_entry_match *match,
                           int rule_num)
 {
     int status;
-    value_t values[1];
     value_list_t vl = VALUE_LIST_INIT;
 
     /* Select the rules to collect */
@@ -260,8 +259,6 @@ static int submit6_match (const struct ip6t_entry_match *match,
             return (0);
     }
 
-    vl.values = values;
-    vl.values_len = 1;
     sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "ip6tables", sizeof (vl.plugin));
 
@@ -285,16 +282,16 @@ static int submit6_match (const struct ip6t_entry_match *match,
     }
 
     sstrncpy (vl.type, "ipt_bytes", sizeof (vl.type));
-    values[0].derive = (derive_t) entry->counters.bcnt;
+    vl.values = &(value_t) { .derive = (derive_t) entry->counters.bcnt };
+    vl.values_len = 1;
     plugin_dispatch_values (&vl);
 
     sstrncpy (vl.type, "ipt_packets", sizeof (vl.type));
-    values[0].derive = (derive_t) entry->counters.pcnt;
+    vl.values = &(value_t) { .derive = (derive_t) entry->counters.pcnt };
     plugin_dispatch_values (&vl);
 
     return (0);
-} /* int submit_match */
-
+} /* int submit6_match */
 
 /* This needs to return `int' for IPT_MATCH_ITERATE to work. */
 static int submit_match (const struct ipt_entry_match *match,
@@ -303,7 +300,6 @@ static int submit_match (const struct ipt_entry_match *match,
                          int rule_num)
 {
     int status;
-    value_t values[1];
     value_list_t vl = VALUE_LIST_INIT;
 
     /* Select the rules to collect */
@@ -321,8 +317,6 @@ static int submit_match (const struct ipt_entry_match *match,
             return (0);
     }
 
-    vl.values = values;
-    vl.values_len = 1;
     sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "iptables", sizeof (vl.plugin));
 
@@ -346,11 +340,12 @@ static int submit_match (const struct ipt_entry_match *match,
     }
 
     sstrncpy (vl.type, "ipt_bytes", sizeof (vl.type));
-    values[0].derive = (derive_t) entry->counters.bcnt;
+    vl.values = &(value_t) { .derive = (derive_t) entry->counters.bcnt };
+    vl.values_len = 1;
     plugin_dispatch_values (&vl);
 
     sstrncpy (vl.type, "ipt_packets", sizeof (vl.type));
-    values[0].derive = (derive_t) entry->counters.pcnt;
+    vl.values = &(value_t) { .derive = (derive_t) entry->counters.pcnt };
     plugin_dispatch_values (&vl);
 
     return (0);

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -247,14 +247,14 @@ static void cipvs_submit_connections (const char *pi, const char *ti,
 static void cipvs_submit_if (const char *pi, const char *t, const char *ti,
 		derive_t rx, derive_t tx)
 {
-	value_t values[2];
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = rx;
-	values[1].derive = tx;
-
 	vl.values     = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "ipvs", sizeof (vl.plugin));

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -228,12 +228,9 @@ static int get_ti (struct ip_vs_dest_entry *de, char *ti, size_t size)
 static void cipvs_submit_connections (const char *pi, const char *ti,
 		derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = value;
-
-	vl.values     = values;
+	vl.values     = &(value_t) { .derive = value };
 	vl.values_len = 1;
 
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/irq.c
+++ b/src/irq.c
@@ -72,15 +72,12 @@ static int irq_config (const char *key, const char *value)
 
 static void irq_submit (const char *irq_name, derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
 	if (ignorelist_match (ignorelist, irq_name) != 0)
 		return;
 
-	values[0].derive = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "irq", sizeof (vl.plugin));

--- a/src/load.c
+++ b/src/load.c
@@ -78,8 +78,6 @@ static int load_config (const char *key, const char *value)
 }
 static void load_submit (gauge_t snum, gauge_t mnum, gauge_t lnum)
 {
-	value_t values[3];
-	value_list_t vl = VALUE_LIST_INIT;
         int cores = 0;
         char errbuf[1024];
 
@@ -97,9 +95,12 @@ static void load_submit (gauge_t snum, gauge_t mnum, gauge_t lnum)
 		lnum /= cores;
 	}
 
-	values[0].gauge = snum;
-	values[1].gauge = mnum;
-	values[2].gauge = lnum;
+	value_list_t vl = VALUE_LIST_INIT;
+	value_t values[] = {
+		{ .gauge = snum },
+		{ .gauge = mnum },
+		{ .gauge = lnum },
+	};
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -114,12 +114,9 @@ static int lpar_init (void)
 
 static void lpar_submit (const char *type_instance, double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = (gauge_t)value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	if (report_by_serial)
 	{

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -55,12 +55,9 @@ static char const *get_lv_property_string(lv_t lv, char const *property)
 static void lvm_submit (char const *plugin_instance, char const *type_instance,
         uint64_t ivalue)
 {
-    value_t v;
     value_list_t vl = VALUE_LIST_INIT;
 
-    v.gauge = (gauge_t) ivalue;
-
-    vl.values = &v;
+    vl.values = &(value_t) { .gauge = (gauge_t) ivalue };
     vl.values_len = 1;
 
     sstrncpy(vl.host, hostname_g, sizeof (vl.host));

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -538,7 +538,7 @@ static int madwifi_config (const char *key, const char *value)
 
 
 static void submit (const char *dev, const char *type, const char *ti1,
-			const char *ti2, value_t *val, int len)
+			const char *ti2, value_t *val, size_t len)
 {
 	value_list_t vl = VALUE_LIST_INIT;
 
@@ -558,11 +558,9 @@ static void submit (const char *dev, const char *type, const char *ti1,
 }
 
 static void submit_derive (const char *dev, const char *type, const char *ti1,
-				const char *ti2, derive_t val)
+				const char *ti2, derive_t value)
 {
-	value_t item;
-	item.derive = val;
-	submit (dev, type, ti1, ti2, &item, 1);
+	submit (dev, type, ti1, ti2, &(value_t) { .derive = value }, 1);
 }
 
 static void submit_derive2 (const char *dev, const char *type, const char *ti1,
@@ -575,11 +573,9 @@ static void submit_derive2 (const char *dev, const char *type, const char *ti1,
 }
 
 static void submit_gauge (const char *dev, const char *type, const char *ti1,
-				const char *ti2, gauge_t val)
+				const char *ti2, gauge_t value)
 {
-	value_t item;
-	item.gauge = val;
-	submit (dev, type, ti1, ti2, &item, 1);
+	submit (dev, type, ti1, ti2, &(value_t) { .gauge = value }, 1);
 }
 
 static void submit_antx (const char *dev, const char *name,

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -566,10 +566,12 @@ static void submit_derive (const char *dev, const char *type, const char *ti1,
 static void submit_derive2 (const char *dev, const char *type, const char *ti1,
 				const char *ti2, derive_t val1, derive_t val2)
 {
-	value_t items[2];
-	items[0].derive = val1;
-	items[1].derive = val2;
-	submit (dev, type, ti1, ti2, items, 2);
+	value_t values[] = {
+          { .derive = val1 },
+          { .derive = val2 },
+        };
+
+	submit (dev, type, ti1, ti2, values, STATIC_ARRAY_SIZE (values));
 }
 
 static void submit_gauge (const char *dev, const char *type, const char *ti1,

--- a/src/mbmon.c
+++ b/src/mbmon.c
@@ -218,12 +218,9 @@ static int mbmon_config (const char *key, const char *value)
 static void mbmon_submit (const char *type, const char *type_instance,
 		double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "mbmon", sizeof (vl.plugin));

--- a/src/md.c
+++ b/src/md.c
@@ -72,12 +72,9 @@ static int md_config (const char *key, const char *value)
 static void md_submit (const int minor, const char *type_instance,
     gauge_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "md", sizeof (vl.plugin));

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -441,14 +441,11 @@ static int cmc_init (void) /* {{{ */
 } /* }}} int cmc_init */
 
 static void cmc_submit (const web_page_t *wp, const web_match_t *wm, /* {{{ */
-    const cu_match_value_t *mv)
+    value_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0] = mv->value;
-
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "memcachec", sizeof (vl.plugin));
@@ -496,7 +493,7 @@ static int cmc_read_page (web_page_t *wp) /* {{{ */
       continue;
     }
 
-    cmc_submit (wp, wm, mv);
+    cmc_submit (wp, wm, mv->value);
     match_value_reset (mv);
   } /* for (wm = wp->matches; wm != NULL; wm = wm->next) */
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -262,13 +262,10 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
 static void submit_derive (const char *type, const char *type_inst,
     derive_t value, memcached_t *st)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
+
   memcached_init_vl (&vl, st);
-
-  values[0].derive = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
   sstrncpy (vl.type, type, sizeof (vl.type));
   if (type_inst != NULL)
@@ -299,13 +296,10 @@ static void submit_derive2 (const char *type, const char *type_inst,
 static void submit_gauge (const char *type, const char *type_inst,
     gauge_t value, memcached_t *st)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
+
   memcached_init_vl (&vl, st);
-
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.type, type, sizeof (vl.type));
   if (type_inst != NULL)

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -277,15 +277,15 @@ static void submit_derive (const char *type, const char *type_inst,
 static void submit_derive2 (const char *type, const char *type_inst,
     derive_t value0, derive_t value1, memcached_t *st)
 {
-  value_t values[2];
   value_list_t vl = VALUE_LIST_INIT;
+  value_t values[] = {
+    { .derive = value0 },
+    { .derive = value1 },
+  };
+
   memcached_init_vl (&vl, st);
-
-  values[0].derive = value0;
-  values[1].derive = value1;
-
   vl.values = values;
-  vl.values_len = 2;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.type, type, sizeof (vl.type));
   if (type_inst != NULL)
     sstrncpy (vl.type_instance, type_inst, sizeof (vl.type_instance));
@@ -311,15 +311,15 @@ static void submit_gauge (const char *type, const char *type_inst,
 static void submit_gauge2 (const char *type, const char *type_inst,
     gauge_t value0, gauge_t value1, memcached_t *st)
 {
-  value_t values[2];
   value_list_t vl = VALUE_LIST_INIT;
+  value_t values[] = {
+    { .gauge = value0 },
+    { .gauge = value1 },
+  };
+
   memcached_init_vl (&vl, st);
-
-  values[0].gauge = value0;
-  values[1].gauge = value1;
-
   vl.values = values;
-  vl.values_len = 2;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.type, type, sizeof (vl.type));
   if (type_inst != NULL)
     sstrncpy (vl.type_instance, type_inst, sizeof (vl.type_instance));

--- a/src/mic.c
+++ b/src/mic.c
@@ -150,17 +150,15 @@ static int mic_config (const char *key, const char *value) {
 	return (0);
 }
 
-static void mic_submit_memory_use(int micnumber, const char *type_instance, U32 val)
+static void mic_submit_memory_use(int micnumber, const char *type_instance, U32 value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
 	/* MicAccessAPI reports KB's of memory, adjust for this */
-	DEBUG("mic plugin: Memory Value Report; %u %lf",val,((gauge_t)val)*1024.0);
-	values[0].gauge = ((gauge_t)val)*1024.0;
+	DEBUG("mic plugin: Memory Value Report; %u %lf",value,((gauge_t)value)*1024.0);
 
-	vl.values=values;
-	vl.values_len=1;
+	vl.values = &(value_t) { .gauge = ((gauge_t)value) * 1024.0 };
+	vl.values_len = 1;
 
 	strncpy (vl.host, hostname_g, sizeof (vl.host));
 	strncpy (vl.plugin, "mic", sizeof (vl.plugin));
@@ -190,15 +188,12 @@ static int mic_read_memory(int mic)
 	return (0);
 }
 
-static void mic_submit_temp(int micnumber, const char *type, gauge_t val)
+static void mic_submit_temp(int micnumber, const char *type, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = val;
-
-	vl.values=values;
-	vl.values_len=1;
+	vl.values = &(value_t) { .gauge = value };
+	vl.values_len = 1;
 
 	strncpy (vl.host, hostname_g, sizeof (vl.host));
 	strncpy (vl.plugin, "mic", sizeof (vl.plugin));
@@ -237,15 +232,12 @@ static int mic_read_temps(int mic)
 }
 
 static void mic_submit_cpu(int micnumber, const char *type_instance,
-		int core, derive_t val)
+		int core, derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = val;
-
-	vl.values=values;
-	vl.values_len=1;
+	vl.values = &(value_t) { .derive = value };
+	vl.values_len = 1;
 
 	strncpy (vl.host, hostname_g, sizeof (vl.host));
 	strncpy (vl.plugin, "mic", sizeof (vl.plugin));
@@ -296,15 +288,12 @@ static int mic_read_cpu(int mic)
 	return (0);
 }
 
-static void mic_submit_power(int micnumber, const char *type, const char *type_instance, gauge_t val)
+static void mic_submit_power(int micnumber, const char *type, const char *type_instance, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = val;
-
-	vl.values=values;
-	vl.values_len=1;
+	vl.values = &(value_t) { .gauge = value };
+	vl.values_len = 1;
 
 	strncpy (vl.host, hostname_g, sizeof (vl.host));
 	strncpy (vl.plugin, "mic", sizeof (vl.plugin));
@@ -358,13 +347,13 @@ static int mic_read (void)
 	U32 ret;
 	int error;
 
-	error=0;
-	for (int i=0;i<num_mics;i++) {
+	error = 0;
+	for (int i = 0;i<num_mics;i++) {
 		ret = MicInitAdapter(&mic_handle,&mics[i]);
 		if (ret != MIC_ACCESS_API_SUCCESS) {
 			ERROR("mic plugin: Problem initializing MicAdapter: %s",
 					MicGetErrorString(ret));
-			error=1;
+			error = 1;
 		}
 
 		if (error == 0 && show_memory)
@@ -383,12 +372,12 @@ static int mic_read (void)
 		if (ret != MIC_ACCESS_API_SUCCESS) {
 			ERROR("mic plugin: Problem closing MicAdapter: %s",
 					MicGetErrorString(ret));
-			error=2;
+			error = 2;
 			break;
 		}
 	}
 	if (num_mics==0)
-		error=3;
+		error = 3;
 	return error;
 }
 

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -193,12 +193,9 @@ static int multimeter_init (void)
 
 static void multimeter_submit (double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "multimeter", sizeof (vl.plugin));

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -379,10 +379,10 @@ static void derive_submit (const char *type, const char *type_instance,
 
 static void traffic_submit (derive_t rx, derive_t tx, mysql_database_t *db)
 {
-	value_t values[2];
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 
 	submit ("mysql_octets", NULL, values, STATIC_ARRAY_SIZE (values), db);
 } /* void traffic_submit */

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -365,31 +365,16 @@ static void submit (const char *type, const char *type_instance,
 	plugin_dispatch_values (&vl);
 } /* submit */
 
-static void counter_submit (const char *type, const char *type_instance,
-		derive_t value, mysql_database_t *db)
-{
-	value_t values[1];
-
-	values[0].derive = value;
-	submit (type, type_instance, values, STATIC_ARRAY_SIZE (values), db);
-} /* void counter_submit */
-
 static void gauge_submit (const char *type, const char *type_instance,
 		gauge_t value, mysql_database_t *db)
 {
-	value_t values[1];
-
-	values[0].gauge = value;
-	submit (type, type_instance, values, STATIC_ARRAY_SIZE (values), db);
+	submit (type, type_instance, &(value_t) { .gauge = value }, 1, db);
 } /* void gauge_submit */
 
 static void derive_submit (const char *type, const char *type_instance,
 		derive_t value, mysql_database_t *db)
 {
-	value_t values[1];
-
-	values[0].derive = value;
-	submit (type, type_instance, values, STATIC_ARRAY_SIZE (values), db);
+	submit (type, type_instance, &(value_t) { .derive = value }, 1, db);
 } /* void derive_submit */
 
 static void traffic_submit (derive_t rx, derive_t tx, mysql_database_t *db)
@@ -462,7 +447,7 @@ static int mysql_read_master_stats (mysql_database_t *db, MYSQL *con)
 	}
 
 	position = atoll (row[1]);
-	counter_submit ("mysql_log_position", "master-bin", position, db);
+	derive_submit ("mysql_log_position", "master-bin", position, db);
 
 	row = mysql_fetch_row (res);
 	if (row != NULL)
@@ -520,10 +505,10 @@ static int mysql_read_slave_stats (mysql_database_t *db, MYSQL *con)
 		double gauge;
 
 		counter = atoll (row[READ_MASTER_LOG_POS_IDX]);
-		counter_submit ("mysql_log_position", "slave-read", counter, db);
+		derive_submit ("mysql_log_position", "slave-read", counter, db);
 
 		counter = atoll (row[EXEC_MASTER_LOG_POS_IDX]);
-		counter_submit ("mysql_log_position", "slave-exec", counter, db);
+		derive_submit ("mysql_log_position", "slave-exec", counter, db);
 
 		if (row[SECONDS_BEHIND_MASTER_IDX] != NULL)
 		{
@@ -673,7 +658,7 @@ static int mysql_read_innodb_stats (mysql_database_t *db, MYSQL *con)
 
 		switch (metrics[i].ds_type) {
 			case DS_TYPE_COUNTER:
-				counter_submit(metrics[i].type, key, (counter_t)val, db);
+				derive_submit(metrics[i].type, key, (counter_t)val, db);
 				break;
 			case DS_TYPE_GAUGE:
 				gauge_submit(metrics[i].type, key, (gauge_t)val, db);
@@ -836,7 +821,7 @@ static int mysql_read (user_data_t *ud)
 
 			/* Ignore `prepared statements' */
 			if (strncmp (key, "Com_stmt_", strlen ("Com_stmt_")) != 0)
-				counter_submit ("mysql_commands",
+				derive_submit ("mysql_commands",
 						key + strlen ("Com_"),
 						val, db);
 		}
@@ -846,7 +831,7 @@ static int mysql_read (user_data_t *ud)
 			if (val == 0ULL)
 				continue;
 
-			counter_submit ("mysql_handler",
+			derive_submit ("mysql_handler",
 					key + strlen ("Handler_"),
 					val, db);
 		}
@@ -887,7 +872,7 @@ static int mysql_read (user_data_t *ud)
 		else if (strncmp (key, "Table_locks_",
 					strlen ("Table_locks_")) == 0)
 		{
-			counter_submit ("mysql_locks",
+			derive_submit ("mysql_locks",
 					key + strlen ("Table_locks_"),
 					val, db);
 		}
@@ -899,7 +884,7 @@ static int mysql_read (user_data_t *ud)
 			else if (strcmp (key, "Innodb_buffer_pool_pages_dirty") == 0)
 				gauge_submit ("mysql_bpool_pages", "dirty", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_pages_flushed") == 0)
-				counter_submit ("mysql_bpool_counters", "pages_flushed", val, db);
+				derive_submit ("mysql_bpool_counters", "pages_flushed", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_pages_free") == 0)
 				gauge_submit ("mysql_bpool_pages", "free", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_pages_misc") == 0)
@@ -907,19 +892,19 @@ static int mysql_read (user_data_t *ud)
 			else if (strcmp (key, "Innodb_buffer_pool_pages_total") == 0)
 				gauge_submit ("mysql_bpool_pages", "total", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_read_ahead_rnd") == 0)
-				counter_submit ("mysql_bpool_counters", "read_ahead_rnd", val, db);
+				derive_submit ("mysql_bpool_counters", "read_ahead_rnd", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_read_ahead") == 0)
-				counter_submit ("mysql_bpool_counters", "read_ahead", val, db);
+				derive_submit ("mysql_bpool_counters", "read_ahead", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_read_ahead_evicted") == 0)
-				counter_submit ("mysql_bpool_counters", "read_ahead_evicted", val, db);
+				derive_submit ("mysql_bpool_counters", "read_ahead_evicted", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_read_requests") == 0)
-				counter_submit ("mysql_bpool_counters", "read_requests", val, db);
+				derive_submit ("mysql_bpool_counters", "read_requests", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_reads") == 0)
-				counter_submit ("mysql_bpool_counters", "reads", val, db);
+				derive_submit ("mysql_bpool_counters", "reads", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_wait_free") == 0)
-				counter_submit ("mysql_bpool_counters", "wait_free", val, db);
+				derive_submit ("mysql_bpool_counters", "wait_free", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_write_requests") == 0)
-				counter_submit ("mysql_bpool_counters", "write_requests", val, db);
+				derive_submit ("mysql_bpool_counters", "write_requests", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_bytes_data") == 0)
 				gauge_submit ("mysql_bpool_bytes", "data", val, db);
 			else if (strcmp (key, "Innodb_buffer_pool_bytes_dirty") == 0)
@@ -927,80 +912,80 @@ static int mysql_read (user_data_t *ud)
 
 			/* data */
 			if (strcmp (key, "Innodb_data_fsyncs") == 0)
-				counter_submit ("mysql_innodb_data", "fsyncs", val, db);
+				derive_submit ("mysql_innodb_data", "fsyncs", val, db);
 			else if (strcmp (key, "Innodb_data_read") == 0)
-				counter_submit ("mysql_innodb_data", "read", val, db);
+				derive_submit ("mysql_innodb_data", "read", val, db);
 			else if (strcmp (key, "Innodb_data_reads") == 0)
-				counter_submit ("mysql_innodb_data", "reads", val, db);
+				derive_submit ("mysql_innodb_data", "reads", val, db);
 			else if (strcmp (key, "Innodb_data_writes") == 0)
-				counter_submit ("mysql_innodb_data", "writes", val, db);
+				derive_submit ("mysql_innodb_data", "writes", val, db);
 			else if (strcmp (key, "Innodb_data_written") == 0)
-				counter_submit ("mysql_innodb_data", "written", val, db);
+				derive_submit ("mysql_innodb_data", "written", val, db);
 
 			/* double write */
 			else if (strcmp (key, "Innodb_dblwr_writes") == 0)
-				counter_submit ("mysql_innodb_dblwr", "writes", val, db);
+				derive_submit ("mysql_innodb_dblwr", "writes", val, db);
 			else if (strcmp (key, "Innodb_dblwr_pages_written") == 0)
-				counter_submit ("mysql_innodb_dblwr", "written", val, db);
+				derive_submit ("mysql_innodb_dblwr", "written", val, db);
 			else if (strcmp (key, "Innodb_dblwr_page_size") == 0)
 				gauge_submit ("mysql_innodb_dblwr", "page_size", val, db);
 
 			/* log */
 			else if (strcmp (key, "Innodb_log_waits") == 0)
-				counter_submit ("mysql_innodb_log", "waits", val, db);
+				derive_submit ("mysql_innodb_log", "waits", val, db);
 			else if (strcmp (key, "Innodb_log_write_requests") == 0)
-				counter_submit ("mysql_innodb_log", "write_requests", val, db);
+				derive_submit ("mysql_innodb_log", "write_requests", val, db);
 			else if (strcmp (key, "Innodb_log_writes") == 0)
-				counter_submit ("mysql_innodb_log", "writes", val, db);
+				derive_submit ("mysql_innodb_log", "writes", val, db);
 			else if (strcmp (key, "Innodb_os_log_fsyncs") == 0)
-				counter_submit ("mysql_innodb_log", "fsyncs", val, db);
+				derive_submit ("mysql_innodb_log", "fsyncs", val, db);
 			else if (strcmp (key, "Innodb_os_log_written") == 0)
-				counter_submit ("mysql_innodb_log", "written", val, db);
+				derive_submit ("mysql_innodb_log", "written", val, db);
 
 			/* pages */
 			else if (strcmp (key, "Innodb_pages_created") == 0)
-				counter_submit ("mysql_innodb_pages", "created", val, db);
+				derive_submit ("mysql_innodb_pages", "created", val, db);
 			else if (strcmp (key, "Innodb_pages_read") == 0)
-				counter_submit ("mysql_innodb_pages", "read", val, db);
+				derive_submit ("mysql_innodb_pages", "read", val, db);
 			else if (strcmp (key, "Innodb_pages_written") == 0)
-				counter_submit ("mysql_innodb_pages", "written", val, db);
+				derive_submit ("mysql_innodb_pages", "written", val, db);
 
 			/* row lock */
 			else if (strcmp (key, "Innodb_row_lock_time") == 0)
-				counter_submit ("mysql_innodb_row_lock", "time", val, db);
+				derive_submit ("mysql_innodb_row_lock", "time", val, db);
 			else if (strcmp (key, "Innodb_row_lock_waits") == 0)
-				counter_submit ("mysql_innodb_row_lock", "waits", val, db);
+				derive_submit ("mysql_innodb_row_lock", "waits", val, db);
 
 			/* rows */
 			else if (strcmp (key, "Innodb_rows_deleted") == 0)
-				counter_submit ("mysql_innodb_rows", "deleted", val, db);
+				derive_submit ("mysql_innodb_rows", "deleted", val, db);
 			else if (strcmp (key, "Innodb_rows_inserted") == 0)
-				counter_submit ("mysql_innodb_rows", "inserted", val, db);
+				derive_submit ("mysql_innodb_rows", "inserted", val, db);
 			else if (strcmp (key, "Innodb_rows_read") == 0)
-				counter_submit ("mysql_innodb_rows", "read", val, db);
+				derive_submit ("mysql_innodb_rows", "read", val, db);
 			else if (strcmp (key, "Innodb_rows_updated") == 0)
-				counter_submit ("mysql_innodb_rows", "updated", val, db);
+				derive_submit ("mysql_innodb_rows", "updated", val, db);
 		}
 		else if (strncmp (key, "Select_", strlen ("Select_")) == 0)
 		{
-			counter_submit ("mysql_select", key + strlen ("Select_"),
+			derive_submit ("mysql_select", key + strlen ("Select_"),
 					val, db);
 		}
 		else if (strncmp (key, "Sort_", strlen ("Sort_")) == 0)
 		{
 			if (strcmp (key, "Sort_merge_passes") == 0)
-				counter_submit ("mysql_sort_merge_passes", NULL, val, db);
+				derive_submit ("mysql_sort_merge_passes", NULL, val, db);
 			else if (strcmp (key, "Sort_rows") == 0)
-				counter_submit ("mysql_sort_rows", NULL, val, db);
+				derive_submit ("mysql_sort_rows", NULL, val, db);
 			else if (strcmp (key, "Sort_range") == 0)
-				counter_submit ("mysql_sort", "range", val, db);
+				derive_submit ("mysql_sort", "range", val, db);
 			else if (strcmp (key, "Sort_scan") == 0)
-				counter_submit ("mysql_sort", "scan", val, db);
+				derive_submit ("mysql_sort", "scan", val, db);
 
 		}
 		else if (strncmp (key, "Slow_queries", strlen ("Slow_queries")) == 0)
 		{
-			counter_submit ("mysql_slow_queries", NULL , val, db);
+			derive_submit ("mysql_slow_queries", NULL , val, db);
 		}
 	}
 	mysql_free_result (res); res = NULL;

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -649,13 +649,13 @@ static int submit_two_derive (const char *host, const char *plugin_inst, /* {{{ 
 		const char *type, const char *type_inst, derive_t val0, derive_t val1,
 		cdtime_t timestamp, cdtime_t interval)
 {
-	value_t values[2];
-
-	values[0].derive = val0;
-	values[1].derive = val1;
+	value_t values[] = {
+		{ .derive = val0 },
+		{ .derive = val1 },
+	};
 
 	return (submit_values (host, plugin_inst, type, type_inst,
-				values, 2, timestamp, interval));
+				values, STATIC_ARRAY_SIZE (values), timestamp, interval));
 } /* }}} int submit_two_derive */
 
 static int submit_derive (const char *host, const char *plugin_inst, /* {{{ */
@@ -670,13 +670,13 @@ static int submit_two_gauge (const char *host, const char *plugin_inst, /* {{{ *
 		const char *type, const char *type_inst, gauge_t val0, gauge_t val1,
 		cdtime_t timestamp, cdtime_t interval)
 {
-	value_t values[2];
-
-	values[0].gauge = val0;
-	values[1].gauge = val1;
+	value_t values[] = {
+		{ .gauge = val0 },
+		{ .gauge = val1 },
+	};
 
 	return (submit_values (host, plugin_inst, type, type_inst,
-				values, 2, timestamp, interval));
+				values, STATIC_ARRAY_SIZE (values), timestamp, interval));
 } /* }}} int submit_two_gauge */
 
 static int submit_double (const char *host, const char *plugin_inst, /* {{{ */

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -617,7 +617,7 @@ static data_volume_perf_t *get_volume_perf (cfg_volume_perf_t *cvp, /* {{{ */
 static int submit_values (const char *host, /* {{{ */
 		const char *plugin_inst,
 		const char *type, const char *type_inst,
-		value_t *values, int values_len,
+		value_t *values, size_t values_len,
 		cdtime_t timestamp, cdtime_t interval)
 {
 	value_list_t vl = VALUE_LIST_INIT;
@@ -662,12 +662,8 @@ static int submit_derive (const char *host, const char *plugin_inst, /* {{{ */
 		const char *type, const char *type_inst, derive_t counter,
 		cdtime_t timestamp, cdtime_t interval)
 {
-	value_t v;
-
-	v.derive = counter;
-
 	return (submit_values (host, plugin_inst, type, type_inst,
-				&v, 1, timestamp, interval));
+				&(value_t) { .derive = counter }, 1, timestamp, interval));
 } /* }}} int submit_derive */
 
 static int submit_two_gauge (const char *host, const char *plugin_inst, /* {{{ */
@@ -687,12 +683,8 @@ static int submit_double (const char *host, const char *plugin_inst, /* {{{ */
 		const char *type, const char *type_inst, double d,
 		cdtime_t timestamp, cdtime_t interval)
 {
-	value_t v;
-
-	v.gauge = (gauge_t) d;
-
 	return (submit_values (host, plugin_inst, type, type_inst,
-				&v, 1, timestamp, interval));
+				&(value_t) { .gauge = counter }, 1, timestamp, interval));
 } /* }}} int submit_uint64 */
 
 /* Calculate hit ratio from old and new counters and submit the resulting
@@ -707,7 +699,7 @@ static int submit_cache_ratio (const char *host, /* {{{ */
 		cdtime_t timestamp,
 		cdtime_t interval)
 {
-	value_t v;
+	value_t v = { .gauge = NAN };
 
 	if ((new_hits >= old_hits) && (new_misses >= old_misses)) {
 		uint64_t hits;
@@ -717,8 +709,6 @@ static int submit_cache_ratio (const char *host, /* {{{ */
 		misses = new_misses - old_misses;
 
 		v.gauge = 100.0 * ((gauge_t) hits) / ((gauge_t) (hits + misses));
-	} else {
-		v.gauge = NAN;
 	}
 
 	return (submit_values (host, plugin_inst, "cache_ratio", type_inst,

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -194,12 +194,9 @@ static int check_ignorelist (const char *dev,
 static void submit_one (const char *dev, const char *type,
     const char *type_instance, derive_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].derive = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "netlink", sizeof (vl.plugin));

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -213,14 +213,14 @@ static void submit_two (const char *dev, const char *type,
     const char *type_instance,
     derive_t rx, derive_t tx)
 {
-  value_t values[2];
   value_list_t vl = VALUE_LIST_INIT;
-
-  values[0].derive = rx;
-  values[1].derive = tx;
+  value_t values[] = {
+    { .derive = rx },
+    { .derive = tx },
+  };
 
   vl.values = values;
-  vl.values_len = 2;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "netlink", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -210,7 +210,7 @@ static void submit (const char *type, const char *inst, long long value)
     return;
 
   vl.values = values;
-  vl.values_len = 1;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "nginx", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -313,12 +313,9 @@ static int ntpd_config (const char *key, const char *value)
 
 static void ntpd_submit (const char *type, const char *type_inst, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "ntpd", sizeof (vl.plugin));

--- a/src/nut.c
+++ b/src/nut.c
@@ -120,13 +120,10 @@ static int nut_config (const char *key, const char *value)
 static void nut_submit (nut_ups_t *ups, const char *type,
     const char *type_instance, gauge_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
-  vl.values_len = STATIC_ARRAY_SIZE (values);
+  vl.values = &(value_t) { .gauge = value };
+  vl.values_len = 1;
   sstrncpy (vl.host,
       (strcasecmp (ups->hostname, "localhost") == 0)
       ? hostname_g

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -216,12 +216,9 @@ __attribute__ ((nonnull(2)))
 static void olsrd_submit (const char *plugin_instance, /* {{{ */
     const char *type, const char *type_instance, gauge_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
 
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -192,17 +192,13 @@ static void cldap_submit_value (const char *type, const char *type_instance, /* 
 static void cldap_submit_derive (const char *type, const char *type_instance, /* {{{ */
 		derive_t d, cldap_t *st)
 {
-	value_t v;
-	v.derive = d;
-	cldap_submit_value (type, type_instance, v, st);
+	cldap_submit_value (type, type_instance, (value_t) { .derive = d }, st);
 } /* }}} void cldap_submit_derive */
 
 static void cldap_submit_gauge (const char *type, const char *type_instance, /* {{{ */
 		gauge_t g, cldap_t *st)
 {
-	value_t v;
-	v.gauge = g;
-	cldap_submit_value (type, type_instance, v, st);
+	cldap_submit_value (type, type_instance, (value_t) { .gauge = g }, st);
 } /* }}} void cldap_submit_gauge */
 
 static int cldap_read_host (user_data_t *ud) /* {{{ */

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -119,11 +119,11 @@ static void numusers_submit (const char *pinst, const char *tinst,
 static void iostats_submit (const char *pinst, const char *tinst,
 		derive_t rx, derive_t tx)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+    { .derive = rx },
+    { .derive = tx },
+  };
 
 	/* NOTE ON THE NEW NAMING SCHEMA:
 	 *       using plugin_instance to identify each vpn config (and
@@ -149,11 +149,11 @@ static void iostats_submit (const char *pinst, const char *tinst,
 static void compression_submit (const char *pinst, const char *tinst,
 		derive_t uncompressed, derive_t compressed)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = uncompressed;
-	values[1].derive = compressed;
+	value_t values[] = {
+    { .derive = uncompressed },
+    { .derive = compressed },
+  };
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -99,13 +99,10 @@ static int openvpn_strsplit (char *string, char **fields, size_t size)
 static void numusers_submit (const char *pinst, const char *tinst,
 		gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
-	vl.values_len = STATIC_ARRAY_SIZE (values);
+	vl.values = &(value_t) { .gauge = value };
+	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "openvpn", sizeof (vl.plugin));
 	sstrncpy (vl.type, "users", sizeof (vl.type));

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -677,38 +677,36 @@ static int plugin_shutdown (void) /* {{{ */
 
 static int plugin_submit (const pinba_statnode_t *res) /* {{{ */
 {
-  value_t value;
   value_list_t vl = VALUE_LIST_INIT;
 
-  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "pinba", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, res->name, sizeof (vl.plugin_instance));
 
-  value.derive = res->req_count;
+  vl.values = &(value_t) { .derive = res->req_count };
   sstrncpy (vl.type, "total_requests", sizeof (vl.type));
   plugin_dispatch_values (&vl);
 
-  value.derive = float_counter_get (&res->req_time, /* factor = */ 1000);
+  vl.values = &(value_t) { .derive = float_counter_get (&res->req_time, /* factor = */ 1000) };
   sstrncpy (vl.type, "total_time_in_ms", sizeof (vl.type));
   plugin_dispatch_values (&vl);
 
-  value.derive = res->doc_size;
+  vl.values = &(value_t) { .derive = res->doc_size };
   sstrncpy (vl.type, "total_bytes", sizeof (vl.type));
   plugin_dispatch_values (&vl);
 
-  value.derive = float_counter_get (&res->ru_utime, /* factor = */ 100);
+  vl.values = &(value_t) { .derive = float_counter_get (&res->ru_utime, /* factor = */ 100) };
   sstrncpy (vl.type, "cpu", sizeof (vl.type));
   sstrncpy (vl.type_instance, "user", sizeof (vl.type_instance));
   plugin_dispatch_values (&vl);
 
-  value.derive = float_counter_get (&res->ru_stime, /* factor = */ 100);
+  vl.values = &(value_t) { .derive = float_counter_get (&res->ru_stime, /* factor = */ 100) };
   sstrncpy (vl.type, "cpu", sizeof (vl.type));
   sstrncpy (vl.type_instance, "system", sizeof (vl.type_instance));
   plugin_dispatch_values (&vl);
 
-  value.gauge = res->mem_peak;
+  vl.values = &(value_t) { .gauge = res->mem_peak };
   sstrncpy (vl.type, "memory", sizeof (vl.type));
   sstrncpy (vl.type_instance, "peak", sizeof (vl.type_instance));
   plugin_dispatch_values (&vl);

--- a/src/ping.c
+++ b/src/ping.c
@@ -615,12 +615,9 @@ static int ping_config (const char *key, const char *value) /* {{{ */
 static void submit (const char *host, const char *type, /* {{{ */
     gauge_t value)
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0].gauge = value;
-
-  vl.values = values;
+  vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ping", sizeof (vl.plugin));

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -300,10 +300,10 @@ static char *local_sockpath = NULL;
 
 /* <https://doc.powerdns.com/md/recursor/stats/> */
 static void submit (const char *plugin_instance, /* {{{ */
-    const char *pdns_type, const char *value)
+    const char *pdns_type, const char *value_str)
 {
   value_list_t vl = VALUE_LIST_INIT;
-  value_t values[1];
+  value_t value;
 
   const char *type = NULL;
   const char *type_instance = NULL;
@@ -318,7 +318,7 @@ static void submit (const char *plugin_instance, /* {{{ */
   if (i >= lookup_table_length)
   {
     INFO ("powerdns plugin: submit: Not found in lookup table: %s = %s;",
-        pdns_type, value);
+        pdns_type, value_str);
     return;
   }
 
@@ -345,14 +345,14 @@ static void submit (const char *plugin_instance, /* {{{ */
     return;
   }
 
-  if (0 != parse_value (value, &values[0], ds->ds[0].type))
+  if (0 != parse_value (value_str, &value, ds->ds[0].type))
   {
     ERROR ("powerdns plugin: Cannot convert `%s' "
-        "to a number.", value);
+        "to a number.", value_str);
     return;
   }
 
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "powerdns", sizeof (vl.plugin));

--- a/src/processes.c
+++ b/src/processes.c
@@ -660,12 +660,9 @@ static int ps_init (void)
 /* submit global state (e.g.: qty of zombies, running, etc..) */
 static void ps_submit_state (const char *state, double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
@@ -784,12 +781,9 @@ static void ps_submit_proc_list (procstat_t *ps)
 #if KERNEL_LINUX || KERNEL_SOLARIS
 static void ps_submit_fork_rate (derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
 	sstrncpy(vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy(vl.plugin, "processes", sizeof (vl.plugin));

--- a/src/processes.c
+++ b/src/processes.c
@@ -676,11 +676,10 @@ static void ps_submit_state (const char *state, double value)
 /* submit info about specific process (e.g.: memory taken, cpu usage, etc..) */
 static void ps_submit_proc_list (procstat_t *ps)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
+	value_t values[2];
 
 	vl.values = values;
-	vl.values_len = 2;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, ps->name, sizeof (vl.plugin_instance));

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -55,11 +55,11 @@ static ignorelist_t *values_list = NULL;
 static void submit (const char *protocol_name,
     const char *str_key, const char *str_value)
 {
-  value_t values[1];
+  value_t value;
   value_list_t vl = VALUE_LIST_INIT;
   int status;
 
-  status = parse_value (str_value, values, DS_TYPE_DERIVE);
+  status = parse_value (str_value, &value, DS_TYPE_DERIVE);
   if (status != 0)
   {
     ERROR ("protocols plugin: Parsing string as integer failed: %s",
@@ -67,7 +67,7 @@ static void submit (const char *protocol_name,
     return;
   }
 
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "protocols", sizeof (vl.plugin));

--- a/src/redis.c
+++ b/src/redis.c
@@ -252,12 +252,9 @@ static void redis_submit (char *plugin_instance,
     const char *type, const char *type_instance,
     value_t value) /* {{{ */
 {
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
-  values[0] = value;
-
-  vl.values = values;
+  vl.values = &value;
   vl.values_len = 1;
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "redis", sizeof (vl.plugin));

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -52,11 +52,11 @@ typedef struct cr_data_s cr_data_t;
 static void cr_submit_io (cr_data_t *rd, const char *type, /* {{{ */
     const char *type_instance, derive_t rx, derive_t tx)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+	  { .derive = rx },
+	  { .derive = tx },
+	};
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -292,17 +292,15 @@ static int rc_read (void)
   int status;
   rrdc_stats_t *head;
 
-  value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
+  vl.values = &(value_t) { .gauge = NAN };
+  vl.values_len = 1;
 
   if (daemon_address == NULL)
     return (-1);
 
   if (!config_collect_stats)
     return (-1);
-
-  vl.values = values;
-  vl.values_len = 1;
 
   if ((strncmp ("unix:", daemon_address, strlen ("unix:")) == 0)
       || (daemon_address[0] == '/'))
@@ -330,9 +328,9 @@ static int rc_read (void)
   for (rrdc_stats_t *ptr = head; ptr != NULL; ptr = ptr->next)
   {
     if (ptr->type == RRDC_STATS_TYPE_GAUGE)
-      values[0].gauge = (gauge_t) ptr->value.gauge;
+      vl.values[0].gauge = (gauge_t) ptr->value.gauge;
     else if (ptr->type == RRDC_STATS_TYPE_COUNTER)
-      values[0].counter = (counter_t) ptr->value.counter;
+      vl.values[0].counter = (counter_t) ptr->value.counter;
     else
       continue;
 

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -481,12 +481,11 @@ static int sensors_shutdown (void)
 
 static void sensors_submit (const char *plugin_instance,
 		const char *type, const char *type_instance,
-		double val)
+		double value)
 {
 	char match_key[1024];
 	int status;
 
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
 	status = ssnprintf (match_key, sizeof (match_key), "%s/%s-%s",
@@ -501,9 +500,7 @@ static void sensors_submit (const char *plugin_instance,
 			return;
 	}
 
-	values[0].gauge = val;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/serial.c
+++ b/src/serial.c
@@ -33,14 +33,14 @@
 static void serial_submit (const char *type_instance,
 		derive_t rx, derive_t tx)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "serial", sizeof (vl.plugin));
 	sstrncpy (vl.type, "serial_octets", sizeof (vl.type));

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -161,7 +161,6 @@ static void sigrok_feed_callback(const struct sr_dev_inst *sdi,
 {
 	const struct sr_datafeed_analog *analog;
 	struct config_device *cfdev;
-	value_t value;
 	value_list_t vl = VALUE_LIST_INIT;
 
 	/* Find this device's configuration. */
@@ -199,8 +198,7 @@ static void sigrok_feed_callback(const struct sr_dev_inst *sdi,
 
 	/* Ignore all but the first sample on the first probe. */
 	analog = packet->payload;
-	value.gauge = analog->data[0];
-	vl.values = &value;
+	vl.values = &(value_t) { .gauge = analog->data[0] };
 	vl.values_len = 1;
 	sstrncpy(vl.host, hostname_g, sizeof(vl.host));
 	sstrncpy(vl.plugin, "sigrok", sizeof(vl.plugin));

--- a/src/smart.c
+++ b/src/smart.c
@@ -86,12 +86,9 @@ static int smart_config (const char *key, const char *value)
 static void smart_submit (const char *dev, const char *type,
 		const char *type_inst, double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "smart", sizeof (vl.plugin));

--- a/src/smart.c
+++ b/src/smart.c
@@ -103,17 +103,20 @@ static void smart_handle_disk_attribute(SkDisk *d, const SkSmartAttributeParsedD
                                         void* userdata)
 {
   const char *dev = userdata;
-  value_t values[4];
-  value_list_t vl = VALUE_LIST_INIT;
 
-  if (!a->current_value_valid || !a->worst_value_valid) return;
-  values[0].gauge = a->current_value;
-  values[1].gauge = a->worst_value;
-  values[2].gauge = a->threshold_valid?a->threshold:0;
-  values[3].gauge = a->pretty_value;
+  if (!a->current_value_valid || !a->worst_value_valid)
+    return;
+
+  value_list_t vl = VALUE_LIST_INIT;
+  value_t values[] = {
+    { .gauge = a->current_value },
+    { .gauge = a->worst_value },
+    { .gauge = a->threshold_valid ? a->threshold : 0 },
+    { .gauge = a->pretty_value },
+  };
 
   vl.values = values;
-  vl.values_len = 4;
+  vl.values_len = STATIC_ARRAY_SIZE (values);
   sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "smart", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));

--- a/src/swap.c
+++ b/src/swap.c
@@ -194,11 +194,10 @@ static void swap_submit_usage (char const *plugin_instance, /* {{{ */
 		gauge_t used, gauge_t free,
 		char const *other_name, gauge_t other_value)
 {
-	value_t v[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	vl.values = v;
-	vl.values_len = STATIC_ARRAY_SIZE (v);
+	vl.values = &(value_t) { .gauge = NAN };
+	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "swap", sizeof (vl.plugin));
 	if (plugin_instance != NULL)
@@ -222,12 +221,9 @@ static void swap_submit_derive (char const *type_instance, /* {{{ */
 		derive_t value)
 {
 	value_list_t vl = VALUE_LIST_INIT;
-	value_t v[1];
 
-	v[0].derive = value;
-
-	vl.values = v;
-	vl.values_len = STATIC_ARRAY_SIZE (v);
+	vl.values = &(value_t) { .derive = value };
+	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "swap", sizeof (vl.plugin));
 	sstrncpy (vl.type, "swap_io", sizeof (vl.type));

--- a/src/tape.c
+++ b/src/tape.c
@@ -61,14 +61,14 @@ static void tape_submit (const char *plugin_instance,
 		const char *type,
 		derive_t read, derive_t write)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = read;
-	values[1].derive = write;
+	value_t values[] = {
+		{ .derive = read },
+		{ .derive = write },
+	};
 
 	vl.values = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "tape", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -53,7 +53,6 @@ static void v5_swap_instances (value_list_t *vl) /* {{{ */
 static int v5_df (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   /* Can't upgrade if both instances have been set. */
   if ((vl->plugin_instance[0] != 0)
@@ -64,7 +63,7 @@ static int v5_df (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -113,7 +112,6 @@ static int v5_interface (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_mysql_qcache (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   if (vl->values_len != 5)
     return (FC_TARGET_STOP);
@@ -122,7 +120,7 @@ static int v5_mysql_qcache (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -171,7 +169,6 @@ static int v5_mysql_qcache (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_mysql_threads (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   if (vl->values_len != 4)
     return (FC_TARGET_STOP);
@@ -180,7 +177,7 @@ static int v5_mysql_threads (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -224,7 +221,6 @@ static int v5_mysql_threads (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_zfs_arc_counts (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
   _Bool is_hits;
 
   if (vl->values_len != 4)
@@ -241,7 +237,7 @@ static int v5_zfs_arc_counts (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -322,7 +318,6 @@ static int v5_zfs_arc_l2_bytes (const data_set_t *ds, value_list_t *vl) /* {{{ *
 static int v5_zfs_arc_l2_size (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   if (vl->values_len != 1)
     return (FC_TARGET_STOP);
@@ -331,7 +326,7 @@ static int v5_zfs_arc_l2_size (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -359,7 +354,6 @@ static int v5_zfs_arc_l2_size (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_zfs_arc_ratio (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   if (vl->values_len != 1)
     return (FC_TARGET_STOP);
@@ -368,7 +362,7 @@ static int v5_zfs_arc_ratio (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 
@@ -397,7 +391,6 @@ static int v5_zfs_arc_ratio (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_zfs_arc_size (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_value;
 
   if (vl->values_len != 4)
     return (FC_TARGET_STOP);
@@ -406,7 +399,7 @@ static int v5_zfs_arc_size (const data_set_t *ds, value_list_t *vl) /* {{{ */
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = &new_value;
+  new_vl.values = &(value_t) { .gauge = NAN };
   new_vl.values_len = 1;
   new_vl.meta = NULL;
 

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -281,7 +281,6 @@ static int v5_zfs_arc_counts (const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_zfs_arc_l2_bytes (const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   value_list_t new_vl;
-  value_t new_values[2];
 
   if (vl->values_len != 2)
     return (FC_TARGET_STOP);
@@ -290,8 +289,6 @@ static int v5_zfs_arc_l2_bytes (const data_set_t *ds, value_list_t *vl) /* {{{ *
   memcpy (&new_vl, vl, sizeof (new_vl));
 
   /* Reset data we can't simply copy */
-  new_vl.values = new_values;
-  new_vl.values_len = 2;
   new_vl.meta = NULL;
 
   /* Change the type/-instance to "io_octets-L2" */
@@ -299,8 +296,12 @@ static int v5_zfs_arc_l2_bytes (const data_set_t *ds, value_list_t *vl) /* {{{ *
   sstrncpy (new_vl.type_instance, "L2", sizeof (new_vl.type_instance));
 
   /* Copy the actual values. */
-  new_vl.values[0].derive = (derive_t) vl->values[0].counter;
-  new_vl.values[1].derive = (derive_t) vl->values[1].counter;
+  value_t values[] = {
+    { .derive = (derive_t) vl->values[0].counter },
+    { .derive = (derive_t) vl->values[1].counter },
+  };
+  new_vl.values = values;
+  new_vl.values_len = STATIC_ARRAY_SIZE (values);
 
   /* Dispatch new value lists instead of this one */
   plugin_dispatch_values (&new_vl);

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -147,14 +147,14 @@ static void tss2_submit_io (const char *plugin_instance, const char *type,
 	/*
 	 * Submits the io rx/tx tuple to the collectd daemon
 	 */
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 
 	vl.values     = values;
-	vl.values_len = 2;
+	vl.values_len = STATIC_ARRAY_SIZE (values);
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "teamspeak2", sizeof (vl.plugin));
 

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -121,12 +121,9 @@ static void tss2_submit_gauge (const char *plugin_instance,
 	/*
 	 * Submits a gauge value to the collectd daemon
 	 */
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values     = values;
+	vl.values     = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "teamspeak2", sizeof (vl.plugin));

--- a/src/ted.c
+++ b/src/ted.c
@@ -263,12 +263,9 @@ static int ted_open_device (void)
 
 static void ted_submit (const char *type, double value)
 {
-    value_t values[1];
     value_list_t vl = VALUE_LIST_INIT;
 
-    values[0].gauge = value;
-
-    vl.values = values;
+    vl.values = &(value_t) { .gauge = value };
     vl.values_len = 1;
     sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "ted", sizeof (vl.plugin));

--- a/src/tokyotyrant.c
+++ b/src/tokyotyrant.c
@@ -86,15 +86,12 @@ static void printerr (void)
 			ecode, tcrdberrmsg(ecode));
 }
 
-static void tt_submit (gauge_t val, const char* type)
+static void tt_submit (gauge_t value, const char* type)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = val;
-
-	vl.values = values;
-	vl.values_len = STATIC_ARRAY_SIZE (values);
+	vl.values = &(value_t) { .gauge = value };
+	vl.values_len = 1;
 
 	sstrncpy (vl.host, config_host, sizeof (vl.host));
 	sstrncpy (vl.plugin, "tokyotyrant", sizeof (vl.plugin));

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -524,10 +524,8 @@ turbostat_submit (const char *plugin_instance,
 	gauge_t value)
 {
 	value_list_t vl = VALUE_LIST_INIT;
-	value_t v;
 
-	v.gauge = value;
-	vl.values = &v;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, PLUGIN_NAME, sizeof (vl.plugin));

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -58,14 +58,11 @@ static time_t boottime;
 extern kstat_ctl_t *kc;
 #endif /* #endif HAVE_LIBKSTAT */
 
-static void uptime_submit (gauge_t uptime)
+static void uptime_submit (gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = uptime;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));

--- a/src/users.c
+++ b/src/users.c
@@ -45,12 +45,9 @@
 
 static void users_submit (gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "users", sizeof (vl.plugin));

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -117,22 +117,16 @@ static int varnish_submit_gauge (const char *plugin_instance, /* {{{ */
 		const char *category, const char *type, const char *type_instance,
 		uint64_t gauge_value)
 {
-	value_t value;
-
-	value.gauge = (gauge_t) gauge_value;
-
-	return (varnish_submit (plugin_instance, category, type, type_instance, value));
+	return (varnish_submit (plugin_instance, category, type, type_instance,
+				(value_t) { .gauge = (gauge_t) gauge_value }));
 } /* }}} int varnish_submit_gauge */
 
 static int varnish_submit_derive (const char *plugin_instance, /* {{{ */
 		const char *category, const char *type, const char *type_instance,
 		uint64_t derive_value)
 {
-	value_t value;
-
-	value.derive = (derive_t) derive_value;
-
-	return (varnish_submit (plugin_instance, category, type, type_instance, value));
+	return (varnish_submit (plugin_instance, category, type, type_instance,
+				(value_t) { .derive = (derive_t) derive_value }));
 } /* }}} int varnish_submit_derive */
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4

--- a/src/virt.c
+++ b/src/virt.c
@@ -223,83 +223,59 @@ init_value_list (value_list_t *vl, virDomainPtr dom)
 
 } /* void init_value_list */
 
-static void
-memory_submit (gauge_t memory, virDomainPtr dom)
+static void submit (virDomainPtr dom,
+                    char const *type, char const *type_instance,
+                    value_t *values, size_t values_len)
 {
-    value_t values[1];
     value_list_t vl = VALUE_LIST_INIT;
-
     init_value_list (&vl, dom);
 
-    values[0].gauge = memory;
-
     vl.values = values;
-    vl.values_len = 1;
+    vl.values_len = values_len;
 
-    sstrncpy (vl.type, "memory", sizeof (vl.type));
-    sstrncpy (vl.type_instance, "total", sizeof (vl.type_instance));
+    sstrncpy (vl.type, type, sizeof (vl.type));
+    if (type_instance != NULL)
+        sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
 
     plugin_dispatch_values (&vl);
 }
 
 static void
-memory_stats_submit (gauge_t memory, virDomainPtr dom, int tag_index)
+memory_submit (gauge_t value, virDomainPtr dom)
+{
+    submit (dom, "memory", "total", &(value_t) { .gauge = value }, 1);
+}
+
+static void
+memory_stats_submit (gauge_t value, virDomainPtr dom, int tag_index)
 {
     static const char *tags[] = { "swap_in", "swap_out", "major_fault", "minor_fault",
                                     "unused", "available", "actual_balloon", "rss"};
 
-    value_t values[1];
-    value_list_t vl = VALUE_LIST_INIT;
+    if ((tag_index < 0) || (tag_index >= STATIC_ARRAY_SIZE (tags))) {
+        ERROR ("virt plugin: Array index out of bounds: tag_index = %d", tag_index);
+        return;
+    }
 
-    init_value_list (&vl, dom);
-
-    values[0].gauge = memory;
-
-    vl.values = values;
-    vl.values_len = 1;
-
-    sstrncpy (vl.type, "memory", sizeof (vl.type));
-    sstrncpy (vl.type_instance, tags[tag_index], sizeof (vl.type_instance));
-
-    plugin_dispatch_values (&vl);
+    submit (dom, "memory", tags[tag_index], &(value_t) { .gauge = value }, 1);
 }
 
 static void
-cpu_submit (unsigned long long cpu_time,
+cpu_submit (unsigned long long value,
             virDomainPtr dom, const char *type)
 {
-    value_t values[1];
-    value_list_t vl = VALUE_LIST_INIT;
-
-    init_value_list (&vl, dom);
-
-    values[0].derive = cpu_time;
-
-    vl.values = values;
-    vl.values_len = 1;
-
-    sstrncpy (vl.type, type, sizeof (vl.type));
-
-    plugin_dispatch_values (&vl);
+    submit (dom, type, NULL, &(value_t) { .derive = (derive_t) value }, 1);
 }
 
 static void
-vcpu_submit (derive_t cpu_time,
+vcpu_submit (derive_t value,
              virDomainPtr dom, int vcpu_nr, const char *type)
 {
-    value_t values[1];
-    value_list_t vl = VALUE_LIST_INIT;
+    char type_instance[DATA_MAX_NAME_LEN];
 
-    init_value_list (&vl, dom);
+    ssnprintf (type_instance, sizeof (type_instance), "%d", vcpu_nr);
 
-    values[0].derive = cpu_time;
-    vl.values = values;
-    vl.values_len = 1;
-
-    sstrncpy (vl.type, type, sizeof (vl.type));
-    ssnprintf (vl.type_instance, sizeof (vl.type_instance), "%d", vcpu_nr);
-
-    plugin_dispatch_values (&vl);
+    submit (dom, type, type_instance, &(value_t) { .derive = value }, 1);
 }
 
 static void

--- a/src/virt.c
+++ b/src/virt.c
@@ -282,20 +282,12 @@ static void
 submit_derive2 (const char *type, derive_t v0, derive_t v1,
              virDomainPtr dom, const char *devname)
 {
-    value_t values[2];
-    value_list_t vl = VALUE_LIST_INIT;
+    value_t values[] = {
+        { .derive = v0 },
+        { .derive = v1 },
+    };
 
-    init_value_list (&vl, dom);
-
-    values[0].derive = v0;
-    values[1].derive = v1;
-    vl.values = values;
-    vl.values_len = 2;
-
-    sstrncpy (vl.type, type, sizeof (vl.type));
-    sstrncpy (vl.type_instance, devname, sizeof (vl.type_instance));
-
-    plugin_dispatch_values (&vl);
+    submit (dom, type, devname, values, STATIC_ARRAY_SIZE (values));
 } /* void submit_derive2 */
 
 static int

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -65,12 +65,13 @@ static void submit (const char *plugin_instance, const char *type,
 static void submit_two (const char *plugin_instance, const char *type,
     const char *type_instance, derive_t c0, derive_t c1)
 {
-  value_t values[2];
+  value_t values[] = {
+    { .derive = c0 },
+    { .derive = c1 },
+  };
 
-  values[0].derive = c0;
-  values[1].derive = c1;
-
-  submit (plugin_instance, type, type_instance, values, 2);
+  submit (plugin_instance, type, type_instance,
+      values, STATIC_ARRAY_SIZE (values));
 } /* void submit_one */
 
 static void submit_one (const char *plugin_instance, const char *type,

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -97,13 +97,10 @@ static void submit_gauge (const char *plugin_instance, const char *type,
 		const char *type_instance, gauge_t value)
 
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
-	vl.values_len = STATIC_ARRAY_SIZE (values);
+	vl.values = &(value_t) { .gauge = value };
+	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "vserver", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -56,11 +56,11 @@ static int vserver_init (void)
 static void traffic_submit (const char *plugin_instance,
 		const char *type_instance, derive_t rx, derive_t tx)
 {
-	value_t values[2];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].derive = rx;
-	values[1].derive = tx;
+	value_t values[] = {
+		{ .derive = rx },
+		{ .derive = tx },
+	};
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
@@ -76,12 +76,12 @@ static void traffic_submit (const char *plugin_instance,
 static void load_submit (const char *plugin_instance,
 		gauge_t snum, gauge_t mnum, gauge_t lnum)
 {
-	value_t values[3];
 	value_list_t vl = VALUE_LIST_INIT;
-
-	values[0].gauge = snum;
-	values[1].gauge = mnum;
-	values[2].gauge = lnum;
+	value_t values[] = {
+		{ .gauge = snum },
+		{ .gauge = mnum },
+		{ .gauge = lnum },
+	};
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -54,12 +54,9 @@ static double wireless_dbm_to_watt (double dbm)
 static void wireless_submit (const char *plugin_instance, const char *type,
 		double value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "wireless", sizeof (vl.plugin));

--- a/src/xencpu.c
+++ b/src/xencpu.c
@@ -108,14 +108,11 @@ static int xencpu_shutdown (void)
     return 0;
 } /* static int xencpu_shutdown */
 
-static void submit_value (int cpu_num, gauge_t percent)
+static void submit_value (int cpu_num, gauge_t value)
 {
-    value_t values[1];
     value_list_t vl = VALUE_LIST_INIT;
 
-    values[0].gauge = percent;
-
-    vl.values = values;
+    vl.values = &(value_t) { .gauge = value };
     vl.values_len = 1;
 
     sstrncpy (vl.host, hostname_g, sizeof (vl.host));
@@ -145,9 +142,10 @@ static int xencpu_read (void)
     int status;
     for (int cpu = 0; cpu < nr_cpus; cpu++) {
         gauge_t rate = NAN;
-        value_t value = {.derive = cpu_info[cpu].idletime};
 
-        status = value_to_rate (&rate, value, DS_TYPE_DERIVE, now, &cpu_states[cpu]);
+        status = value_to_rate (&rate,
+                                (value_t) { .derive = cpu_info[cpu].idletime }, DS_TYPE_DERIVE,
+                                now, &cpu_states[cpu]);
         if (status == 0) {
             submit_value(cpu, 100 - rate/10000000);
         }

--- a/src/xmms.c
+++ b/src/xmms.c
@@ -35,12 +35,9 @@ static gint xmms_session;
 
 static void cxmms_submit (const char *type, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = value;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "xmms", sizeof (vl.plugin));

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -138,7 +138,7 @@ static long long get_zfs_value(kstat_t *dummy __attribute__((unused)),
 }
 #endif
 
-static void za_submit (const char* type, const char* type_instance, value_t* values, int values_len)
+static void za_submit (const char* type, const char* type_instance, value_t* values, size_t values_len)
 {
 	value_list_t vl = VALUE_LIST_INIT;
 
@@ -155,45 +155,34 @@ static void za_submit (const char* type, const char* type_instance, value_t* val
 
 static void za_submit_gauge (const char* type, const char* type_instance, gauge_t value)
 {
-	value_t vv;
-
-	vv.gauge = value;
-	za_submit (type, type_instance, &vv, 1);
+	za_submit (type, type_instance, &(value_t) { .gauge = value }, 1);
 }
 
 static int za_read_derive (kstat_t *ksp, const char *kstat_value,
     const char *type, const char *type_instance)
 {
-  long long tmp;
-  value_t v;
-
-  tmp = get_zfs_value (ksp, (char *)kstat_value);
+  long long tmp = get_zfs_value (ksp, (char *)kstat_value);
   if (tmp == -1LL)
   {
     WARNING ("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
     return (-1);
   }
 
-  v.derive = (derive_t) tmp;
-  za_submit (type, type_instance, /* values = */ &v, /* values_num = */ 1);
+  za_submit (type, type_instance, &(value_t) { .derive = (derive_t) tmp }, /* values_num = */ 1);
   return (0);
 }
 
 static int za_read_gauge (kstat_t *ksp, const char *kstat_value,
     const char *type, const char *type_instance)
 {
-  long long tmp;
-  value_t v;
-
-  tmp = get_zfs_value (ksp, (char *)kstat_value);
+  long long tmp = get_zfs_value (ksp, (char *)kstat_value);
   if (tmp == -1LL)
   {
     WARNING ("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
     return (-1);
   }
 
-  v.gauge = (gauge_t) tmp;
-  za_submit (type, type_instance, /* values = */ &v, /* values_num = */ 1);
+  za_submit (type, type_instance, &(value_t) { .gauge = (gauge_t) tmp }, /* values_num = */ 1);
   return (0);
 }
 

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -204,7 +204,6 @@ static void za_submit_ratio (const char* type_instance, gauge_t hits, gauge_t mi
 static int za_read (void)
 {
 	gauge_t  arc_hits, arc_misses, l2_hits, l2_misses;
-	value_t  l2_io[2];
 	kstat_t	 *ksp	= NULL;
 
 #if defined(KERNEL_LINUX)
@@ -320,10 +319,11 @@ static int za_read (void)
 	za_submit_ratio ("L2", l2_hits, l2_misses);
 
 	/* I/O */
-	l2_io[0].derive = get_zfs_value(ksp, "l2_read_bytes");
-	l2_io[1].derive = get_zfs_value(ksp, "l2_write_bytes");
-
-	za_submit ("io_octets", "L2", l2_io, /* num values = */ 2);
+	value_t  l2_io[] = {
+		{ .derive = (derive_t) get_zfs_value(ksp, "l2_read_bytes") },
+		{ .derive = (derive_t) get_zfs_value(ksp, "l2_write_bytes") },
+	};
+	za_submit ("io_octets", "L2", l2_io, STATIC_ARRAY_SIZE (l2_io));
 
 #if defined(KERNEL_LINUX)
 	free_zfs_values (ksp);

--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -66,14 +66,11 @@ static int zookeeper_config(const char *key, const char *value)
 	return 0;
 }
 
-static void zookeeper_submit_gauge (const char * type, const char * type_inst, gauge_t val)
+static void zookeeper_submit_gauge (const char * type, const char * type_inst, gauge_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].gauge = val;
-
-	vl.values = values;
+	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zookeeper", sizeof (vl.plugin));
@@ -84,14 +81,11 @@ static void zookeeper_submit_gauge (const char * type, const char * type_inst, g
 	plugin_dispatch_values (&vl);
 } /* zookeeper_submit_gauge */
 
-static void zookeeper_submit_derive (const char * type, const char * type_inst, derive_t val)
+static void zookeeper_submit_derive (const char * type, const char * type_inst, derive_t value)
 {
-	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 
-	values[0].derive = val;
-
-	vl.values = values;
+	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zookeeper", sizeof (vl.plugin));


### PR DESCRIPTION
There are a lot of `value_t` and `value_t[]` in "submit" functions that are effectively used to cast a function argument from `gauge_t` or `derive_t` to `value_t`. This is more elegently done using compound literals.