### PR TITLE
use fgets in parse_value_file, fixes #1941

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1091,6 +1091,11 @@ int parse_identifier_vl (const char *str, value_list_t *vl) /* {{{ */
 
 int parse_value (const char *value_orig, value_t *ret_value, int ds_type)
 {
+  return parse_value_ext(value_orig, ret_value, ds_type, "");
+}
+
+int parse_value_ext (const char *value_orig, value_t *ret_value, int ds_type, const char *error_identifier)
+{
   char *value;
   char *endptr = NULL;
   size_t value_len;
@@ -1129,19 +1134,19 @@ int parse_value (const char *value_orig, value_t *ret_value, int ds_type)
 
     default:
       sfree (value);
-      ERROR ("parse_value: Invalid data source type: %i.", ds_type);
+      ERROR ("parse_value %s: Invalid data source type: %i.", error_identifier, ds_type);
       return -1;
   }
 
   if (value == endptr) {
-    ERROR ("parse_value: Failed to parse string as %s: %s.",
+    ERROR ("parse_value %s: Failed to parse string as %s: %s.", error_identifier,
         DS_TYPE_TO_STRING (ds_type), value);
     sfree (value);
     return -1;
   }
   else if ((NULL != endptr) && ('\0' != *endptr))
-    INFO ("parse_value: Ignoring trailing garbage \"%s\" after %s value. "
-        "Input string was \"%s\".",
+    INFO ("parse_value %s: Ignoring trailing garbage \"%s\" after %s value. "
+        "Input string was \"%s\".", error_identifier,
         endptr, DS_TYPE_TO_STRING (ds_type), value_orig);
 
   sfree (value);
@@ -1211,14 +1216,22 @@ int parse_values (char *buffer, value_list_t *vl, const data_set_t *ds)
 
 int parse_value_file (char const *path, value_t *ret_value, int ds_type)
 {
+	FILE *fh;
 	char buffer[256];
 
-	if (read_file_contents (path, buffer, sizeof (buffer)) < 0)
-		return errno;
+	fh = fopen (path, "r");
+	if (fh == NULL)
+		return (-1);
 
-	strstripnewline (buffer);
+	if (fgets (buffer, sizeof (buffer), fh) == NULL)
+	{
+		fclose (fh);
+		return (-1);
+	}
 
-	return parse_value (buffer, ret_value, ds_type);
+	fclose (fh);
+
+	return parse_value_ext (buffer, ret_value, ds_type, path);
 } /* int parse_value_file */
 
 #if !HAVE_GETPWNAM_R

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1091,11 +1091,6 @@ int parse_identifier_vl (const char *str, value_list_t *vl) /* {{{ */
 
 int parse_value (const char *value_orig, value_t *ret_value, int ds_type)
 {
-  return parse_value_ext(value_orig, ret_value, ds_type, "");
-}
-
-int parse_value_ext (const char *value_orig, value_t *ret_value, int ds_type, const char *error_identifier)
-{
   char *value;
   char *endptr = NULL;
   size_t value_len;
@@ -1134,19 +1129,19 @@ int parse_value_ext (const char *value_orig, value_t *ret_value, int ds_type, co
 
     default:
       sfree (value);
-      ERROR ("parse_value %s: Invalid data source type: %i.", error_identifier, ds_type);
+      ERROR ("parse_value: Invalid data source type: %i.", ds_type);
       return -1;
   }
 
   if (value == endptr) {
-    ERROR ("parse_value %s: Failed to parse string as %s: %s.", error_identifier,
+    ERROR ("parse_value: Failed to parse string as %s: %s.",
         DS_TYPE_TO_STRING (ds_type), value);
     sfree (value);
     return -1;
   }
   else if ((NULL != endptr) && ('\0' != *endptr))
-    INFO ("parse_value %s: Ignoring trailing garbage \"%s\" after %s value. "
-        "Input string was \"%s\".", error_identifier,
+    INFO ("parse_value: Ignoring trailing garbage \"%s\" after %s value. "
+        "Input string was \"%s\".",
         endptr, DS_TYPE_TO_STRING (ds_type), value_orig);
 
   sfree (value);
@@ -1231,7 +1226,9 @@ int parse_value_file (char const *path, value_t *ret_value, int ds_type)
 
 	fclose (fh);
 
-	return parse_value_ext (buffer, ret_value, ds_type, path);
+	strstripnewline (buffer);
+
+	return parse_value (buffer, ret_value, ds_type);
 } /* int parse_value_file */
 
 #if !HAVE_GETPWNAM_R

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -323,6 +323,7 @@ int parse_identifier (char *str, char **ret_host,
 		char **ret_type, char **ret_type_instance);
 int parse_identifier_vl (const char *str, value_list_t *vl);
 int parse_value (const char *value, value_t *ret_value, int ds_type);
+int parse_value_ext (const char *value, value_t *ret_value, int ds_type, const char *error_identifier);
 int parse_values (char *buffer, value_list_t *vl, const data_set_t *ds);
 
 /* parse_value_file reads "path" and parses its content as an integer or

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -323,7 +323,6 @@ int parse_identifier (char *str, char **ret_host,
 		char **ret_type, char **ret_type_instance);
 int parse_identifier_vl (const char *str, value_list_t *vl);
 int parse_value (const char *value, value_t *ret_value, int ds_type);
-int parse_value_ext (const char *value, value_t *ret_value, int ds_type, const char *error_identifier);
 int parse_values (char *buffer, value_list_t *vl, const data_set_t *ds);
 
 /* parse_value_file reads "path" and parses its content as an integer or


### PR DESCRIPTION
By using fgets in parse_value_file, this PR fixes #1941.

In addition, parse_value_ext is introduced that simplifies the debugging of the issues raised in this function. It allows to add comment string that is printed as a part of INFO or other messages. It allowed me to find which file was responsible for garbage errors when used together with parse_value_file