### PR TITLE
dpdkstat: Fixed issue with unused var when configured w/o debug

### DIFF
--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -152,10 +152,8 @@ static int dpdk_config(oconfig_item_t *ci) {
    */
   int err = dpdk_shm_init(sizeof(dpdk_config_t));
   if (err) {
-#if COLLECT_DEBUG
     char errbuf[ERR_BUF_SIZE];
-#endif
-    DEBUG("dpdkstat: error in shm_init, %s",
+    ERROR("dpdkstat: error in shm_init, %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     return -1;
   }

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -147,12 +147,14 @@ static void dpdk_config_init_default(void) {
 
 static int dpdk_config(oconfig_item_t *ci) {
   int port_counter = 0;
-  char errbuf[ERR_BUF_SIZE];
   /* Allocate g_configuration and
    * initialize a POSIX SHared Memory (SHM) object.
    */
   int err = dpdk_shm_init(sizeof(dpdk_config_t));
   if (err) {
+#if COLLECT_DEBUG
+    char errbuf[ERR_BUF_SIZE];
+#endif
     DEBUG("dpdkstat: error in shm_init, %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     return -1;


### PR DESCRIPTION
Signed-off-by: Taras Chornyi <tarasx.chornyi@intel.com>