### PR TITLE
write_graphite: remove linking against libyajl

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1251,7 +1251,6 @@ pkglib_LTLIBRARIES += write_graphite.la
 write_graphite_la_SOURCES = write_graphite.c \
                         utils_format_graphite.c utils_format_graphite.h
 write_graphite_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-write_graphite_la_LIBADD = libformat_json.la
 endif
 
 if BUILD_PLUGIN_WRITE_HTTP


### PR DESCRIPTION
write_graphite doesn't have anything to do with json. This seems to have
been accidentally added in 30c1111.

Fixes https://bugs.debian.org/839771