### PR TITLE
Tree wide: Set vl.host within plugin_dispatch_values(), instead in plugin code.

### DIFF
--- a/contrib/examples/myplugin.c
+++ b/contrib/examples/myplugin.c
@@ -101,7 +101,6 @@ static int my_submit (gauge_t value)
 	 * have the same timestamp. */
 	/* vl.time = cdtime(); */
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "myplugin", sizeof (vl.plugin));
 
 	/* it is strongly recommended to use a type defined in the types.db file

--- a/src/apache.c
+++ b/src/apache.c
@@ -394,8 +394,8 @@ static void submit_value (const char *type, const char *type_instance,
 	vl.values = &value;
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, (st->host != NULL) ? st->host : hostname_g,
-			sizeof (vl.host));
+	if (st->host != NULL)
+		sstrncpy (vl.host, st->host, sizeof (vl.host));
 
 	sstrncpy (vl.plugin, "apache", sizeof (vl.plugin));
 	if (st->name != NULL)

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -420,9 +420,7 @@ static void apc_submit_generic (const char *type, const char *type_inst, double 
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "apcups", sizeof (vl.plugin));
-	sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_inst, sizeof (vl.type_instance));
 

--- a/src/apple_sensors.c
+++ b/src/apple_sensors.c
@@ -87,9 +87,7 @@ static void as_submit (const char *type, const char *type_instance,
 
 	vl.values = &(value_t) { .gauge = val };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "apple_sensors", sizeof (vl.plugin));
-	sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
 

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -69,7 +69,6 @@ static void aquaero_submit (const char *type, const char *type_instance,
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "aquaero", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -130,7 +130,6 @@ static int ascent_submit_gauge (const char *plugin_instance, /* {{{ */
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ascent", sizeof (vl.plugin));
 
   if (plugin_instance != NULL)

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -1600,7 +1600,6 @@ static int MPL115_collectd_barometer_read (void)
 
     norm_pressure = abs_to_mean_sea_level_pressure(pressure);
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "barometer", sizeof (vl.plugin));
     sstrncpy (vl.plugin_instance, "mpl115", sizeof (vl.plugin_instance));
 
@@ -1663,7 +1662,6 @@ static int MPL3115_collectd_barometer_read (void)
 
     norm_pressure = abs_to_mean_sea_level_pressure(pressure);
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "barometer", sizeof (vl.plugin));
     sstrncpy (vl.plugin_instance, "mpl3115", sizeof (vl.plugin_instance));
 
@@ -1726,7 +1724,6 @@ static int BMP085_collectd_barometer_read (void)
 
     norm_pressure = abs_to_mean_sea_level_pressure(pressure);
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "barometer", sizeof (vl.plugin));
     sstrncpy (vl.plugin_instance, "bmp085", sizeof (vl.plugin_instance));
 

