### PR TITLE
Adding IPV6 support to ip_vs plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -629,7 +629,7 @@ fi
 
 AM_CONDITIONAL(IP_VS_H_NEEDS_KERNEL_CFLAGS, test "x$ip_vs_h_needs_kernel_cflags" = "xyes")
 PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
-PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes], 
+PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes],
 	[PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
 		[PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
  		])
@@ -639,7 +639,6 @@ if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
         CFLAGS+=" $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS -DLIBIPVS_USE_NL"
         LIBS+=" $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
 #	LIBS+=" $"
-	echo $LIBS
 elif (test "${have_libnl2}" = "yes"); then
 	CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
 	LIBS+="$LIBNL2_LIBS"
@@ -5933,7 +5932,7 @@ then
 	then
 		plugin_turbostat="yes"
 	fi
-	
+
 	if test "x$c_cv_have_clock_boottime_monotonic" = "xyes"
 	then
 		plugin_cpusleep="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -626,7 +626,25 @@ then
 		CFLAGS="$SAVE_CFLAGS"
 	fi
 fi
+
 AM_CONDITIONAL(IP_VS_H_NEEDS_KERNEL_CFLAGS, test "x$ip_vs_h_needs_kernel_cflags" = "xyes")
+
+PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes], 
+	[PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
+		[PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
+ 		])
+	])
+
+if (test "${have_libnl3}" = "yes"); then
+        CFLAGS+=" $LIBNL3_CFLAGS -DLIBIPVS_USE_NL"
+        LIBS+=" $LIBNL3_LIBS"
+elif (test "${have_libnl2}" = "yes"); then
+	CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+	LIBS+="$LIBNL2_LIBS"
+elif  (test "${have_libnl1}" = "yes"); then
+        CFLAGS+="$LIBNL1_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+	LIBS+="$LIBNL1_LIBS"
+fi
 
 # For quota module
 AC_CHECK_HEADERS(sys/ucred.h, [], [],

--- a/configure.ac
+++ b/configure.ac
@@ -628,16 +628,18 @@ then
 fi
 
 AM_CONDITIONAL(IP_VS_H_NEEDS_KERNEL_CFLAGS, test "x$ip_vs_h_needs_kernel_cflags" = "xyes")
-
+PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
 PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes], 
 	[PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
 		[PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
  		])
 	])
 
-if (test "${have_libnl3}" = "yes"); then
-        CFLAGS+=" $LIBNL3_CFLAGS -DLIBIPVS_USE_NL"
-        LIBS+=" $LIBNL3_LIBS"
+if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
+        CFLAGS+=" $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS -DLIBIPVS_USE_NL"
+        LIBS+=" $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+#	LIBS+=" $"
+	echo $LIBS
 elif (test "${have_libnl2}" = "yes"); then
 	CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
 	LIBS+="$LIBNL2_LIBS"

