### PR TITLE
Fix Lua header detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2901,15 +2901,15 @@ fi
 
 if test "x$with_liblua" = "xyes"
 then
-  SAVE_CFLAGS="$CFLAGS"
-  CFLAGS="$CFLAGS $LUA_CFLAGS"
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $LUA_CFLAGS"
 
   AC_CHECK_HEADERS([lua.h lauxlib.h lualib.h],
     [with_liblua="yes"],
     [with_liblua="no (header not found)"]
   )
 
-  CFLAGS="$SAVE_CFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
 if test "x$with_liblua" = "xyes"


### PR DESCRIPTION
checking lua.h usability... yes
checking lua.h presence... no
configure: WARNING: lua.h: accepted by the compiler, rejected by the
preprocessor!
configure: WARNING: lua.h: proceeding with the compiler's result
checking for lua.h... yes
checking lauxlib.h usability... yes
checking lauxlib.h presence... no
configure: WARNING: lauxlib.h: accepted by the compiler, rejected by the
preprocessor!
configure: WARNING: lauxlib.h: proceeding with the compiler's result
checking for lauxlib.h... yes
checking lualib.h usability... yes
checking lualib.h presence... no
configure: WARNING: lualib.h: accepted by the compiler, rejected by the
preprocessor!
configure: WARNING: lualib.h: proceeding with the compiler's result
checking for lualib.h... yes

AC_CHECK_HEADERS uses the preprocessor directly, which doesn't use
CFLAGS. Fixes detection of the lua-5.1 compat libs on Fedora Rawhide.