### PR TITLE
write_kafka plugin: Fix support for librdkafka 0.9.0.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3914,11 +3914,10 @@ then
   if test "x$with_librdkafka_log_cb" = "xyes"
   then
         AC_DEFINE(HAVE_LIBRDKAFKA_LOG_CB, 1, [Define if librdkafka log facility is present and usable.])
-  fi
-  if test "x$with_librdkafka_logger" = "xyes"
+  else if test "x$with_librdkafka_logger" = "xyes"
   then
         AC_DEFINE(HAVE_LIBRDKAFKA_LOGGER, 1, [Define if librdkafka log facility is present and usable.])
-  fi
+  fi; fi
 fi
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -25,6 +25,7 @@
  */
 
 #include "collectd.h"
+
 #include "plugin.h"
 #include "common.h"
 #include "configfile.h"
@@ -65,7 +66,14 @@ static int kafka_write(const data_set_t *, const value_list_t *, user_data_t *);
 static int32_t kafka_partition(const rd_kafka_topic_t *, const void *, size_t,
                                int32_t, void *, void *);
 
-#if defined HAVE_LIBRDKAFKA_LOGGER || defined HAVE_LIBRDKAFKA_LOG_CB
+/* Version 0.9.0 of librdkafka deprecates rd_kafka_set_logger() in favor of
+ * rd_kafka_conf_set_log_cb(). This is to make sure we're not using the
+ * deprecated function. */
+#ifdef HAVE_LIBRDKAFKA_LOG_CB
+# undef HAVE_LIBRDKAFKA_LOGGER
+#endif
+
+#if defined(HAVE_LIBRDKAFKA_LOGGER) || defined(HAVE_LIBRDKAFKA_LOG_CB)
 static void kafka_log(const rd_kafka_t *, int, const char *, const char *);
 
 static void kafka_log(const rd_kafka_t *rkt, int level,


### PR DESCRIPTION
Use `rd_kafka_set_logger()` only when `rd_kafka_conf_set_log_cb()` is not
available:

    write_kafka.c: In function 'kafka_handle':
    write_kafka.c:119:6: error: 'rd_kafka_set_logger' is deprecated (declared at /usr/local/include/librdkafka/rdkafka.h:2400) [-Werror=deprecated-declarations]
          rd_kafka_set_logger(ctx->kafka, kafka_log);
          ^

Fixes: #2029