--- a/src/ip_vs.h
+++ b/src/ip_vs.h
@@ -1,0 +1,601 @@
+/*
+ *      IP Virtual Server
+ *      data structure and functionality definitions
+ */
+
+#ifndef _IP_VS_H
+#define _IP_VS_H
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <linux/types.h>	/* For __beXX types in userland */
+
+#ifdef LIBIPVS_USE_NL
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+//#include <libnl3/netlink/netlink.h>
+//#include <libnl3/netlink/genl/genl.h>
+//#include <libnl3/netlink/genl/ctrl.h>
+
+#endif
+
+#define IP_VS_VERSION_CODE	0x010201
+#define NVERSION(version)			\
+	(version >> 16) & 0xFF,			\
+	(version >> 8) & 0xFF,			\
+	version & 0xFF
+
+/*
+ *      Virtual Service Flags
+ */
+#define IP_VS_SVC_F_PERSISTENT	0x0001		/* persistent port */
+#define IP_VS_SVC_F_HASHED	0x0002		/* hashed entry */
+#define IP_VS_SVC_F_ONEPACKET	0x0004		/* one-packet scheduling */
+#define IP_VS_SVC_F_SCHED1	0x0008		/* scheduler flag 1 */
+#define IP_VS_SVC_F_SCHED2	0x0010		/* scheduler flag 2 */
+#define IP_VS_SVC_F_SCHED3	0x0020		/* scheduler flag 3 */
+
+#define IP_VS_SVC_F_SCHED_SH_FALLBACK	IP_VS_SVC_F_SCHED1 /* SH fallback */
+#define IP_VS_SVC_F_SCHED_SH_PORT	IP_VS_SVC_F_SCHED2 /* SH use port */
+
+
+/*
+ *      IPVS sync daemon states
+ */
+#define IP_VS_STATE_NONE	0x0000		/* daemon is stopped */
+#define IP_VS_STATE_MASTER	0x0001		/* started as master */
+#define IP_VS_STATE_BACKUP	0x0002		/* started as backup */
+
+/*
+ *      IPVS socket options
+ */
+#define IP_VS_BASE_CTL		(64+1024+64)		/* base */
+
+#define IP_VS_SO_SET_NONE	IP_VS_BASE_CTL		/* just peek */
+#define IP_VS_SO_SET_INSERT	(IP_VS_BASE_CTL+1)
+#define IP_VS_SO_SET_ADD	(IP_VS_BASE_CTL+2)
+#define IP_VS_SO_SET_EDIT	(IP_VS_BASE_CTL+3)
+#define IP_VS_SO_SET_DEL	(IP_VS_BASE_CTL+4)
+#define IP_VS_SO_SET_FLUSH	(IP_VS_BASE_CTL+5)
+#define IP_VS_SO_SET_LIST	(IP_VS_BASE_CTL+6)
+#define IP_VS_SO_SET_ADDDEST	(IP_VS_BASE_CTL+7)
+#define IP_VS_SO_SET_DELDEST	(IP_VS_BASE_CTL+8)
+#define IP_VS_SO_SET_EDITDEST	(IP_VS_BASE_CTL+9)
+#define IP_VS_SO_SET_TIMEOUT	(IP_VS_BASE_CTL+10)
+#define IP_VS_SO_SET_STARTDAEMON (IP_VS_BASE_CTL+11)
+#define IP_VS_SO_SET_STOPDAEMON (IP_VS_BASE_CTL+12)
+#define IP_VS_SO_SET_RESTORE    (IP_VS_BASE_CTL+13)
+#define IP_VS_SO_SET_SAVE       (IP_VS_BASE_CTL+14)
+#define IP_VS_SO_SET_ZERO	(IP_VS_BASE_CTL+15)
+#define IP_VS_SO_SET_MAX	IP_VS_SO_SET_ZERO
+
+#define IP_VS_SO_GET_VERSION	IP_VS_BASE_CTL
+#define IP_VS_SO_GET_INFO	(IP_VS_BASE_CTL+1)
+#define IP_VS_SO_GET_SERVICES	(IP_VS_BASE_CTL+2)
+#define IP_VS_SO_GET_SERVICE	(IP_VS_BASE_CTL+3)
+#define IP_VS_SO_GET_DESTS	(IP_VS_BASE_CTL+4)
+#define IP_VS_SO_GET_DEST	(IP_VS_BASE_CTL+5)	/* not used now */
+#define IP_VS_SO_GET_TIMEOUT	(IP_VS_BASE_CTL+6)
+#define IP_VS_SO_GET_DAEMON	(IP_VS_BASE_CTL+7)
+#define IP_VS_SO_GET_MAX	IP_VS_SO_GET_DAEMON
+
+
+/*
+ *      IPVS Connection Flags
+ */
+#define IP_VS_CONN_F_FWD_MASK	0x0007		/* mask for the fwd methods */
+#define IP_VS_CONN_F_MASQ	0x0000		/* masquerading/NAT */
+#define IP_VS_CONN_F_LOCALNODE	0x0001		/* local node */
+#define IP_VS_CONN_F_TUNNEL	0x0002		/* tunneling */
+#define IP_VS_CONN_F_DROUTE	0x0003		/* direct routing */
+#define IP_VS_CONN_F_BYPASS	0x0004		/* cache bypass */
+#define IP_VS_CONN_F_SYNC	0x0020		/* entry created by sync */
+#define IP_VS_CONN_F_HASHED	0x0040		/* hashed entry */
+#define IP_VS_CONN_F_NOOUTPUT	0x0080		/* no output packets */
+#define IP_VS_CONN_F_INACTIVE	0x0100		/* not established */
+#define IP_VS_CONN_F_OUT_SEQ	0x0200		/* must do output seq adjust */
+#define IP_VS_CONN_F_IN_SEQ	0x0400		/* must do input seq adjust */
+#define IP_VS_CONN_F_SEQ_MASK	0x0600		/* in/out sequence mask */
+#define IP_VS_CONN_F_NO_CPORT	0x0800		/* no client port set yet */
+#define IP_VS_CONN_F_TEMPLATE	0x1000		/* template, not connection */
+#define IP_VS_CONN_F_ONE_PACKET	0x2000		/* forward only one packet */
+
+#define IP_VS_SCHEDNAME_MAXLEN	16
+#define IP_VS_PENAME_MAXLEN	16
+#define IP_VS_IFNAME_MAXLEN	16
+
+#define IP_VS_PEDATA_MAXLEN	255
+
+union nf_inet_addr {
+        __u32           all[4];
+        __be32          ip;
+        __be32          ip6[4];
+        struct in_addr  in;
+        struct in6_addr in6;
+};
+
+/*
+ *	The struct ip_vs_service_user and struct ip_vs_dest_user are
+ *	used to set IPVS rules through setsockopt.
+ */
+struct ip_vs_service_kern {
+	/* virtual service addresses */
+	u_int16_t		protocol;
+	__be32			addr;	/* virtual ip address */
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* virtual service options */
+	char			sched_name[IP_VS_SCHEDNAME_MAXLEN];
+	unsigned		flags;		/* virtual service flags */
+	unsigned		timeout;	/* persistent timeout in sec */
+	__be32			netmask;	/* persistent netmask */
+};
+
+struct ip_vs_service_user {
+	/* virtual service addresses */
+	u_int16_t		protocol;
+	__be32			__addr_v4;	/* virtual ip address - internal use only */
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* virtual service options */
+	char			sched_name[IP_VS_SCHEDNAME_MAXLEN];
+	unsigned		flags;		/* virtual service flags */
+	unsigned		timeout;	/* persistent timeout in sec */
+	__be32			netmask;	/* persistent netmask */
+	u_int16_t		af;
+	union nf_inet_addr	addr;
+	char			pe_name[IP_VS_PENAME_MAXLEN];
+};
+
+struct ip_vs_dest_kern {
+	/* destination server address */
+	__be32			addr;
+	__be16			port;
+
+	/* real server options */
+	unsigned		conn_flags;	/* connection flags */
+	int			weight;		/* destination weight */
+
+	/* thresholds for active connections */
+	u_int32_t		u_threshold;	/* upper threshold */
+	u_int32_t		l_threshold;	/* lower threshold */
+};
+
+struct ip_vs_dest_user {
+	/* destination server address */
+	__be32			__addr_v4; /* internal use only */
+	__be16			port;
+
+	/* real server options */
+	unsigned		conn_flags;	/* connection flags */
+	int			weight;		/* destination weight */
+
+	/* thresholds for active connections */
+	u_int32_t		u_threshold;	/* upper threshold */
+	u_int32_t		l_threshold;	/* lower threshold */
+	u_int16_t		af;
+	union nf_inet_addr	addr;
+};
+
+/*
+ *	IPVS statistics object (for user space)
+ */
+struct ip_vs_stats_user
+{
+	__u32                   conns;          /* connections scheduled */
+	__u32                   inpkts;         /* incoming packets */
+	__u32                   outpkts;        /* outgoing packets */
+	__u64                   inbytes;        /* incoming bytes */
+	__u64                   outbytes;       /* outgoing bytes */
+
+	__u32			cps;		/* current connection rate */
+	__u32			inpps;		/* current in packet rate */
+	__u32			outpps;		/* current out packet rate */
+	__u32			inbps;		/* current in byte rate */
+	__u32			outbps;		/* current out byte rate */
+};
+
+/*
+ *	IPVS statistics object (for user space), 64-bit
+ */
+struct ip_vs_stats64 {
+	__u64			conns;		/* connections scheduled */
+	__u64			inpkts;		/* incoming packets */
+	__u64			outpkts;	/* outgoing packets */
+	__u64			inbytes;	/* incoming bytes */
+	__u64			outbytes;	/* outgoing bytes */
+
+	__u64			cps;		/* current connection rate */
+	__u64			inpps;		/* current in packet rate */
+	__u64			outpps;		/* current out packet rate */
+	__u64			inbps;		/* current in byte rate */
+	__u64			outbps;		/* current out byte rate */
+};
+
+/* The argument to IP_VS_SO_GET_INFO */
+struct ip_vs_getinfo {
+	/* version number */
+	unsigned int		version;
+
+	/* size of connection hash table */
+	unsigned int		size;
+
+	/* number of virtual services */
+	unsigned int		num_services;
+};
+
+
+/* The argument to IP_VS_SO_GET_SERVICE */
+struct ip_vs_service_entry_kern {
+	/* which service: user fills in these */
+	u_int16_t		protocol;
+	__be32			addr;	/* virtual address */
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* service options */
+	char			sched_name[IP_VS_SCHEDNAME_MAXLEN];
+	unsigned		flags;          /* virtual service flags */
+	unsigned		timeout;	/* persistent timeout */
+	__be32			netmask;	/* persistent netmask */
+
+	/* number of real servers */
+	unsigned int		num_dests;
+
+	/* statistics */
+	struct ip_vs_stats_user stats;
+};
+
+struct ip_vs_service_entry {
+	/* which service: user fills in these */
+	u_int16_t		protocol;
+	__be32			__addr_v4;	/* virtual address - internal use only*/
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* service options */
+	char			sched_name[IP_VS_SCHEDNAME_MAXLEN];
+	unsigned		flags;          /* virtual service flags */
+	unsigned		timeout;	/* persistent timeout */
+	__be32			netmask;	/* persistent netmask */
+
+	/* number of real servers */
+	unsigned int		num_dests;
+
+	/* statistics */
+	struct ip_vs_stats_user stats;
+
+	u_int16_t		af;
+	union nf_inet_addr	addr;
+	char			pe_name[IP_VS_PENAME_MAXLEN];
+
+	/* statistics, 64-bit */
+	struct ip_vs_stats64	stats64;
+};
+
+struct ip_vs_dest_entry_kern {
+	__be32			addr;	/* destination address */
+	__be16			port;
+	unsigned		conn_flags;	/* connection flags */
+	int			weight;		/* destination weight */
+
+	u_int32_t		u_threshold;	/* upper threshold */
+	u_int32_t		l_threshold;	/* lower threshold */
+
+	u_int32_t		activeconns;	/* active connections */
+	u_int32_t		inactconns;	/* inactive connections */
+	u_int32_t		persistconns;	/* persistent connections */
+
+	/* statistics */
+	struct ip_vs_stats_user stats;
+};
+
+struct ip_vs_dest_entry {
+	__be32			__addr_v4;	/* destination address - internal use only */
+	__be16			port;
+	unsigned		conn_flags;	/* connection flags */
+	int			weight;		/* destination weight */
+
+	u_int32_t		u_threshold;	/* upper threshold */
+	u_int32_t		l_threshold;	/* lower threshold */
+
+	u_int32_t		activeconns;	/* active connections */
+	u_int32_t		inactconns;	/* inactive connections */
+	u_int32_t		persistconns;	/* persistent connections */
+
+	/* statistics */
+	struct ip_vs_stats_user stats;
+	u_int16_t		af;
+	union nf_inet_addr	addr;
+
+	/* statistics, 64-bit */
+	struct ip_vs_stats64	stats64;
+};
+
+/* The argument to IP_VS_SO_GET_DESTS */
+struct ip_vs_get_dests_kern {
+	/* which service: user fills in these */
+	u_int16_t		protocol;
+	__be32			addr;	/* virtual address - internal use only */
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* number of real servers */
+	unsigned int		num_dests;
+
+	/* the real servers */
+	struct ip_vs_dest_entry_kern	entrytable[0];
+};
+
+struct ip_vs_get_dests {
+	/* which service: user fills in these */
+	u_int16_t		protocol;
+	__be32			__addr_v4;	/* virtual address - internal use only */
+	__be16			port;
+	u_int32_t		fwmark;		/* firwall mark of service */
+
+	/* number of real servers */
+	unsigned int		num_dests;
+	u_int16_t		af;
+	union nf_inet_addr	addr;
+
+	/* the real servers */
+	struct ip_vs_dest_entry	entrytable[0];
+};
+
+/* The argument to IP_VS_SO_GET_SERVICES */
+struct ip_vs_get_services {
+	/* number of virtual services */
+	unsigned int		num_services;
+
+	/* service table */
+	struct ip_vs_service_entry entrytable[0];
+};
+
+struct ip_vs_get_services_kern {
+	/* number of virtual services */
+	unsigned int		num_services;
+
+	/* service table */
+	struct ip_vs_service_entry_kern entrytable[0];
+};
+
+/* The argument to IP_VS_SO_GET_TIMEOUT */
+struct ip_vs_timeout_user {
+	int			tcp_timeout;
+	int			tcp_fin_timeout;
+	int			udp_timeout;
+};
+
+
+/* The argument to IP_VS_SO_GET_DAEMON */
+struct ip_vs_daemon_kern {
+	/* sync daemon state (master/backup) */
+	int			state;
+
+	/* multicast interface name */
+	char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
+
+	/* SyncID we belong to */
+	int			syncid;
+};
+
+struct ip_vs_daemon_user {
+	/* sync daemon state (master/backup) */
+	int			state;
+
+	/* multicast interface name */
+	char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
+
+	/* SyncID we belong to */
+	int			syncid;
+
+	/* UDP Payload Size */
+	int			sync_maxlen;
+
+	/* Multicast Port (base) */
+	u_int16_t		mcast_port;
+
+	/* Multicast TTL */
+	u_int16_t		mcast_ttl;
+
+	/* Multicast Address Family */
+	u_int16_t		mcast_af;
+
+	/* Multicast Address */
+	union nf_inet_addr	mcast_group;
+};
+
+
+/*
+ *
+ * IPVS Generic Netlink interface definitions
+ *
+ */
+
+/* Generic Netlink family info */
+
+#define IPVS_GENL_NAME		"IPVS"
+#define IPVS_GENL_VERSION	0x1
+
+struct ip_vs_flags {
+	__be32 flags;
+	__be32 mask;
+};
+
+/* Generic Netlink command attributes */
+enum {
+	IPVS_CMD_UNSPEC = 0,
+
+	IPVS_CMD_NEW_SERVICE,		/* add service */
+	IPVS_CMD_SET_SERVICE,		/* modify service */
+	IPVS_CMD_DEL_SERVICE,		/* delete service */
+	IPVS_CMD_GET_SERVICE,		/* get info about specific service */
+
+	IPVS_CMD_NEW_DEST,		/* add destination */
+	IPVS_CMD_SET_DEST,		/* modify destination */
+	IPVS_CMD_DEL_DEST,		/* delete destination */
+	IPVS_CMD_GET_DEST,		/* get list of all service dests */
+
+	IPVS_CMD_NEW_DAEMON,		/* start sync daemon */
+	IPVS_CMD_DEL_DAEMON,		/* stop sync daemon */
+	IPVS_CMD_GET_DAEMON,		/* get sync daemon status */
+
+	IPVS_CMD_SET_TIMEOUT,		/* set TCP and UDP timeouts */
+	IPVS_CMD_GET_TIMEOUT,		/* get TCP and UDP timeouts */
+
+	IPVS_CMD_SET_INFO,		/* only used in GET_INFO reply */
+	IPVS_CMD_GET_INFO,		/* get general IPVS info */
+
+	IPVS_CMD_ZERO,			/* zero all counters and stats */
+	IPVS_CMD_FLUSH,			/* flush services and dests */
+
+	__IPVS_CMD_MAX,
+};
+
+#define IPVS_CMD_MAX (__IPVS_CMD_MAX - 1)
+
+/* Attributes used in the first level of commands */
+enum {
+	IPVS_CMD_ATTR_UNSPEC = 0,
+	IPVS_CMD_ATTR_SERVICE,		/* nested service attribute */
+	IPVS_CMD_ATTR_DEST,		/* nested destination attribute */
+	IPVS_CMD_ATTR_DAEMON,		/* nested sync daemon attribute */
+	IPVS_CMD_ATTR_TIMEOUT_TCP,	/* TCP connection timeout */
+	IPVS_CMD_ATTR_TIMEOUT_TCP_FIN,	/* TCP FIN wait timeout */
+	IPVS_CMD_ATTR_TIMEOUT_UDP,	/* UDP timeout */
+	__IPVS_CMD_ATTR_MAX,
+};
+
+#define IPVS_CMD_ATTR_MAX (__IPVS_CMD_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe a service
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_SERVICE
+ */
+enum {
+	IPVS_SVC_ATTR_UNSPEC = 0,
+	IPVS_SVC_ATTR_AF,		/* address family */
+	IPVS_SVC_ATTR_PROTOCOL,		/* virtual service protocol */
+	IPVS_SVC_ATTR_ADDR,		/* virtual service address */
+	IPVS_SVC_ATTR_PORT,		/* virtual service port */
+	IPVS_SVC_ATTR_FWMARK,		/* firewall mark of service */
+
+	IPVS_SVC_ATTR_SCHED_NAME,	/* name of scheduler */
+	IPVS_SVC_ATTR_FLAGS,		/* virtual service flags */
+	IPVS_SVC_ATTR_TIMEOUT,		/* persistent timeout */
+	IPVS_SVC_ATTR_NETMASK,		/* persistent netmask */
+
+	IPVS_SVC_ATTR_STATS,		/* nested attribute for service stats */
+
+	IPVS_SVC_ATTR_PE_NAME,		/* name of scheduler */
+
+	IPVS_SVC_ATTR_STATS64,		/* nested attribute for service stats */
+
+	__IPVS_SVC_ATTR_MAX,
+};
+
+#define IPVS_SVC_ATTR_MAX (__IPVS_SVC_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe a destination (real server)
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_DEST
+ */
+enum {
+	IPVS_DEST_ATTR_UNSPEC = 0,
+	IPVS_DEST_ATTR_ADDR,		/* real server address */
+	IPVS_DEST_ATTR_PORT,		/* real server port */
+
+	IPVS_DEST_ATTR_FWD_METHOD,	/* forwarding method */
+	IPVS_DEST_ATTR_WEIGHT,		/* destination weight */
+
+	IPVS_DEST_ATTR_U_THRESH,	/* upper threshold */
+	IPVS_DEST_ATTR_L_THRESH,	/* lower threshold */
+
+	IPVS_DEST_ATTR_ACTIVE_CONNS,	/* active connections */
+	IPVS_DEST_ATTR_INACT_CONNS,	/* inactive connections */
+	IPVS_DEST_ATTR_PERSIST_CONNS,	/* persistent connections */
+
+	IPVS_DEST_ATTR_STATS,		/* nested attribute for dest stats */
+
+	IPVS_DEST_ATTR_ADDR_FAMILY,	/* Address family of address */
+
+	IPVS_DEST_ATTR_STATS64,		/* nested attribute for dest stats */
+
+	__IPVS_DEST_ATTR_MAX,
+};
+
+#define IPVS_DEST_ATTR_MAX (__IPVS_DEST_ATTR_MAX - 1)
+
+/*
+ * Attributes describing a sync daemon
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_DAEMON
+ */
+enum {
+	IPVS_DAEMON_ATTR_UNSPEC = 0,
+	IPVS_DAEMON_ATTR_STATE,		/* sync daemon state (master/backup) */
+	IPVS_DAEMON_ATTR_MCAST_IFN,	/* multicast interface name */
+	IPVS_DAEMON_ATTR_SYNC_ID,	/* SyncID we belong to */
+	IPVS_DAEMON_ATTR_SYNC_MAXLEN,	/* UDP Payload Size */
+	IPVS_DAEMON_ATTR_MCAST_GROUP,	/* IPv4 Multicast Address */
+	IPVS_DAEMON_ATTR_MCAST_GROUP6,	/* IPv6 Multicast Address */
+	IPVS_DAEMON_ATTR_MCAST_PORT,	/* Multicast Port (base) */
+	IPVS_DAEMON_ATTR_MCAST_TTL,	/* Multicast TTL */
+	__IPVS_DAEMON_ATTR_MAX,
+};
+
+#define IPVS_DAEMON_ATTR_MAX (__IPVS_DAEMON_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe service or destination entry statistics
+ *
+ * Used inside nested attributes IPVS_SVC_ATTR_STATS, IPVS_DEST_ATTR_STATS,
+ * IPVS_SVC_ATTR_STATS64 and IPVS_DEST_ATTR_STATS64.
+ */
+enum {
+	IPVS_STATS_ATTR_UNSPEC = 0,
+	IPVS_STATS_ATTR_CONNS,		/* connections scheduled */
+	IPVS_STATS_ATTR_INPKTS,		/* incoming packets */
+	IPVS_STATS_ATTR_OUTPKTS,	/* outgoing packets */
+	IPVS_STATS_ATTR_INBYTES,	/* incoming bytes */
+	IPVS_STATS_ATTR_OUTBYTES,	/* outgoing bytes */
+
+	IPVS_STATS_ATTR_CPS,		/* current connection rate */
+	IPVS_STATS_ATTR_INPPS,		/* current in packet rate */
+	IPVS_STATS_ATTR_OUTPPS,		/* current out packet rate */
+	IPVS_STATS_ATTR_INBPS,		/* current in byte rate */
+	IPVS_STATS_ATTR_OUTBPS,		/* current out byte rate */
+	__IPVS_STATS_ATTR_MAX,
+};
+
+#define IPVS_STATS_ATTR_MAX (__IPVS_STATS_ATTR_MAX - 1)
+
+/* Attributes used in response to IPVS_CMD_GET_INFO command */
+enum {
+	IPVS_INFO_ATTR_UNSPEC = 0,
+	IPVS_INFO_ATTR_VERSION,		/* IPVS version number */
+	IPVS_INFO_ATTR_CONN_TAB_SIZE,	/* size of connection hash table */
+	__IPVS_INFO_ATTR_MAX,
+};
+
+#define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
+
+#ifdef LIBIPVS_USE_NL
+extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
+extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
+extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
+extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
+extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
+extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
+#endif
+
+/* End of Generic Netlink interface definitions */
+
+#endif	/* _IP_VS_H */

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -42,14 +42,28 @@
 # include <netinet/in.h>
 #endif /* HAVE_NETINET_IN_H */
 
