### PR TITLE
Use readdir() instead of the deprecated readdir_r().

### DIFF
--- a/src/vserver.c
+++ b/src/vserver.c
@@ -131,15 +131,7 @@ static derive_t vserver_get_sock_bytes(const char *s)
 
 static int vserver_read (void)
 {
-#if NAME_MAX < 1024
-# define DIRENT_BUFFER_SIZE (sizeof (struct dirent) + 1024 + 1)
-#else
-# define DIRENT_BUFFER_SIZE (sizeof (struct dirent) + NAME_MAX + 1)
-#endif
-
-	DIR 			*proc;
-	struct dirent 	*dent; /* 42 */
-	char dirent_buffer[DIRENT_BUFFER_SIZE];
+	DIR *proc;
 
 	errno = 0;
 	proc = opendir (PROCDIR);
@@ -153,6 +145,7 @@ static int vserver_read (void)
 
 	while (42)
 	{
+		struct dirent *dent;
 		int len;
 		char file[BUFSIZE];
 
@@ -164,19 +157,19 @@ static int vserver_read (void)
 
 		int status;
 
-		status = readdir_r (proc, (struct dirent *) dirent_buffer, &dent);
-		if (status != 0)
+		errno = 0;
+		dent = readdir (proc);
+		if (dent == NULL)
 		{
 			char errbuf[4096];
-			ERROR ("vserver plugin: readdir_r failed: %s",
-					sstrerror (errno, errbuf, sizeof (errbuf)));
+
+			if (errno == 0) /* end of directory */
+				break;
+
+			ERROR ("vserver plugin: failed to read directory %s: %s",
+					PROCDIR, sstrerror (errno, errbuf, sizeof (errbuf)));
 			closedir (proc);
 			return (-1);
-		}
-		else if (dent == NULL)
-		{
-			/* end of directory */
-			break;
 		}
 
 		if (dent->d_name[0] == '.')


### PR DESCRIPTION
Cf. https://sourceware.org/ml/libc-alpha/2016-02/msg00093.html