### PR TITLE
memcached: Added Address option

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -705,7 +705,8 @@
 
 #<Plugin memcached>
 #	<Instance "local">
-#		Host "127.0.0.1"
+#		#Host "memcache.example.com"
+#		Address "127.0.0.1"
 #		Port "11211"
 #	</Instance>
 #</Plugin>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3341,11 +3341,12 @@ interpreted. For a description of match blocks, please see L<"Plugin tail">.
 
 The B<memcached plugin> connects to a memcached server and queries statistics
 about cache utilization, memory and bandwidth used.
-L<http://www.danga.com/memcached/>
+L<http://memcached.org/>
 
  <Plugin "memcached">
    <Instance "name">
-     Host "memcache.example.com"
+     #Host "memcache.example.com"
+     Address "127.0.0.1"
      Port 11211
    </Instance>
  </Plugin>
@@ -3358,7 +3359,15 @@ following options are allowed:
 
 =item B<Host> I<Hostname>
 
-Hostname to connect to. Defaults to B<127.0.0.1>.
+Sets the B<host> field of dispatched values. Defaults to the global hostname
+setting.
+For backwards compatibility, values are also dispatched with the global hostname
+when B<Host> is set to "127.0.0.1" or "localhost" and B<Address> is not set.
+
+=item B<Address> I<Address>
+
+Hostname or IP to connect to. For backwards compatibility, it defaults to B<Host>
+value or to B<127.0.0.1> if it does not set.
 
 =item B<Port> I<Port>
 
@@ -3367,7 +3376,7 @@ TCP-Port to connect to. Defaults to B<11211>.
 =item B<Socket> I<Path>
 
 Connect to I<memcached> using the UNIX domain socket at I<Path>. If this
-setting is given, the B<Host> and B<Port> settings are ignored.
+setting is given, the B<Address> and B<Port> settings are ignored.
 
 =back
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -44,9 +44,10 @@
 struct memcached_s
 {
   char *name;
-  char *socket;
   char *host;
-  char *port;
+  char *socket;
+  char *connhost;
+  char *connport;
 };
 typedef struct memcached_s memcached_t;
 
@@ -59,9 +60,10 @@ static void memcached_free (void *arg)
     return;
 
   sfree (st->name);
-  sfree (st->socket);
   sfree (st->host);
-  sfree (st->port);
+  sfree (st->socket);
+  sfree (st->connhost);
+  sfree (st->connport);
   sfree (st);
 }
 
