### PR TITLE
processes plugin: Code cleanup + add per-process open files count

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1138,7 +1138,18 @@
 #</Plugin>
 
 #<Plugin processes>
+#	CollectFileDescriptor true
+#	CollectContextSwitch true
 #	Process "name"
+#	ProcessMatch "name" "regex"
+#	<Process "collectd">
+#		CollectFileDescriptor false
+#		CollectContextSwitch false
+#	</Process>
+#	<ProcessMatch "name" "regex">
+#		CollectFileDescriptor false
+#		CollectContextSwitch true
+#	</Process>
 #</Plugin>
 
 #<Plugin protocols>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6528,9 +6528,15 @@ C<I<prefix>/var/run/collectd-powerdns>.
 =item B<Process> I<Name>
 
 Select more detailed statistics of processes matching this name. The statistics
-collected for these selected processes are size of the resident segment size
-(RSS), user- and system-time used, number of processes and number of threads,
-io data (where available) and minor and major pagefaults.
+collected for these selected processes are:
+ - size of the resident segment size (RSS)
+ - user- and system-time used
+ - number of processes
+ - number of threads
+ - number of open files (under Linux)
+ - io data (where available)
+ - context switches (under Linux)
+ - minor and major pagefaults.
 
 Some platforms have a limit on the length of process names. I<Name> must stay
 below this limit.


### PR DESCRIPTION
The `procstat_entry_s` used in improper way.
Added new type and simplified the code - removed unneeded assignments and values copying.
