### PR TITLE
Filecount plugin: Custom values for reported plugin, type and type instance

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -588,12 +588,16 @@
 
 #<Plugin filecount>
 #	<Directory "/path/to/dir">
+#		#Plugin "foo"
 #		Instance "foodir"
 #		Name "*.conf"
 #		MTime "-5m"
 #		Size "+10k"
 #		Recursive true
 #		IncludeHidden false
+#		#FilesSizeType "bytes"
+#		#FilesCountType "files"
+#		#TypeInstance "instance"
 #	</Directory>
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2730,12 +2730,16 @@ blocks, the following options are recognized:
 
 =over 4
 
+=item B<Plugin> I<Plugin>
+
+Use I<Plugin> as the plugin name when submitting values.
+Defaults to B<filecount>.
+
 =item B<Instance> I<Instance>
 
-Sets the plugin instance to I<Instance>. That instance name must be unique, but
-it's your responsibility, the plugin doesn't check for that. If not given, the
-instance is set to the directory name with all slashes replaced by underscores
-and all leading underscores removed.
+Sets the plugin instance to I<Instance>. If not given, the instance is set to
+the directory name with all slashes replaced by underscores and all leading
+underscores removed. Empty value is allowed.
 
 =item B<Name> I<Pattern>
 
@@ -2780,6 +2784,21 @@ Controls whether or not to recurse into subdirectories. Enabled by default.
 Controls whether or not to include "hidden" files and directories in the count.
 "Hidden" files and directories are those, whose name begins with a dot.
 Defaults to I<false>, i.e. by default hidden files and directories are ignored.
