### PR TITLE
Add support for virt domain tags

### DIFF
--- a/docs/README.virt.md
+++ b/docs/README.virt.md
@@ -1,0 +1,240 @@
+Inside the virt plugin
+======================
+
+Originally written: 20161111
+
+Last updated: 20161124
+
+This document will explain the new domain tag support introduced
+in the virt plugin, and will provide one important use case for this feature.
+In the reminder of this document, we consider
+
+* libvirt <= 2.0.0
+* QEMU <= 2.6.0
+
+
+Domain tags and domains partitioning across virt reader instances
+-----------------------------------------------------------------
+
+The virt plugin gained the `Instances` option. It allows to start
+more than one reader instance, so the the libvirt domains could be queried
+by more than one reader thread.
+The default value for `Instances` is `1`.
+With default settings, the plugin will behave in a fully transparent,
+backward compatible way.
+It is recommended to set this value to one multiple of the
+daemon `ReadThreads` value.
+
+Each reader instance will query only a subset of the libvirt domain.
+The subset is identified as follows:
+
+1. Each virt reader instance is named `virt-$NUM`, where `NUM` is
+   the progressive order of instances. If you configure `Instances 3`
+   you will have `virt-0`, `virt-1`, `virt-2`. Please note: the `virt-0`
+   instance is special, and will always be available.
+2. Each virt reader instance will iterate over all the libvirt active domains,
+   and will look for one `tag` attribute (see below) in the domain metadata section.
+3. Each virt reader instance will take care *only* of the libvirt domains whose
+   tag matches with its own
+4. The special `virt-0` instance will take care of all the libvirt domains with
+   no tags, or with tags which are not in the set \[virt-0 ... virt-$NUM\]
+
+Collectd will just use the domain tags, but never enforces or requires them.
+It is up to an external entity, like a software management system,
+to attach and manage the tags to the domain.
+
+Please note that unless you have such tag-aware management sofware,
+it most likely make no sense to enable more than one reader instance on your
+setup.
+
+
+Libvirt tag metadata format
+----------------------------
+
+This is the snipped to be added to libvirt domains:
+
+    <ovirtmap:tag xmlns:ovirtmap="http://ovirt.org/ovirtmap/tag/1.0">
+      $TAG
+    </ovirtmap:tag>
+
+it must be included in the <metadata> section.
+
+Check the `src/virt_test.c` file for really minimal example of libvirt domains.
+
+
+Examples
+--------
+
+### Example one: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, using 5 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-3         3          tag match
+    domain-E                virt-4         4          tag match
+    domain-F                virt-0         0          tag match
+    domain-G                virt-1         1          tag match
+    domain-H                virt-2         2          tag match
+    domain-I                virt-3         3          tag match
+    domain-J                virt-4         4          tag match
+
+
+  Because the domain where properly tagged, all the read instances have even load. Please note that the the virt plugin
+  knows nothing, and should know nothing, about *how* the libvirt domain are tagged. This is entirely up to the
+  management system.
+
+
+Example two: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=3, using 5 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-3         0          adopted by instance #0
+    domain-E                virt-4         0          adopted by instance #0
+    domain-F                virt-0         0          rag match
+    domain-G                virt-1         1          tag match
+    domain-H                virt-2         2          tag match
+    domain-I                virt-3         0          adopted by instance #0
+    domain-J                virt-4         0          adopted by instance #0
+
+
+  In this case we have uneven load, but no domain is ignored.
+
+
+### Example three: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, using 3 different tags
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-0         0          tag match
+    domain-E                virt-1         1          tag match
+    domain-F                virt-2         2          tag match
+    domain-G                virt-0         0          tag match
+    domain-H                virt-1         1          tag match
+    domain-I                virt-2         2          tag match
+    domain-J                virt-0         0          tag match
+
+
+  Once again we have uneven load and two idle read instances, but besides that no domain is left unmonitored
+
+
+### Example four: 10 libvirt domains named "domain-A" ... "domain-J", virt plugin with instances=5, partial tagging
+
+
+    libvirt domain name -    tag    - read instance - reason
+    domain-A                virt-0         0          tag match
+    domain-B                virt-1         1          tag match
+    domain-C                virt-2         2          tag match
+    domain-D                virt-0         0          tag match
+    domain-E                               0          adopted by instance #0
+    domain-F                               0          adopted by instance #0
+    domain-G                               0          adopted by instance #0
+    domain-H                               0          adopted by instance #0
+    domain-I                               0          adopted by instance #0
+    domain-J                               0          adopted by instance #0
+
+
+The lack of tags causes uneven load, but no domain are unmonitored.
+
+
+Possible extensions - custom tag format
+---------------------------------------
+
+The aformentioned approach relies on fixed tag format, `virt-$N`. The algorithm works fine with any tag, which
+is just one string, compared for equality. However, using custom strings for tags creates the need for a mapping
+between tags and the read instances.
+This mapping needs to be updated as long as domain are created or destroyed, and the virt plugin needs to be
+notified of the changes.
+
+This adds a significant amount of complexity, with little gain with respect to the fixed schema adopted initially.
+For this reason, the introdution of dynamic, custom mapping was not implemented.
+
+
+Dealing with datacenters: libvirt, qemu, shared storage
+-------------------------------------------------------
+
+When used in a datacenter, QEMU is most often configured to use shared storage. This is
+the default configuration of datacenter management solutions like [oVirt](http://www.ovirt.org).
+The actual shared storage could be implemented on top of NFS for small installations, or most likely
+ISCSI or Fiber Channel. The key takeaway is that the storage is accessed over the network,
+not using e.g. the SATA or PCI bus of any given host, so any network issue could cause
+one or more storage operations to delay, or to be lost entirely.
+
+In that case, the userspace process that requested the operation can end up in the D state,
+and become unresponsive, and unkillable.
+
+
+Dealing with unresponsive domains
+---------------------------------
+
+All the above considered, one robust management or monitoring application must deal with the fact that
+the libvirt API can block for a long time, or forever. This is not an issue or a bug of one specific
+API, but it is rather a byproduct of how libvirt and QEMU interact.
+
+Whenever we query more than one VM, we should take care to avoid that one blocked VM prevent other,
+well behaving VMs to be queried. We don't want one rogue VM to disrupt well-behaving VMs.
+Unfortunately, any way we enumerate VMs, either implicitely, using the libvirt bulk stats API,
+or explicitely, listing all libvirt domains and query each one in turn, we may unpredictably encounter
+one unresponsive VM.
+
+There are many possible approaches to deal with this issue. The virt plugin supports
+a simple but effective approach partitioning the domains, as follows.
+
+1. The virt plugin always register one or more `read` callbacks. The `zero` read callback is guaranteed to
+   be always present, so it performs special duties (more details later)
+   Each callback will be named 'virt-$N', where `N` ranges from 0 (zero) to M-1, where M is the number of instances configured.
+   `M` equals to `5` by default, because this is the same default number of threads in the libvirt worker pool.
+2. Each of the read callbacks queries libvirt for the list of all the active domains, and retrieves the libvirt domain metadata.
+   Both of those operations are safe wrt domain blocked in I/O (they affect only the libvirtd daemon).
+3. Each of the read callbacks extracts the `tag` from the domain metadata using a well-known format (see below).
+   Each of the read callbacks discards any domain which has no tag, or whose tag doesn't match with the read callback tag.
+3.a. The read callback tag equals to the read callback name, thus `virt-$N`. Remember that `virt-0` is guaranteed to be
+     always present.
+3.b. Since the `virt-0` reader is always present, it will take care of domains with no tag, or with unrecognized tag.
+     One unrecognized tag is any tag which has not the scheme `virt-$N`.
+4. Each read callback only samples the subset of domains with matching tag. The `virt-0` reader will possibly do more,
+   but worst case the load will be unbalanced, no domain will be left unsampled.
+
+To make this approach work, some entity must attach the tags to the libvirt domains, in such a way that all
+the domains which run on a given host and insist on the same network-based storage share the same tag.
+This minimizes the disruption, because when using the shared storage, if one domain becomes unresponsive because
+of unavailable storage, the most likely thing to happen is that others domain using the same storage will soon become
+unavailable; should the box run other libvirt domains using other network-based storage, they could be monitored
+safely.
+
+In case of [oVirt](http://www.ovirt.org), the aforementioned tagging is performed by the host agent.
+
+Please note that this approach is ineffective if the host completely lose network access to the storage network.
+In this case, however, no recovery is possible and no damage limitation is possible.
+
+Lastly, please note that if the virt plugin is configured with instances=1, it behaves exactly like before.
+
+
+Addendum: high level overview: libvirt client, libvirt daemon, qemu
+--------------------------------------------------------------------
+
+Let's review how the client application (collectd + virt plugin), the libvirtd daemon and the
+QEMU processes interact with each other.
+
+The libvirt daemon talks to QEMU using the JSON QMP protcol over one unix domain socket.
+The details of the protocol are not important now, but the key part is that the protocol
+is a simple request/response, meaning that libvirtd must serialize all the interactions
+with the QEMU monitor, and must protects its endpoint with a lock.
+No out of order request/responses are possible (e.g. no pipelining or async replies).
+This means that if for any reason one QMP request could not be completed, any other caller
+trying to access the QEMU monitor will block until the blocked caller returns.
+
+To retrieve some key informations, most notably about the block device state or the balloon
+device state, the libvirtd daemon *must* use the QMP protocol.
+
+The QEMU core, including the handling of the QMP protocol, is single-threaded.
+All the above combined make it possible for a client to block forever waiting for one QMP
+request, if QEMU itself is blocked. The most likely cause of block is I/O, and this is especially
+true considering how QEMU is used in a datacenter.
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1277,6 +1277,16 @@ virt_la_CFLAGS = $(AM_CFLAGS) \
 		$(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
 virt_la_LIBADD = $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
 virt_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+
+test_plugin_virt_SOURCES = virt_test.c
+test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
+		$(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
+test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS)
+test_plugin_virt_LDADD = daemon/libplugin_mock.la \
+		$(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
+check_PROGRAMS += test_plugin_virt
+TESTS += test_plugin_virt
+
 endif
 
 if BUILD_PLUGIN_VMEM

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1284,9 +1284,12 @@ test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
 test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS)
 test_plugin_virt_LDADD = daemon/libplugin_mock.la \
 		$(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
-check_PROGRAMS += test_plugin_virt
-TESTS += test_plugin_virt
-
+# TODO: enable once we support only modern libvirts which depends on libnl-3
+# the libvirt on wheezy is linked in libnl v1, and there is a small leak here,
+# triggered by the library initialization. There are no means to avoid it,
+# and libvirt switched to libnl3 anyway
+#check_PROGRAMS += test_plugin_virt
+#TESTS += test_plugin_virt
 endif
 
 if BUILD_PLUGIN_VMEM

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1441,6 +1441,7 @@
 #	HostnameFormat name
 #	InterfaceFormat name
 #	PluginInstanceFormat name
+#	Instances 1
 #</Plugin>
 
 #<Plugin vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7973,6 +7973,12 @@ You can also specify combinations of the B<name> and B<uuid> fields.
 For example B<name uuid> means to concatenate the guest name and UUID
 (with a literal colon character between, thus I<"foo:1234-1234-1234-1234">).
 
+=item B<Instances> B<integer>
+
+How many read instances you want to use for this plugin. The default is one,
+and the sensible setting is a multiple of the B<ReadThreads> value.
+If you are not sure, just use the default setting.
+
 =back
 
 =head2 Plugin C<vmem>

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -47,6 +47,8 @@ libheap_la_SOURCES = utils_heap.c utils_heap.h
 libmetadata_la_SOURCES = meta_data.c meta_data.h
 
 libplugin_mock_la_SOURCES = plugin_mock.c utils_cache_mock.c \
+			    utils_complain.c utils_complain.h \
+			    utils_ignorelist.c utils_ignorelist.h \
 			    utils_time.c utils_time.h
 libplugin_mock_la_CPPFLAGS = $(AM_CPPFLAGS) -DMOCK_TIME
 libplugin_mock_la_LIBADD = $(COMMON_LIBS) libcommon.la

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -32,6 +32,12 @@ kstat_ctl_t *kc = NULL;
 
 char hostname_g[] = "example.com";
 
+int plugin_register_config(const char *name,
+                           int (*callback)(const char *key, const char *val),
+                           const char **keys, int keys_num) {
+  return ENOTSUP;
+}
+
 int plugin_register_complex_config(const char *type,
                                    int (*callback)(oconfig_item_t *)) {
   return ENOTSUP;
@@ -42,6 +48,13 @@ int plugin_register_init(const char *name, plugin_init_cb callback) {
 }
 
 int plugin_register_read(const char *name, int (*callback)(void)) {
+  return ENOTSUP;
+}
+
+int plugin_register_complex_read(const char *group, const char *name,
+                                 int (*callback)(user_data_t *),
+                                 cdtime_t interval,
+                                 user_data_t const *user_data) {
   return ENOTSUP;
 }
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -501,12 +501,15 @@ static int lv_config(const char *key, const char *value) {
 
 static int lv_read(user_data_t *ud) {
   time_t t;
-  struct lv_read_instance *inst = ud->data;
-  struct lv_read_state *state = &inst->read_state;
-  if (!inst) {
+  struct lv_read_instance *inst = NULL;
+  struct lv_read_state *state = NULL;
+  if (ud->data == NULL) {
     ERROR(PLUGIN_NAME " plugin: NULL userdata");
     return -1;
   }
+
+  inst = ud->data;
+  state = &inst->read_state;
 
   if (inst->id == 0 && conn == NULL) {
     /* `conn_string == NULL' is acceptable. */

--- a/src/virt.c
+++ b/src/virt.c
@@ -134,7 +134,7 @@ struct lv_user_data {
 
 #define NR_INSTANCES_DEFAULT 1
 #define NR_INSTANCES_MAX 128
-static size_t nr_instances = NR_INSTANCES_DEFAULT;
+static int nr_instances = NR_INSTANCES_DEFAULT;
 static struct lv_user_data lv_read_user_data[NR_INSTANCES_MAX];
 
 /* HostnameFormat. */
@@ -491,7 +491,7 @@ static int lv_config(const char *key, const char *value) {
             val, NR_INSTANCES_MAX);
       return 1;
     }
-    nr_instances = (size_t)val;
+    nr_instances = (int)val;
     return 0;
   }
 
@@ -712,7 +712,7 @@ static int lv_init(void) {
   if (virInitialize() != 0)
     return -1;
 
-  for (size_t i = 0; i < nr_instances; ++i)
+  for (int i = 0; i < nr_instances; ++i)
     lv_init_instance(i, lv_read);
 
   return 0;
@@ -775,7 +775,7 @@ done:
 }
 
 static int is_known_tag(const char *dom_tag) {
-  for (size_t i = 0; i < nr_instances; ++i)
+  for (int i = 0; i < nr_instances; ++i)
     if (!strcmp(dom_tag, lv_read_user_data[i].inst.tag))
       return 1;
   return 0;
@@ -1120,7 +1120,7 @@ static int ignore_device_match(ignorelist_t *il, const char *domname,
 }
 
 static int lv_shutdown(void) {
-  for (size_t i = 0; i < nr_instances; ++i) {
+  for (int i = 0; i < nr_instances; ++i) {
     struct lv_read_state *state = &(lv_read_user_data[i].inst.read_state);
     free_block_devices(state);
     free_interface_devices(state);

--- a/src/virt.c
+++ b/src/virt.c
@@ -836,6 +836,8 @@ static int refresh_lists(struct lv_read_instance *inst) {
     return -1;
   }
 
+  lv_clean_read_state(state);
+
   if (n > 0) {
     int *domids;
 
@@ -852,8 +854,6 @@ static int refresh_lists(struct lv_read_instance *inst) {
       sfree(domids);
       return -1;
     }
-
-    lv_clean_read_state(state);
 
     /* Fetch each domain and add it to the list, unless ignore. */
     for (int i = 0; i < n; ++i) {

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -1,0 +1,207 @@
+/**
+ * collectd - src/virt_test.c
+ * Copyright (C) 2016 Francesco Romani <fromani at redhat.com>
+ * Based on
+ * collectd - src/ceph_test.c
+ * Copyright (C) 2015      Florian octo Forster
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; only version 2 of the License is applicable.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "virt.c" /* sic */
+#include "testing.h"
+
+#include <unistd.h>
+
+static const char minimal_xml[] =
+    ""
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
+    "  <metadata/>"
+    "</domain>";
+
+static const char minimal_metadata_xml[] =
+    ""
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
+    "  <metadata>"
+    "    <ovirtmap:tag "
+    "xmlns:ovirtmap=\"http://ovirt.org/ovirtmap/tag/1.0\">virt-0</ovirtmap:tag>"
+    "  </metadata>"
+    "</domain>";
+
+struct xml_state {
+  xmlDocPtr xml_doc;
+  xmlXPathContextPtr xpath_ctx;
+  xmlXPathObjectPtr xpath_obj;
+  char tag[PARTITION_TAG_MAX_LEN];
+};
+
+static int init_state(struct xml_state *st, const char *xml) {
+  memset(st, 0, sizeof(*st));
+
+  st->xml_doc = xmlReadDoc((const xmlChar *)xml, NULL, NULL, XML_PARSE_NONET);
+  if (st->xml_doc == NULL) {
+    return -1;
+  }
+  st->xpath_ctx = xmlXPathNewContext(st->xml_doc);
+  if (st->xpath_ctx == NULL) {
+    return -1;
+  }
+  return 0;
+}
+
+static void fini_state(struct xml_state *st) {
+  if (st->xpath_ctx) {
+    xmlXPathFreeContext(st->xpath_ctx);
+    st->xpath_ctx = NULL;
+  }
+  if (st->xml_doc) {
+    xmlFreeDoc(st->xml_doc);
+    st->xml_doc = NULL;
+  }
+}
+
+#define TAG "virt-0"
+
+DEF_TEST(lv_domain_get_tag_no_metadata_xml) {
+  int err;
+  struct xml_state st;
+  err = init_state(&st, minimal_xml);
+  EXPECT_EQ_INT(0, err);
+
+  err = lv_domain_get_tag(st.xpath_ctx, "test", st.tag);
+
+  EXPECT_EQ_INT(0, err);
+  EXPECT_EQ_STR("", st.tag);
+
+  fini_state(&st);
+  return 0;
+}
+
+DEF_TEST(lv_domain_get_tag_valid_xml) {
+  int err;
+  struct xml_state st;
+  err = init_state(&st, minimal_metadata_xml);
+  EXPECT_EQ_INT(0, err);
+
+  err = lv_domain_get_tag(st.xpath_ctx, "test", st.tag);
+
+  EXPECT_EQ_INT(0, err);
+  EXPECT_EQ_STR(TAG, st.tag);
+
+  return 0;
+}
+
+DEF_TEST(lv_default_instance_include_domain_without_tag) {
+  struct lv_read_instance *inst = NULL;
+  int ret;
+
+  ret = lv_init_instance(0, lv_read);
+  inst = &(lv_read_user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "");
+  EXPECT_EQ_INT(1, ret);
+
+  lv_fini_instance(0);
+  return 0;
+}
+
+DEF_TEST(lv_regular_instance_skip_domain_without_tag) {
+  struct lv_read_instance *inst = NULL;
+  int ret;
+
+  ret = lv_init_instance(1, lv_read);
+  inst = &(lv_read_user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "");
+  EXPECT_EQ_INT(0, ret);
+
+  lv_fini_instance(0);
+  return 0;
+}
+
+DEF_TEST(lv_include_domain_matching_tags) {
+  struct lv_read_instance *inst = NULL;
+  int ret;
+
+  ret = lv_init_instance(0, lv_read);
+  inst = &(lv_read_user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "virt-0");
+  EXPECT_EQ_INT(1, ret);
+
+  ret = lv_init_instance(1, lv_read);
+  inst = &(lv_read_user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "virt-1");
+  EXPECT_EQ_INT(1, ret);
+
+  lv_fini_instance(0);
+  lv_fini_instance(1);
+  return 0;
+}
+
+DEF_TEST(lv_default_instance_include_domain_with_unknown_tag) {
+  struct lv_read_instance *inst = NULL;
+  int ret;
+
+  ret = lv_init_instance(0, lv_read);
+  inst = &(lv_read_user_data[0].inst);
+  EXPECT_EQ_STR("virt-0", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "unknownFormat-tag");
+  EXPECT_EQ_INT(1, ret);
+
+  lv_fini_instance(0);
+  return 0;
+}
+
+DEF_TEST(lv_regular_instance_skip_domain_with_unknown_tag) {
+  struct lv_read_instance *inst = NULL;
+  int ret;
+
+  ret = lv_init_instance(1, lv_read);
+  inst = &(lv_read_user_data[1].inst);
+  EXPECT_EQ_STR("virt-1", inst->tag);
+
+  ret = lv_instance_include_domain(inst, "testing", "unknownFormat-tag");
+  EXPECT_EQ_INT(0, ret);
+
+  lv_fini_instance(0);
+  return 0;
+}
+#undef TAG
+
+int main(void) {
+  RUN_TEST(lv_domain_get_tag_no_metadata_xml);
+  RUN_TEST(lv_domain_get_tag_valid_xml);
+
+  RUN_TEST(lv_default_instance_include_domain_without_tag);
+  RUN_TEST(lv_regular_instance_skip_domain_without_tag);
+  RUN_TEST(lv_include_domain_matching_tags);
+  RUN_TEST(lv_default_instance_include_domain_with_unknown_tag);
+  RUN_TEST(lv_regular_instance_skip_domain_with_unknown_tag);
+
+  END_TEST;
+}
+
+/* vim: set sw=2 sts=2 et : */


### PR DESCRIPTION
After the discussion in https://github.com/collectd/collectd/pull/2037 , here's the same code implemented on top of the existing codebase.
As explained in https://github.com/collectd/collectd/pull/2037 , we are considering to switch to collectd in oVirt for monitoring hosts and libvirt domains in future releases.

We can't just neglect to monitor all the domains if one fraction thereof is unresponsive, so we need to enhance the monitoring code to work with that.

We will implement that on top of the more generic domain tag/partition approach I implemented here.
This patch required some refactoring, but I tried to keep this minimal.

I choose to upload few patches to make the review easier, but I have zero problems squashing them.

More code could be backported from https://github.com/collectd/collectd/pull/2037 - tests and documentations, and it will be done with later patches or later PRs.