### PR TITLE
common.c: Use _LINUX_CAPABILITY_VERSION_3 in cap_header

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1730,7 +1730,7 @@ int check_capability (int capability) /* {{{ */
 	}
 
 	cap_header->pid = getpid();
-	cap_header->version = _LINUX_CAPABILITY_VERSION;
+	cap_header->version = _LINUX_CAPABILITY_VERSION_3;
 	if (capget(cap_header, cap_data) < 0)
 	{
 		ERROR("check_capability: capget failed");


### PR DESCRIPTION
While check_capability() function already requires
_LINUX_CAPABILITY_VERSION_3 via "#ifdef" since commit 448627953c we still
set the cap_header's version to deprecated _LINUX_CAPABILITY_VERSION. This
results in a warning like

 > capability: warning: `collectd' uses 32-bit capabilities (legacy support in use)

from the kernel when a plugin (like iptables) calls our check_capability()
function.

With this commit we will set cap_header to kernel's current capability
version (_LINUX_CAPABILITY_VERSION_3), which is default since
kernel 2.6.26.