### PR TITLE
utils_format_graphite: terminate buffer with \0

### DIFF
--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -257,6 +257,7 @@ int format_graphite (char *buffer, size_t buffer_size,
         }
         memcpy((void *) (buffer + buffer_pos), message, message_len);
         buffer_pos += message_len;
+        buffer[buffer_pos] = '\0';
     }
     sfree (rates);
     return (status);


### PR DESCRIPTION
ssnprintf returns message_len without \0 and then that many bytes are copied with memcpy and \0 is lost. This adds it again.