-/* this can probably only be found in the kernel sources */
-#if HAVE_LINUX_IP_VS_H
-# include <linux/ip_vs.h>
-#elif HAVE_NET_IP_VS_H
-# include <net/ip_vs.h>
-#elif HAVE_IP_VS_H
-# include <ip_vs.h>
-#endif /* HAVE_IP_VS_H */
+
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/msg.h>
+
+//Include our own version of ip_vs.h
+#include "ip_vs.h"
+
+
+#ifdef LIBIPVS_USE_NL
+#ifdef FALLBACK_LIBNL1
+#define nl_sock         nl_handle
+#define nl_socket_alloc nl_handle_alloc
+#define nl_socket_free  nl_handle_destroy
+#endif
+static  struct nl_sock *sock = NULL;
+static  int family, try_nl = 1;
+typedef struct ip_vs_service_entry      ipvs_service_entry_t;
+typedef struct ip_vs_dest_entry         ipvs_dest_entry_t;
+#endif
+
 
 #define log_err(...) ERROR ("ipvs: " __VA_ARGS__)
 #define log_info(...) INFO ("ipvs: " __VA_ARGS__)
@@ -58,81 +72,554 @@
  * private variables
  */
 static int sockfd = -1;
+static void* ipvs_func = NULL;
+struct ip_vs_getinfo ipvs_info;
 
