### PR TITLE
libcollectdclient: Increase LCC_NAME_LEN to 128.

### DIFF
--- a/src/libcollectdclient/Makefile.am
+++ b/src/libcollectdclient/Makefile.am
@@ -11,7 +11,7 @@ libcollectdclient_la_CPPFLAGS = $(AM_CPPFLAGS) \
 				-I$(top_srcdir)/src/libcollectdclient/collectd \
 				-I$(top_builddir)/src/libcollectdclient/collectd \
 				-I$(top_srcdir)/src/daemon
-libcollectdclient_la_LDFLAGS = -version-info 1:0:0
+libcollectdclient_la_LDFLAGS = -version-info 2:0:0
 libcollectdclient_la_LIBADD = 
 if BUILD_WITH_LIBGCRYPT
 libcollectdclient_la_CPPFLAGS += $(GCRYPT_CPPFLAGS)

--- a/src/libcollectdclient/collectd/client.h
+++ b/src/libcollectdclient/collectd/client.h
@@ -48,16 +48,16 @@
 /*
  * Defines
  */
-#define LCC_NAME_LEN 64
+#define LCC_NAME_LEN 128
 #define LCC_DEFAULT_PORT "25826"
 
 /*
  * Types
  */
-#define LCC_TYPE_COUNTER 0
-#define LCC_TYPE_GAUGE   1
+#define LCC_TYPE_COUNTER  0
+#define LCC_TYPE_GAUGE    1
 #define LCC_TYPE_DERIVE   2
-#define LCC_TYPE_ABSOLUTE   3
+#define LCC_TYPE_ABSOLUTE 3
 
 LCC_BEGIN_DECLS
 


### PR DESCRIPTION
This matches the new default in collectd itself. Unfortunately, this changes the size of public structures and therefore breaks ABI compatibility, hence the update to "version-info".

Fixes: #1921
