### PR TITLE
Extend global variables with BIOS information

### DIFF
--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -64,7 +64,8 @@ collectd_SOURCES = collectd.c collectd.h \
 		   utils_tail.c utils_tail.h \
 		   utils_time.c utils_time.h \
 		   types_list.c types_list.h \
-		   utils_threshold.c utils_threshold.h
+		   utils_threshold.c utils_threshold.h \
+		   utils_dmi.c utils_dmi.h
 
 
 collectd_CPPFLAGS =  $(AM_CPPFLAGS) $(LTDLINCL)

--- a/src/daemon/collectd.h
+++ b/src/daemon/collectd.h
@@ -305,10 +305,22 @@ typedef int _Bool;
 # define GAUGE_FORMAT "%.15g"
 #endif
 
+#include "utils_dmi.h"
+#define DMI_SETTING_NOT_AVAILABLE "N/A"
+
 /* Type for time as used by "utils_time.h" */
 typedef uint64_t cdtime_t;
 
+/* If setting is not found, it is set to DMI_SETTING_NOT_AVAILABLE */
+typedef struct bios_info_s {
+  char vendor[DMI_MAX_VAL_LEN];
+  char version[DMI_MAX_VAL_LEN];
+  char release_date[DMI_MAX_VAL_LEN];
+  char revision[DMI_MAX_VAL_LEN];
+} bios_info_t;
+
 extern char     hostname_g[];
+extern bios_info_t bios_info_g;
 extern cdtime_t interval_g;
 extern int      timeout_g;
 

--- a/src/daemon/utils_dmi.c
+++ b/src/daemon/utils_dmi.c
@@ -1,0 +1,152 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ * Przemyslaw Szczerbik <przemyslawx.szczerbik@intel.com>
+ * Roman Ulan <romanx.ulan@intel.com>
+ *
+ */
+
+#include "collectd.h"
+
+#include "plugin.h"
+#include "common.h"
+#include "utils_dmi.h"
+
+#define DMI_FOR_EACH(fun, dmi_reader, dmi_t, len, ...)                         \
+  int rval = 0;                                                                \
+  TRACE();                                                                     \
+  if (!dmi_reader || !dmi_t) {                                                 \
+    ERROR("%s: NULL pointer", __func__);                                       \
+    return -1;                                                                 \
+  }                                                                            \
+  for (int i = 0; i < len; ++i) {                                              \
+    rval += fun(__VA_ARGS__);                                                  \
+  }                                                                            \
+  if (len != rval)                                                             \
+    ERROR("%s: Failed to get all DMI settings", __func__);                     \
+  return rval;
+
+#define DMIDECODE_CMD_FMT_LEN (256 + DMI_MAX_NAME_LEN)
+#define DMIDECODE_CMD_FMT                                                      \
+  "dmidecode -t %d | grep \"%s\" | cut -d ':' -f 2 | sed -e 's/^[ \\t]*//' "   \
+  "2>/dev/null"
+#define TRACE() DEBUG("%s:%s:%d", __FILE__, __FUNCTION__, __LINE__)
+
+static size_t dmi_get_bulk(dmi_reader *self, dmi_t **s, size_t s_len);
+static size_t dmi_get(dmi_reader *self, dmi_t *s);
+static void dmi_clean(dmi_reader *self);
+static void dmi_free(dmi_reader *self);
+
+static size_t dmidecode_get_setting(dmi_type type, dmi_setting *s);
+static size_t dmidecode_parse_output(FILE *output, dmi_setting *s);
+
+void dmidecode_init(dmi_reader *self) {
+  if (!self) {
+    ERROR("%s: NULL pointer", __func__);
+    return;
+  }
+
+  self->ctx = NULL;
+  self->get = dmi_get;
+  self->get_bulk = dmi_get_bulk;
+  self->clean = dmi_clean;
+  self->free = dmi_free;
+
+  assert(self->get != NULL);
+  assert(self->get_bulk != NULL);
+  assert(self->clean != NULL);
+  assert(self->free != NULL);
+}
+
+dmi_reader *dmidecode_alloc(void) {
+  dmi_reader *self = (dmi_reader *)malloc(sizeof(dmi_reader));
+  dmidecode_init(self);
+
+  return self;
+}
+
+static void dmi_clean(dmi_reader *self) {
+  self->get = NULL;
+  self->get_bulk = NULL;
+  self->clean = NULL;
+  self->free = NULL;
+}
+
+static void dmi_free(dmi_reader *self) {
+  self->clean(self);
+  sfree(self);
+}
+
+static size_t dmidecode_parse_output(FILE *output, dmi_setting *s) {
+  TRACE();
+
+  while (fgets(s->value, (sizeof(char) * DMI_MAX_VAL_LEN), output) != NULL) {
+    strstripnewline(s->value);
+
+    /* TODO: Handle multiple lanes with same setting */
+    return 1;
+  }
+
+  /* Setting not found */
+  s->value[0] = '\0';
+  ERROR("Failed to read DMI setting");
+  return 0;
+}
+
+static size_t dmidecode_get_setting(dmi_type type, dmi_setting *s) {
+  FILE *output;
+  char cmd[DMIDECODE_CMD_FMT_LEN];
+  size_t rval;
+
+  TRACE();
+
+  if (!s || !s->name || !s->value) {
+    ERROR("%s: NULL pointer", __func__);
+    return 0;
+  }
+
+  ssnprintf(cmd, sizeof(cmd), DMIDECODE_CMD_FMT, type, s->name);
+  DEBUG("dmidecode cmd=%s", cmd);
+
+  output = popen(cmd, "r");
+  if (!output) {
+    ERROR("popen failed");
+    return 0;
+  }
+
+  rval = dmidecode_parse_output(output, s);
+  DEBUG("%s=%s", s->name, s->value);
+
+  pclose(output);
+  return rval;
+}
+
+static size_t dmi_get(dmi_reader *self, dmi_t *s) {
+  DMI_FOR_EACH(dmidecode_get_setting, self, s, s->s_len, s->type,
+               &s->settings[i]);
+}
+
+static size_t dmi_get_bulk(dmi_reader *self, dmi_t **s, size_t s_len) {
+  DMI_FOR_EACH(self->get, self, s, s_len, self, s[i]);
+}