+#ifdef LIBIPVS_USE_NL
+/* Policy definitions */
+struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
+	[IPVS_CMD_ATTR_SERVICE]		= { .type = NLA_NESTED },
+	[IPVS_CMD_ATTR_DEST]		= { .type = NLA_NESTED },
+	[IPVS_CMD_ATTR_DAEMON]		= { .type = NLA_NESTED },
+	[IPVS_CMD_ATTR_TIMEOUT_TCP]	= { .type = NLA_U32 },
+	[IPVS_CMD_ATTR_TIMEOUT_TCP_FIN]	= { .type = NLA_U32 },
+	[IPVS_CMD_ATTR_TIMEOUT_UDP]	= { .type = NLA_U32 },
+};
+
+struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
+	[IPVS_SVC_ATTR_AF]		= { .type = NLA_U16 },
+	[IPVS_SVC_ATTR_PROTOCOL]	= { .type = NLA_U16 },
+	[IPVS_SVC_ATTR_ADDR]		= { .type = NLA_UNSPEC,
+					    .maxlen = sizeof(struct in6_addr) },
+	[IPVS_SVC_ATTR_PORT]		= { .type = NLA_U16 },
+	[IPVS_SVC_ATTR_FWMARK]		= { .type = NLA_U32 },
+	[IPVS_SVC_ATTR_SCHED_NAME]	= { .type = NLA_STRING,
+					    .maxlen = IP_VS_SCHEDNAME_MAXLEN },
+	[IPVS_SVC_ATTR_FLAGS]		= { .type = NLA_UNSPEC,
+					    .minlen = sizeof(struct ip_vs_flags),
+					    .maxlen = sizeof(struct ip_vs_flags) },
+	[IPVS_SVC_ATTR_TIMEOUT]		= { .type = NLA_U32 },
+	[IPVS_SVC_ATTR_NETMASK]		= { .type = NLA_U32 },
+	[IPVS_SVC_ATTR_STATS]		= { .type = NLA_NESTED },
+};
+
+struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
+	[IPVS_DEST_ATTR_ADDR]		= { .type = NLA_UNSPEC,
+					    .maxlen = sizeof(struct in6_addr) },
+	[IPVS_DEST_ATTR_PORT]		= { .type = NLA_U16 },
+	[IPVS_DEST_ATTR_FWD_METHOD]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_WEIGHT]		= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_U_THRESH]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_L_THRESH]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_ACTIVE_CONNS]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_INACT_CONNS]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_PERSIST_CONNS]	= { .type = NLA_U32 },
+	[IPVS_DEST_ATTR_STATS]		= { .type = NLA_NESTED },
+};
+
+struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
+	[IPVS_STATS_ATTR_CONNS]		= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_INPKTS]	= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_OUTPKTS]	= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_INBYTES]	= { .type = NLA_U64 },
+	[IPVS_STATS_ATTR_OUTBYTES]	= { .type = NLA_U64 },
+	[IPVS_STATS_ATTR_CPS]		= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_INPPS]		= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_OUTPPS]	= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_INBPS]		= { .type = NLA_U32 },
+	[IPVS_STATS_ATTR_OUTBPS]	= { .type = NLA_U32 },
+};
+
+struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
+	[IPVS_INFO_ATTR_VERSION]	= { .type = NLA_U32 },
+	[IPVS_INFO_ATTR_CONN_TAB_SIZE]	= { .type = NLA_U32 },
+};
+#endif
 /*
  * libipvs API
  */
