### PR TITLE
plugins: add fast path CPU usage monitoring plugin

### DIFF
--- a/README
+++ b/README
@@ -117,6 +117,9 @@ Features
       Values gathered by a custom program or script.
       See collectd-exec(5).
 
+    - fastpath
+      Gather per core statistics of CPU cores running a fast path dataplane.
+
     - fhcount
       File handles statistics.
 

--- a/configure.ac
+++ b/configure.ac
@@ -5830,6 +5830,7 @@ plugin_drbd="no"
 plugin_dpdk="no"
 plugin_entropy="no"
 plugin_ethstat="no"
+plugin_fastpath="yes"
 plugin_fhcount="no"
 plugin_fscache="no"
 plugin_gps="no"
@@ -6285,6 +6286,7 @@ AC_PLUGIN([email],               [yes],                     [EMail statistics])
 AC_PLUGIN([entropy],             [$plugin_entropy],         [Entropy statistics])
 AC_PLUGIN([ethstat],             [$plugin_ethstat],         [Stats from NIC driver])
 AC_PLUGIN([exec],                [yes],                     [Execution of external programs])
+AC_PLUGIN([fastpath],            [yes],                     [Dataplane fast path statistics])
 AC_PLUGIN([fhcount],             [$plugin_fhcount],         [File handles statistics])
 AC_PLUGIN([filecount],           [yes],                     [Count files in directories])
 AC_PLUGIN([fscache],             [$plugin_fscache],         [fscache statistics])
@@ -6720,6 +6722,7 @@ AC_MSG_RESULT([    email . . . . . . . . $enable_email])
 AC_MSG_RESULT([    entropy . . . . . . . $enable_entropy])
 AC_MSG_RESULT([    ethstat . . . . . . . $enable_ethstat])
 AC_MSG_RESULT([    exec  . . . . . . . . $enable_exec])
+AC_MSG_RESULT([    fastpath  . . . . . . $enable_fastpath])
 AC_MSG_RESULT([    fhcount . . . . . . . $enable_fhcount])
 AC_MSG_RESULT([    filecount . . . . . . $enable_filecount])
 AC_MSG_RESULT([    fscache . . . . . . . $enable_fscache])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -448,6 +448,13 @@ ethstat_la_SOURCES = ethstat.c
 ethstat_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
+if BUILD_PLUGIN_FASTPATH
+pkglib_LTLIBRARIES += fastpath.la
+fastpath_la_SOURCES = fastpath.c
+fastpath_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+fastpath_la_LIBADD = -ljansson
+endif
+
 if BUILD_PLUGIN_FHCOUNT
 pkglib_LTLIBRARIES += fhcount.la
 fhcount_la_SOURCES = fhcount.c

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2534,6 +2534,20 @@ expected from them. This is documented in great detail in L<collectd-exec(5)>.
 
 =back
 
+=head2 Plugin C<fastpath>
+
+The C<fastpath> plugin monitors CPU usage for cores running a fast path process.
+
+The following elements are collected:
+
+=over 4
+
+=item B<busy_cpu>
+
+The occupancy percentage of a each CPU core running packet processing.
+
+=back
+
 =head2 Plugin C<fhcount>
 
 The C<fhcount> plugin provides statistics about used, unused and total number of

