### PR TITLE
Pr/fix uptime plugin boottime

### DIFF
--- a/src/uptime.c
+++ b/src/uptime.c
@@ -25,8 +25,7 @@
 #include "plugin.h"
 
 #if KERNEL_LINUX
-#define UPTIME_FILE "/proc/uptime"
-/* Using /proc filesystem to retrieve the boot time, Linux only. */
+#include <sys/sysinfo.h>
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
@@ -53,8 +52,6 @@
 /*
  * Global variables
  */
-/* boottime always used, no OS distinction */
-static time_t boottime;
 
 #if HAVE_LIBKSTAT
 extern kstat_ctl_t *kc;
@@ -72,8 +69,6 @@ static void uptime_submit(gauge_t value) {
   plugin_dispatch_values(&vl);
 }
 
-static int uptime_init(void) /* {{{ */
-{
 /*
  * On most unix systems the uptime is calculated by looking at the boot
  * time (stored in unix time, since epoch) and the current one. We are
@@ -84,32 +79,21 @@ static int uptime_init(void) /* {{{ */
  * the boot time, the plugin is unregistered and there is no chance to
  * try again later. Nevertheless, this is very unlikely to happen.
  */
-
+static time_t uptime_get_sys(void) { /* {{{ */
+  time_t result;
 #if KERNEL_LINUX
-  FILE *fh = fopen(UPTIME_FILE, "r");
-  if (fh == NULL) {
+  struct sysinfo info;
+  int status;
+
+  status = sysinfo(&info);
+  if (status != 0) {
     char errbuf[1024];
-    ERROR("uptime plugin: Cannot open " UPTIME_FILE ": %s",
+    ERROR("uptime plugin: Error calling sysinfo: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     return -1;
   }
 
-  double uptime_seconds = 0.0;
-  if (fscanf(fh, "%lf", &uptime_seconds) != 1) {
-    ERROR("uptime plugin: No value read from " UPTIME_FILE "");
-    fclose(fh);
-    return -1;
-  }
-
-  fclose(fh);
-
-  if (uptime_seconds == 0.0) {
-    ERROR("uptime plugin: uptime read from " UPTIME_FILE ", "
-          "but it is zero!");
-    return -1;
-  }
-
-  boottime = time(NULL) - (long)uptime_seconds;
+  result = (time_t)info.uptime;
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
@@ -143,13 +127,13 @@ static int uptime_init(void) /* {{{ */
     return -1;
   }
 
-  boottime = (time_t)knp->value.ui32;
-
-  if (boottime == 0) {
+  if (knp->value.ui32 == 0) {
     ERROR("uptime plugin: kstat_data_lookup returned success, "
           "but `boottime' is zero!");
     return -1;
   }
+
+  result = time(NULL) - (time_t)knp->value.ui32;
 /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYS_SYSCTL_H
@@ -170,13 +154,13 @@ static int uptime_init(void) /* {{{ */
     return -1;
   }
 
-  boottime = boottv.tv_sec;
-
-  if (boottime == 0) {
+  if (boottv.tv_sec == 0) {
     ERROR("uptime plugin: sysctl(3) returned success, "
           "but `boottime' is zero!");
     return -1;
   }
+
+  result = time(NULL) - boottv.tv_sec;
 /* #endif HAVE_SYS_SYSCTL_H */
 
 #elif HAVE_PERFSTAT
@@ -196,18 +180,18 @@ static int uptime_init(void) /* {{{ */
   if (hertz <= 0)
     hertz = HZ;
 
-  boottime = time(NULL) - cputotal.lbolt / hertz;
+  result = cputotal.lbolt / hertz;
 #endif /* HAVE_PERFSTAT */
 
-  return 0;
-} /* }}} int uptime_init */
+  return result;
+} /* }}} int uptime_get_sys */
 
 static int uptime_read(void) {
   gauge_t uptime;
   time_t elapsed;
 
   /* calculate the amount of time elapsed since boot, AKA uptime */
-  elapsed = time(NULL) - boottime;
+  elapsed = uptime_get_sys();
 
   uptime = (gauge_t)elapsed;
 
@@ -217,6 +201,5 @@ static int uptime_read(void) {
 }
 
 void module_register(void) {
-  plugin_register_init("uptime", uptime_init);
   plugin_register_read("uptime", uptime_read);
 } /* void module_register */


### PR DESCRIPTION
Original uptime plugin implementation is susceptible to system date changes, which is likely to happen on embedded system without RTC. 
The cause of the problem is a combination of two factors:

1. the method used to calculate uptime (subtracting boottime from current time),
1. reading boottime only once, during plugin initialization phase.

This set of commits changes the implementation in the following way:
1. On Linux and AIX, uptime is read directly using a system call. A side effect is a simpler and faster code (no need to parse /proc filesystem, no double time() system call).
2. On BSD and Solaris, uptime is calculated using original method (subtracting boottime from current time).