-static struct ip_vs_get_services *ipvs_get_services (void)
+#ifdef LIBIPVS_USE_NL
+struct nl_msg *ipvs_nl_message(int cmd, int flags)
 {
-	struct ip_vs_getinfo       ipvs_info;
-	struct ip_vs_get_services *ret;
+	struct nl_msg *msg;
 
+	msg = nlmsg_alloc();
+	if (!msg)
+		return NULL;
+
+	genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, family, 0, flags,
+		cmd, IPVS_GENL_VERSION);
+
+	return msg;
+}
+
+int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, void *arg)
+{
+	int err = EINVAL;
+
+	sock = nl_socket_alloc();
+	if (!sock) {
+		nlmsg_free(msg);
+		return -1;
+	}
+
+	if (genl_connect(sock) < 0)
+		goto fail_genl;
+
+	family = genl_ctrl_resolve(sock, IPVS_GENL_NAME);
+	if (family < 0)
+		goto fail_genl;
+
+/* To test connections and set the family */
+	if (msg == NULL) {
+		nl_socket_free(sock);
+		sock = NULL;
+		return 0;
+	}
+
+	if (nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, func, arg) != 0)
+		goto fail_genl;
+
+	if (nl_send_auto_complete(sock, msg) < 0)
+		goto fail_genl;
+
+	if ((err = -nl_recvmsgs_default(sock)) > 0)
+		goto fail_genl;
+
+	nlmsg_free(msg);
+
+	nl_socket_free(sock);
+
+	return 0;
+
+fail_genl:
+	nl_socket_free(sock);
+	sock = NULL;
+	nlmsg_free(msg);
+	errno = err;
+	return -1;
+}
+
+static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg)
+{
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *attrs[IPVS_INFO_ATTR_MAX + 1];
+
+	if (genlmsg_parse(nlh, 0, attrs, IPVS_INFO_ATTR_MAX, ipvs_info_policy) != 0)
+		return -1;
+
+	if (!(attrs[IPVS_INFO_ATTR_VERSION] &&
+			attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]))
+		return -1;
+
+	ipvs_info.version = nla_get_u32(attrs[IPVS_INFO_ATTR_VERSION]);
+	ipvs_info.size = nla_get_u32(attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]);
+
+	return NL_OK;
+}
+#endif
+
+int ipvs_getinfo(void)
+{
 	socklen_t len;
 
-	len = sizeof (ipvs_info);
+#ifdef LIBIPVS_USE_NL
+	if (try_nl) {
+		struct nl_msg *msg;
+		msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
+		if (msg)
+			return ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb,NULL);
+		return -1;
+	}
+#endif
 
