### PR TITLE
src/daemon/common.c: Rewrite check_capability() using cap_get_bound().

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -808,7 +808,20 @@ fi
 have_cpuid_h="no"
 AC_CHECK_HEADERS(cpuid.h, [have_cpuid_h="yes"])
 
-AC_CHECK_HEADERS(sys/capability.h)
+have_capability="yes"
+AC_CHECK_HEADERS(sys/capability.h,
+                 [have_capability="yes"],
+                 [have_capability="no (<sys/capability.h> not found)"])
+if test "x$have_capability" = "xyes"; then
+AC_CHECK_LIB(cap, cap_get_bound,
+                 [have_capability="yes"],
+                 [have_capability="no (cap_get_bound() not found)"])
+fi
+if test "x$have_capability" = "xyes"; then
+  AC_DEFINE(HAVE_CAPABILITY, 1, [Define to 1 if you have cap_get_bound() (-lcap).])
+fi
+AM_CONDITIONAL(BUILD_WITH_CAPABILITY, test "x$have_capability" = "xyes")
+
 #
 # Checks for typedefs, structures, and compiler characteristics.
 #

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -11,6 +11,9 @@ AM_CPPFLAGS += -DPKGDATADIR='"${pkgdatadir}"'
 
 # Link to these libraries..
 COMMON_LIBS = $(PTHREAD_LIBS)
+if BUILD_WITH_CAPABILITY
+COMMON_LIBS += -lcap
+endif
 if BUILD_WITH_LIBRT
 COMMON_LIBS += -lrt
 endif


### PR DESCRIPTION
capget(2) is Linux specific and the use of the raw syscalls is
discouraged. Also, there have been interesting crashes on some systems.

Issue: #2009