+
+=item B<FilesSizeType> I<Type>
+
+Sets the type used to dispatch files combined size. Empty value ("") disables
+reporting. Defaults to B<bytes>.
+
+=item B<FilesCountType> I<Type>
+
+Sets the type used to dispatch number of files. Empty value ("") disables
+reporting. Defaults to B<files>.
+
+=item B<TypeInstance> I<Instance>
+
+Sets the I<type instance> used to dispatch values. Defaults to an empty string
+(no plugin instance).
 
 =back
 

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -70,14 +70,14 @@ void fc_free_dir(fc_directory_conf_t *dir) {
   sfree(dir->files_num_type);
   sfree(dir->type_instance);
   sfree(dir->name);
-  
+
   sfree(dir);
 } /* void fc_free_dir */
 
 static void fc_submit_dir(const fc_directory_conf_t *dir) {
   value_list_t vl = VALUE_LIST_INIT;
 
-  sstrncpy (vl.plugin, dir->plugin_name, sizeof (vl.plugin));
+  sstrncpy(vl.plugin, dir->plugin_name, sizeof(vl.plugin));
   if (dir->instance != NULL)
     sstrncpy(vl.plugin_instance, dir->instance, sizeof(vl.plugin_instance));
   if (dir->type_instance != NULL)
@@ -86,15 +86,15 @@ static void fc_submit_dir(const fc_directory_conf_t *dir) {
   vl.values_len = 1;
 
   if (dir->files_num_type != NULL) {
-    vl.values = &(value_t) {.gauge = (gauge_t)dir->files_num};
-    sstrncpy (vl.type, dir->files_num_type, sizeof(vl.type));
+    vl.values = &(value_t){.gauge = (gauge_t)dir->files_num};
+    sstrncpy(vl.type, dir->files_num_type, sizeof(vl.type));
     plugin_dispatch_values(&vl);
   }
 
   if (dir->files_size_type != NULL) {
-    vl.values = &(value_t) {.gauge = (gauge_t)dir->files_size};
-    sstrncpy (vl.type, dir->files_size_type, sizeof(vl.type));
-    plugin_dispatch_values (&vl);
+    vl.values = &(value_t){.gauge = (gauge_t)dir->files_size};
+    sstrncpy(vl.type, dir->files_size_type, sizeof(vl.type));
+    plugin_dispatch_values(&vl);
   }
 } /* void fc_submit_dir */
 
@@ -123,7 +123,6 @@ static void fc_submit_dir(const fc_directory_conf_t *dir) {
 static int fc_config_set_instance(fc_directory_conf_t *dir, const char *str) {
   char buffer[1024];
   char *ptr;
-  char *copy;
 
   sstrncpy(buffer, str, sizeof(buffer));
   for (ptr = buffer; *ptr != 0; ptr++)
@@ -133,7 +132,7 @@ static int fc_config_set_instance(fc_directory_conf_t *dir, const char *str) {
   for (ptr = buffer; *ptr == '_'; ptr++)
     /* do nothing */;
 
-  copy = strdup(ptr);
+  char *copy = strdup(ptr);
   if (copy == NULL)
     return -1;
 
@@ -156,15 +155,13 @@ static int fc_config_add_dir_instance(fc_directory_conf_t *dir,
 
 static int fc_config_add_dir_name(fc_directory_conf_t *dir,
                                   oconfig_item_t *ci) {
-  char *temp;
-
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("filecount plugin: The `Name' config option needs exactly one "
             "string argument.");
     return -1;
   }
 
-  temp = strdup(ci->values[0].value.string);
+  char *temp = strdup(ci->values[0].value.string);
   if (temp == NULL) {
     ERROR("filecount plugin: strdup failed.");
     return -1;
@@ -178,9 +175,6 @@ static int fc_config_add_dir_name(fc_directory_conf_t *dir,
 
 static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
                                    oconfig_item_t *ci) {
-  char *endptr;
-  double temp;
-
   if ((ci->values_num != 1) || ((ci->values[0].type != OCONFIG_TYPE_STRING) &&
                                 (ci->values[0].type != OCONFIG_TYPE_NUMBER))) {
     WARNING("filecount plugin: The `MTime' config option needs exactly one "
@@ -194,8 +188,8 @@ static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
   }
 
   errno = 0;
-  endptr = NULL;
-  temp = strtod(ci->values[0].value.string, &endptr);
+  char *endptr = NULL;
+  double temp = strtod(ci->values[0].value.string, &endptr);
   if ((errno != 0) || (endptr == NULL) ||
       (endptr == ci->values[0].value.string)) {
     WARNING("filecount plugin: Converting `%s' to a number failed.",
@@ -246,9 +240,6 @@ static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
 
 static int fc_config_add_dir_size(fc_directory_conf_t *dir,
                                   oconfig_item_t *ci) {
-  char *endptr;
-  double temp;
-
   if ((ci->values_num != 1) || ((ci->values[0].type != OCONFIG_TYPE_STRING) &&
                                 (ci->values[0].type != OCONFIG_TYPE_NUMBER))) {
     WARNING("filecount plugin: The `Size' config option needs exactly one "
@@ -262,8 +253,8 @@ static int fc_config_add_dir_size(fc_directory_conf_t *dir,
   }
 
   errno = 0;
-  endptr = NULL;
-  temp = strtod(ci->values[0].value.string, &endptr);
+  char *endptr = NULL;
+  double temp = strtod(ci->values[0].value.string, &endptr);
   if ((errno != 0) || (endptr == NULL) ||
       (endptr == ci->values[0].value.string)) {
     WARNING("filecount plugin: Converting `%s' to a number failed.",
@@ -329,9 +320,6 @@ static int fc_config_add_dir_option(fc_directory_conf_t *dir,
 } /* int fc_config_add_dir_option */
 
 static int fc_config_add_dir(oconfig_item_t *ci) {
-  fc_directory_conf_t *dir, **temp;
-  int status;
-
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("filecount plugin: `Directory' needs exactly one string "
             "argument.");
@@ -339,7 +327,7 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
   }
 
   /* Initialize `dir' */
-  dir = calloc(1, sizeof(*dir));
+  fc_directory_conf_t *dir = calloc(1, sizeof(*dir));
   if (dir == NULL) {
     ERROR("filecount plugin: calloc failed.");
     return -1;
@@ -364,15 +352,14 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
   dir->files_size_type = strdup("bytes");
   dir->files_num_type = strdup("files");
 
-  if (dir->plugin_name == NULL
-      || dir->files_size_type == NULL
-      || dir->files_num_type == NULL) {
+  if (dir->plugin_name == NULL || dir->files_size_type == NULL ||
+      dir->files_num_type == NULL) {
     ERROR("filecount plugin: strdup failed.");
     fc_free_dir(dir);
     return -1;
   }
 
-  status = 0;
+  int status = 0;
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *option = ci->children + i;
 
@@ -391,11 +378,11 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
     else if (strcasecmp("IncludeHidden", option->key) == 0)
       status = fc_config_add_dir_option(dir, option, FC_HIDDEN);
     else if (strcasecmp("FilesSizeType", option->key) == 0)
-      status = cf_util_get_string (option, &dir->files_size_type);
+      status = cf_util_get_string(option, &dir->files_size_type);
     else if (strcasecmp("FilesCountType", option->key) == 0)
-      status = cf_util_get_string (option, &dir->files_num_type);
+      status = cf_util_get_string(option, &dir->files_num_type);
     else if (strcasecmp("TypeInstance", option->key) == 0)
-      status = cf_util_get_string (option, &dir->type_instance);
+      status = cf_util_get_string(option, &dir->type_instance);
     else {
       WARNING("filecount plugin: fc_config_add_dir: "
               "Option `%s' not allowed here.",
@@ -441,7 +428,8 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
   }
 
   /* Ready to add it to list */
-  temp = realloc(directories, sizeof(*directories) * (directories_num + 1));
+  fc_directory_conf_t **temp =
+      realloc(directories, sizeof(*directories) * (directories_num + 1));
   if (temp == NULL) {
     ERROR("filecount plugin: realloc failed.");
     fc_free_dir(dir);
@@ -483,14 +471,13 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
   fc_directory_conf_t *dir = user_data;
   char abs_path[PATH_MAX];
   struct stat statbuf;
-  int status;
 
   if (dir == NULL)
     return -1;
 
   snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
-  status = lstat(abs_path, &statbuf);
+  int status = lstat(abs_path, &statbuf);
   if (status != 0) {
     ERROR("filecount plugin: stat (%s) failed.", abs_path);
     return -1;
@@ -547,15 +534,13 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
 } /* int fc_read_dir_callback */
 
 static int fc_read_dir(fc_directory_conf_t *dir) {
-  int status;
-
   dir->files_num = 0;
   dir->files_size = 0;
 
   if (dir->mtime != 0)
     dir->now = time(NULL);
 
-  status =
+  int status =
       walk_directory(dir->path, fc_read_dir_callback, dir,
                      /* include hidden */ (dir->options & FC_HIDDEN) ? 1 : 0);
   if (status != 0) {


### PR DESCRIPTION
Hi!

Proposed patch adds ability to make flexible configuration of `filecount` plugin:
- Allow to set plugin name;
- Allow to set empty plugin instance;
- Allow to set metrics type: 'FilesSizeType' and 'FilesCountType' options added;
- Allow to disable metric reporting;
- Allow to set metrics type instance ('TypeInstance' option added).

Continues work of #1944.

Configuration example:

```
<Plugin filecount>
 <Directory "/var/spool/postfix/active">
    Plugin "postfix"
    Instance ""
    TypeInstance "active"
 </Directory>
 <Directory "/var/spool/postfix/deferred">
    Plugin "postfix"
    Instance ""
    TypeInstance "deferred"
 </Directory>
 <Directory "/var/spool/postfix/incoming">
    Plugin "postfix"
    Instance ""
    TypeInstance "incoming"
 </Directory>
 <Directory "/var/spool/postfix/maildrop">
    Plugin "postfix"
    Instance ""
    TypeInstance "maildrop"
 </Directory>
 <Directory "/var/spool/postfix/hold">
    Plugin "postfix"
    Instance ""
    TypeInstance "hold"
 </Directory>
</Plugin>
```