-	if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,
-				(void *)&ipvs_info, &len)) {
-		char errbuf[1024];
-		log_err ("ip_vs_get_services: getsockopt() failed: %s",
-				sstrerror (errno, errbuf, sizeof (errbuf)));
-		return NULL;
+	ipvs_func = ipvs_getinfo;
+	len = sizeof(ipvs_info);
+	return getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,
+			(char *)&ipvs_info, &len);
+}
+
+int ipvs_init(void)
+{
+	socklen_t len;
+
+	ipvs_func = ipvs_init;
+
+#ifdef LIBIPVS_USE_NL
+	try_nl = 1;
+
+	if (ipvs_nl_send_message(NULL, NULL, NULL) == 0) {
+		try_nl = 1;
+		return ipvs_getinfo();
 	}
 
-	len = sizeof (*ret) +
-		sizeof (struct ip_vs_service_entry) * ipvs_info.num_services;
+	try_nl = 0;
+#endif
 
-	if (NULL == (ret = malloc (len))) {
-		log_err ("ipvs_get_services: Out of memory.");
-		exit (3);
+	len = sizeof(ipvs_info);
+	if ((sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) == -1)
+		return -1;
+
+	if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,
+			(char *)&ipvs_info, &len))
+		return -1;
+
+	return 0;
+}
+
+static int ipvs_parse_stats(struct ip_vs_stats64 *stats, struct nlattr *nla)
+{
+	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+
+	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
+		return -1;
+
+	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
+			attrs[IPVS_STATS_ATTR_INPKTS] &&
+			attrs[IPVS_STATS_ATTR_OUTPKTS] &&
+			attrs[IPVS_STATS_ATTR_INBYTES] &&
+			attrs[IPVS_STATS_ATTR_OUTBYTES] &&
+			attrs[IPVS_STATS_ATTR_CPS] &&
+			attrs[IPVS_STATS_ATTR_INPPS] &&
+			attrs[IPVS_STATS_ATTR_OUTPPS] &&
+			attrs[IPVS_STATS_ATTR_INBPS] &&
+			attrs[IPVS_STATS_ATTR_OUTBPS]))
+		return -1;
+
+	stats->conns = nla_get_u32(attrs[IPVS_STATS_ATTR_CONNS]);
+	stats->inpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_INPKTS]);
+	stats->outpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+	stats->cps = nla_get_u32(attrs[IPVS_STATS_ATTR_CPS]);
+	stats->inpps = nla_get_u32(attrs[IPVS_STATS_ATTR_INPPS]);
+	stats->outpps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPPS]);
+	stats->inbps = nla_get_u32(attrs[IPVS_STATS_ATTR_INBPS]);
+	stats->outbps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTBPS]);
+
+	return 0;
+
+}
+
+static int ipvs_parse_stats64(struct ip_vs_stats64 *stats, struct nlattr *nla)
+{
+	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+
+	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla,
+			ipvs_stats_policy))
+		return -1;
+
+	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
+		attrs[IPVS_STATS_ATTR_INPKTS] &&
+		attrs[IPVS_STATS_ATTR_OUTPKTS] &&
+		attrs[IPVS_STATS_ATTR_INBYTES] &&
+		attrs[IPVS_STATS_ATTR_OUTBYTES] &&
+		attrs[IPVS_STATS_ATTR_CPS] &&
+		attrs[IPVS_STATS_ATTR_INPPS] &&
+		attrs[IPVS_STATS_ATTR_OUTPPS] &&
+		attrs[IPVS_STATS_ATTR_INBPS] &&
+		attrs[IPVS_STATS_ATTR_OUTBPS]))
+	return -1;
+
+	stats->conns = nla_get_u64(attrs[IPVS_STATS_ATTR_CONNS]);
+	stats->inpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_INPKTS]);
+	stats->outpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+	stats->cps = nla_get_u64(attrs[IPVS_STATS_ATTR_CPS]);
+	stats->inpps = nla_get_u64(attrs[IPVS_STATS_ATTR_INPPS]);
+	stats->outpps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPPS]);
+	stats->inbps = nla_get_u64(attrs[IPVS_STATS_ATTR_INBPS]);
+	stats->outbps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBPS]);
+
+	return 0;
+}
+
+static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
+{
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+	struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
+	struct ip_vs_get_services **getp = (struct ip_vs_get_services **)arg;
+	struct ip_vs_get_services *get = (struct ip_vs_get_services *)*getp;
+	struct ip_vs_flags flags;
+	int i = get->num_services;
+
+	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+		return -1;
+
+	if (!attrs[IPVS_CMD_ATTR_SERVICE])
+		return -1;
+
+	if (nla_parse_nested(svc_attrs, IPVS_SVC_ATTR_MAX, attrs[IPVS_CMD_ATTR_SERVICE], ipvs_service_policy))
+		return -1;
+
+		memset(&(get->entrytable[i]), 0, sizeof(get->entrytable[i]));
+
+		if (!(svc_attrs[IPVS_SVC_ATTR_AF] &&
+			(svc_attrs[IPVS_SVC_ATTR_FWMARK] ||
+			(svc_attrs[IPVS_SVC_ATTR_PROTOCOL] &&
+			svc_attrs[IPVS_SVC_ATTR_ADDR] &&
+			svc_attrs[IPVS_SVC_ATTR_PORT])) &&
+			svc_attrs[IPVS_SVC_ATTR_SCHED_NAME] &&
+			svc_attrs[IPVS_SVC_ATTR_NETMASK] &&
+			svc_attrs[IPVS_SVC_ATTR_TIMEOUT] &&
+			svc_attrs[IPVS_SVC_ATTR_FLAGS]))
+			return -1;
+
+		get->entrytable[i].af = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_AF]);
+
+		if (svc_attrs[IPVS_SVC_ATTR_FWMARK])
+			get->entrytable[i].fwmark = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_FWMARK]);
+		else {
+			get->entrytable[i].protocol = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PROTOCOL]);
+			memcpy(&(get->entrytable[i].addr), nla_data(svc_attrs[IPVS_SVC_ATTR_ADDR]),
+				sizeof(get->entrytable[i].addr));
+			get->entrytable[i].port = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PORT]);
+		}
+
+		strncpy(get->entrytable[i].sched_name,
+			nla_get_string(svc_attrs[IPVS_SVC_ATTR_SCHED_NAME]),
+		IP_VS_SCHEDNAME_MAXLEN);
+
+		if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
+			strncpy(get->entrytable[i].pe_name,
+				nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
+				IP_VS_PENAME_MAXLEN);
+
+		get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
+		get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
+		nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
+		get->entrytable[i].flags = flags.flags & flags.mask;
+
+		if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
+			if (ipvs_parse_stats64(&get->entrytable[i].stats64,
+					svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
+				return -1;
+		} else if (svc_attrs[IPVS_SVC_ATTR_STATS]) {
+			if (ipvs_parse_stats(&get->entrytable[i].stats64,
+				svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
+				return -1;
+		}
+
+		get->entrytable[i].num_dests = 0;
+		i++;
+
+		get->num_services = i;
+		get = realloc(get, sizeof(*get)
+				+ sizeof(ipvs_service_entry_t) * (get->num_services + 1));
+		*getp = get;
+		return 0;
+}
+
+struct ip_vs_get_services *ipvs_get_services(void)
+{
+		struct ip_vs_get_services *get;
+		struct ip_vs_get_services_kern *getk;
+		socklen_t len;
+		int i;
+	//	char straddr[INET6_ADDRSTRLEN];
+
+#ifdef LIBIPVS_USE_NL
+		if (try_nl) {
+			struct nl_msg *msg;
+			len = sizeof(*get) +
+					sizeof(ipvs_service_entry_t);
+			if (!(get = malloc(len)))
+				return NULL;
+
+			get->num_services = 0;
+
+			msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
+
+			if (msg && (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &get) == 0)) {
+				return get;
+			}
+			free(get);
+			return NULL;
+		}
+#endif
+
+		len = sizeof(*get) +
+			sizeof(ipvs_service_entry_t) * ipvs_info.num_services;
+		if (!(get = malloc(len)))
+			return NULL;
+		len = sizeof(*getk) +
+			sizeof(struct ip_vs_service_entry_kern) * ipvs_info.num_services;
+		if (!(getk = malloc(len))) {
+			free(get);
+			return NULL;
+		}
+
+		ipvs_func = ipvs_get_services;
+		getk->num_services = ipvs_info.num_services;
+
+		if (getsockopt(sockfd, IPPROTO_IP,
+			IP_VS_SO_GET_SERVICES, getk, &len) < 0) {
+			free(get);
+			free(getk);
+			return NULL;
+		}
+		memcpy(get, getk, sizeof(struct ip_vs_get_services));
+		for (i = 0; i < getk->num_services; i++) {
+				memcpy(&get->entrytable[i], &getk->entrytable[i],
+					sizeof(struct ip_vs_service_entry_kern));
+				get->entrytable[i].af = AF_INET;
+				get->entrytable[i].addr.ip = get->entrytable[i].__addr_v4;
+		}
+		free(getk);
+		return get;
+}
+
+static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg)
+{
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+	struct nlattr *dest_attrs[IPVS_DEST_ATTR_MAX + 1];
+	struct nlattr *attr_addr_family = NULL;
+	struct ip_vs_get_dests **dp = (struct ip_vs_get_dests **)arg;
+	struct ip_vs_get_dests *d = (struct ip_vs_get_dests *)*dp;
+	int i = d->num_dests;
+
+	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+		return -1;
+
+	if (!attrs[IPVS_CMD_ATTR_DEST])
+		return -1;
+
+	if (nla_parse_nested(dest_attrs, IPVS_DEST_ATTR_MAX, attrs[IPVS_CMD_ATTR_DEST], ipvs_dest_policy))
+		return -1;
+
+	memset(&(d->entrytable[i]), 0, sizeof(d->entrytable[i]));
+
+	if (!(dest_attrs[IPVS_DEST_ATTR_ADDR] &&
+			dest_attrs[IPVS_DEST_ATTR_PORT] &&
+			dest_attrs[IPVS_DEST_ATTR_FWD_METHOD] &&
+			dest_attrs[IPVS_DEST_ATTR_WEIGHT] &&
+			dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
+			dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
+			dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS] &&
+			dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
+			dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
+		return -1;
+
+	memcpy(&(d->entrytable[i].addr),
+		nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
+		sizeof(d->entrytable[i].addr));
+	d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
+	d->entrytable[i].conn_flags = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
+	d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
+	d->entrytable[i].u_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
+	d->entrytable[i].l_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
+	d->entrytable[i].activeconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
+	d->entrytable[i].inactconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
+	d->entrytable[i].persistconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
+	attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
+	if (attr_addr_family)
+		d->entrytable[i].af = nla_get_u16(attr_addr_family);
+	else
+		d->entrytable[i].af = d->af;
+
+	if (dest_attrs[IPVS_DEST_ATTR_STATS64]) {
+		if (ipvs_parse_stats(&d->entrytable[i].stats64,
+				dest_attrs[IPVS_DEST_ATTR_STATS64]) != 0)
+			return -1;
+	} else if (dest_attrs[IPVS_DEST_ATTR_STATS]) {
+		if (ipvs_parse_stats(&d->entrytable[i].stats64,
+				dest_attrs[IPVS_DEST_ATTR_STATS]) != 0)
+			return -1;
 	}
 
-	ret->num_services = ipvs_info.num_services;
+	i++;
 
-	if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_SERVICES,
-				(void *)ret, &len)) {
-		char errbuf[1024];
-		log_err ("ipvs_get_services: getsockopt failed: %s",
-				sstrerror (errno, errbuf, sizeof (errbuf)));
-
-		free(ret);
-		return NULL;
-	}
-	return ret;
-} /* ipvs_get_services */
+	d->num_dests = i;
+	d = realloc(d, sizeof(*d) + sizeof(ipvs_dest_entry_t) * (d->num_dests + 1));
+	*dp = d;
+	return 0;
+}
 
 static struct ip_vs_get_dests *ipvs_get_dests (struct ip_vs_service_entry *se)
 {
-	struct ip_vs_get_dests *ret;
-	socklen_t len;
+		struct ip_vs_get_dests *ret;
+		socklen_t len;
 
-	len = sizeof (*ret) + sizeof (struct ip_vs_dest_entry) * se->num_dests;
+		len = sizeof (*ret) + sizeof (struct ip_vs_dest_entry) * se->num_dests;
 
-	if (NULL == (ret = malloc (len))) {
-		log_err ("ipvs_get_dests: Out of memory.");
-		exit (3);
-	}
+		if (NULL == (ret = malloc (len))) {
+				log_err ("ipvs_get_dests: Out of memory.");
+				exit (3);
+		}
 
-	ret->fwmark    = se->fwmark;
-	ret->protocol  = se->protocol;
-	ret->addr      = se->addr;
-	ret->port      = se->port;
-	ret->num_dests = se->num_dests;
+#ifdef LIBIPVS_USE_NL
+		if (try_nl) {
+			struct nl_msg *msg;
+			struct nlattr *nl_service;
+				if (se->num_dests == 0)
+					ret  = realloc(ret,sizeof(*ret) + sizeof(struct ip_vs_dest_entry));
 
-	if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS,
-				(void *)ret, &len)) {
-		char errbuf[1024];
-		log_err ("ipvs_get_dests: getsockopt() failed: %s",
-				sstrerror (errno, errbuf, sizeof (errbuf)));
-		free (ret);
-		return NULL;
-	}
-	return ret;
+				ret->fwmark = se->fwmark;
+				ret->protocol = se->protocol;
+				ret->addr = se->addr;
+				ret->port = se->port;
+				ret->num_dests = se->num_dests;
+				ret->af = se->af;
+
+				msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
+				if (!msg)
+					goto ipvs_nl_dest_failure;
+
+				nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
+				if (!nl_service)
+					goto nla_put_failure;
+
+				NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
+
+				if (se->fwmark) {
+					NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
+				} else {
+					NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
+					NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr),
+						&se->addr);
+					NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
+				}
+
+				nla_nest_end(msg, nl_service);
+				if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
+					goto ipvs_nl_dest_failure;
+
+				return ret;
+
+nla_put_failure:
+				nlmsg_free(msg);
+ipvs_nl_dest_failure:
+				free(ret);
+				return NULL;
+		}
+#endif
+
+		ret->fwmark    = se->fwmark;
+		ret->protocol  = se->protocol;
+		ret->addr      = se->addr;
+		ret->port      = se->port;
+		ret->num_dests = se->num_dests;
+
+		if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS,
+					(void *)ret, &len)) {
+				char errbuf[1024];
+				log_err ("ipvs_get_dests: getsockopt() failed: %s",
+                                sstrerror (errno, errbuf, sizeof (errbuf)));
+				free (ret);
+				return NULL;
+		}
+		return ret;
 } /* ip_vs_get_dests */
