### PR TITLE
ipmi plugin: Add support for power supply presence.

### DIFF
--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -303,6 +303,10 @@ static int sensor_list_add (ipmi_sensor_t *sensor)
       type = "fanspeed";
       break;
 
+    case IPMI_SENSOR_TYPE_POWER_SUPPLY:
+      type = "presence";
+      break;
+
     default:
       {
         const char *sensor_type_str;

--- a/src/types.db
+++ b/src/types.db
@@ -176,6 +176,7 @@ ping_droprate           value:GAUGE:0:100
 ping_stddev             value:GAUGE:0:65535
 players                 value:GAUGE:0:1000000
 power                   value:GAUGE:U:U
+presence                value:GAUGE:0:U
 pressure                value:GAUGE:0:U
 protocol_counter        value:DERIVE:0:U
 ps_code                 value:GAUGE:0:9223372036854775807


### PR DESCRIPTION
Fixes: #735