--- a/src/battery.c
+++ b/src/battery.c
@@ -82,7 +82,6 @@ static void battery_submit2 (char const *plugin_instance, /* {{{ */
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "battery", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/battery_statefs.c
+++ b/src/battery_statefs.c
@@ -58,7 +58,6 @@ static void battery_submit(const char *type, gauge_t value,
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "battery", sizeof(vl.plugin));
   /* statefs supports 1 battery at present */
   sstrncpy(vl.plugin_instance, "0", sizeof(vl.plugin_instance));

--- a/src/bind.c
+++ b/src/bind.c
@@ -253,7 +253,6 @@ static void submit (time_t ts, const char *plugin_instance, /* {{{ */
   vl.values_len = 1;
   if (config_parse_time)
     vl.time = TIME_T_TO_CDTIME_T (ts);
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "bind", sizeof(vl.plugin));
   if (plugin_instance) {
     sstrncpy(vl.plugin_instance, plugin_instance,

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1162,7 +1162,6 @@ cconn_process_data(struct cconn *io, yajl_struct *yajl, yajl_handle hand)
     }
 
     vtmp->vlist = (value_list_t)VALUE_LIST_INIT;
-    sstrncpy(vtmp->vlist.host, hostname_g, sizeof(vtmp->vlist.host));
     sstrncpy(vtmp->vlist.plugin, "ceph", sizeof(vtmp->vlist.plugin));
     sstrncpy(vtmp->vlist.plugin_instance, io->d->name, sizeof(vtmp->vlist.plugin_instance));
 

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -46,7 +46,6 @@ static void cgroups_submit_one (char const *plugin_instance,
 
 	vl.values = &value;
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "cgroups", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -683,9 +683,6 @@ chrony_push_data(const char *p_type, const char *p_type_inst, double p_value)
   vl.values_len = 1;
 
   /* XXX: Shall g_chrony_host/g_chrony_port be reflected in the plugin's output? */
-  /* hostname_g is set in daemon/collectd.c (from config, via gethostname or by resolving localhost) */
-  /* defined as: char hostname_g[DATA_MAX_NAME_LEN]; (never NULL) */
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, PLUGIN_NAME_SHORT, sizeof(vl.plugin));
   if (g_chrony_plugin_instance != NULL)
   {

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -61,7 +61,6 @@ static void conntrack_submit (const char *type, const char *type_instance,
 
 	vl.values = &conntrack;
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "conntrack", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	if (type_instance != NULL)

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -53,7 +53,6 @@ static void cs_submit (derive_t context_switches)
 
 	vl.values = &(value_t) { .derive = context_switches };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "contextswitch", sizeof (vl.plugin));
 	sstrncpy (vl.type, "contextswitch", sizeof (vl.type));
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -330,7 +330,6 @@ static void submit_value (int cpu_num, int cpu_state, const char *type, value_t 
 	vl.values = &value;
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "cpu", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, cpu_state_names[cpu_state],
@@ -464,7 +463,6 @@ static void cpu_commit_num_cpu (gauge_t value) /* {{{ */
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "cpu", sizeof (vl.plugin));
 	sstrncpy (vl.type, "count", sizeof (vl.type));
 

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -63,7 +63,6 @@ static void cpufreq_submit (int cpu_num, value_t value)
 
 	vl.values = &value;
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "cpufreq", sizeof (vl.plugin));
 	sstrncpy (vl.type, "cpufreq", sizeof (vl.type));
 	ssnprintf (vl.type_instance, sizeof (vl.type_instance), "%i", cpu_num);

--- a/src/cpusleep.c
+++ b/src/cpusleep.c
@@ -41,7 +41,6 @@ static void cpusleep_submit(derive_t cpu_sleep) {
 
   vl.values = &(value_t) { .derive = cpu_sleep };
   vl.values_len = 1;
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "cpusleep", sizeof(vl.plugin));
   sstrncpy(vl.type, "total_time_in_ms", sizeof(vl.type));
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -614,7 +614,6 @@ static void cc_submit (const web_page_t *wp, const web_match_t *wm, /* {{{ */
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, wp->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, wm->type, sizeof (vl.type));
@@ -630,7 +629,6 @@ static void cc_submit_response_code (const web_page_t *wp, long code) /* {{{ */
 
   vl.values = &(value_t) { .gauge = (gauge_t) code };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, wp->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, "response_code", sizeof (vl.type));
@@ -645,7 +643,6 @@ static void cc_submit_response_time (const web_page_t *wp, /* {{{ */
 
   vl.values = &(value_t) { .gauge = CDTIME_T_TO_DOUBLE (response_time) };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "curl", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, wp->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, "response_time", sizeof (vl.type));

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -101,7 +101,7 @@ static int init_hostname (void)
 	int status;
 
 	str = global_option_get ("Hostname");
-	if (str != NULL)
+	if ((str != NULL) && (str[0] != 0))
 	{
 		sstrncpy (hostname_g, str, sizeof (hostname_g));
 		return (0);
@@ -602,7 +602,7 @@ int main (int argc, char **argv)
 	 * something wrong.
 	 */
 	if (init_global_variables () != 0)
-		return (1);
+		exit (EXIT_FAILURE);
 
 	if (test_config)
 		return (0);

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -110,9 +110,7 @@ struct value_list_s
 };
 typedef struct value_list_s value_list_t;
 
-#define VALUE_LIST_INIT { NULL, 0, 0, plugin_get_interval (), \
-	"localhost", "", "", "", "", NULL }
-#define VALUE_LIST_STATIC { NULL, 0, 0, 0, "localhost", "", "", "", "", NULL }
+#define VALUE_LIST_INIT { .values = NULL, .meta = NULL }
 
 struct data_source_s
 {

--- a/src/daemon/utils_tail_match.c
+++ b/src/daemon/utils_tail_match.c
@@ -88,7 +88,6 @@ static int simple_submit_match (cu_match_t *match, void *user_data)
 
   vl.values = values;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, data->plugin, sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, data->plugin_instance,
       sizeof (vl.plugin_instance));

--- a/src/df.c
+++ b/src/df.c
@@ -165,7 +165,6 @@ static void df_submit_one (char *plugin_instance,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "df", sizeof (vl.plugin));
 	if (plugin_instance != NULL)
 		sstrncpy (vl.plugin_instance, plugin_instance,

--- a/src/disk.c
+++ b/src/disk.c
@@ -305,7 +305,6 @@ static void disk_submit (const char *plugin_instance,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));
@@ -325,7 +324,6 @@ static void submit_io_time (char const *plugin_instance, derive_t io_time, deriv
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "disk_io_time", sizeof (vl.type));
@@ -341,7 +339,6 @@ static void submit_in_progress (char const *disk_name, gauge_t in_progress)
 
 	vl.values = &(value_t) { .gauge = in_progress };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "disk", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, disk_name, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "pending_operations", sizeof (vl.type));