--- a/src/daemon/utils_dmi.h
+++ b/src/daemon/utils_dmi.h
@@ -1,0 +1,184 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ * Przemyslaw Szczerbik <przemyslawx.szczerbik@intel.com>
+ * Roman Ulan <romanx.ulan@intel.com>
+ */
+
+#ifndef UTILS_DMI_H
+#define UTILS_DMI_H
+
+#define DMI_MAX_VAL_LEN 128
+#define DMI_MAX_NAME_LEN 64
+
+/* Following values should match Types assigned in System Management BIOS
+ * (SMBIOS) Reference Specification
+ */
+typedef enum dmi_type {
+  BIOS = 0,
+  SYSTEM,
+  BASEBOARD,
+  CHASSIS,
+  PROCESSOR,
+  MEMORY_CONTROLLER,
+  MEMORY_MODULE,
+  CACHE,
+  PORT_CONNECTOR,
+  SYSTEM_SLOTS,
+  ON_BOARD_DEVICES,
+  OEM_STRINGS,
+  SYSTEM_CONFIGURATION_OPTIONS,
+  BIOS_LANGUAGE,
+  GROUP_ASSOCIATIONS,
+  SYSTEM_EVENT_LOG,
+  PHYSICAL_MEMORY_ARRAY,
+  MEMORY_DEVICE,
+  MEMORY_ERROR_32_BIT,
+  MEMORY_ARRAY_MAPPED_ADDRESS,
+  MEMORY_DEVICE_MAPPED_ADDRESS,
+  BUILT_IN_POINTING_DEVICE,
+  PORTABLE_BATTERY,
+  SYSTEM_RESET,
+  HARDWARE_SECURITY,
+  SYSTEM_POWER_CONTROLS,
+  VOLTAGE_PROBE,
+  COOLING_DEVICE,
+  TEMPERATURE_PROBE,
+  ELECTRICAL_CURRENT_PROBE,
+  OUT_OF_BAND_REMOTE_ACCESS,
+  BOOT_INTEGRITY_SERVICES,
+  SYSTEM_BOOT,
+  MEMORY_ERROR_64_BIT,
+  MANAGEMENT_DEVICE,
+  MANAGEMENT_DEVICE_COMPONENT,
+  MANAGEMENT_DEVICE_THRESHOLD_DATA,
+  MEMORY_CHANNEL,
+  IPMI_DEVICE,
+  POWER_SUPPLY,
+  ADDITIONAL_INFORMATION,
+  ONBOARD_DEVICES_EXTENDED_INFORMATION,
+  MANAGEMENT_CONTROLLER_HOST_INTERFACE
+} dmi_type;
+
+typedef struct dmi_setting {
+  /* Setting to be read. Can't be longer than DMI_MAX_NAME_LEN */
+  const char *name;
+  /* Setting value. At most DMI_MAX_VAL_LEN characters are read */
+  char *value;
+} dmi_setting;
+
+typedef struct dmi_s {
+  /* SMBIOS structure type for which settings will be read */
+  dmi_type type;
+  /* Pointer to dmi_setting structure array */
+  dmi_setting *settings;
+  /* dmi_setting structure array size */
+  size_t s_len;
+} dmi_t;
+
+typedef struct dmi_reader {
+  /* Private context. */
+  void *ctx;
+  /*
+  * NAME
+  * get
+  *
+  * DESCRIPTION
+  * Method for retrieving multiple settings from a single SMBIOS structure.
+  *
+  * PARAMETERS
+  * `self' Pointer to dmi_reader structure. Can't be a NULL pointer.
+  * `s'    Pointer to dmi_t structure. Can't be a NULL pointer.
+  *
+  * RETURN VALUE
+  * Number of successfully retrieved DMI settings.
+  */
+  size_t (*get)(struct dmi_reader *self, dmi_t *s);
+  /*
+  * NAME
+  * get_bulk
+  *
+  * DESCRIPTION
+  * Method for retrieving multiple settings from multiple SMBIOS structures.
+  *
+  * PARAMETERS
+  * `self'    Pointer to dmi_reader structure. Can't be a NULL pointer.
+  * `s'       Pointer to dmi_t structure array. Can't be a NULL pointer.
+  * `s_len'   dmi_t structure array size.
+  *
+  * RETURN VALUE
+  * Number of successfully retrieved DMI settings.
+  */
+  size_t (*get_bulk)(struct dmi_reader *self, dmi_t **s, size_t s_len);
+  /*
+  * NAME
+  * clean
+  *
+  * DESCRIPTION
+  * dmi_reader destructor. Should be called before object goes out of scope or
+  * memory is freed.
+  *
+  * PARAMETERS
+  * `self'    Pointer to dmi_reader structure. Can't be a NULL pointer.
+  */
+  void (*clean)(struct dmi_reader *self);
+  /*
+  * NAME
+  * free
+  *
+  * DESCRIPTION
+  * Calls dmi_reader destructor and deallocates memory. Do *NOT* use for
+  * automatic variables. Should be used only if dmi_reader was allocated with
+  * dmidecode_alloc function.
+  *
+  * PARAMETERS
+  * `self'    Pointer to dmi_reader structure. Can't be a NULL pointer.
+  */
+  void (*free)(struct dmi_reader *self);
+} dmi_reader;
+
+/*
+ * NAME
+ * dmidecode_init
+ *
+ * DESCRIPTION
+ * dmidecode constructor, which initializes dmi_reader structure pointers
+ *
+ * PARAMETERS
+ * `self' Pointer to dmi_reader structure. Can't be a NULL pointer.
+ */
+void dmidecode_init(dmi_reader *self);
+/*
+ * NAME
+ * dmidecode_alloc
+ *
+ * DESCRIPTION
+ * Allocates memory for dmi_reader structure and calls dmidecode constructor.
+ *
+ * RETURN VALUE
+ * Pointer to dmi_reader structure or NULL pointer if an error occurred.
+ */
+dmi_reader *dmidecode_alloc(void);
+
+#endif /* UTILS_DMI_H */


### PR DESCRIPTION
- Add utils to read DMI table using dmidecode.
- Extend collectd global variables with BIOS information (vendor, version,
  release date and revision).

Signed-off-by: Przemyslaw Szczerbik przemyslawx.szczerbik@intel.com