@@ -98,15 +100,9 @@ static int memcached_connect_unix (memcached_t *st)
 
 static int memcached_connect_inet (memcached_t *st)
 {
-  const char *host;
-  const char *port;
-
   struct addrinfo *ai_list;
   int status;
   int fd = -1;
-
-  host = (st->host != NULL) ? st->host : MEMCACHED_DEF_HOST;
-  port = (st->port != NULL) ? st->port : MEMCACHED_DEF_PORT;
 
   struct addrinfo ai_hints = {
     .ai_family = AF_UNSPEC,
@@ -114,13 +110,13 @@ static int memcached_connect_inet (memcached_t *st)
     .ai_socktype = SOCK_STREAM
   };
 
-  status = getaddrinfo (host, port, &ai_hints, &ai_list);
+  status = getaddrinfo (st->connhost, st->connport, &ai_hints, &ai_list);
   if (status != 0)
   {
     char errbuf[1024];
     ERROR ("memcached plugin: memcached_connect_inet: "
         "getaddrinfo(%s,%s) failed: %s",
-        host, port,
+        st->connhost, st->connport,
         (status == EAI_SYSTEM)
         ? sstrerror (errno, errbuf, sizeof (errbuf))
         : gai_strerror (status));
@@ -239,22 +235,10 @@ static int memcached_query_daemon (char *buffer, size_t buffer_size, memcached_t
 
 static void memcached_init_vl (value_list_t *vl, memcached_t const *st)
 {
-  char const *host = st->host;
-
-  /* Keep default hostname, if:
-   * - Legacy mode is used.
-   * - "Socket" option is given (doc: "Host option is ignored").
-   * - "Host" option is not provided.
-   * - "Host" option is set to "localhost" or "127.0.0.1". */
-  if ((strcmp (st->name, "__legacy__") != 0)
-      && (st->socket == NULL)
-      && (st->host != NULL)
-      && (strcmp ("127.0.0.1", st->host) != 0)
-      && (strcmp ("localhost", st->host) != 0))
-    sstrncpy (vl->host, host, sizeof (vl->host));
-
   sstrncpy (vl->plugin, "memcached", sizeof (vl->plugin));
-  if (strcmp (st->name, "__legacy__") != 0)
+  if (st->host != NULL)
+    sstrncpy (vl->host, st->host, sizeof (vl->host));
+  if (st->name != NULL)
     sstrncpy (vl->plugin_instance, st->name, sizeof (vl->plugin_instance));
 }
 
@@ -544,8 +528,48 @@ static int memcached_add_read_callback (memcached_t *st)
   char callback_name[3*DATA_MAX_NAME_LEN];
   int status;
 
-  assert (st->name != NULL);
-  ssnprintf (callback_name, sizeof (callback_name), "memcached/%s", st->name);
+  ssnprintf (callback_name, sizeof (callback_name), "memcached/%s",
+      (st->name != NULL) ? st->name : "__legacy__");
+
+  /* If no <Address> used then:
+   * - connect to destination, specified by <Host>, if it presents.
+   * - Keep default hostname, if any:
+   *    - Legacy mode is used (no configuration options at all);
+   *    - "Host" option is not provided;
+   *    - "Host" option is set to "localhost" or "127.0.0.1".
+   *
+   * If <Address> used then host may be set to "localhost"
+   * or "127.0.0.1" explicitly.
+   */
+  if (st->connhost == NULL)
+  {
+    if (st->host)
+    {
+      st->connhost = strdup(st->host);
+      if (st->connhost == NULL)
+        return (ENOMEM);
+
+      if ((strcmp ("127.0.0.1", st->host) == 0)
+          || (strcmp ("localhost", st->host) == 0))
+        sfree(st->host);
+    }
+    else
+    {
+      st->connhost = strdup(MEMCACHED_DEF_HOST);
+      if (st->connhost == NULL)
+        return (ENOMEM);
+    }
+  }
+
+  if (st->connport == NULL)
+  {
+      st->connport = strdup(MEMCACHED_DEF_PORT);
+      if (st->connport == NULL)
+        return (ENOMEM);
+  }
+
+  assert (st->connhost != NULL);
+  assert (st->connport != NULL);
 
   status = plugin_register_complex_read (/* group = */ "memcached",
       /* name      = */ callback_name,
@@ -563,6 +587,7 @@ static int memcached_add_read_callback (memcached_t *st)
  * <Plugin memcached>
  *   <Instance "instance_name">
  *     Host foo.zomg.com
+ *     Address 1.2.3.4
  *     Port "1234"
  *   </Instance>
  * </Plugin>
@@ -579,24 +604,23 @@ static int config_add_instance(oconfig_item_t *ci)
   if (st == NULL)
   {
     ERROR ("memcached plugin: calloc failed.");
-    return (-1);
+    return (ENOMEM);
   }
 
   st->name = NULL;
-  st->socket = NULL;
   st->host = NULL;
-  st->port = NULL;
+  st->socket = NULL;
+  st->connhost = NULL;
+  st->connport = NULL;
 
-  if (strcasecmp (ci->key, "Plugin") == 0) /* default instance */
-    st->name = sstrdup ("__legacy__");
-  else /* <Instance /> block */
+  if (strcasecmp (ci->key, "Instance") == 0)
     status = cf_util_get_string (ci, &st->name);
+
   if (status != 0)
   {
     sfree (st);
     return (status);
   }
-  assert (st->name != NULL);
 
   for (int i = 0; i < ci->children_num; i++)
   {
@@ -606,8 +630,10 @@ static int config_add_instance(oconfig_item_t *ci)
       status = cf_util_get_string (child, &st->socket);
     else if (strcasecmp ("Host", child->key) == 0)
       status = cf_util_get_string (child, &st->host);
+    else if (strcasecmp ("Address", child->key) == 0)
+      status = cf_util_get_string (child, &st->connhost);
     else if (strcasecmp ("Port", child->key) == 0)
-      status = cf_util_get_service (child, &st->port);
+      status = cf_util_get_service (child, &st->connport);
     else
     {
       WARNING ("memcached plugin: Option `%s' not allowed here.",
@@ -674,10 +700,11 @@ static int memcached_init (void)
   st = calloc (1, sizeof (*st));
   if (st == NULL)
     return (ENOMEM);
-  st->name = sstrdup ("__legacy__");
-  st->socket = NULL;
+  st->name = NULL;
   st->host = NULL;
-  st->port = NULL;
+  st->socket = NULL;
+  st->connhost = NULL;
+  st->connport = NULL;
 
   status = memcached_add_read_callback (st);
   if (status == 0)


### PR DESCRIPTION
Added new option "Address".

We use separate Memcached instances per project on single server.
Each project has its own IP in 127.0.0.0/8 and each Apache or Memcached instance binds to appropriate IP on standard 80 and 11211 ports. Check for "localhost" or "127.0.0.1", as it now implemented in `memcached` plugin, is not suitable for us. Our internal patch was reworked to be applied to current `master` branch and proposed to review and merge.

Superseedes: #905