--- a/src/dns.c
+++ b/src/dns.c
@@ -374,7 +374,6 @@ static void submit_derive (const char *type, const char *type_instance,
 
 	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "dns", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
@@ -392,7 +391,6 @@ static void submit_octets (derive_t queries, derive_t responses)
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "dns", sizeof (vl.plugin));
 	sstrncpy (vl.type, "dns_octets", sizeof (vl.type));
 

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -555,76 +555,75 @@ static void dpdk_submit_xstats(const char *dev_name,
                                const struct rte_eth_xstats *xstats,
                                uint32_t counters, cdtime_t port_read_time) {
   for (uint32_t j = 0; j < counters; j++) {
-    value_list_t dpdkstat_vl = VALUE_LIST_INIT;
+    value_list_t vl = VALUE_LIST_INIT;
     char *type_end;
 
-    dpdkstat_vl.values = &(value_t){.derive = (derive_t)xstats[j].value};
-    dpdkstat_vl.values_len = 1; /* Submit stats one at a time */
-    dpdkstat_vl.time = port_read_time;
-    sstrncpy(dpdkstat_vl.host, hostname_g, sizeof(dpdkstat_vl.host));
-    sstrncpy(dpdkstat_vl.plugin, "dpdkstat", sizeof(dpdkstat_vl.plugin));
-    sstrncpy(dpdkstat_vl.plugin_instance, dev_name,
-             sizeof(dpdkstat_vl.plugin_instance));
+    vl.values = &(value_t){.derive = (derive_t)xstats[j].value};
+    vl.values_len = 1; /* Submit stats one at a time */
+    vl.time = port_read_time;
+    sstrncpy(vl.plugin, "dpdkstat", sizeof(vl.plugin));
+    sstrncpy(vl.plugin_instance, dev_name,
+             sizeof(vl.plugin_instance));
 
     type_end = strrchr(xstats[j].name, '_');
 
     if ((type_end != NULL) &&
         (strncmp(xstats[j].name, "rx_", strlen("rx_")) == 0)) {
       if (strncmp(type_end, "_errors", strlen("_errors")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_errors", sizeof(vl.type));
       } else if (strncmp(type_end, "_dropped", strlen("_dropped")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_dropped", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_dropped", sizeof(vl.type));
       } else if (strncmp(type_end, "_bytes", strlen("_bytes")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_octets", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_octets", sizeof(vl.type));
       } else if (strncmp(type_end, "_packets", strlen("_packets")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_packets", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_packets", sizeof(vl.type));
       } else if (strncmp(type_end, "_placement", strlen("_placement")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_errors", sizeof(vl.type));
       } else if (strncmp(type_end, "_buff", strlen("_buff")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_rx_errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_rx_errors", sizeof(vl.type));
       } else {
         /* Does not fit obvious type: use a more generic one */
-        sstrncpy(dpdkstat_vl.type, "derive", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "derive", sizeof(vl.type));
       }
 
     } else if ((type_end != NULL) &&
                (strncmp(xstats[j].name, "tx_", strlen("tx_"))) == 0) {
       if (strncmp(type_end, "_errors", strlen("_errors")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_tx_errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_tx_errors", sizeof(vl.type));
       } else if (strncmp(type_end, "_dropped", strlen("_dropped")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_tx_dropped", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_tx_dropped", sizeof(vl.type));
       } else if (strncmp(type_end, "_bytes", strlen("_bytes")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_tx_octets", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_tx_octets", sizeof(vl.type));
       } else if (strncmp(type_end, "_packets", strlen("_packets")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "if_tx_packets", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "if_tx_packets", sizeof(vl.type));
       } else {
         /* Does not fit obvious type: use a more generic one */
-        sstrncpy(dpdkstat_vl.type, "derive", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "derive", sizeof(vl.type));
       }
     } else if ((type_end != NULL) &&
                (strncmp(xstats[j].name, "flow_", strlen("flow_"))) == 0) {
 
       if (strncmp(type_end, "_filters", strlen("_filters")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "operations", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "operations", sizeof(vl.type));
       } else if (strncmp(type_end, "_errors", strlen("_errors")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "errors", sizeof(vl.type));
       } else if (strncmp(type_end, "_filters", strlen("_filters")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "filter_result", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "filter_result", sizeof(vl.type));
       }
     } else if ((type_end != NULL) &&
                (strncmp(xstats[j].name, "mac_", strlen("mac_"))) == 0) {
       if (strncmp(type_end, "_errors", strlen("_errors")) == 0) {
-        sstrncpy(dpdkstat_vl.type, "errors", sizeof(dpdkstat_vl.type));
+        sstrncpy(vl.type, "errors", sizeof(vl.type));
       }
     } else {
       /* Does not fit obvious type, or strrchr error:
        *   use a more generic type */
-      sstrncpy(dpdkstat_vl.type, "derive", sizeof(dpdkstat_vl.type));
+      sstrncpy(vl.type, "derive", sizeof(vl.type));
     }
 
-    sstrncpy(dpdkstat_vl.type_instance, xstats[j].name,
-             sizeof(dpdkstat_vl.type_instance));
-    plugin_dispatch_values(&dpdkstat_vl);
+    sstrncpy(vl.type_instance, xstats[j].name,
+             sizeof(vl.type_instance));
+    plugin_dispatch_values(&vl);
   }
 }
 

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -101,7 +101,6 @@ static int drbd_submit_fields (long int resource,
 	}
 
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "drbd", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/email.c
+++ b/src/email.c
@@ -657,7 +657,6 @@ static void email_submit (const char *type, const char *type_instance, gauge_t v
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "email", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/entropy.c
+++ b/src/entropy.c
@@ -41,7 +41,6 @@ static void entropy_submit (value_t value)
 
 	vl.values = &value;
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "entropy", sizeof (vl.plugin));
 	sstrncpy (vl.type, "entropy", sizeof (vl.type));
 

--- a/src/ethstat.c
+++ b/src/ethstat.c
@@ -191,7 +191,6 @@ static void ethstat_submit_value (const char *device,
   vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ethstat", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, device, sizeof (vl.plugin_instance));
   if (map != NULL)

--- a/src/exec.c
+++ b/src/exec.c
@@ -274,7 +274,7 @@ static void set_environment (void) /* {{{ */
       CDTIME_T_TO_DOUBLE (plugin_get_interval ()));
   setenv ("COLLECTD_INTERVAL", buffer, /* overwrite = */ 1);
 
-  ssnprintf (buffer, sizeof (buffer), "%s", hostname_g);
+  sstrncpy (buffer, hostname_g, sizeof (buffer));
   setenv ("COLLECTD_HOSTNAME", buffer, /* overwrite = */ 1);
 #else
   ssnprintf (buffer, sizeof (buffer), "COLLECTD_INTERVAL=%.3f",

--- a/src/fhcount.c
+++ b/src/fhcount.c
@@ -66,7 +66,6 @@ static void fhcount_submit(
   vl.values_len = 1;
 
   // Compose the metric
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, "fhcount", sizeof(vl.plugin));
   sstrncpy(vl.type, type, sizeof(vl.type));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -65,7 +65,6 @@ static void fc_submit_dir (const fc_directory_conf_t *dir)
 
   vl.values = &(value_t) { .gauge = (gauge_t) dir->files_num };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "filecount", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dir->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, "files", sizeof (vl.type));

--- a/src/fscache.c
+++ b/src/fscache.c
@@ -115,7 +115,6 @@ static void fscache_submit (const char *section, const char *name,
     vl.values = &value;
     vl.values_len = 1;
 
-    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
     sstrncpy(vl.plugin, "fscache", sizeof (vl.plugin));
     sstrncpy(vl.plugin_instance, section, sizeof (vl.plugin_instance));
     sstrncpy(vl.type, "fscache_stat", sizeof(vl.type));

--- a/src/gps.c
+++ b/src/gps.c
@@ -224,7 +224,6 @@ static void cgps_submit (const char *type, gauge_t value, const char *type_insta
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "gps", sizeof (vl.plugin));
   sstrncpy (vl.type, type, sizeof (vl.type));
   sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -230,7 +230,6 @@ static void hddtemp_submit (char *type_instance, double value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "hddtemp", sizeof (vl.plugin));
 	sstrncpy (vl.type, "temperature", sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -85,7 +85,6 @@ static void submit_hp(const struct entry_info *info) {
   vl.values = &(value_t) { .gauge = NAN };
   vl.values_len = 1;
 
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, g_plugin_name, sizeof(vl.plugin));
   if (info->node) {
     ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",

--- a/src/interface.c
+++ b/src/interface.c
@@ -179,7 +179,6 @@ static void if_submit (const char *dev, const char *type,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "interface", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -101,7 +101,6 @@ static void ipc_submit_g (const char *plugin_instance,
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ipc", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -216,7 +216,6 @@ static void sensor_read_handler (ipmi_sensor_t *sensor,
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ipmi", sizeof (vl.plugin));
   sstrncpy (vl.type, list_item->sensor_type, sizeof (vl.type));
   sstrncpy (vl.type_instance, list_item->sensor_name, sizeof (vl.type_instance));

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -259,7 +259,6 @@ static int submit6_match (const struct ip6t_entry_match *match,
             return (0);
     }
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "ip6tables", sizeof (vl.plugin));
 
     status = ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance),
@@ -317,7 +316,6 @@ static int submit_match (const struct ipt_entry_match *match,
             return (0);
     }
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "iptables", sizeof (vl.plugin));
 
     status = ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance),

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -233,7 +233,6 @@ static void cipvs_submit_connections (const char *pi, const char *ti,
 	vl.values     = &(value_t) { .derive = value };
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "ipvs", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, pi, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "connections", sizeof (vl.type));
@@ -256,7 +255,6 @@ static void cipvs_submit_if (const char *pi, const char *t, const char *ti,
 	vl.values     = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "ipvs", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, pi, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, t, sizeof (vl.type));

--- a/src/irq.c
+++ b/src/irq.c
@@ -79,7 +79,6 @@ static void irq_submit (const char *irq_name, derive_t value)
 
 	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "irq", sizeof (vl.plugin));
 	sstrncpy (vl.type, "irq", sizeof (vl.type));
 	sstrncpy (vl.type_instance, irq_name, sizeof (vl.type_instance));

--- a/src/load.c
+++ b/src/load.c
@@ -105,7 +105,6 @@ static void load_submit (gauge_t snum, gauge_t mnum, gauge_t lnum)
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "load", sizeof (vl.plugin));
 	sstrncpy (vl.type, "load", sizeof (vl.type));
 

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -123,10 +123,6 @@ static void lpar_submit (const char *type_instance, double value)
 		sstrncpy (vl.host, serial, sizeof (vl.host));
 		sstrncpy (vl.plugin_instance, hostname_g, sizeof (vl.plugin));
 	}
-	else
-	{
-		sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-	}
 	sstrncpy (vl.plugin, "lpar", sizeof (vl.plugin));
 	sstrncpy (vl.type, "vcpu", sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -60,7 +60,6 @@ static void lvm_submit (char const *plugin_instance, char const *type_instance,
     vl.values = &(value_t) { .gauge = (gauge_t) ivalue };
     vl.values_len = 1;
 
-    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
     sstrncpy(vl.plugin, "lvm", sizeof (vl.plugin));
     sstrncpy(vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
     sstrncpy(vl.type, "df_complex", sizeof (vl.type));

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -544,7 +544,6 @@ static void submit (const char *dev, const char *type, const char *ti1,
 
 	vl.values = val;
 	vl.values_len = len;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "madwifi", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/mbmon.c
+++ b/src/mbmon.c
@@ -222,7 +222,6 @@ static void mbmon_submit (const char *type, const char *type_instance,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "mbmon", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/md.c
+++ b/src/md.c
@@ -76,7 +76,6 @@ static void md_submit (const int minor, const char *type_instance,
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "md", sizeof (vl.plugin));
   ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance),
       "%i", minor);

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -447,7 +447,6 @@ static void cmc_submit (const web_page_t *wp, const web_match_t *wm, /* {{{ */
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "memcachec", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, wp->instance, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, wm->type, sizeof (vl.type));

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -241,20 +241,19 @@ static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
 {
   char const *host = st->host;
 
-  /* Set vl->host to hostname_g, if:
+  /* Keep default hostname, if:
    * - Legacy mode is used.
    * - "Socket" option is given (doc: "Host option is ignored").
    * - "Host" option is not provided.
    * - "Host" option is set to "localhost" or "127.0.0.1". */
-  if ((strcmp (st->name, "__legacy__") == 0)
-      || (st->socket != NULL)
-      || (st->host == NULL)
-      || (strcmp ("127.0.0.1", st->host) == 0)
-      || (strcmp ("localhost", st->host) == 0))
-    host = hostname_g;
+  if ((strcmp (st->name, "__legacy__") != 0)
+      && (st->socket == NULL)
+      && (st->host != NULL)
+      && (strcmp ("127.0.0.1", st->host) != 0)
+      && (strcmp ("localhost", st->host) != 0))
+    sstrncpy (vl->host, host, sizeof (vl->host));
 
   sstrncpy (vl->plugin, "memcached", sizeof (vl->plugin));
-  sstrncpy (vl->host, host, sizeof (vl->host));
   if (strcmp (st->name, "__legacy__") != 0)
     sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -527,7 +527,6 @@ static int memory_read (void) /* {{{ */
 
 	vl.values = v;
 	vl.values_len = STATIC_ARRAY_SIZE (v);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "memory", sizeof (vl.plugin));
 	sstrncpy (vl.type, "memory", sizeof (vl.type));
 	vl.time = cdtime ();

--- a/src/mic.c
+++ b/src/mic.c
@@ -160,7 +160,6 @@ static void mic_submit_memory_use(int micnumber, const char *type_instance, U32 
 	vl.values = &(value_t) { .gauge = ((gauge_t)value) * 1024.0 };
 	vl.values_len = 1;
 
-	strncpy (vl.host, hostname_g, sizeof (vl.host));
 	strncpy (vl.plugin, "mic", sizeof (vl.plugin));
 	ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance), "%i", micnumber);
 	strncpy (vl.type, "memory", sizeof (vl.type));

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -197,7 +197,6 @@ static void multimeter_submit (double value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "multimeter", sizeof (vl.plugin));
 	sstrncpy (vl.type, "multimeter", sizeof (vl.type));
 

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -633,8 +633,6 @@ static int submit_values (const char *host, /* {{{ */
 
 	if (host != NULL)
 		sstrncpy (vl.host, host, sizeof (vl.host));
-	else
-		sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "netapp", sizeof (vl.plugin));
 	if (plugin_inst != NULL)
 		sstrncpy (vl.plugin_instance, plugin_inst, sizeof (vl.plugin_instance));

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -198,7 +198,6 @@ static void submit_one (const char *dev, const char *type,
 
   vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "netlink", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, type, sizeof (vl.type));
@@ -221,7 +220,6 @@ static void submit_two (const char *dev, const char *type,
 
   vl.values = values;
   vl.values_len = STATIC_ARRAY_SIZE (values);
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "netlink", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/network.c
+++ b/src/network.c
@@ -303,7 +303,7 @@ static char            *send_buffer;
 static char            *send_buffer_ptr;
 static int              send_buffer_fill;
 static cdtime_t         send_buffer_last_update;
-static value_list_t     send_buffer_vl = VALUE_LIST_STATIC;
+static value_list_t     send_buffer_vl = VALUE_LIST_INIT;
 static pthread_mutex_t  send_buffer_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* XXX: These counters are incremented from one place only. The spot in which

--- a/src/network.c
+++ b/src/network.c
@@ -3386,7 +3386,6 @@ static int network_stats_read (void) /* {{{ */
 	vl.values = values;
 	vl.values_len = 2;
 	vl.time = 0;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "network", sizeof (vl.plugin));
 
 	/* Octets received / sent */

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -386,7 +386,6 @@ static void nfs_procedures_submit (const char *plugin_instance,
 	value_list_t vl = VALUE_LIST_INIT;
 
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "nfs", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -211,9 +211,7 @@ static void submit (const char *type, const char *inst, long long value)
 
   vl.values = values;
   vl.values_len = STATIC_ARRAY_SIZE (values);
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "nginx", sizeof (vl.plugin));
-  sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
   sstrncpy (vl.type, type, sizeof (vl.type));
 
   if (inst != NULL)

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -317,9 +317,7 @@ static void ntpd_submit (const char *type, const char *type_inst, gauge_t value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "ntpd", sizeof (vl.plugin));
-	sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_inst, sizeof (vl.type_instance));
 

--- a/src/numa.c
+++ b/src/numa.c
@@ -47,7 +47,6 @@ static void numa_dispatch_value (int node, /* {{{ */
   vl.values = &v;
   vl.values_len = 1;
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "numa", sizeof (vl.plugin));
   ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance), "node%i", node);
   sstrncpy (vl.type, "vmpage_action", sizeof (vl.type));

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -221,7 +221,6 @@ static void olsrd_submit (const char *plugin_instance, /* {{{ */
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "olsrd", sizeof (vl.plugin));
   if (plugin_instance != NULL)
     sstrncpy (vl.plugin_instance, plugin_instance,

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -346,7 +346,6 @@ static int cow_read_values (const char *path, const char *name,
       return 0;
   }
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "onewire", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, name, sizeof (vl.plugin_instance));
 
@@ -505,7 +504,6 @@ static int cow_simple_read (void)
   /* traverse list and check entries */
   for (traverse = direct_list; traverse != NULL; traverse = traverse->next)
   {
-      sstrncpy (vl.host, hostname_g, sizeof (vl.host));
       sstrncpy (vl.plugin, "onewire", sizeof (vl.plugin));
       sstrncpy (vl.plugin_instance, traverse->address, sizeof (vl.plugin_instance));
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -169,11 +169,7 @@ static void cldap_submit_value (const char *type, const char *type_instance, /* 
 	vl.values     = &value;
 	vl.values_len = 1;
 
-	if ((st->host == NULL)
-			|| (strcmp ("", st->host) == 0)
-			|| (strcmp ("localhost", st->host) == 0))
-		sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-	else
+	if ((st->host != NULL) && (strcmp ("localhost", st->host) != 0))
 		sstrncpy (vl.host, st->host, sizeof (vl.host));
 
 	sstrncpy (vl.plugin, "openldap", sizeof (vl.plugin));

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -103,7 +103,6 @@ static void numusers_submit (const char *pinst, const char *tinst,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "openvpn", sizeof (vl.plugin));
 	sstrncpy (vl.type, "users", sizeof (vl.type));
 	if (pinst != NULL)
@@ -133,7 +132,6 @@ static void iostats_submit (const char *pinst, const char *tinst,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "openvpn", sizeof (vl.plugin));
 	if (pinst != NULL)
 		sstrncpy (vl.plugin_instance, pinst,
@@ -157,7 +155,6 @@ static void compression_submit (const char *pinst, const char *tinst,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "openvpn", sizeof (vl.plugin));
 	if (pinst != NULL)
 		sstrncpy (vl.plugin_instance, pinst,

--- a/src/pf.c
+++ b/src/pf.c
@@ -70,7 +70,6 @@ static void pf_submit (char const *type, char const *type_instance,
 
 	vl.values = values;
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "pf", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof(vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof(vl.type_instance));

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -680,7 +680,6 @@ static int plugin_submit (const pinba_statnode_t *res) /* {{{ */
   value_list_t vl = VALUE_LIST_INIT;
 
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "pinba", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, res->name, sizeof (vl.plugin_instance));
 

--- a/src/ping.c
+++ b/src/ping.c
@@ -619,9 +619,7 @@ static void submit (const char *host, const char *type, /* {{{ */
 
   vl.values = &(value_t) { .gauge = value };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "ping", sizeof (vl.plugin));
-  sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
   sstrncpy (vl.type_instance, host, sizeof (vl.type_instance));
   sstrncpy (vl.type, type, sizeof (vl.type));
 

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -354,7 +354,6 @@ static void submit (const char *plugin_instance, /* {{{ */
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "powerdns", sizeof (vl.plugin));
   sstrncpy (vl.type, type, sizeof (vl.type));
   if (type_instance != NULL)

--- a/src/processes.c
+++ b/src/processes.c
@@ -664,7 +664,6 @@ static void ps_submit_state (const char *state, double value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, "", sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "ps_state", sizeof (vl.type));
@@ -680,7 +679,6 @@ static void ps_submit_proc_list (procstat_t *ps)
 	value_t values[2];
 
 	vl.values = values;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, ps->name, sizeof (vl.plugin_instance));
 
@@ -784,7 +782,6 @@ static void ps_submit_fork_rate (derive_t value)
 
 	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
-	sstrncpy(vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy(vl.plugin, "processes", sizeof (vl.plugin));
 	sstrncpy(vl.plugin_instance, "", sizeof (vl.plugin_instance));
 	sstrncpy(vl.type, "fork_rate", sizeof (vl.type));

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -69,7 +69,6 @@ static void submit (const char *protocol_name,
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "protocols", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, protocol_name, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, "protocol_counter", sizeof (vl.type));

--- a/src/redis.c
+++ b/src/redis.c
@@ -256,7 +256,6 @@ static void redis_submit (char *plugin_instance,
 
   vl.values = &value;
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "redis", sizeof (vl.plugin));
   if (plugin_instance != NULL)
     sstrncpy (vl.plugin_instance, plugin_instance,

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -302,10 +302,8 @@ static int rc_read (void)
   if (!config_collect_stats)
     return (-1);
 
-  if ((strncmp ("unix:", daemon_address, strlen ("unix:")) == 0)
-      || (daemon_address[0] == '/'))
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-  else
+  if ((strncmp ("unix:", daemon_address, strlen ("unix:")) != 0)
+      && (daemon_address[0] != '/'))
     sstrncpy (vl.host, daemon_address, sizeof (vl.host));
   sstrncpy (vl.plugin, "rrdcached", sizeof (vl.plugin));
 

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -503,7 +503,6 @@ static void sensors_submit (const char *plugin_instance,
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "sensors", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/serial.c
+++ b/src/serial.c
@@ -41,7 +41,6 @@ static void serial_submit (const char *type_instance,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "serial", sizeof (vl.plugin));
 	sstrncpy (vl.type, "serial_octets", sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance,

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -200,10 +200,8 @@ static void sigrok_feed_callback(const struct sr_dev_inst *sdi,
 	analog = packet->payload;
 	vl.values = &(value_t) { .gauge = analog->data[0] };
 	vl.values_len = 1;
-	sstrncpy(vl.host, hostname_g, sizeof(vl.host));
 	sstrncpy(vl.plugin, "sigrok", sizeof(vl.plugin));
-	ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
-			"%s", cfdev->name);
+	sstrncpy(vl.plugin_instance, cfdev->name, sizeof(vl.plugin_instance));
 	sstrncpy(vl.type, sigrok_value_type(analog), sizeof(vl.type));
 
 	plugin_dispatch_values(&vl);

--- a/src/smart.c
+++ b/src/smart.c
@@ -90,7 +90,6 @@ static void smart_submit (const char *dev, const char *type,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "smart", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));
@@ -117,7 +116,6 @@ static void smart_handle_disk_attribute(SkDisk *d, const SkSmartAttributeParsedD
 
   vl.values = values;
   vl.values_len = STATIC_ARRAY_SIZE (values);
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "smart", sizeof (vl.plugin));
   sstrncpy (vl.plugin_instance, dev, sizeof (vl.plugin_instance));
   sstrncpy (vl.type, "smart_attribute", sizeof (vl.type));

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -756,7 +756,6 @@ static int statsd_metric_submit_unsafe (char const *name, statsd_metric_t *metri
 
   vl.values = &(value_t) { .gauge = NAN };
   vl.values_len = 1;
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "statsd", sizeof (vl.plugin));
 
   if (metric->type == STATSD_GAUGE)

--- a/src/swap.c
+++ b/src/swap.c
@@ -198,7 +198,6 @@ static void swap_submit_usage (char const *plugin_instance, /* {{{ */
 
 	vl.values = &(value_t) { .gauge = NAN };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "swap", sizeof (vl.plugin));
 	if (plugin_instance != NULL)
 		sstrncpy (vl.plugin_instance, plugin_instance,
@@ -224,7 +223,6 @@ static void swap_submit_derive (char const *type_instance, /* {{{ */
 
 	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "swap", sizeof (vl.plugin));
 	sstrncpy (vl.type, "swap_io", sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/table.c
+++ b/src/table.c
@@ -384,7 +384,6 @@ static int tbl_result_dispatch (tbl_t *tbl, tbl_result_t *res,
 	vl.values     = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "table", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, tbl->instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, res->type, sizeof (vl.type));

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -69,7 +69,6 @@ static int tcsv_submit (instance_definition_t *id,
     vl.values_len = 1;
     vl.values = &v;
 
-    sstrncpy(vl.host, hostname_g, sizeof (vl.host));
     sstrncpy(vl.plugin, "tail_csv", sizeof(vl.plugin));
     if (id->instance != NULL)
         sstrncpy(vl.plugin_instance, id->instance, sizeof(vl.plugin_instance));

--- a/src/tape.c
+++ b/src/tape.c
@@ -69,7 +69,6 @@ static void tape_submit (const char *plugin_instance,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "tape", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -296,7 +296,6 @@ static void conn_prepare_vl (value_list_t *vl, value_t *values)
 {
   vl->values = values;
   vl->values_len = 1;
-  sstrncpy (vl->host, hostname_g, sizeof (vl->host));
   sstrncpy (vl->plugin, "tcpconns", sizeof (vl->plugin));
   sstrncpy (vl->type, "tcp_connections", sizeof (vl->type));
 }

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -125,7 +125,6 @@ static void tss2_submit_gauge (const char *plugin_instance,
 
 	vl.values     = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "teamspeak2", sizeof (vl.plugin));
 
 	if (plugin_instance != NULL)
@@ -155,7 +154,6 @@ static void tss2_submit_io (const char *plugin_instance, const char *type,
 
 	vl.values     = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "teamspeak2", sizeof (vl.plugin));
 
 	if (plugin_instance != NULL)

--- a/src/ted.c
+++ b/src/ted.c
@@ -267,7 +267,6 @@ static void ted_submit (const char *type, double value)
 
     vl.values = &(value_t) { .gauge = value };
     vl.values_len = 1;
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "ted", sizeof (vl.plugin));
     sstrncpy (vl.type, type, sizeof (vl.type));
 

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -54,7 +54,6 @@ static void thermal_submit (const char *plugin_instance, enum dev_type dt,
 	vl.values = &value;
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "thermal", sizeof(vl.plugin));
 	if (plugin_instance != NULL)
 		sstrncpy (vl.plugin_instance, plugin_instance,

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -527,7 +527,6 @@ turbostat_submit (const char *plugin_instance,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, PLUGIN_NAME, sizeof (vl.plugin));
 	if (plugin_instance != NULL)
 		sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -65,7 +65,6 @@ static void uptime_submit (gauge_t value)
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "uptime", sizeof (vl.plugin));
 	sstrncpy (vl.type, "uptime", sizeof (vl.type));
 

--- a/src/users.c
+++ b/src/users.c
@@ -49,7 +49,6 @@ static void users_submit (gauge_t value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "users", sizeof (vl.plugin));
 	sstrncpy (vl.type, "users", sizeof (vl.plugin));
 

--- a/src/utils_vl_lookup_test.c
+++ b/src/utils_vl_lookup_test.c
@@ -111,7 +111,7 @@ static int checked_lookup_search (lookup_t *obj,
     _Bool expect_new)
 {
   int status;
-  value_list_t vl = VALUE_LIST_STATIC;
+  value_list_t vl = VALUE_LIST_INIT;
   data_set_t const *ds = &ds_unknown;
 
   strncpy (vl.host, host, sizeof (vl.host));

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -94,13 +94,10 @@ static int varnish_submit (const char *plugin_instance, /* {{{ */
 	vl.values = &value;
 	vl.values_len = 1;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-
 	sstrncpy (vl.plugin, "varnish", sizeof (vl.plugin));
 
 	if (plugin_instance == NULL)
 		plugin_instance = "default";
-
 	ssnprintf (vl.plugin_instance, sizeof (vl.plugin_instance),
 		"%s-%s", plugin_instance, category);
 

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -51,7 +51,6 @@ static void submit (const char *plugin_instance, const char *type,
   vl.values = values;
   vl.values_len = values_len;
 
-  sstrncpy (vl.host, hostname_g, sizeof (vl.host));
   sstrncpy (vl.plugin, "vmem", sizeof (vl.plugin));
   if (plugin_instance != NULL)
     sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -64,7 +64,6 @@ static void traffic_submit (const char *plugin_instance,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "vserver", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "if_octets", sizeof (vl.type));
@@ -85,7 +84,6 @@ static void load_submit (const char *plugin_instance,
 
 	vl.values = values;
 	vl.values_len = STATIC_ARRAY_SIZE (values);
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "vserver", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, "load", sizeof (vl.type));
@@ -101,7 +99,6 @@ static void submit_gauge (const char *plugin_instance, const char *type,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "vserver", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance, sizeof (vl.plugin_instance));
 	sstrncpy (vl.type, type, sizeof (vl.type));

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -58,7 +58,6 @@ static void wireless_submit (const char *plugin_instance, const char *type,
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "wireless", sizeof (vl.plugin));
 	sstrncpy (vl.plugin_instance, plugin_instance,
 			sizeof (vl.plugin_instance));

--- a/src/xencpu.c
+++ b/src/xencpu.c
@@ -115,7 +115,6 @@ static void submit_value (int cpu_num, gauge_t value)
     vl.values = &(value_t) { .gauge = value };
     vl.values_len = 1;
 
-    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
     sstrncpy (vl.plugin, "xencpu", sizeof (vl.plugin));
     sstrncpy (vl.type, "percent", sizeof (vl.type));
     sstrncpy (vl.type_instance, "load", sizeof (vl.type_instance));

--- a/src/xmms.c
+++ b/src/xmms.c
@@ -39,7 +39,6 @@ static void cxmms_submit (const char *type, gauge_t value)
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "xmms", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -145,7 +145,6 @@ static void za_submit (const char* type, const char* type_instance, value_t* val
 	vl.values = values;
 	vl.values_len = values_len;
 
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zfs_arc", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));

--- a/src/zone.c
+++ b/src/zone.c
@@ -91,7 +91,6 @@ zone_submit_value(char *zone, gauge_t value)
 
 	vl.values = values;
 	vl.values_len = 1; /*STATIC_ARRAY_SIZE (values);*/
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zone", sizeof (vl.plugin));
  	sstrncpy (vl.type, "percent", sizeof (vl.type));
  	sstrncpy (vl.type_instance, zone, sizeof (vl.type_instance));

--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -72,7 +72,6 @@ static void zookeeper_submit_gauge (const char * type, const char * type_inst, g
 
 	vl.values = &(value_t) { .gauge = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zookeeper", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	if (type_inst != NULL)
@@ -87,7 +86,6 @@ static void zookeeper_submit_derive (const char * type, const char * type_inst, 
 
 	vl.values = &(value_t) { .derive = value };
 	vl.values_len = 1;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "zookeeper", sizeof (vl.plugin));
 	sstrncpy (vl.type, type, sizeof (vl.type));
 	if (type_inst != NULL)


### PR DESCRIPTION
Fixes: #1951