### PR TITLE
virt plugin: Rewrite from scratch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2314,6 +2314,18 @@ AC_SUBST(GCRYPT_LIBS)
 AM_CONDITIONAL(BUILD_WITH_LIBGCRYPT, test "x$with_libgcrypt" = "xyes")
 # }}}
 
+# --with-libglib2 {{{
+# we will detect the CFLAGS and LDFLAGS later, when we need it.
+# here we check only for the minimal subset needed.
+$PKG_CONFIG --exists glib-2.0 2>/dev/null
+if test "$?" = "0"
+then
+	with_glib2="yes"
+else
+	with_glib2="no (pkg-config doesn't know glib)"
+fi
+# }}}
+
 # --with-libgps {{{
 with_libgps_cflags=""
 with_libgps_ldflags=""
@@ -5511,7 +5523,7 @@ then
 fi
 # }}}
 
-# pkg-config --exists 'libxml-2.0'; pkg-config --exists libvirt {{{
+# pkg-config --exists 'libxml-2.0'; pkg-config --exists libvirt; pkg-config --exists glib-2.0; {{{
 with_libxml2="no (pkg-config isn't available)"
 with_libxml2_cflags=""
 with_libxml2_ldflags=""
@@ -5623,6 +5635,52 @@ if test "x$with_libvirt" = "xyes"; then
 	AC_SUBST(BUILD_WITH_LIBVIRT_CFLAGS)
 	AC_SUBST(BUILD_WITH_LIBVIRT_LIBS)
 fi
+if test "x$with_glib2" = "xyes"
+then
+	with_glib2_cflags="`$PKG_CONFIG --cflags glib-2.0`"
+	if test $? -ne 0
+	then
+		with_glib2="no"
+	fi
+	with_glib2_ldflags="`$PKG_CONFIG --libs glib-2.0`"
+	if test $? -ne 0
+	then
+		with_glib2="no"
+	fi
+fi
+if test "x$with_glib2" = "xyes"
+then
+	SAVE_CPPFLAGS="$CPPFLAGS"
+	CPPFLAGS="$CPPFLAGS $with_glib2_cflags"
+
+	AC_CHECK_HEADERS(glib.h, [],
+		      [with_glib2="no (glib.h not found)"])
+
+	CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+if test "x$with_glib2" = "xyes"
+then
+	SAVE_CFLAGS="$CFLAGS"
+	SAVE_LDFLAGS="$LDFLAGS"
+
+	CFLAGS="$CFLAGS $with_glib2_cflags"
+	LDFLAGS="$LDFLAGS $with_glib2_ldflags"
+
+	AC_CHECK_LIB(glib-2.0, g_hash_table_new,
+		     [with_glib2="yes"],
+		     [with_glib2="no (symbol g_hash_table_new not found)"])
+
+	CFLAGS="$SAVE_CFLAGS"
+	LDFLAGS="$SAVE_LDFLAGS"
+fi
+dnl Add the right compiler flags and libraries.
+if test "x$with_glib2" = "xyes"; then
+	BUILD_WITH_GLIB2_CFLAGS="$with_glib2_cflags"
+	BUILD_WITH_GLIB2_LIBS="$with_glib2_ldflags"
+	AC_SUBST(BUILD_WITH_GLIB2_CFLAGS)
+	AC_SUBST(BUILD_WITH_GLIB2_LIBS)
+fi
+
 # }}}
 
 # $PKG_CONFIG --exists OpenIPMIpthread {{{
@@ -6304,7 +6362,7 @@ then
 	plugin_users="yes"
 fi
 
-if test "x$with_libxml2" = "xyes" && test "x$with_libvirt" = "xyes"
+if test "x$with_libxml2" = "xyes" && test "x$with_libvirt" = "xyes" && test "x$with_glib2" = "xyes"
 then
 	plugin_virt="yes"
 fi
@@ -6707,6 +6765,7 @@ AC_MSG_RESULT([    libdpdk . . . . . . . $with_libdpdk])
 AC_MSG_RESULT([    libesmtp  . . . . . . $with_libesmtp])
 AC_MSG_RESULT([    libganglia  . . . . . $with_libganglia])
 AC_MSG_RESULT([    libgcrypt . . . . . . $with_libgcrypt])
+AC_MSG_RESULT([    libglib2  . . . . . . $with_glib2])
 AC_MSG_RESULT([    libgps  . . . . . . . $with_libgps])
 AC_MSG_RESULT([    libgrpc++ . . . . . . $with_libgrpcpp])
 AC_MSG_RESULT([    libhal  . . . . . . . $with_libhal])

--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -802,7 +802,7 @@ The Varnish plugin collects information about Varnish, an HTTP accelerator.
 Summary:	Virt plugin for collectd
 Group:		System Environment/Daemons
 Requires:	%{name}%{?_isa} = %{version}-%{release}
-BuildRequires:	libvirt-devel
+BuildRequires:	libvirt-devel, glib2-devel, libxml2-devel
 %description virt
 This plugin collects information from virtualized guests.
 %endif
@@ -2373,7 +2373,6 @@ fi
 %if %{with_virt}
 %files virt
 %{_libdir}/%{name}/virt.so
-%endif
 
 %if %{with_log_logstash}
 %files log_logstash

