### PR TITLE
cpu: Fix cpu aggregation on AIX

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -418,8 +418,7 @@ static int total_rate(gauge_t *sum_by_state, size_t state, derive_t d,
 				          value_to_rate_state_t* conv, cdtime_t now)
 {
 	gauge_t rate = NAN;
-	value_t val = { .derive = d };
-	int status = value_to_rate (&rate, val, DS_TYPE_DERIVE, now, conv);
+	int status = value_to_rate (&rate, (value_t) { .derive = d }, DS_TYPE_DERIVE, now, conv);
 	if (status != 0)
 		return (status);
 
@@ -462,10 +461,9 @@ static void aggregate (gauge_t *sum_by_state) /* {{{ */
 
 #if defined(HAVE_PERFSTAT) /* {{{ */
 	cdtime_t now = cdtime ();
-	perfstat_cpu_total_t cputotal;
-	memset(&cputotal, 0, sizeof(perfstat_cpu_total_t));
+	perfstat_cpu_total_t cputotal = { 0 };
 
-	if (!perfstat_cpu_total(NULL, &cputotal, sizeof(perfstat_cpu_total_t), 1)) {
+	if (!perfstat_cpu_total(NULL, &cputotal, sizeof(cputotal), 1)) {
 		char errbuf[1024];
 		WARNING ("cpu plugin: perfstat_cpu_total: %s",
 				sstrerror (errno, errbuf, sizeof (errbuf)));

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -162,6 +162,12 @@ static int maxcpu;
 /* #endif  HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT)
+#define TOTAL_IDLE 0
+#define TOTAL_USER 1
+#define TOTAL_SYS 2
+#define TOTAL_WAIT 3
+#define TOTAL_STAT_NUM 4
+static value_to_rate_state_t total_conv[TOTAL_STAT_NUM];
 static perfstat_cpu_t *perfcpu;
 static int numcpu;
 static int pnumcpu;
@@ -406,6 +412,25 @@ static cpu_state_t *get_cpu_state (size_t cpu_num, size_t state) /* {{{ */
 	return (&cpu_states[index]);
 } /* }}} cpu_state_t *get_cpu_state */
 
+#if defined(HAVE_PERFSTAT) /* {{{ */
+/* populate global aggregate cpu rate */
+static int total_rate(gauge_t *sum_by_state, size_t state, derive_t d,
+				          value_to_rate_state_t* conv, cdtime_t now)
+{
+	gauge_t rate = NAN;
+	value_t val = { .derive = d };
+	int status = value_to_rate (&rate, val, DS_TYPE_DERIVE, now, conv);
+	if (status != 0)
+		return (status);
+
+	sum_by_state[state] = rate;
+
+	if (state != COLLECTD_CPU_STATE_IDLE)
+		RATE_ADD (sum_by_state[COLLECTD_CPU_STATE_ACTIVE], sum_by_state[state]);
+	return (0);
+}
+#endif /* }}} HAVE_PERFSTAT */
+
 /* Populates the per-CPU COLLECTD_CPU_STATE_ACTIVE rate and the global rate_by_state
  * array. */
 static void aggregate (gauge_t *sum_by_state) /* {{{ */
@@ -434,6 +459,28 @@ static void aggregate (gauge_t *sum_by_state) /* {{{ */
 
 		RATE_ADD (sum_by_state[COLLECTD_CPU_STATE_ACTIVE], this_cpu_states[COLLECTD_CPU_STATE_ACTIVE].rate);
 	}
+
+#if defined(HAVE_PERFSTAT) /* {{{ */
+	cdtime_t now = cdtime ();
+	perfstat_cpu_total_t cputotal;
+	memset(&cputotal, 0, sizeof(perfstat_cpu_total_t));
+
+	if (!perfstat_cpu_total(NULL, &cputotal, sizeof(perfstat_cpu_total_t), 1)) {
+		char errbuf[1024];
+		WARNING ("cpu plugin: perfstat_cpu_total: %s",
+				sstrerror (errno, errbuf, sizeof (errbuf)));
+		return;
+	}
+
+	/* Reset COLLECTD_CPU_STATE_ACTIVE */
+	sum_by_state[COLLECTD_CPU_STATE_ACTIVE] = NAN;
+
+	/* Physical Processor Utilization */
+	total_rate(sum_by_state, COLLECTD_CPU_STATE_IDLE,   (derive_t) cputotal.pidle, &total_conv[TOTAL_IDLE], now);
+	total_rate(sum_by_state, COLLECTD_CPU_STATE_USER,   (derive_t) cputotal.puser, &total_conv[TOTAL_USER], now);
+	total_rate(sum_by_state, COLLECTD_CPU_STATE_SYSTEM, (derive_t) cputotal.psys , &total_conv[TOTAL_SYS],  now);
+	total_rate(sum_by_state, COLLECTD_CPU_STATE_WAIT,   (derive_t) cputotal.pwait, &total_conv[TOTAL_WAIT], now);
+#endif /* }}} HAVE_PERFSTAT */
 } /* }}} void aggregate */
 
 /* Commits (dispatches) the values for one CPU or the global aggregation.


### PR DESCRIPTION
This change lets us track the physical total cpu usage on AIX by invoking perfstat_cpu_total and reading pidle, puser, psys and pwait.
Current aggregation of each cpu is different from lparstat results. 