--- a/src/fastpath.c
+++ b/src/fastpath.c
@@ -1,0 +1,144 @@
+/**
+ * collectd - src/fastpath.c
+ * Copyright 2016 6WIND S.A.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Authors:
+ *   Amine Kherbouche <amine.kherbouche at 6wind.com>
+ **/
+
+#include "collectd.h"
+#include "common.h" /* auxiliary functions */
+#include "plugin.h" /* plugin_register_*, plugin_dispatch_values */
+
+#include <stdio.h>
+#include <jansson.h>
+
+#define PLUGIN_NAME "fastpath"
+#define PLUGIN_VALUE_TYPE_CPU "fastpath_cpu_busy"
+
+static int fp_init (void)
+{
+	int status;
+	char cmd[256];
+
+	status = ssnprintf (cmd, sizeof(cmd),
+			    "/usr/local/bin/fp-cpu-usage --json");
+	if ((status < 1) || ((unsigned int)status >= sizeof (cmd))
+	    || (!access (cmd, R_OK))) {
+		ERROR ("fastpath plugin: not started/installed, missing fp-cpu-usage");
+		return (-1);
+	}
+	return (0);
+} /* int fp_init */
+
+static void fp_submit (int type_inst, char *type, int value)
+{
+	value_t values[1];
+	value_list_t vl = VALUE_LIST_INIT;
+
+	values[0].gauge = value;
+	vl.values = values;
+	vl.values_len = 1;
+
+	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+	sstrncpy (vl.plugin, PLUGIN_NAME, sizeof (vl.plugin));
+	sstrncpy (vl.type, type, sizeof (vl.type));
+	ssnprintf (vl.type_instance, sizeof (vl.type_instance),
+		   "%i", type_inst);
+
+	plugin_dispatch_values (&vl);
+
+} /* void fp_submit */
+
+static int fp_read (void)
+{
+	FILE * cpu_usage_json = NULL;
+	int i;
+	json_t *root, *cpus_info,
+	       *data, *core_id, *busy;
+	json_error_t error;
+
+	cpu_usage_json = popen("/usr/local/bin/fp-cpu-usage --json", "r");
+	if (cpu_usage_json  == NULL) {
+		ERROR ("fastpath plugin: popen failed");
+		return (-1);
+	}
+
+	root = json_loadf (cpu_usage_json, 0, &error);
+
+	if (!root) {
+		ERROR ("fastpath plugin: error on line %d: %s",
+		       error.line, error.text);
+		return (-1);
+	}
+
+	if (!json_is_object(root)) {
+		ERROR ("fastpath plugin: root is not an object");
+		json_decref (root);
+		return (-1);
+	}
+
+	cpus_info = json_object_get (root, "cpus");
+
+	for (i = 0; i < json_array_size(cpus_info); i++) {
+
+		data = json_array_get (cpus_info, i);
+
+		if (!json_is_object(data)) {
+			ERROR ("fastpath plugin: error data %d "
+			       "is not an object", (i + 1));
+			json_decref (root);
+			return (-1);
+		}
+
+		core_id = json_object_get (data, "cpu");
+
+		if (!json_is_integer(core_id)) {
+			ERROR ("fastpath plugin: error while getting "
+			       "cpu id %i", (i + 1));
+			json_decref (root);
+			return (-1);
+		}
+
+		busy = json_object_get (data, "busy");
+
+		if (!json_is_integer(busy)) {
+			ERROR ("fastpath plugin: error while getting "
+			       "cpu usage of core id %i", (i + 1));
+			json_decref (root);
+			return (-1);
+		}
+		fp_submit (json_integer_value(core_id), PLUGIN_VALUE_TYPE_CPU,
+			   json_integer_value(busy));
+	}
+
+	json_decref (root);
+	pclose (cpu_usage_json);
+	return (0);
+
+} /* int fp_read */
+
+void module_register (void)
+{
+	plugin_register_init ("fastpath", fp_init);
+	plugin_register_read ("fastpath", fp_read);
+
+} /* void module_register */

--- a/src/types.db
+++ b/src/types.db
@@ -80,6 +80,7 @@ entropy                 value:GAUGE:0:4294967295
 errors                  value:DERIVE:0:U
 evicted_keys            value:DERIVE:0:U
 expired_keys            value:DERIVE:0:U
+fastpath_cpu_busy       value:GAUGE:0:100
 fanspeed                value:GAUGE:0:U
 file_handles            value:GAUGE:0:U
 file_size               value:GAUGE:0:U


### PR DESCRIPTION
This commit introduces a plugin to monitor CPU usage
for cores running a fast path process.
It works using fp-cpu-usage command, that dumps in json
format, statistics about each core running packet
processing.
Since the json output and the fp-cpu-usage command are
independent for any Packet Processing CPUs, this plugin
can be reused for any Packet Processing CPUs (P8,
ARM, Octeon, x86, etc.).

Signed-off-by: Amine Kherbouche amine.kherbouche@6wind.com