--- a/docs/README.virt.md
+++ b/docs/README.virt.md
@@ -1,0 +1,215 @@
+Inside the virt plugin
+======================
+
+Originally written: 20161111
+
+Last updated: 20161115
+
+This is a rewrite of the collectd virt plugin as found in collectd <= 5.6.0,
+enhanced to use the libvirt [bulk stats API](https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainListGetStats)
+and to add support to deal with with unresponsive domains.
+
+In the reminder of this document, we consider
+
+* libvirt <= 2.0.0
+* QEMU <= 2.6.0
+
+
+
+High level overview: libvirt client, libvirt daemon, qemu
+---------------------------------------------------------
+
+Before to dig into the details, it is useful to review how
+the client application (collectd + virt plugin), the libvirtd daemon and the
+QEMU processes interact with each other.
+
+The libvirt daemon talks to QEMU using the JSON QMP protcol over one unix domain socket.
+The details of the protocol are not important now, but the key part is that the protocol
+is a simple request/response, meaning that libvirtd must serialize all the interactions
+with the QEMU monitor, and must protects its endpoint with a lock.
+This means that if for any reason one QMP request could not be completed, any other caller
+trying to access the QEMU monitor will block until the blocked caller returns.
+
+To retrieve some key informations, most notably about the block device state or the balloon
+device state, the libvirtd daemon *must* use the QMP protocol.
+
+The QEMU core, including the handling of the QMP protocol, is single-threaded.
+All the above combined make it possible for a client to block forever waiting for one QMP
+request, if QEMU itself is blocked. The most likely cause of block is I/O, and this is especially
+true considering how QEMU is used in a datacenter.
+
+Dealing with datacenters: libvirt, qemu, shared storage
+-------------------------------------------------------
+
+When used in a datacenter, QEMU is most often configured to use shared storage. This is
+the default configuration of datacenter management solutions like [oVirt](http://www.ovirt.org).
+The actual shared storage could be implemented on top of NFS for small installations, or most likely
+ISCSI or Fiber Channel. The key takeaway is that the storage is accessed over the network,
+not using e.g. the SATA or PCI bus of any given host, so any network issue could cause
+one or more storage operations to delay, or to be lost entirely.
+
+In that case, the userspace process that requested the operation can end up in the D state,
+and become unresponsive, and unkillable.
+
+Dealing with unresponsive domains
+---------------------------------
+
+All the above considered, one robust management or monitoring application must deal with the fact that
+the libvirt API can block for a long time, or forever. This is not an issue or a bug of one specific
+API, but it is rather a byproduct of how libvirt and QEMU interact.
+
+Whenever we query more than one VM, we should take care to avoid that one blocked VM prevent other,
+well behaving VMs to be queried. We don't want one rogue VM to disrupt well-behaving VMs.
+Unfortunately, any way we enumerate VMs, either implicitely, using the libvirt bulk stats API,
+or explicitely, listing all libvirt domains and query each one in turn, we may unpredictably encounter
+one unresponsive VM.
+
+There are many possible approaches to deal with this issue. The virt plugin supports
+a simple but effective approach partitioning the domains, as follows.
+
+1. The virt plugin always register one or more `read` callbacks. The `zero` read callback is guaranteed to
+   be always present, so it performs special duties (more details later)
+   Each callback will be named 'virt-$N', where `N` ranges from 0 (zero) to M-1, where M is the number of instances configured.
+   `M` equals to `5` by default, because this is the same default number of threads in the libvirt worker pool.
+2. Each of the read callbacks queries libvirt for the list of all the active domains, and retrieves the libvirt domain metadata.
+   Both of those operations are safe wrt domain blocked in I/O (they affect only the libvirtd daemon).
+3. Each of the read callbacks extracts the `tag` from the domain metadata using a well-known format (see below).
+   Each of the read callbacks discards any domain which has no tag, or whose tag doesn't match with the read callback tag.
+3.a. The read callback tag equals to the read callback name, thus `virt-$N`. Remember that `virt-0` is guaranteed to be
+     always present.
+3.b. Since the `virt-0` reader is always present, it will take care of domains with no tag, or with unrecognized tag.
+     One unrecognized tag is any tag which has not the scheme `virt-$N`.
+4. Each read callback only samples the subset of domains with matching tag. The `virt-0` reader will possibly do more,
+   but worst case the load will be unbalanced, no domain will be left unsampled.
+
+To make this approach work, some entity must attach the tags to the libvirt domains, in such a way that all
+the domains which run on a given host and insist on the same network-based storage share the same tag.
+This minimizes the disruption, because when using the shared storage, if one domain becomes unresponsive because
+of unavailable storage, the most likely thing to happen is that others domain using the same storage will soon become
+unavailable; should the box run other libvirt domains using other network-based storage, they could be monitored
+safely.
+
+In case of [oVirt](http://www.ovirt.org), the aforementioned tagging is performed by the host agent.
+
+Please note that this approach is ineffective if the host completely lose network access to the storage network.
+In this case, however, no recovery is possible and no damage limitation is possible.
+
+Lastly, please note that if the virt plugin is configured with instances=1, it behaves exactly like the old virt plugin.
+
+Examples
+--------
+
+### Example one: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, using 5 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-3         3          tag match
+    domain-E                virt-4         4          tag match
+    domain-F                virt-0         0          tag match
+    domain-G                virt-1         1          tag match
+    domain-H                virt-2         2          tag match
+    domain-I                virt-3         3          tag match
+    domain-J                virt-4         4          tag match
+
+
+  Because the domain where properly tagged, all the read instances have even load. Please note that the the virt plugin
+  knows nothing, and should know nothing, about *how* the libvirt domain are tagged. This is entirely up to the
+  management system.
+
+
+Example two: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=3, using 5 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-3         0          adopted by instance #0
+    domain-E                virt-4         0          adopted by instance #0
+    domain-F                virt-0         0          rag match
+    domain-G                virt-1         1          tag match
+    domain-H                virt-2         2          tag match
+    domain-I                virt-3         0          adopted by instance #0
+    domain-J                virt-4         0          adopted by instance #0
+
+
+  In this case we have uneven load, but no domain is ignored.
+
+
+### Example three: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, using 3 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-0         0          tag match
+    domain-E                virt-1         1          tag match
+    domain-F                virt-2         2          tag match
+    domain-G                virt-0         0          tag match
+    domain-H                virt-1         1          tag match
+    domain-I                virt-2         2          tag match
+    domain-J                virt-0         0          tag match
+
+
+  Once again we have uneven load and two idle read instances, but besides that no domain is left unmonitored
+
+
+### Example four: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, partial tagging
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-0         0          tag match
+    domain-E                               0          adopted by instance #0
+    domain-F                               0          adopted by instance #0
+    domain-G                               0          adopted by instance #0
+    domain-H                               0          adopted by instance #0
+    domain-I                               0          adopted by instance #0
+    domain-J                               0          adopted by instance #0
+
+
+The lack of tags causes uneven load, but no domain are unmonitored.
+
+
+Note about the libvirt bulk stats API
+--------------------------------------
+
+The rewritten virt plugin makes use of the libvirt [bulk stats API](https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainListGetStats).
+This API provides all the data the more specific calls provide, but in one go and in one
+unified output format.
+It is worth to highlight that the above issues related to the unresponsive domains are *not* a byproduct
+of the use of the bulk stats API. The very same set of issue arises if we use finer grained libvirt APIs.
+The issue could arise anytime we need to access the QEMU monitor when QEMU is stuck in one I/O operation,
+not how we access it.
+
+
+Possible extensions - custom tag format
+---------------------------------------
+
+The aformentioned approach relies on fixed tag format, `virt-$N`. The algorithm works fine with any tag, which
+is just one string, compared for equality. However, using custom strings for tags creates the need for a mapping
+between tags and the read instances.
+This mapping needs to be updated as long as domain are created or destroyed, and the virt plugin needs to be
+notified of the changes.
+
+This adds a significant amount of complexity, with little gain with respect to the fixed schema adopted initially.
+For this reason, the introdution of dynamic, custom mapping was not implemented.
+
+Libvirt tag metadata format
+----------------------------
+
+This is the snipped to be added to libvirt domains:
+
+    <ovirtmap:tag xmlns:ovirtmap="http://ovirt.org/ovirtmap/tag/1.0">
+      $TAG
+    </ovirtmap:tag>
+
+it must be included in the <metadata> section.
+
+Check the `src/virt_test.c` file for really minimal example of libvirt domains.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1261,11 +1261,20 @@ endif
 
 if BUILD_PLUGIN_VIRT
 pkglib_LTLIBRARIES += virt.la
-virt_la_SOURCES = virt.c
+virt_la_SOURCES = virt.c vminfo.c vminfo.h
 virt_la_CFLAGS = $(AM_CFLAGS) \
-		$(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
-virt_la_LIBADD = $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
+		$(BUILD_WITH_GLIB2_CFLAGS) $(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
+virt_la_LIBADD = $(BUILD_WITH_GLIB2_LIBS) $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
 virt_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+
+test_plugin_virt_SOURCES = virt_test.c fake_libvirt.c fake_vminfo.c virt_test.h
+test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
+		$(BUILD_WITH_GLIB2_CFLAGS) $(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
+test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS)
+test_plugin_virt_LDADD = daemon/libplugin_mock.la \
+		$(BUILD_WITH_GLIB2_LIBS) $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
+check_PROGRAMS += test_plugin_virt
+TESTS += test_plugin_virt
 endif
 
 if BUILD_PLUGIN_VMEM

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1420,6 +1420,8 @@
 #	HostnameFormat name
 #	InterfaceFormat name
 #	PluginInstanceFormat name
+#	Instances 1
+#	DebugPartitioning false
 #</Plugin>
 
 #<Plugin vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7890,6 +7890,20 @@ You can also specify combinations of the B<name> and B<uuid> fields.
 For example B<name uuid> means to concatenate the guest name and UUID
 (with a literal colon character between, thus I<"foo:1234-1234-1234-1234">).
 
+=item B<Instances> B<integer>
+
+How many read instances you want to use for this plugin. The default is one,
+and the sensible setting is a multiple of the B<ReadThreads> value.
+Use this value to enable the partitioning of the libvirt domains according
+to domain tags, to enable the resiliency in presence of unresponsive domains.
+Check the B<README.virt.md> to learn more.
+If you are not sure, just use the default setting.
+
+= item B<DebugPartitioning> B<true|false>
+
+Enable to have extra logs to see how the learn plugin is spreading the libvirt
+domains across its instances. Use this for troubleshooting. Default is 'false'.
+
 =back
 
 =head2 Plugin C<vmem>

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -47,7 +47,8 @@ libheap_la_SOURCES = utils_heap.c utils_heap.h
 libmetadata_la_SOURCES = meta_data.c meta_data.h
 
 libplugin_mock_la_SOURCES = plugin_mock.c utils_cache_mock.c \
-			    utils_time.c utils_time.h
+			    utils_time.c utils_time.h \
+			    utils_ignorelist.c utils_ignorelist.h
 libplugin_mock_la_CPPFLAGS = $(AM_CPPFLAGS) -DMOCK_TIME
 libplugin_mock_la_LIBADD = $(COMMON_LIBS) libcommon.la
 

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -32,6 +32,13 @@ kstat_ctl_t *kc = NULL;
 
 char hostname_g[] = "example.com";
 
+int plugin_register_config (const char *name,
+		int (*callback) (const char *key, const char *val),
+		const char **keys, int keys_num)
+{
+  return ENOTSUP;
+}
+
 int plugin_register_complex_config (const char *type, int (*callback) (oconfig_item_t *))
 {
   return ENOTSUP;
@@ -43,6 +50,14 @@ int plugin_register_init (const char *name, plugin_init_cb callback)
 }
 
 int plugin_register_read (const char *name, int (*callback) (void))
+{
+  return ENOTSUP;
+}
+
+int plugin_register_complex_read (const char *group, const char *name,
+        int (*callback) (user_data_t *),
+		cdtime_t interval,
+		user_data_t const *user_data)
 {
   return ENOTSUP;
 }

--- a/src/fake_libvirt.c
+++ b/src/fake_libvirt.c
@@ -1,0 +1,30 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "virt_test.h"
+
+typedef struct fakeVirDomain *virDomainPtr;
+
+int virDomainGetUUIDString(virDomainPtr _dom, char *out) {
+  if (!_dom || !out)
+    return -1;
+  fakeVirDomainPtr dom = (fakeVirDomainPtr)_dom;
+  strncpy(out, dom->uuid, UUID_STRLEN);
+  return 0;
+}
+
+const char *virDomainGetXMLDesc(virDomainPtr _dom) {
+  if (!_dom)
+    return NULL;
+  fakeVirDomainPtr dom = (fakeVirDomainPtr)_dom;
+  return strdup(dom->xml);
+}
+
+const char *virDomainGetName(virDomainPtr _dom) {
+  if (!_dom)
+    return NULL;
+  fakeVirDomainPtr dom = (fakeVirDomainPtr)_dom;
+  return dom->name;
+}

--- a/src/fake_vminfo.c
+++ b/src/fake_vminfo.c
@@ -1,0 +1,15 @@
+
+#include "virt_test.h"
+
+typedef struct VMInfo VMInfo;
+typedef struct virDomainStatsRecord virDomainStatsRecord;
+typedef virDomainStatsRecord *virDomainStatsRecordPtr;
+
+int vminfo_parse(VMInfo *vm, const virDomainStatsRecordPtr record,
+                 int extrainfo) {
+  return 0;
+}
+
+void vminfo_init(VMInfo *vm) { return; }
+
+void vminfo_free(VMInfo *vm) { return; }

--- a/src/virt.c
+++ b/src/virt.c
@@ -1,5 +1,6 @@
 /**
  * collectd - src/virt.c
+ * Copyright (C) 2016 Francesco Romani <fromani at redhat.com>
  * Copyright (C) 2006-2008  Red Hat Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,998 +17,900 @@
  * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  *
  * Authors:
- *   Richard W.M. Jones <rjones@redhat.com>
+ *   Francesco Romani <fromani at redhat.com>
+ *   Richard W.M. Jones <rjones at redhat.com>
  **/
 
-#include "collectd.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "common.h"
-#include "plugin.h"
-#include "utils_ignorelist.h"
-#include "utils_complain.h"
+#include <glib.h>
 
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
-#include <libgen.h> /* for basename(3) */
+#include <libxml/xpathInternals.h>
 
-/* Plugin name */
-#define PLUGIN_NAME "virt"
+#include "common.h"
+#include "configfile.h"
+#include "plugin.h"
+#include "utils_complain.h"
+#include "utils_ignorelist.h"
+#include "collectd.h"
 
-static const char *config_keys[] = {
-    "Connection",
+#include "vminfo.h"
 
-    "RefreshInterval",
+#define PLUGIN_NAME "virt2"
 
-    "Domain",
-    "BlockDevice",
-    "BlockDeviceFormat",
-    "BlockDeviceFormatBasename",
-    "InterfaceDevice",
-    "IgnoreSelected",
+/*
+ * Synopsis:
+ * <Plugin "virt">
+ *   Connection "qemu:///system"
+ *   Instances 5
+ * </Plugin>
+ */
 
-    "HostnameFormat",
-    "InterfaceFormat",
+#define METADATA_VM_PARTITION_URI "http://ovirt.org/ovirtmap/tag/1.0"
+#define METADATA_VM_PARTITION_ELEMENT "tag"
+#define METADATA_VM_PARTITION_PREFIX "ovirtmap"
 
-    "PluginInstanceFormat",
-
-    NULL
-};
-#define NR_CONFIG_KEYS ((sizeof config_keys / sizeof config_keys[0]) - 1)
-
-/* Connection. */
-static virConnectPtr conn = 0;
-static char *conn_string = NULL;
-static c_complain_t conn_complain = C_COMPLAIN_INIT_STATIC;
-
-/* Seconds between list refreshes, 0 disables completely. */
-static int interval = 60;
-
-/* List of domains, if specified. */
-static ignorelist_t *il_domains = NULL;
-/* List of block devices, if specified. */
-static ignorelist_t *il_block_devices = NULL;
-/* List of network interface devices, if specified. */
-static ignorelist_t *il_interface_devices = NULL;
-
-static int ignore_device_match (ignorelist_t *,
-                                const char *domname, const char *devpath);
-
-/* Actual list of domains found on last refresh. */
-static virDomainPtr *domains = NULL;
-static int nr_domains = 0;
-
-static void free_domains (void);
-static int add_domain (virDomainPtr dom);
-
-/* Actual list of block devices found on last refresh. */
-struct block_device {
-    virDomainPtr dom;           /* domain */
-    char *path;                 /* name of block device */
+enum {
+  INSTANCES_DEFAULT_NUM = 1,
+  BUFFER_MAX_LEN = 256,
+  PARTITION_TAG_MAX_LEN = 32,
+  INTERFACE_NUMBER_MAX_LEN = 32,
+  INSTANCES_MAX = 128,
+  VM_VALUES_NUM = 256,
 };
 
-static struct block_device *block_devices = NULL;
-static int nr_block_devices = 0;
+const char *virt2_config_keys[] = {"Connection",
 
-static void free_block_devices (void);
-static int add_block_device (virDomainPtr dom, const char *path);
+                                   "RefreshInterval",
 
-/* Actual list of network interfaces found on last refresh. */
-struct interface_device {
-    virDomainPtr dom;           /* domain */
-    char *path;                 /* name of interface device */
-    char *address;              /* mac address of interface device */
-    char *number;               /* interface device number */
-};
+                                   "Domain",
+                                   "BlockDevice",
+                                   "InterfaceDevice",
+                                   "IgnoreSelected",
 
-static struct interface_device *interface_devices = NULL;
-static int nr_interface_devices = 0;
+                                   "HostnameFormat",
+                                   "InterfaceFormat",
 
-static void free_interface_devices (void);
-static int add_interface_device (virDomainPtr dom, const char *path, const char *address, unsigned int number);
+                                   "PluginInstanceFormat",
+
+                                   "Instances",
+                                   "DebugPartitioning",
+                                   NULL};
+#define NR_CONFIG_KEYS                                                         \
+  ((sizeof virt2_config_keys / sizeof virt2_config_keys[0]) - 1)
 
 /* HostnameFormat. */
 #define HF_MAX_FIELDS 3
 
-enum hf_field {
-    hf_none = 0,
-    hf_hostname,
-    hf_name,
-    hf_uuid
-};
-
-static enum hf_field hostname_format[HF_MAX_FIELDS] =
-    { hf_name };
+enum hf_field { hf_none = 0, hf_hostname, hf_name, hf_uuid };
 
 /* PluginInstanceFormat */
 #define PLGINST_MAX_FIELDS 2
 
-enum plginst_field {
-    plginst_none = 0,
-    plginst_name,
-    plginst_uuid
-};
-
-static enum plginst_field plugin_instance_format[PLGINST_MAX_FIELDS] =
-    { plginst_none };
-
-/* BlockDeviceFormat */
-enum bd_field {
-	target,
-	source
-};
+enum plginst_field { plginst_none = 0, plginst_name, plginst_uuid };
 
 /* InterfaceFormat. */
-enum if_field {
-    if_address,
-    if_name,
-    if_number
+enum if_field { if_address, if_name, if_number };
+
+typedef struct virt2_config_s virt2_config_t;
+struct virt2_config_s {
+  char *connection_uri;
+  size_t instances;
+  cdtime_t interval; /* could be 0, and it's OK */
+  int debug_partitioning;
+  enum hf_field hostname_format[HF_MAX_FIELDS];
+  enum plginst_field plugin_instance_format[PLGINST_MAX_FIELDS];
+  enum if_field interface_format;
+  /* not user-facing */
+  int stats;
+  int flags;
 };
 
-/* BlockDeviceFormatBasename */
-_Bool blockdevice_format_basename = 0;
-static enum bd_field blockdevice_format = target;
-static enum if_field interface_format = if_name;
+typedef struct virt2_state_s virt2_state_t;
 
-/* Time that we last refreshed. */
-static time_t last_refresh = (time_t) 0;
+typedef struct virt2_instance_s virt2_instance_t;
+struct virt2_instance_s {
+  virt2_state_t *state;
+  const virt2_config_t *conf;
 
-static int refresh_lists (void);
+  GArray *doms;
+  virDomainPtr *domains_all;
+  size_t domains_num;
 
-/* ERROR(...) macro for virterrors. */
-#define VIRT_ERROR(conn,s) do {                 \
-        virErrorPtr err;                        \
-        err = (conn) ? virConnGetLastError ((conn)) : virGetLastError (); \
-        if (err) ERROR ("%s: %s", (s), err->message);                   \
-    } while(0)
+  char tag[PARTITION_TAG_MAX_LEN];
+  size_t id;
+};
 
-static void
-init_value_list (value_list_t *vl, virDomainPtr dom)
-{
-    int n;
-    const char *name;
-    char uuid[VIR_UUID_STRING_BUFLEN];
+typedef struct virt2_user_data_s virt2_user_data_t;
+struct virt2_user_data_s {
+  virt2_instance_t inst;
+  user_data_t ud;
+};
 
-    sstrncpy (vl->plugin, PLUGIN_NAME, sizeof (vl->plugin));
+struct virt2_state_s {
+  virConnectPtr conn;
+  GHashTable *known_tags;
+  ignorelist_t *il_domains;
+  ignorelist_t *il_block_devices;
+  ignorelist_t *il_iface_devices;
+  size_t instances;
+};
 
-    vl->host[0] = '\0';
+typedef struct virt2_context_s virt2_context_t;
+struct virt2_context_s {
+  virt2_user_data_t user_data[INSTANCES_MAX];
+  virt2_state_t state;
+  virt2_config_t conf;
+};
 
-    /* Construct the hostname field according to HostnameFormat. */
-    for (int i = 0; i < HF_MAX_FIELDS; ++i) {
-        if (hostname_format[i] == hf_none)
-            continue;
+typedef struct virt2_domain_s virt2_domain_t;
+struct virt2_domain_s {
+  virDomainPtr dom;
+  char tag[PARTITION_TAG_MAX_LEN];
+  char uuid[VIR_UUID_STRING_BUFLEN + 1];
+  char *name;
+};
 
-        n = DATA_MAX_NAME_LEN - strlen (vl->host) - 2;
+typedef struct virt2_array_s virt2_array_t;
+struct virt2_array_s {
+  gchar *data;
+  guint len;
+};
 
-        if (i > 0 && n >= 1) {
-            strncat (vl->host, ":", 1);
-            n--;
-        }
 
-        switch (hostname_format[i]) {
-        case hf_none: break;
-        case hf_hostname:
-            strncat (vl->host, hostname_g, n);
-            break;
-        case hf_name:
-            name = virDomainGetName (dom);
-            if (name)
-                strncat (vl->host, name, n);
-            break;
-        case hf_uuid:
-            if (virDomainGetUUIDString (dom, uuid) == 0)
-                strncat (vl->host, uuid, n);
-            break;
-        }
+/* *** */
+
+static int ignore_device_match(ignorelist_t *il, const char *domname,
+                               const char *devpath) {
+  char *name;
+  int n, r;
+
+  if ((domname == NULL) || (devpath == NULL))
+    return 0;
+
+  n = strlen(domname) + strlen(devpath) + 2;
+  name = malloc(n);
+  if (name == NULL) {
+    ERROR(PLUGIN_NAME " plugin: malloc failed.");
+    return 0;
+  }
+  ssnprintf(name, n, "%s:%s", domname, devpath);
+  r = ignorelist_match(il, name);
+  sfree(name);
+  return r;
+}
+
+/* *** */
+
+virt2_context_t default_context = {
+    .conf =
+        {
+            .hostname_format = {hf_name},
+            .plugin_instance_format = {plginst_none},
+            .interface_format = if_name,
+            /*
+             * Using 0 for @stats returns all stats groups supported by the
+             * given hypervisor.
+             * http://libvirt.org/html/libvirt-libvirt-domain.html#virConnectGetAllDomainStats
+             */
+            .stats = 0,
+            .flags = 0,
+        },
+};
+
+static virt2_context_t *virt2_get_default_context() { return &default_context; }
+
+/* *** */
+
+static void virt2_value_list_set_plugin_instance(value_list_t *vl,
+                                                 const VMInfo *info,
+                                                 const virt2_config_t *cfg) {
+  int i, n;
+  for (i = 0; i < PLGINST_MAX_FIELDS; ++i) {
+    if (cfg->plugin_instance_format[i] == plginst_none)
+      continue;
+
+    n = sizeof(vl->plugin_instance) - strlen(vl->plugin_instance) - 2;
+
+    if (i > 0 && n >= 1) {
+      strncat(vl->plugin_instance, ":", 1);
+      n--;
     }
 
-    vl->host[sizeof (vl->host) - 1] = '\0';
+    switch (cfg->plugin_instance_format[i]) {
+    case plginst_none:
+      break;
+    case plginst_name:
+      strncat(vl->plugin_instance, info->name, n);
+      break;
+    case plginst_uuid:
+      strncat(vl->plugin_instance, info->uuid, n);
+      break;
+    }
+  }
 
-    /* Construct the plugin instance field according to PluginInstanceFormat. */
-    for (int i = 0; i < PLGINST_MAX_FIELDS; ++i) {
-        if (plugin_instance_format[i] == plginst_none)
-            continue;
+  vl->plugin_instance[sizeof(vl->plugin_instance) - 1] = '\0';
+}
 
-        n = sizeof(vl->plugin_instance) - strlen (vl->plugin_instance) - 2;
+static void virt2_value_list_set_host(value_list_t *vl, const VMInfo *info,
+                                      const virt2_config_t *cfg) {
+  int i, n;
+  vl->host[0] = '\0';
+  for (i = 0; i < HF_MAX_FIELDS; i++) {
+    if (cfg->hostname_format[i] == hf_none)
+      continue;
 
-        if (i > 0 && n >= 1) {
-            strncat (vl->plugin_instance, ":", 1);
-            n--;
-        }
+    n = DATA_MAX_NAME_LEN - strlen(vl->host) - 2;
 
-        switch (plugin_instance_format[i]) {
-        case plginst_none: break;
-        case plginst_name:
-            name = virDomainGetName (dom);
-            if (name)
-                strncat (vl->plugin_instance, name, n);
-            break;
-        case plginst_uuid:
-            if (virDomainGetUUIDString (dom, uuid) == 0)
-                strncat (vl->plugin_instance, uuid, n);
-            break;
-        }
+    if (i > 0 && n >= 1) {
+      strncat(vl->host, ":", 1);
+      n--;
     }
 
-    vl->plugin_instance[sizeof (vl->plugin_instance) - 1] = '\0';
-
-} /* void init_value_list */
-
-static void submit (virDomainPtr dom,
-                    char const *type, char const *type_instance,
-                    value_t *values, size_t values_len)
-{
-    value_list_t vl = VALUE_LIST_INIT;
-    init_value_list (&vl, dom);
-
-    vl.values = values;
-    vl.values_len = values_len;
-
-    sstrncpy (vl.type, type, sizeof (vl.type));
-    if (type_instance != NULL)
-        sstrncpy (vl.type_instance, type_instance, sizeof (vl.type_instance));
-
-    plugin_dispatch_values (&vl);
-}
-
-static void
-memory_submit (gauge_t value, virDomainPtr dom)
-{
-    submit (dom, "memory", "total", &(value_t) { .gauge = value }, 1);
-}
-
-static void
-memory_stats_submit (gauge_t value, virDomainPtr dom, int tag_index)
-{
-    static const char *tags[] = { "swap_in", "swap_out", "major_fault", "minor_fault",
-                                    "unused", "available", "actual_balloon", "rss"};
-
-    if ((tag_index < 0) || (tag_index >= STATIC_ARRAY_SIZE (tags))) {
-        ERROR ("virt plugin: Array index out of bounds: tag_index = %d", tag_index);
-        return;
+    switch (cfg->hostname_format[i]) {
+    case hf_none:
+      break;
+    case hf_hostname:
+      strncat(vl->host, hostname_g, n);
+      break;
+    case hf_name:
+      strncat(vl->host, info->name, n);
+      break;
+    case hf_uuid:
+      strncat(vl->host, info->uuid, n);
+      break;
     }
-
-    submit (dom, "memory", tags[tag_index], &(value_t) { .gauge = value }, 1);
+  }
+  vl->host[sizeof(vl->host) - 1] = '\0';
 }
 
-static void
-cpu_submit (unsigned long long value,
-            virDomainPtr dom, const char *type)
-{
-    submit (dom, type, NULL, &(value_t) { .derive = (derive_t) value }, 1);
+static int virt2_submit(const virt2_config_t *cfg, const VMInfo *info,
+                        const char *type, const char *type_instance,
+                        value_t *values, size_t values_len) {
+  value_list_t vl = VALUE_LIST_INIT;
+
+  sstrncpy(vl.plugin, PLUGIN_NAME, sizeof(vl.plugin));
+  virt2_value_list_set_plugin_instance(&vl, info, cfg);
+  virt2_value_list_set_host(&vl, info, cfg);
+  sstrncpy(vl.type, type, sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+
+  vl.values = values;
+  vl.values_len = values_len;
+
+  plugin_dispatch_values(&vl);
+  return 0;
 }
 
-static void
-vcpu_submit (derive_t value,
-             virDomainPtr dom, int vcpu_nr, const char *type)
-{
+static int virt2_dispatch_cpu(virt2_instance_t *inst, const VMInfo *vm) {
+  value_t val;
+
+  val.derive = vm->info.cpuTime;
+  virt2_submit(inst->conf, vm, "virt_cpu_total", "", &val, 1);
+  // TODO: cpu.user, cpu.sys, cpu.total
+
+  for (size_t j = 0; j < vm->vcpu.nstats; j++) {
     char type_instance[DATA_MAX_NAME_LEN];
+    ssnprintf(type_instance, sizeof(type_instance), "%zu", j);
+    const VCpuStats *stats =
+        (vm->vcpu.xstats) ? vm->vcpu.xstats : vm->vcpu.stats;
+    val.derive = stats[j].time;
+    virt2_submit(inst->conf, vm, "virt_vcpu", type_instance, &val, 1);
+  }
 
-    ssnprintf (type_instance, sizeof (type_instance), "%d", vcpu_nr);
-
-    submit (dom, type, type_instance, &(value_t) { .derive = value }, 1);
+  return 0;
 }
 
-static void
-submit_derive2 (const char *type, derive_t v0, derive_t v1,
-             virDomainPtr dom, const char *devname)
-{
-    value_t values[] = {
-        { .derive = v0 },
-        { .derive = v1 },
-    };
+static int virt2_dispatch_memory(virt2_instance_t *inst, const VMInfo *vm) {
+  value_t val;
+  val.gauge = vm->info.memory * 1024;
+  virt2_submit(inst->conf, vm, "memory", "total", &val, 1);
+  for (int j = 0; j < vm->memstats_count; j++) {
+    static const char *tags[] = {"swap_in",        "swap_out", "major_fault",
+                                 "minor_fault",    "unused",   "available",
+                                 "actual_balloon", "rss"};
+    if ((vm->memstats[j].tag < 0) ||
+        (vm->memstats[j].tag >= STATIC_ARRAY_SIZE(tags))) {
+      ERROR(PLUGIN_NAME " plugin#%s: unknown tag %i", inst->tag,
+            vm->memstats[j].tag);
+      continue;
+    }
+    val.gauge = vm->memstats[j].val * 1024;
+    virt2_submit(inst->conf, vm, "memory", tags[vm->memstats[j].tag], &val, 1);
+  }
 
-    submit (dom, type, devname, values, STATIC_ARRAY_SIZE (values));
-} /* void submit_derive2 */
-
-static int
-lv_init (void)
-{
-    if (virInitialize () != 0)
-        return -1;
-    else
-        return 0;
+  return 0;
 }
 
-static int
-lv_config (const char *key, const char *value)
-{
-    if (virInitialize () != 0)
-        return 1;
+static int virt2_dispatch_block(virt2_instance_t *inst, const VMInfo *vm) {
+  value_t vals[2];
 
-    if (il_domains == NULL)
-        il_domains = ignorelist_create (1);
-    if (il_block_devices == NULL)
-        il_block_devices = ignorelist_create (1);
-    if (il_interface_devices == NULL)
-        il_interface_devices = ignorelist_create (1);
+  for (size_t j = 0; j < vm->block.nstats; j++) {
+    const BlockStats *stats =
+        (vm->block.xstats) ? vm->block.xstats : vm->block.stats;
+    const char *name = stats[j].xname ? stats[j].xname : stats[j].name;
 
-    if (strcasecmp (key, "Connection") == 0) {
-        char *tmp = strdup (value);
-        if (tmp == NULL) {
-            ERROR (PLUGIN_NAME " plugin: Connection strdup failed.");
-            return 1;
-        }
-        sfree (conn_string);
-        conn_string = tmp;
-        return 0;
+    if (inst->state->il_block_devices != NULL &&
+        ignore_device_match(inst->state->il_block_devices, vm->name, name) != 0)
+      continue;
+
+    vals[0].derive = stats[j].rd_reqs;
+    vals[1].derive = stats[j].wr_reqs;
+    virt2_submit(inst->conf, vm, "disk_ops", name, vals,
+                 STATIC_ARRAY_SIZE(vals));
+
+    vals[0].derive = stats[j].rd_bytes;
+    vals[1].derive = stats[j].wr_bytes;
+    virt2_submit(inst->conf, vm, "disk_octets", name, vals,
+                 STATIC_ARRAY_SIZE(vals));
+  }
+  return 0;
+}
+
+static int virt2_dispatch_iface(virt2_instance_t *inst, const VMInfo *vm) {
+  value_t vals[2]; // TODO: magic number
+  size_t j;
+
+  for (j = 0; j < vm->iface.nstats; j++) {
+    char iface_num[INTERFACE_NUMBER_MAX_LEN] = {'\0'};
+    const IFaceStats *stats =
+        (vm->iface.xstats) ? vm->iface.xstats : vm->iface.stats;
+    const char *iface_name = stats[j].xname ? stats[j].xname : stats[j].name;
+    const char *display_name = NULL;
+
+    if (inst->state->il_iface_devices != NULL &&
+        ignore_device_match(inst->state->il_iface_devices, vm->name,
+                            iface_name) != 0)
+      // TODO: check match by address
+      continue;
+
+    switch (inst->conf->interface_format) {
+    case if_address:
+      ERROR(PLUGIN_NAME " plugin: not yet supported, fallback to 'name'");
+      display_name = iface_name;
+      break;
+    case if_number:
+      ssnprintf(iface_num, sizeof(iface_num), "interface-%zu", j + 1);
+      display_name = iface_num;
+      break;
+    case if_name: // fallthrough
+    default:
+      display_name = iface_name;
+      break;
     }
 
-    if (strcasecmp (key, "RefreshInterval") == 0) {
-        char *eptr = NULL;
-        interval = strtol (value, &eptr, 10);
-        if (eptr == NULL || *eptr != '\0') return 1;
-        return 0;
-    }
+    vals[0].derive = stats[j].rx_bytes;
+    vals[1].derive = stats[j].tx_bytes;
+    virt2_submit(inst->conf, vm, "if_octets", display_name, vals,
+                 STATIC_ARRAY_SIZE(vals));
 
-    if (strcasecmp (key, "Domain") == 0) {
-        if (ignorelist_add (il_domains, value)) return 1;
-        return 0;
-    }
-    if (strcasecmp (key, "BlockDevice") == 0) {
-        if (ignorelist_add (il_block_devices, value)) return 1;
-        return 0;
-    }
+    vals[0].derive = stats[j].rx_pkts;
+    vals[1].derive = stats[j].tx_pkts;
+    virt2_submit(inst->conf, vm, "if_packets", display_name, vals,
+                 STATIC_ARRAY_SIZE(vals));
 
-    if (strcasecmp (key, "BlockDeviceFormat") == 0) {
-        if (strcasecmp (value, "target") == 0)
-            blockdevice_format = target;
-        else if (strcasecmp (value, "source") == 0)
-            blockdevice_format = source;
-        else {
-            ERROR (PLUGIN_NAME " plugin: unknown BlockDeviceFormat: %s", value);
-            return -1;
-        }
-        return 0;
-    }
-    if (strcasecmp (key, "BlockDeviceFormatBasename") == 0) {
-        blockdevice_format_basename = IS_TRUE (value);
-        return 0;
-    }
-    if (strcasecmp (key, "InterfaceDevice") == 0) {
-        if (ignorelist_add (il_interface_devices, value)) return 1;
-        return 0;
-    }
+    vals[0].derive = stats[j].rx_errs;
+    vals[1].derive = stats[j].tx_errs;
+    virt2_submit(inst->conf, vm, "if_errors", display_name, vals,
+                 STATIC_ARRAY_SIZE(vals));
 
-    if (strcasecmp (key, "IgnoreSelected") == 0) {
-        if (IS_TRUE (value))
-        {
-            ignorelist_set_invert (il_domains, 0);
-            ignorelist_set_invert (il_block_devices, 0);
-            ignorelist_set_invert (il_interface_devices, 0);
-        }
-        else
-        {
-            ignorelist_set_invert (il_domains, 1);
-            ignorelist_set_invert (il_block_devices, 1);
-            ignorelist_set_invert (il_interface_devices, 1);
-        }
-        return 0;
-    }
+    vals[0].derive = stats[j].rx_drop;
+    vals[1].derive = stats[j].tx_drop;
+    virt2_submit(inst->conf, vm, "if_dropped", display_name, vals,
+                 STATIC_ARRAY_SIZE(vals));
+  }
 
-    if (strcasecmp (key, "HostnameFormat") == 0) {
-        char *value_copy;
-        char *fields[HF_MAX_FIELDS];
-        int n;
+  return 0;
+}
 
-        value_copy = strdup (value);
-        if (value_copy == NULL) {
-            ERROR (PLUGIN_NAME " plugin: strdup failed.");
-            return -1;
-        }
+/* *** */
 
-        n = strsplit (value_copy, fields, HF_MAX_FIELDS);
-        if (n < 1) {
-            sfree (value_copy);
-            ERROR (PLUGIN_NAME " plugin: HostnameFormat: no fields");
-            return -1;
-        }
+static size_t virt2_get_optimal_instance_count(virt2_context_t *ctx) {
+  /*
+   * TODO: if ctx->conf.instances == -1, query libvirt using
+   * the ADMIN API for the worker thread pool size, and return
+   * that value.
+   */
+  size_t num = ctx->conf.instances;
+  if (num == 0) {
+    num = INSTANCES_DEFAULT_NUM;
+  }
+  INFO(PLUGIN_NAME " plugin: using %zu instances (configured=%zu)", num,
+       ctx->conf.instances);
+  return num;
+}
 
-        for (int i = 0; i < n; ++i) {
-            if (strcasecmp (fields[i], "hostname") == 0)
-                hostname_format[i] = hf_hostname;
-            else if (strcasecmp (fields[i], "name") == 0)
-                hostname_format[i] = hf_name;
-            else if (strcasecmp (fields[i], "uuid") == 0)
-                hostname_format[i] = hf_uuid;
-            else {
-                ERROR (PLUGIN_NAME " plugin: unknown HostnameFormat field: %s", fields[i]);
-                sfree (value_copy);
-                return -1;
-            }
-        }
-        sfree (value_copy);
+static int virt2_init_instance(virt2_context_t *ctx, size_t i,
+                               int (*func_body)(user_data_t *ud)) {
+  virt2_user_data_t *user_data = &(ctx->user_data[i]);
 
-        for (int i = n; i < HF_MAX_FIELDS; ++i)
-            hostname_format[i] = hf_none;
+  virt2_instance_t *inst = &user_data->inst;
+  ssnprintf(inst->tag, sizeof(inst->tag), "virt-%zu", i);
+  inst->state = &ctx->state;
+  inst->conf = &ctx->conf;
+  inst->id = i;
 
-        return 0;
-    }
+  user_data_t *ud = &user_data->ud;
+  ud->data = inst;
+  ud->free_func = NULL;
 
-    if (strcasecmp (key, "PluginInstanceFormat") == 0) {
-        char *value_copy;
-        char *fields[PLGINST_MAX_FIELDS];
-        int n;
+  g_hash_table_add(ctx->state.known_tags, inst->tag);
+  return plugin_register_complex_read(NULL, inst->tag, func_body,
+                                      ctx->conf.interval, ud);
+}
 
-        value_copy = strdup (value);
-        if (value_copy == NULL) {
-            ERROR (PLUGIN_NAME " plugin: strdup failed.");
-            return -1;
-        }
+static int virt2_domain_get_tag(virt2_domain_t *vdom, const char *xml) {
+  char xpath_str[BUFFER_MAX_LEN] = {'\0'};
+  xmlDocPtr xml_doc = NULL;
+  xmlXPathContextPtr xpath_ctx = NULL;
+  xmlXPathObjectPtr xpath_obj = NULL;
+  xmlNodePtr xml_node = NULL;
+  int err = -1;
 
-        n = strsplit (value_copy, fields, PLGINST_MAX_FIELDS);
-        if (n < 1) {
-            sfree (value_copy);
-            ERROR (PLUGIN_NAME " plugin: PluginInstanceFormat: no fields");
-            return -1;
-        }
+  if (xml == NULL) {
+    ERROR(PLUGIN_NAME " plugin: xmlReadDoc() NULL XML on domain %s",
+          vdom->uuid);
+    goto done;
+  }
 
-        for (int i = 0; i < n; ++i) {
-            if (strcasecmp (fields[i], "none") == 0) {
-                plugin_instance_format[i] = plginst_none;
-                break;
-            } else if (strcasecmp (fields[i], "name") == 0)
-                plugin_instance_format[i] = plginst_name;
-            else if (strcasecmp (fields[i], "uuid") == 0)
-                plugin_instance_format[i] = plginst_uuid;
-            else {
-                ERROR (PLUGIN_NAME " plugin: unknown PluginInstanceFormat field: %s", fields[i]);
-                sfree (value_copy);
-                return -1;
-            }
-        }
-        sfree (value_copy);
+  xml_doc = xmlReadDoc((const xmlChar *)xml, NULL, NULL,
+                       XML_PARSE_NONET | XML_PARSE_NSCLEAN);
+  if (xml_doc == NULL) {
+    ERROR(PLUGIN_NAME " plugin: xmlReadDoc() failed on domain %s", vdom->uuid);
+    goto done;
+  }
 
-        for (int i = n; i < PLGINST_MAX_FIELDS; ++i)
-            plugin_instance_format[i] = plginst_none;
+  xpath_ctx = xmlXPathNewContext(xml_doc);
+  err = xmlXPathRegisterNs(xpath_ctx,
+                           (const xmlChar *)METADATA_VM_PARTITION_PREFIX,
+                           (const xmlChar *)METADATA_VM_PARTITION_URI);
+  if (err) {
+    ERROR(PLUGIN_NAME " plugin: xmlXpathRegisterNs(%s, %s) failed on domain %s",
+          METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_URI, vdom->uuid);
+    goto done;
+  }
 
-        return 0;
-    }
+  ssnprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
+            METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
+  xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
+  if (xpath_obj == NULL) {
+    ERROR(PLUGIN_NAME " plugin: xmlXPathEval(%s) failed on domain %s",
+          xpath_str, vdom->uuid);
+    goto done;
+  }
 
-    if (strcasecmp (key, "InterfaceFormat") == 0) {
-        if (strcasecmp (value, "name") == 0)
-            interface_format = if_name;
-        else if (strcasecmp (value, "address") == 0)
-            interface_format = if_address;
-        else if (strcasecmp (value, "number") == 0)
-            interface_format = if_number;
-        else {
-            ERROR (PLUGIN_NAME " plugin: unknown InterfaceFormat: %s", value);
-            return -1;
-        }
-        return 0;
-    }
+  if (xpath_obj->type != XPATH_NODESET) {
+    ERROR(PLUGIN_NAME " plugin: xmlXPathEval(%s) unexpected return type %d "
+                      "(wanted %d) on domain %s",
+          xpath_str, xpath_obj->type, XPATH_NODESET, vdom->uuid);
+    goto done;
+  }
 
-    /* Unrecognised option. */
+  /*
+   * from now on there is no real error, it's ok if a domain
+   * doesn't have the metadata partition tag.
+   */
+  err = 0;
+
+  if (xpath_obj->nodesetval == NULL || xpath_obj->nodesetval->nodeNr != 1) {
+    DEBUG(PLUGIN_NAME " plugin: xmlXPathEval(%s) return nodeset size=%i "
+                      "expected=1 on domain %s",
+          xpath_str,
+          (xpath_obj->nodesetval == NULL) ? 0 : xpath_obj->nodesetval->nodeNr,
+          vdom->uuid);
+  } else {
+    xml_node = xpath_obj->nodesetval->nodeTab[0];
+    sstrncpy(vdom->tag, (const char *)xml_node->content, sizeof(vdom->tag));
+  }
+
+done:
+  if (xpath_obj)
+    xmlXPathFreeObject(xpath_obj);
+  if (xpath_ctx)
+    xmlXPathFreeContext(xpath_ctx);
+  if (xml_doc)
+    xmlFreeDoc(xml_doc);
+
+  return err;
+}
+
+static int virt2_acquire_domains(virt2_instance_t *inst) {
+  unsigned int flags = VIR_CONNECT_LIST_DOMAINS_RUNNING;
+  int ret =
+      virConnectListAllDomains(inst->state->conn, &inst->domains_all, flags);
+  if (ret < 0) {
+    ERROR(PLUGIN_NAME " plugin#%s: virConnectListAllDomains failed: %s",
+          inst->tag, virGetLastErrorMessage());
     return -1;
+  }
+  inst->domains_num = (size_t)ret;
+  DEBUG(PLUGIN_NAME " plugin#%s: found %i domains", inst->tag,
+        inst->domains_num);
+
+  if (inst->domains_num == 0)
+    return 1;
+  return 0;
 }
 
-static int
-lv_read (void)
-{
-    time_t t;
+static void virt2_release_domains(virt2_instance_t *inst) {
+  for (size_t i = 0; i < inst->domains_num; i++)
+    virDomainFree(inst->domains_all[i]);
+  sfree(inst->domains_all);
+  inst->domains_num = 0;
+}
 
-    if (conn == NULL) {
-        /* `conn_string == NULL' is acceptable. */
-        conn = virConnectOpenReadOnly (conn_string);
-        if (conn == NULL) {
-            c_complain (LOG_ERR, &conn_complain,
-                    PLUGIN_NAME " plugin: Unable to connect: "
-                    "virConnectOpenReadOnly failed.");
-            return -1;
-        }
+static int virt2_dispatch_samples(virt2_instance_t *inst,
+                                  virDomainStatsRecordPtr *records,
+                                  int records_num) {
+  for (int i = 0; i < records_num; i++) {
+    VMInfo vm;
+    vminfo_init(&vm);
+    vminfo_parse(&vm, records[i], TRUE);
+
+    virt2_dispatch_cpu(inst, &vm);
+    virt2_dispatch_memory(inst, &vm);
+    virt2_dispatch_block(inst, &vm);
+    virt2_dispatch_iface(inst, &vm);
+
+    vminfo_free(&vm);
+  }
+  return 0;
+}
+
+static int virt2_sample_domains(virt2_instance_t *inst, GArray *doms) {
+  if (doms->len == 0) // nothing to do, and it's OK
+    return 0;
+
+  virDomainStatsRecordPtr *records = NULL;
+  int ret =
+      virDomainListGetStats(((virDomainPtr *)doms->data), inst->conf->stats,
+                            &records, inst->conf->flags);
+  if (ret == -1)
+    return ret;
+
+  int records_num = ret;
+  ret = virt2_dispatch_samples(inst, records, records_num);
+  virDomainStatsRecordListFree(records);
+
+  return ret;
+}
+
+static int virt2_domain_init(virt2_domain_t *vdom, virDomainPtr dom) {
+  memset(vdom, 0, sizeof(*vdom));
+  vdom->dom = dom;
+  virDomainGetUUIDString(dom, vdom->uuid);
+
+  unsigned int flags = 0;
+  char *dom_xml = virDomainGetXMLDesc(dom, flags);
+  if (dom_xml == NULL) {
+    ERROR(PLUGIN_NAME " plugin: domain %s don't provide XML: %s", vdom->uuid,
+          virGetLastErrorMessage());
+    return -1;
+  }
+
+  int err = virt2_domain_get_tag(vdom, dom_xml);
+  sfree(dom_xml);
+  return err;
+}
+
+static int virt2_instance_include_domain(virt2_domain_t *vdom,
+                                         virt2_instance_t *inst) {
+  /* instance#0 will always be there, so it is in charge of extra duties */
+  if (inst->id == 0) {
+    if (vdom->tag[0] == '\0' ||
+        !g_hash_table_contains(inst->state->known_tags, vdom->tag)) {
+      if (inst->conf->debug_partitioning)
+        WARNING(PLUGIN_NAME " plugin#%s: adopted domain %s "
+                            "with unknown tag '%s'",
+                inst->tag, vdom->uuid, vdom->tag);
+      return 1;
     }
-    c_release (LOG_NOTICE, &conn_complain,
-            PLUGIN_NAME " plugin: Connection established.");
+  }
+  return (strcmp(vdom->tag, inst->tag) == 0);
+}
 
-    time (&t);
+static int virt2_domain_ignored(virt2_instance_t *inst, virDomainPtr dom) {
+  const char *name = virDomainGetName(dom);
+  return (inst->state->il_domains &&
+          ignorelist_match(inst->state->il_domains, name) != 0);
+}
 
-    /* Need to refresh domain or device lists? */
-    if ((last_refresh == (time_t) 0) ||
-            ((interval > 0) && ((last_refresh + interval) <= t))) {
-        if (refresh_lists () != 0) {
-            if (conn != NULL)
-                virConnectClose (conn);
-            conn = NULL;
-            return -1;
-        }
-        last_refresh = t;
+static GArray *virt2_partition_domains(virt2_instance_t *inst) {
+  GArray *doms =
+      g_array_sized_new(TRUE, FALSE, sizeof(virDomainPtr), inst->domains_num);
+  if (!doms) {
+    ERROR(PLUGIN_NAME " plugin#%s: cannot allocate the libvirt domain "
+                      "partition (%zu domains)",
+          inst->tag, inst->domains_num);
+    return NULL;
+  }
+
+  for (size_t i = 0; i < inst->domains_num; i++) {
+    virt2_domain_t vdom = {NULL};
+    int err;
+    if (virt2_domain_ignored(inst, inst->domains_all[i]))
+      continue;
+    err = virt2_domain_init(&vdom, inst->domains_all[i]);
+    if (err)
+      continue;
+    if (!virt2_instance_include_domain(&vdom, inst))
+      continue;
+
+    g_array_append_val(doms, (inst->domains_all[i]));
+  }
+
+  return doms;
+}
+
+int virt2_read_domains(user_data_t *ud) {
+  int err;
+  virt2_instance_t *inst = ud->data;
+  if (!inst) {
+    ERROR(PLUGIN_NAME " plugin: NULL userdata");
+    return -1;
+  }
+
+  err = virt2_acquire_domains(inst);
+  if (err)
+    return -1;
+
+  if (inst->domains_num == 0)
+    return 0; /* nothing to do here, but it's OK */
+
+  GArray *doms = virt2_partition_domains(inst);
+  if (doms != NULL) {
+    err = virt2_sample_domains(inst, doms);
+    g_array_free(doms, TRUE);
+  } else
+    err = -1;
+
+  virt2_release_domains(inst);
+  return err;
+}
+
+static int virt2_setup(virt2_context_t *ctx) {
+  ctx->state.known_tags = g_hash_table_new(g_str_hash, g_str_equal);
+  ctx->state.il_domains = NULL;       /* will be created lazily */
+  ctx->state.il_block_devices = NULL; /* ditto */
+  ctx->state.il_iface_devices = NULL; /* ditto */
+
+  for (size_t i = 0; i < ctx->state.instances; i++)
+    virt2_init_instance(ctx, i, virt2_read_domains);
+
+  return 0;
+}
+
+static int virt2_teardown(virt2_context_t *ctx) {
+  if (ctx->state.il_domains != NULL)
+    ignorelist_free(ctx->state.il_domains);
+  if (ctx->state.il_block_devices != NULL)
+    ignorelist_free(ctx->state.il_block_devices);
+  if (ctx->state.il_iface_devices != NULL)
+    ignorelist_free(ctx->state.il_iface_devices);
+
+  g_hash_table_destroy(ctx->state.known_tags);
+  return 0;
+}
+
+/* *** */
+
+int virt2_config(const char *key, const char *value) {
+  virt2_context_t *ctx = virt2_get_default_context();
+  virt2_config_t *cfg = &ctx->conf;
+
+  if (strcasecmp(key, "Connection") == 0) {
+    char *tmp = sstrdup(value);
+    if (tmp == NULL) {
+      ERROR(PLUGIN_NAME " plugin: Connection strdup failed.");
+      return 1;
+    }
+    sfree(cfg->connection_uri);
+    cfg->connection_uri = tmp;
+    return 0;
+  }
+  if (strcasecmp(key, "Instances") == 0) {
+    char *eptr = NULL;
+    long val = strtol(value, &eptr, 10);
+    if (eptr == NULL || *eptr != '\0')
+      return 1;
+    if (val <= 0) {
+      // TODO: remove once we have autotune using libvirt admin API
+      ERROR(PLUGIN_NAME " plugin: Instances <= 0 makes no sense.");
+      return 1;
+    }
+    if (val > INSTANCES_MAX) {
+      ERROR(PLUGIN_NAME " plugin: Instances=%li > INSTANCES_MAX=%i"
+                        " use a lower setting or recompile the plugin.",
+            val, INSTANCES_MAX);
+      return 1;
+    }
+    cfg->instances = val;
+    return 0;
+  }
+  if (strcasecmp(key, "RefreshInterval") == 0) {
+    char *eptr = NULL;
+    double val = strtod(value, &eptr);
+    if (eptr == NULL || *eptr != '\0')
+      return 1;
+    if (val <= 0) {
+      ERROR(PLUGIN_NAME " plugin: RefreshInterval <= 0 makes no sense.");
+      return 1;
+    }
+    cfg->interval = DOUBLE_TO_CDTIME_T(val);
+    return 0;
+  }
+  if (strcasecmp(key, "DebugPartitioning") == 0) {
+    cfg->debug_partitioning = IS_TRUE(value);
+    return 0;
+  }
+
+  if (strcasecmp(key, "Domain") == 0) {
+    if (ctx->state.il_domains == NULL)
+      ctx->state.il_domains = ignorelist_create(1);
+    if (ignorelist_add(ctx->state.il_domains, value))
+      return 1;
+    return 0;
+  }
+  if (strcasecmp(key, "BlockDevice") == 0) {
+    if (ctx->state.il_block_devices == NULL)
+      ctx->state.il_block_devices = ignorelist_create(1);
+    if (ignorelist_add(ctx->state.il_block_devices, value))
+      return 1;
+    return 0;
+  }
+  if (strcasecmp(key, "InterfaceDevice") == 0) {
+    if (ctx->state.il_iface_devices == NULL)
+      ctx->state.il_iface_devices = ignorelist_create(1);
+    if (ignorelist_add(ctx->state.il_iface_devices, value))
+      return 1;
+    return 0;
+  }
+
+  if (strcasecmp(key, "IgnoreSelected") == 0) {
+    if (IS_TRUE(value)) {
+      ignorelist_set_invert(ctx->state.il_domains, 0);
+      ignorelist_set_invert(ctx->state.il_block_devices, 0);
+      ignorelist_set_invert(ctx->state.il_iface_devices, 0);
+    } else {
+      ignorelist_set_invert(ctx->state.il_domains, 1);
+      ignorelist_set_invert(ctx->state.il_block_devices, 1);
+      ignorelist_set_invert(ctx->state.il_iface_devices, 1);
+    }
+    return 0;
+  }
+  if (strcasecmp(key, "HostnameFormat") == 0) {
+    int i, n;
+    char *fields[HF_MAX_FIELDS];
+    char *value_copy = strdup(value);
+    if (value_copy == NULL) {
+      ERROR(PLUGIN_NAME " plugin: strdup failed.");
+      return -1;
     }
 
-#if 0
-    for (int i = 0; i < nr_domains; ++i)
-        fprintf (stderr, "domain %s\n", virDomainGetName (domains[i]));
-    for (int i = 0; i < nr_block_devices; ++i)
-        fprintf  (stderr, "block device %d %s:%s\n",
-                  i, virDomainGetName (block_devices[i].dom),
-                  block_devices[i].path);
-    for (int i = 0; i < nr_interface_devices; ++i)
-        fprintf (stderr, "interface device %d %s:%s\n",
-                 i, virDomainGetName (interface_devices[i].dom),
-                 interface_devices[i].path);
-#endif
-
-    /* Get CPU usage, memory, VCPU usage for each domain. */
-    for (int i = 0; i < nr_domains; ++i) {
-        virDomainInfo info;
-        virVcpuInfoPtr vinfo = NULL;
-        virDomainMemoryStatPtr minfo = NULL;
-        int status;
-
-        status = virDomainGetInfo (domains[i], &info);
-        if (status != 0)
-        {
-            ERROR (PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
-                    status);
-            continue;
-        }
-
-        if (info.state != VIR_DOMAIN_RUNNING)
-        {
-            /* only gather stats for running domains */
-            continue;
-        }
-
-        cpu_submit (info.cpuTime, domains[i], "virt_cpu_total");
-        memory_submit ((gauge_t) info.memory * 1024, domains[i]);
-
-        vinfo = malloc (info.nrVirtCpu * sizeof (vinfo[0]));
-        if (vinfo == NULL) {
-            ERROR (PLUGIN_NAME " plugin: malloc failed.");
-            continue;
-        }
-
-        status = virDomainGetVcpus (domains[i], vinfo, info.nrVirtCpu,
-                /* cpu map = */ NULL, /* cpu map length = */ 0);
-        if (status < 0)
-        {
-            ERROR (PLUGIN_NAME " plugin: virDomainGetVcpus failed with status %i.",
-                    status);
-            sfree (vinfo);
-            continue;
-        }
-
-        for (int j = 0; j < info.nrVirtCpu; ++j)
-            vcpu_submit (vinfo[j].cpuTime,
-                    domains[i], vinfo[j].number, "virt_vcpu");
-
-        sfree (vinfo);
-
-        minfo = malloc (VIR_DOMAIN_MEMORY_STAT_NR * sizeof (virDomainMemoryStatStruct));
-        if (minfo == NULL) {
-            ERROR ("virt plugin: malloc failed.");
-            continue;
-        }
-
-        status = virDomainMemoryStats (domains[i], minfo, VIR_DOMAIN_MEMORY_STAT_NR, 0);
-
-        if (status < 0) {
-            ERROR ("virt plugin: virDomainMemoryStats failed with status %i.",
-                    status);
-            sfree (minfo);
-            continue;
-        }
-
-        for (int j = 0; j < status; j++) {
-            memory_stats_submit ((gauge_t) minfo[j].val * 1024, domains[i], minfo[j].tag);
-        }
-
-        sfree (minfo);
+    n = strsplit(value_copy, fields, HF_MAX_FIELDS);
+    if (n < 1) {
+      sfree(value_copy);
+      ERROR(PLUGIN_NAME " plugin: HostnameFormat: no fields");
+      return -1;
     }
 
+    for (i = 0; i < n; ++i) {
+      if (strcasecmp(fields[i], "hostname") == 0)
+        cfg->hostname_format[i] = hf_hostname;
+      else if (strcasecmp(fields[i], "name") == 0)
+        cfg->hostname_format[i] = hf_name;
+      else if (strcasecmp(fields[i], "uuid") == 0)
+        cfg->hostname_format[i] = hf_uuid;
+      else {
+        ERROR(PLUGIN_NAME " plugin: unknown HostnameFormat field: %s",
+              fields[i]);
+        sfree(value_copy);
+        return -1;
+      }
+    }
+    sfree(value_copy);
 
-    /* Get block device stats for each domain. */
-    for (int i = 0; i < nr_block_devices; ++i) {
-        struct _virDomainBlockStats stats;
-
-        if (virDomainBlockStats (block_devices[i].dom, block_devices[i].path,
-                    &stats, sizeof stats) != 0)
-            continue;
-
-        char *type_instance = NULL;
-        if (blockdevice_format_basename && blockdevice_format == source)
-            type_instance = strdup(basename(block_devices[i].path));
-        else
-            type_instance = strdup(block_devices[i].path);
-
-        if ((stats.rd_req != -1) && (stats.wr_req != -1))
-            submit_derive2 ("disk_ops",
-                    (derive_t) stats.rd_req, (derive_t) stats.wr_req,
-                    block_devices[i].dom, type_instance);
-
-        if ((stats.rd_bytes != -1) && (stats.wr_bytes != -1))
-            submit_derive2 ("disk_octets",
-                    (derive_t) stats.rd_bytes, (derive_t) stats.wr_bytes,
-                    block_devices[i].dom, type_instance);
-
-        sfree (type_instance);
-    } /* for (nr_block_devices) */
-
-    /* Get interface stats for each domain. */
-    for (int i = 0; i < nr_interface_devices; ++i) {
-        struct _virDomainInterfaceStats stats;
-        char *display_name = NULL;
-
-        switch (interface_format) {
-            case if_address:
-                display_name = interface_devices[i].address;
-                break;
-            case if_number:
-                display_name = interface_devices[i].number;
-                break;
-            case if_name:
-            default:
-                display_name = interface_devices[i].path;
-        }
-
-        if (virDomainInterfaceStats (interface_devices[i].dom,
-                    interface_devices[i].path,
-                    &stats, sizeof stats) != 0)
-            continue;
-
-	if ((stats.rx_bytes != -1) && (stats.tx_bytes != -1))
-	    submit_derive2 ("if_octets",
-		    (derive_t) stats.rx_bytes, (derive_t) stats.tx_bytes,
-		    interface_devices[i].dom, display_name);
-
-	if ((stats.rx_packets != -1) && (stats.tx_packets != -1))
-	    submit_derive2 ("if_packets",
-		    (derive_t) stats.rx_packets, (derive_t) stats.tx_packets,
-		    interface_devices[i].dom, display_name);
-
-	if ((stats.rx_errs != -1) && (stats.tx_errs != -1))
-	    submit_derive2 ("if_errors",
-		    (derive_t) stats.rx_errs, (derive_t) stats.tx_errs,
-		    interface_devices[i].dom, display_name);
-
-	if ((stats.rx_drop != -1) && (stats.tx_drop != -1))
-	    submit_derive2 ("if_dropped",
-		    (derive_t) stats.rx_drop, (derive_t) stats.tx_drop,
-		    interface_devices[i].dom, display_name);
-    } /* for (nr_interface_devices) */
+    for (i = n; i < HF_MAX_FIELDS; ++i)
+      cfg->hostname_format[i] = hf_none;
 
     return 0;
-}
+  }
+  if (strcasecmp(key, "PluginInstanceFormat") == 0) {
+    int i, n;
+    char *fields[PLGINST_MAX_FIELDS];
+    char *value_copy = strdup(value);
+    if (value_copy == NULL) {
+      ERROR(PLUGIN_NAME " plugin: strdup failed.");
+      return -1;
+    }
 
-static int
-refresh_lists (void)
-{
-    int n;
+    n = strsplit(value_copy, fields, PLGINST_MAX_FIELDS);
+    if (n < 1) {
+      sfree(value_copy);
+      ERROR(PLUGIN_NAME " plugin: PluginInstanceFormat: no fields");
+      return -1;
+    }
 
-    n = virConnectNumOfDomains (conn);
-    if (n < 0) {
-        VIRT_ERROR (conn, "reading number of domains");
+    for (i = 0; i < n; ++i) {
+      if (strcasecmp(fields[i], "none") == 0) {
+        cfg->plugin_instance_format[i] = plginst_none;
+        break;
+      } else if (strcasecmp(fields[i], "name") == 0)
+        cfg->plugin_instance_format[i] = plginst_name;
+      else if (strcasecmp(fields[i], "uuid") == 0)
+        cfg->plugin_instance_format[i] = plginst_uuid;
+      else {
+        ERROR(PLUGIN_NAME " plugin: unknown PluginInstanceFormat field: %s",
+              fields[i]);
+        sfree(value_copy);
         return -1;
+      }
     }
+    sfree(value_copy);
 
-    if (n > 0) {
-        int *domids;
-
-        /* Get list of domains. */
-        domids = malloc (sizeof (*domids) * n);
-        if (domids == NULL) {
-            ERROR (PLUGIN_NAME " plugin: malloc failed.");
-            return -1;
-        }
-
-        n = virConnectListDomains (conn, domids, n);
-        if (n < 0) {
-            VIRT_ERROR (conn, "reading list of domains");
-            sfree (domids);
-            return -1;
-        }
-
-        free_block_devices ();
-        free_interface_devices ();
-        free_domains ();
-
-        /* Fetch each domain and add it to the list, unless ignore. */
-        for (int i = 0; i < n; ++i) {
-            virDomainPtr dom = NULL;
-            const char *name;
-            char *xml = NULL;
-            xmlDocPtr xml_doc = NULL;
-            xmlXPathContextPtr xpath_ctx = NULL;
-            xmlXPathObjectPtr xpath_obj = NULL;
-
-            dom = virDomainLookupByID (conn, domids[i]);
-            if (dom == NULL) {
-                VIRT_ERROR (conn, "virDomainLookupByID");
-                /* Could be that the domain went away -- ignore it anyway. */
-                continue;
-            }
-
-            name = virDomainGetName (dom);
-            if (name == NULL) {
-                VIRT_ERROR (conn, "virDomainGetName");
-                goto cont;
-            }
-
-            if (il_domains && ignorelist_match (il_domains, name) != 0)
-                goto cont;
-
-            if (add_domain (dom) < 0) {
-                ERROR (PLUGIN_NAME " plugin: malloc failed.");
-                goto cont;
-            }
-
-            /* Get a list of devices for this domain. */
-            xml = virDomainGetXMLDesc (dom, 0);
-            if (!xml) {
-                VIRT_ERROR (conn, "virDomainGetXMLDesc");
-                goto cont;
-            }
-
-            /* Yuck, XML.  Parse out the devices. */
-            xml_doc = xmlReadDoc ((xmlChar *) xml, NULL, NULL, XML_PARSE_NONET);
-            if (xml_doc == NULL) {
-                VIRT_ERROR (conn, "xmlReadDoc");
-                goto cont;
-            }
-
-            xpath_ctx = xmlXPathNewContext (xml_doc);
-
-            /* Block devices. */
-            char *bd_xmlpath = "/domain/devices/disk/target[@dev]";
-            if (blockdevice_format == source)
-                bd_xmlpath = "/domain/devices/disk/source[@dev]";
-            xpath_obj = xmlXPathEval ((xmlChar *) bd_xmlpath, xpath_ctx);
-
-            if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
-                xpath_obj->nodesetval == NULL)
-                goto cont;
-
-            for (int j = 0; j < xpath_obj->nodesetval->nodeNr; ++j) {
-                xmlNodePtr node;
-                char *path = NULL;
-
-                node = xpath_obj->nodesetval->nodeTab[j];
-                if (!node) continue;
-                path = (char *) xmlGetProp (node, (xmlChar *) "dev");
-                if (!path) continue;
-
-                if (il_block_devices &&
-                    ignore_device_match (il_block_devices, name, path) != 0)
-                    goto cont2;
-
-                add_block_device (dom, path);
-            cont2:
-                if (path) xmlFree (path);
-            }
-            xmlXPathFreeObject (xpath_obj);
-
-            /* Network interfaces. */
-            xpath_obj = xmlXPathEval
-                ((xmlChar *) "/domain/devices/interface[target[@dev]]",
-                 xpath_ctx);
-            if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
-                xpath_obj->nodesetval == NULL)
-                goto cont;
-
-            xmlNodeSetPtr xml_interfaces = xpath_obj->nodesetval;
-
-            for (int j = 0; j < xml_interfaces->nodeNr; ++j) {
-                char *path = NULL;
-                char *address = NULL;
-                xmlNodePtr xml_interface;
-
-                xml_interface = xml_interfaces->nodeTab[j];
-                if (!xml_interface) continue;
-
-                for (xmlNodePtr child = xml_interface->children; child; child = child->next) {
-                    if (child->type != XML_ELEMENT_NODE) continue;
-
-                    if (xmlStrEqual(child->name, (const xmlChar *) "target")) {
-                        path = (char *) xmlGetProp (child, (const xmlChar *) "dev");
-                        if (!path) continue;
-                    } else if (xmlStrEqual(child->name, (const xmlChar *) "mac")) {
-                        address = (char *) xmlGetProp (child, (const xmlChar *) "address");
-                        if (!address) continue;
-                    }
-                }
-
-                if (il_interface_devices &&
-                    (ignore_device_match (il_interface_devices, name, path) != 0 ||
-                     ignore_device_match (il_interface_devices, name, address) != 0))
-                    goto cont3;
-
-                add_interface_device (dom, path, address, j+1);
-                cont3:
-                    if (path) xmlFree (path);
-                    if (address) xmlFree (address);
-            }
-
-        cont:
-            if (xpath_obj) xmlXPathFreeObject (xpath_obj);
-            if (xpath_ctx) xmlXPathFreeContext (xpath_ctx);
-            if (xml_doc) xmlFreeDoc (xml_doc);
-            sfree (xml);
-        }
-
-        sfree (domids);
-    }
+    for (i = n; i < PLGINST_MAX_FIELDS; ++i)
+      cfg->plugin_instance_format[i] = plginst_none;
 
     return 0;
-}
+  }
 
-static void
-free_domains (void)
-{
-    if (domains) {
-        for (int i = 0; i < nr_domains; ++i)
-            virDomainFree (domains[i]);
-        sfree (domains);
+  if (strcasecmp(key, "InterfaceFormat") == 0) {
+    if (strcasecmp(value, "name") == 0)
+      cfg->interface_format = if_name;
+    else if (strcasecmp(value, "address") == 0)
+      cfg->interface_format = if_address;
+    else if (strcasecmp(value, "number") == 0)
+      cfg->interface_format = if_number;
+    else {
+      ERROR(PLUGIN_NAME " plugin: unknown InterfaceFormat: %s", value);
+      return -1;
     }
-    domains = NULL;
-    nr_domains = 0;
-}
-
-static int
-add_domain (virDomainPtr dom)
-{
-    virDomainPtr *new_ptr;
-    int new_size = sizeof (domains[0]) * (nr_domains+1);
-
-    if (domains)
-        new_ptr = realloc (domains, new_size);
-    else
-        new_ptr = malloc (new_size);
-
-    if (new_ptr == NULL)
-        return -1;
-
-    domains = new_ptr;
-    domains[nr_domains] = dom;
-    return nr_domains++;
-}
-
-static void
-free_block_devices (void)
-{
-    if (block_devices) {
-        for (int i = 0; i < nr_block_devices; ++i)
-            sfree (block_devices[i].path);
-        sfree (block_devices);
-    }
-    block_devices = NULL;
-    nr_block_devices = 0;
-}
-
-static int
-add_block_device (virDomainPtr dom, const char *path)
-{
-    struct block_device *new_ptr;
-    int new_size = sizeof (block_devices[0]) * (nr_block_devices+1);
-    char *path_copy;
-
-    path_copy = strdup (path);
-    if (!path_copy)
-        return -1;
-
-    if (block_devices)
-        new_ptr = realloc (block_devices, new_size);
-    else
-        new_ptr = malloc (new_size);
-
-    if (new_ptr == NULL) {
-        sfree (path_copy);
-        return -1;
-    }
-    block_devices = new_ptr;
-    block_devices[nr_block_devices].dom = dom;
-    block_devices[nr_block_devices].path = path_copy;
-    return nr_block_devices++;
-}
-
-static void
-free_interface_devices (void)
-{
-    if (interface_devices) {
-        for (int i = 0; i < nr_interface_devices; ++i) {
-            sfree (interface_devices[i].path);
-            sfree (interface_devices[i].address);
-            sfree (interface_devices[i].number);
-        }
-        sfree (interface_devices);
-    }
-    interface_devices = NULL;
-    nr_interface_devices = 0;
-}
-
-static int
-add_interface_device (virDomainPtr dom, const char *path, const char *address, unsigned int number)
-{
-    struct interface_device *new_ptr;
-    int new_size = sizeof (interface_devices[0]) * (nr_interface_devices+1);
-    char *path_copy, *address_copy, number_string[15];
-
-    if ((path == NULL) || (address == NULL))
-        return EINVAL;
-
-    path_copy = strdup (path);
-    if (!path_copy) return -1;
-
-    address_copy = strdup (address);
-    if (!address_copy) {
-        sfree(path_copy);
-        return -1;
-    }
-
-    snprintf(number_string, sizeof (number_string), "interface-%u", number);
-
-    if (interface_devices)
-        new_ptr = realloc (interface_devices, new_size);
-    else
-        new_ptr = malloc (new_size);
-
-    if (new_ptr == NULL) {
-        sfree (path_copy);
-        sfree (address_copy);
-        return -1;
-    }
-    interface_devices = new_ptr;
-    interface_devices[nr_interface_devices].dom = dom;
-    interface_devices[nr_interface_devices].path = path_copy;
-    interface_devices[nr_interface_devices].address = address_copy;
-    interface_devices[nr_interface_devices].number = strdup(number_string);
-    return nr_interface_devices++;
-}
-
-static int
-ignore_device_match (ignorelist_t *il, const char *domname, const char *devpath)
-{
-    char *name;
-    int n, r;
-
-    if ((domname == NULL) || (devpath == NULL))
-        return 0;
-
-    n = sizeof (char) * (strlen (domname) + strlen (devpath) + 2);
-    name = malloc (n);
-    if (name == NULL) {
-        ERROR (PLUGIN_NAME " plugin: malloc failed.");
-        return 0;
-    }
-    ssnprintf (name, n, "%s:%s", domname, devpath);
-    r = ignorelist_match (il, name);
-    sfree (name);
-    return r;
-}
-
-static int
-lv_shutdown (void)
-{
-    free_block_devices ();
-    free_interface_devices ();
-    free_domains ();
-
-    if (conn != NULL)
-        virConnectClose (conn);
-    conn = NULL;
-
-    ignorelist_free (il_domains);
-    il_domains = NULL;
-    ignorelist_free (il_block_devices);
-    il_block_devices = NULL;
-    ignorelist_free (il_interface_devices);
-    il_interface_devices = NULL;
-
     return 0;
+  }
+
+  /* Unrecognised option. */
+  return -1;
 }
 
-void
-module_register (void)
-{
-    plugin_register_config (PLUGIN_NAME,
-    lv_config,
-    config_keys, NR_CONFIG_KEYS);
-    plugin_register_init (PLUGIN_NAME, lv_init);
-    plugin_register_read (PLUGIN_NAME, lv_read);
-    plugin_register_shutdown (PLUGIN_NAME, lv_shutdown);
+static int virt2_init(void) {
+  virt2_context_t *ctx = virt2_get_default_context();
+  ctx->state.instances = virt2_get_optimal_instance_count(ctx);
+
+  ctx->state.conn = virConnectOpenReadOnly(ctx->conf.connection_uri);
+  if (ctx->state.conn == NULL) {
+    ERROR(PLUGIN_NAME " plugin: Unable to connect: "
+                      "virConnectOpenReadOnly (%s) failed.",
+          ctx->conf.connection_uri);
+    return -1;
+  }
+
+  return virt2_setup(ctx);
 }
 
-/*
- * vim: shiftwidth=4 tabstop=8 softtabstop=4 expandtab fdm=marker
- */
+static int virt2_shutdown(void) {
+  virt2_context_t *ctx = virt2_get_default_context();
+
+  if (ctx->state.conn != NULL)
+    virConnectClose(ctx->state.conn);
+  ctx->state.conn = NULL;
+
+  return virt2_teardown(ctx);
+}
+
+void module_register(void) {
+  plugin_register_config(PLUGIN_NAME, virt2_config, virt2_config_keys,
+                         NR_CONFIG_KEYS);
+  plugin_register_init(PLUGIN_NAME, virt2_init);
+  plugin_register_shutdown(PLUGIN_NAME, virt2_shutdown);
+}
+
+/* vim: set sw=2 sts=2 et : */

--- a/src/virt.c
+++ b/src/virt.c
@@ -533,7 +533,7 @@ static int virt2_acquire_domains(virt2_instance_t *inst) {
     return -1;
   }
   inst->domains_num = (size_t)ret;
-  DEBUG(PLUGIN_NAME " plugin#%s: found %i domains", inst->tag,
+  DEBUG(PLUGIN_NAME " plugin#%s: found %zu domains", inst->tag,
         inst->domains_num);
 
   if (inst->domains_num == 0)

--- a/src/virt.c
+++ b/src/virt.c
@@ -443,7 +443,7 @@ static int virt2_init_instance(virt2_context_t *ctx, size_t i,
   ud->data = inst;
   ud->free_func = NULL;
 
-  g_hash_table_add(ctx->state.known_tags, inst->tag);
+  g_hash_table_insert(ctx->state.known_tags, inst->tag, inst->tag);
   return plugin_register_complex_read(NULL, inst->tag, func_body,
                                       ctx->conf.interval, ud);
 }
@@ -606,8 +606,8 @@ static int virt2_instance_include_domain(virt2_domain_t *vdom,
                                          virt2_instance_t *inst) {
   /* instance#0 will always be there, so it is in charge of extra duties */
   if (inst->id == 0) {
-    if (vdom->tag[0] == '\0' ||
-        !g_hash_table_contains(inst->state->known_tags, vdom->tag)) {
+    if ((vdom->tag[0] == '\0') ||
+        (g_hash_table_lookup(inst->state->known_tags, vdom->tag) == NULL)) {
       if (inst->conf->debug_partitioning)
         WARNING(PLUGIN_NAME " plugin#%s: adopted domain %s "
                             "with unknown tag '%s'",

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -1,0 +1,357 @@
+/**
+ * collectd-ovirt/virt2.c
+ * Copyright (C) 2016 Francesco Romani <fromani at redhat.com>
+ * Based on
+ * collectd - src/ceph_test.c
+ * Copyright (C) 2015      Florian octo Forster
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; only version 2 of the License is applicable.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "virt_test.h"
+
+#include "testing.h"
+#include "virt.c" /* sic */
+
+#include <unistd.h>
+
+enum {
+  DATA_MAX_LEN = 4096,
+};
+
+static const char minimal_xml[] =
+    ""
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
+    "  <metadata/>"
+    "</domain>";
+
+static const char minimal_metadata_xml[] =
+    ""
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
+    "  <metadata>"
+    "    <ovirtmap:tag "
+    "xmlns:ovirtmap=\"http://ovirt.org/ovirtmap/tag/1.0\">virt-0</ovirtmap:tag>"
+    "  </metadata>"
+    "</domain>";
+
+/* TODO: vminfo unit tests */
+
+#define TAG "virt-0"
+DEF_TEST(virt2_domain_get_tag_null_xml) {
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  int err = virt2_domain_get_tag(&vdom, NULL);
+  EXPECT_EQ_INT(-1, err);
+
+  return 0;
+}
+
+DEF_TEST(virt2_domain_get_tag_empty_xml) {
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  int err = virt2_domain_get_tag(&vdom, "");
+  EXPECT_EQ_INT(-1, err);
+
+  return 0;
+}
+
+DEF_TEST(virt2_domain_get_tag_no_metadata_xml) {
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  int err = virt2_domain_get_tag(&vdom, minimal_xml);
+
+  EXPECT_EQ_INT(0, err);
+  EXPECT_EQ_STR("", vdom.tag);
+
+  return 0;
+}
+
+DEF_TEST(virt2_domain_get_tag_valid_xml) {
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  int err = virt2_domain_get_tag(&vdom, minimal_metadata_xml);
+
+  EXPECT_EQ_INT(0, err);
+  EXPECT_EQ_STR(TAG, vdom.tag);
+
+  return 0;
+}
+
+DEF_TEST(virt_default_instance_include_domain_without_tag) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  virt2_instance_t *inst = &(ctx.user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(1, ret);
+
+  inst = &(ctx.user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt_regular_instance_skip_domain_without_tag) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number > 1
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+
+  virt2_instance_t *inst = &(ctx.user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt_default_instance_include_domain_with_unknown_tag) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+  sstrncpy(vdom.tag, "UnknownFormatTag", sizeof(vdom.tag));
+
+  virt2_instance_t *inst = &(ctx.user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(1, ret);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt_regular_instance_skip_domain_with_unknown_tag) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number > 1
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+  sstrncpy(vdom.tag, "UnknownFormatTag", sizeof(vdom.tag));
+
+  virt2_instance_t *inst = &(ctx.user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt_include_domain_matching_tags) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_domain_t vdom;
+  memset(&vdom, 0, sizeof(vdom));
+  sstrncpy(vdom.uuid, "testing", sizeof(vdom.uuid));
+  sstrncpy(vdom.tag, "virt-0", sizeof(vdom.tag));
+
+  virt2_instance_t *inst = &(ctx.user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  ret = virt2_instance_include_domain(&vdom, inst);
+  EXPECT_EQ_INT(1, ret);
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt2_partition_domains_none) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_instance_t *inst = &(ctx.user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  inst->domains_num = 0;
+
+  GArray *part = virt2_partition_domains(inst);
+  EXPECT_EQ_INT(0, part->len);
+  g_array_free(part, TRUE);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+/* we are cheating with pointers anyway, so I'm intentionally using void * */
+static void *alloc_domain(const char *name, const char *uuid,
+                          const char *xml_data) {
+  fakeVirDomainPtr dom = calloc(1, sizeof(struct fakeVirDomain));
+  dom->name = strdup(name);
+  strncpy(dom->uuid, "testing", sizeof(dom->uuid));
+  dom->xml = strdup(xml_data);
+  return dom;
+}
+
+static void free_domain(void *_dom) {
+  fakeVirDomainPtr dom = _dom;
+  free(dom->name);
+  free(dom->xml);
+  free(dom);
+}
+
+DEF_TEST(virt2_partition_domains_one_untagged) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_instance_t *inst = &(ctx.user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  inst->domains_num = 1;
+  inst->domains_all = calloc(1, sizeof(virDomainPtr));
+  inst->domains_all[0] = alloc_domain("test", "testing", minimal_xml);
+
+  GArray *part = virt2_partition_domains(inst);
+  EXPECT_EQ_INT(1, part->len);
+
+  void *_dom = g_array_index(part, virDomainPtr, 0);
+  fakeVirDomainPtr fake_dom = _dom;
+  EXPECT_EQ_STR("testing", fake_dom->uuid);
+
+  g_array_free(part, TRUE);
+
+  free_domain(inst->domains_all[0]);
+  free(inst->domains_all);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+DEF_TEST(virt2_partition_domains_one_untagged_unpicked) {
+  int ret;
+  virt2_context_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.conf.debug_partitioning = 1;
+  ctx.state.instances = 4; // random "low" number
+
+  ret = virt2_setup(&ctx);
+  EXPECT_EQ_INT(0, ret);
+
+  virt2_instance_t *inst = &(ctx.user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+
+  inst->domains_num = 1;
+  inst->domains_all = calloc(1, sizeof(virDomainPtr));
+  inst->domains_all[0] = alloc_domain("test", "testing", minimal_xml);
+
+  GArray *part = virt2_partition_domains(inst);
+  EXPECT_EQ_INT(0, part->len);
+  g_array_free(part, TRUE);
+
+  free_domain(inst->domains_all[0]);
+  free(inst->domains_all);
+
+  ret = virt2_teardown(&ctx);
+  EXPECT_EQ_INT(0, ret);
+  return 0;
+}
+
+#undef TAG
+
+int main(void) {
+  RUN_TEST(virt2_domain_get_tag_null_xml);
+  RUN_TEST(virt2_domain_get_tag_empty_xml);
+  RUN_TEST(virt2_domain_get_tag_no_metadata_xml);
+  RUN_TEST(virt2_domain_get_tag_valid_xml);
+
+  RUN_TEST(virt_include_domain_matching_tags);
+  RUN_TEST(virt_default_instance_include_domain_without_tag);
+  RUN_TEST(virt_regular_instance_skip_domain_without_tag);
+  RUN_TEST(virt_default_instance_include_domain_with_unknown_tag);
+  RUN_TEST(virt_regular_instance_skip_domain_with_unknown_tag);
+
+  RUN_TEST(virt2_partition_domains_none);
+  RUN_TEST(virt2_partition_domains_one_untagged);
+  RUN_TEST(virt2_partition_domains_one_untagged_unpicked);
+
+  END_TEST;
+}
+
+/* vim: set sw=2 sts=2 et : */

--- a/src/virt_test.h
+++ b/src/virt_test.h
@@ -1,0 +1,14 @@
+
+#ifndef VIRT2_TEST_H
+#define VIRT2_TEST_H
+
+#define UUID_STRLEN 36
+typedef struct fakeVirDomain *fakeVirDomainPtr;
+struct fakeVirDomain {
+  char uuid[UUID_STRLEN + 1];
+  char *name;
+  char *xml;
+};
+
+#endif // VIRT2_TEST_H
+

--- a/src/vminfo.c
+++ b/src/vminfo.c
@@ -1,0 +1,353 @@
+/*
+ * vminfo.c - parse libvirt bulk stats records into C structures
+ * Copyright (C) 2014-2016 Red Hat, Inc.
+ * Written by Francesco Romani <fromani@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "vminfo.h"
+
+static int strequals(const char *s1, const char *s2) {
+  return strcmp(s1, s2) == 0;
+}
+
+static int strstartswith(const char *longest, const char *prefix) {
+  char *ret = strstr(longest, prefix);
+  return ret == longest;
+}
+
+#define DISPATCH(NAME, FIELD)                                                  \
+  do {                                                                         \
+    if (strequals(name, #NAME)) {                                              \
+      stats->FIELD = item->value.ul;                                           \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+#define SETUP(STATS, NAME, ITEM)                                               \
+  do {                                                                         \
+    if (strequals(NAME, "name")) {                                             \
+      size_t len = strlen(ITEM->value.s);                                      \
+      if (len > (STATS_NAME_LEN - 1)) {                                        \
+        STATS->xname = strdup(ITEM->value.s);                                  \
+      } else {                                                                 \
+        strncpy(STATS->name, ITEM->value.s, STATS_NAME_LEN);                   \
+      }                                                                        \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+static void blockinfo_parse_field(BlockStats *stats, const char *name,
+                                  const virTypedParameterPtr item) {
+  SETUP(stats, name, item);
+
+  DISPATCH(rd.reqs, rd_reqs);
+  DISPATCH(rd.bytes, rd_bytes);
+  DISPATCH(rd.times, rd_times);
+
+  DISPATCH(wr.reqs, wr_reqs);
+  DISPATCH(wr.bytes, wr_bytes);
+  DISPATCH(wr.times, wr_times);
+
+  DISPATCH(fl.reqs, fl_reqs);
+  DISPATCH(fl.times, fl_times);
+
+  DISPATCH(allocation, allocation);
+  DISPATCH(capacity, capacity);
+  DISPATCH(physical, physical);
+}
+
+static void ifaceinfo_parse_field(IFaceStats *stats, const char *name,
+                                  const virTypedParameterPtr item) {
+  SETUP(stats, name, item);
+
+  DISPATCH(rx.bytes, rx_bytes);
+  DISPATCH(rx.pkts, rx_pkts);
+  DISPATCH(rx.errs, rx_errs);
+  DISPATCH(rx.drop, rx_drop);
+
+  DISPATCH(tx.bytes, tx_bytes);
+  DISPATCH(tx.pkts, tx_pkts);
+  DISPATCH(tx.errs, tx_errs);
+  DISPATCH(tx.drop, tx_drop);
+}
+
+#undef SETUP
+
+#undef DISPATCH
+
+static void vcpuinfo_parse_field(VCpuStats *stats, const char *name,
+                                 const virTypedParameterPtr item) {
+  if (strequals(name, "state")) {
+    stats->present = 1;
+    stats->state = item->value.i;
+    return;
+  }
+  if (strequals(name, "time")) {
+    stats->present = 1;
+    stats->time = item->value.ul;
+    return;
+  }
+  return;
+}
+
+#define ALLOC_XSTATS(subset, MAXSTATS, ITEMSIZE)                               \
+  do {                                                                         \
+    if (subset->nstats > MAXSTATS) {                                           \
+      subset->xstats = calloc(subset->nstats, ITEMSIZE);                       \
+      if (subset->xstats == NULL) {                                            \
+        goto cleanup;                                                          \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
+
+static int vminfo_setup(VMInfo *vm, const virDomainStatsRecordPtr record) {
+  VCpuInfo *vcpu = &vm->vcpu;
+  BlockInfo *block = &vm->block;
+  IFaceInfo *iface = &vm->iface;
+  int i;
+
+  for (i = 0; i < record->nparams; i++) {
+    const virTypedParameterPtr item = &record->params[i]; /* shortcut */
+
+    if (strequals(item->field, "block.count")) {
+      block->nstats = item->value.ul;
+    }
+    if (strequals(item->field, "net.count")) {
+      iface->nstats = item->value.ul;
+    }
+    if (strequals(item->field, "vcpu.current")) {
+      vcpu->current = item->value.ul;
+    } else if (strequals(item->field, "vcpu.maximum")) {
+      vcpu->nstats = item->value.ul;
+    }
+  }
+
+  ALLOC_XSTATS(vcpu, VCPU_STATS_NUM, sizeof(VCpuInfo));
+  ALLOC_XSTATS(block, BLOCK_STATS_NUM, sizeof(BlockStats));
+  ALLOC_XSTATS(iface, IFACE_STATS_NUM, sizeof(IFaceStats));
+
+  return 0;
+
+cleanup:
+  free(block->xstats);
+  free(vcpu->xstats);
+  return -1;
+}
+
+#undef ALLOC_XSTATS
+
+static int pcpuinfo_parse(PCpuInfo *pcpu, const virTypedParameterPtr item) {
+  if (strequals(item->field, "cpu.time")) {
+    pcpu->time = item->value.ul;
+    return 0;
+  }
+  if (strequals(item->field, "cpu.user")) {
+    pcpu->user = item->value.ul;
+    return 0;
+  }
+  if (strequals(item->field, "cpu.system")) {
+    pcpu->system = item->value.ul;
+    return 0;
+  }
+  return 0;
+}
+
+static int ballooninfo_parse(BalloonInfo *balloon,
+                             const virTypedParameterPtr item) {
+  if (strequals(item->field, "balloon.current")) {
+    balloon->current = item->value.ul;
+    return 0;
+  }
+  if (strequals(item->field, "balloon.maximum")) {
+    balloon->maximum = item->value.ul;
+  }
+  return 0;
+}
+
+enum { OFF_BUF_LEN = 128 };
+
+struct FieldScanner {
+  const char *prefix;
+  size_t maxoffset;
+};
+
+struct FieldMatch {
+  const char *suffix;
+  size_t offset;
+};
+
+static void scan_init(struct FieldScanner *scan, const char *prefix,
+                      size_t maxoffset) {
+  scan->prefix = prefix;
+  scan->maxoffset = maxoffset;
+}
+
+static int scan_field(struct FieldScanner *scan, const char *virFieldName,
+                      struct FieldMatch *match) {
+  const char *pc = virFieldName;
+  char buf[OFF_BUF_LEN] = {'\0'};
+  size_t j = 0;
+
+  if (!scan || !strstartswith(virFieldName, scan->prefix)) {
+    return 0;
+  }
+
+  for (j = 0; j < sizeof(buf) - 1 && virFieldName && isdigit(*pc); j++) {
+    buf[j] = *pc++;
+  }
+  pc++; /* skip '.' separator */
+
+  if (match) {
+    match->suffix = pc;
+    match->offset = atol(buf);
+    return (pc != NULL && match->offset < scan->maxoffset);
+  }
+  return (pc != NULL);
+}
+
+static int vcpuinfo_parse(VCpuInfo *vcpu, const virTypedParameterPtr item) {
+  VCpuStats *stats = (vcpu->xstats) ? vcpu->xstats : vcpu->stats;
+  struct FieldScanner scan;
+  struct FieldMatch match;
+
+  scan_init(&scan, "vcpu.", vcpu->nstats);
+
+  if (scan_field(&scan, item->field, &match)) {
+    vcpuinfo_parse_field(stats + match.offset, match.suffix, item);
+  }
+
+  return 0;
+}
+
+static int blockinfo_parse(BlockInfo *block, const virTypedParameterPtr item) {
+  BlockStats *stats = (block->xstats) ? block->xstats : block->stats;
+  struct FieldScanner scan;
+  struct FieldMatch match;
+
+  scan_init(&scan, "block.", block->nstats);
+
+  if (scan_field(&scan, item->field, &match)) {
+    blockinfo_parse_field(stats + match.offset, match.suffix, item);
+  }
+
+  return 0;
+}
+
+static int ifaceinfo_parse(IFaceInfo *iface, const virTypedParameterPtr item) {
+  IFaceStats *stats = (iface->xstats) ? iface->xstats : iface->stats;
+  struct FieldScanner scan;
+  struct FieldMatch match;
+
+  scan_init(&scan, "iface.", iface->nstats);
+
+  if (scan_field(&scan, item->field, &match)) {
+    ifaceinfo_parse_field(stats + match.offset, match.suffix, item);
+  }
+
+  return 0;
+}
+
+#define TRY_TO_PARSE(subset, vm, record, i)                                    \
+  do {                                                                         \
+    if (subset##info_parse(&vm->subset, &record->params[i]) < 0) {             \
+      /* TODO: logging? */                                                     \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
+
+int vminfo_parse(VMInfo *vm, const virDomainStatsRecordPtr record,
+                 int extrainfo) {
+  int i = 0;
+
+  if (vminfo_setup(vm, record)) {
+    return -1;
+  }
+
+  vm->name = virDomainGetName(record->dom);
+  if (vm->name == NULL) {
+    return -1;
+  }
+  if (virDomainGetUUIDString(record->dom, vm->uuid) < 0) {
+    return -1;
+  }
+  if (extrainfo) {
+    int ret;
+    if (virDomainGetInfo(record->dom, &vm->info) < 0) {
+      return -1;
+    }
+    ret = virDomainMemoryStats(record->dom, vm->memstats,
+                               VIR_DOMAIN_MEMORY_STAT_NR, 0);
+    if (ret < 0) {
+      return -1;
+    }
+    vm->memstats_count = ret;
+  } else {
+    memset(&vm->info, 0, sizeof(vm->info));
+    memset(&vm->memstats, 0, sizeof(vm->memstats));
+  }
+
+  for (i = 0; i < record->nparams; i++) {
+    /* intentionally ignore state, yet */
+    TRY_TO_PARSE(pcpu, vm, record, i);
+    TRY_TO_PARSE(balloon, vm, record, i);
+    TRY_TO_PARSE(vcpu, vm, record, i);
+    TRY_TO_PARSE(block, vm, record, i);
+    TRY_TO_PARSE(iface, vm, record, i);
+  }
+
+  return 0;
+}
+
+#undef TRY_TO_PARSE
+
+static void vcpuinfo_free(VCpuInfo *vcpu) { free(vcpu->xstats); }
+
+static void blockinfo_free(BlockInfo *block) {
+  size_t i;
+  const BlockStats *stats = (block->xstats) ? block->xstats : block->stats;
+
+  for (i = 0; i < block->nstats; i++)
+    free(stats[i].xname);
+
+  free(block->xstats);
+}
+
+static void ifaceinfo_free(IFaceInfo *iface) {
+  size_t i;
+  const IFaceStats *stats = (iface->xstats) ? iface->xstats : iface->stats;
+
+  for (i = 0; i < iface->nstats; i++)
+    free(stats[i].xname);
+
+  free(iface->xstats);
+}
+
+void vminfo_init(VMInfo *vm) { memset(vm, 0, sizeof(*vm)); }
+
+void vminfo_free(VMInfo *vm) {
+  vcpuinfo_free(&vm->vcpu);
+  blockinfo_free(&vm->block);
+  ifaceinfo_free(&vm->iface);
+}
+
+/* vim: set sw=2 sts=2 et : */

--- a/src/vminfo.h
+++ b/src/vminfo.h
@@ -1,0 +1,150 @@
+/*
+ * vminfo.h - parse libvirt bulk stats records into C structures
+ * Copyright (C) 2014-2016 Red Hat, Inc.
+ * Written by Francesco Romani <fromani@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef VMINFO_H
+#define VMINFO_H
+
+#include <stdio.h>
+
+#include <libvirt/libvirt.h>
+
+enum {
+  STATS_NAME_LEN = 128,
+  BLOCK_STATS_NUM = 8,
+  IFACE_STATS_NUM = 8,
+  VCPU_STATS_NUM = 16
+};
+
+typedef struct BlockStats BlockStats;
+struct BlockStats {
+  char *xname;
+  char name[STATS_NAME_LEN];
+
+  unsigned long long rd_reqs;
+  unsigned long long rd_bytes;
+  unsigned long long rd_times;
+  unsigned long long wr_reqs;
+  unsigned long long wr_bytes;
+  unsigned long long wr_times;
+  unsigned long long fl_reqs;
+  unsigned long long fl_times;
+
+  unsigned long long allocation;
+  unsigned long long capacity;
+  unsigned long long physical;
+};
+
+typedef struct BlockInfo BlockInfo;
+struct BlockInfo {
+  size_t nstats;
+  BlockStats *xstats;
+  BlockStats stats[BLOCK_STATS_NUM];
+};
+
+typedef struct IFaceStats IFaceStats;
+struct IFaceStats {
+  char *xname;
+  char name[STATS_NAME_LEN];
+
+  unsigned long long rx_bytes;
+  unsigned long long rx_pkts;
+  unsigned long long rx_errs;
+  unsigned long long rx_drop;
+
+  unsigned long long tx_bytes;
+  unsigned long long tx_pkts;
+  unsigned long long tx_errs;
+  unsigned long long tx_drop;
+};
+
+typedef struct IFaceInfo IFaceInfo;
+struct IFaceInfo {
+  size_t nstats;
+  IFaceStats *xstats;
+  IFaceStats stats[IFACE_STATS_NUM];
+};
+
+typedef struct PCpuInfo PCpuInfo;
+struct PCpuInfo {
+  unsigned long long time;
+  unsigned long long user;
+  unsigned long long system;
+};
+
+typedef struct BalloonInfo BalloonInfo;
+struct BalloonInfo {
+  unsigned long long current;
+  unsigned long long maximum;
+};
+
+typedef struct VCpuStats VCpuStats;
+struct VCpuStats {
+  int present;
+  int state;
+  unsigned long long time;
+};
+
+typedef struct VCpuInfo VCpuInfo;
+struct VCpuInfo {
+  size_t nstats; /* aka maximum */
+  VCpuStats *xstats;
+  VCpuStats stats[VCPU_STATS_NUM];
+
+  size_t current;
+};
+
+typedef struct StateInfo StateInfo;
+struct StateInfo {
+  int state;
+  int reason;
+};
+
+typedef struct VMInfo VMInfo;
+struct VMInfo {
+  char uuid[VIR_UUID_STRING_BUFLEN];
+  const char *name;
+  virDomainInfo info;
+  virDomainMemoryStatStruct memstats[VIR_DOMAIN_MEMORY_STAT_NR];
+  int memstats_count;
+
+  StateInfo state;
+  PCpuInfo pcpu;
+  BalloonInfo balloon;
+  VCpuInfo vcpu;
+  BlockInfo block;
+  IFaceInfo iface;
+};
+
+typedef struct VMChecks VMChecks;
+struct VMChecks {
+  int disk_usage_perc;
+};
+
+int vminfo_parse(VMInfo *vm, const virDomainStatsRecordPtr record,
+                 int extrainfo);
+
+void vminfo_init(VMInfo *vm);
+
+void vminfo_free(VMInfo *vm);
+
+#endif /* VMINFO_H */
+
+/* vim: set sw=2 sts=2 et : */


### PR DESCRIPTION
This patch rewrites the existing virt plugin
almost entirely, borrowing only few bits from
the existing one.

The plugin exports as superset of the metrics the
old plugin exported, and accepts a superset of the
configuration settings the old plugin expected, so
it is intended to act as drop-in replacement.

The new plugin now depends on glib2, libvirt and libxml2.
The new plugin has tests, taking inspiration from the tests
of the ceph plugin (src/ceph_test.c).

The gathering of the libvirt values has been completely overhauled,
and now we use the libvirt bulk stats API:
https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainListGetStats
which is a more modern and convenient way to fetch the
data from running libvirt domains.

We add resiliency in presence of unresponsive domains.
This can happen if a domain used shared storage (NFS, ISCSI)
and it experiences a network failure during one I/O operation.
check docs/README.virt.md to learn more about the issue
and the implemented solution.