### PR TITLE
powerdns plugin: fix parsing of last key

### DIFF
--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -50,7 +50,7 @@
 #define RECURSOR_SOCKET  LOCALSTATEDIR"/run/pdns_recursor.controlsocket"
 #define RECURSOR_COMMAND "get noerror-answers nxdomain-answers " \
   "servfail-answers sys-msec user-msec qa-latency cache-entries cache-hits " \
-  "cache-misses questions\n"
+  "cache-misses questions \n"
 
 struct list_item_s;
 typedef struct list_item_s list_item_t;


### PR DESCRIPTION
I found this in my logs:

collectd[4678]: powerdns plugin: submit: Not found in lookup table: questions#012 = 98797645;

The octal #012 is '\n'. Add a space before the newline so the default
command is split into keys correctly.