+
+
 
 /*
  * collectd plugin API and helper functions
  */
+ //TODO ben pretty sure we should update this to use netlink?
 static int cipvs_init (void)
 {
 	struct ip_vs_getinfo ipvs_info;
@@ -181,19 +668,27 @@ static int cipvs_init (void)
 /* plugin instance */
 static int get_pi (struct ip_vs_service_entry *se, char *pi, size_t size)
 {
-	struct in_addr addr;
+	union nf_inet_addr addr;
+	char straddr[INET6_ADDRSTRLEN];
 	int len = 0;
+
 
 	if ((NULL == se) || (NULL == pi))
 		return 0;
 
-	addr.s_addr = se->addr;
+	addr = se->addr;
 
 	/* inet_ntoa() returns a pointer to a statically allocated buffer
 	 * I hope non-glibc systems behave the same */
-	len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr),
-			(se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-			ntohs (se->port));
+	if ( se->af == AF_INET6) {
+		len = ssnprintf (pi, size, "%s_%s%u", inet_ntop(AF_INET6, &addr,
+			 	straddr, sizeof(straddr)), (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+				ntohs (se->port));
+	}else {
+		len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr.in),
+				(se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+				ntohs (se->port));
+	}
 
 	if ((0 > len) || (size <= ((size_t) len))) {
 		log_err ("plugin instance truncated: %s", pi);
@@ -205,18 +700,25 @@ static int get_pi (struct ip_vs_service_entry *se, char *pi, size_t size)
 /* type instance */
 static int get_ti (struct ip_vs_dest_entry *de, char *ti, size_t size)
 {
-	struct in_addr addr;
+	union nf_inet_addr addr;
+	char straddr[INET6_ADDRSTRLEN];
 	int len = 0;
 
 	if ((NULL == de) || (NULL == ti))
 		return 0;
 
-	addr.s_addr = de->addr;
+	addr = de->addr;
 
 	/* inet_ntoa() returns a pointer to a statically allocated buffer
-	 * I hope non-glibc systems behave the same */
-	len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr),
-			ntohs (de->port));
+	* I hope non-glibc systems behave the same */
+	if ( de->af == AF_INET6) {
+		len = ssnprintf (ti, size, "%s_%u", inet_ntop(AF_INET6, &addr,
+				straddr, sizeof(straddr)),
+				ntohs (de->port));
+	}else {
+		len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr.in),
+				ntohs (de->port));
+	}
 
 	if ((0 > len) || (size <= ((size_t) len))) {
 		log_err ("type instance truncated: %s", ti);
@@ -267,7 +769,7 @@ static void cipvs_submit_if (const char *pi, const char *t, const char *ti,
 
 static void cipvs_submit_dest (const char *pi, struct ip_vs_dest_entry *de)
 {
-	struct ip_vs_stats_user stats = de->stats;
+	struct ip_vs_stats64  stats = de->stats64;
 
 	char ti[DATA_MAX_NAME_LEN];
 
@@ -308,6 +810,7 @@ static int cipvs_read (void)
 {
 	struct ip_vs_get_services *services = NULL;
 
+	//TODO ben check if this needs to be updated for netlink
 	if (sockfd < 0)
 		return (-1);
 


### PR DESCRIPTION
To retrieve IPV6 stats from ipvs requires the use of netlink as well as a newer ip_vs.h than what is in most systems. We check for different versions of netlink and have included a newer ip_vs header to work with netlink.
This is based on the work by Vince Busam adding IPV6 support to ipvsadm.