### PR TITLE
Fix Collectd::Unixsock

### DIFF
--- a/bindings/perl/lib/Collectd/MockDaemon.pm
+++ b/bindings/perl/lib/Collectd/MockDaemon.pm
@@ -56,8 +56,9 @@ sub daemon {
 
 sub listval {
     my $trunc_now = substr(time, 0, -1);
+    my $toggle;
     return print_nvalues(scalar @metrics) .
-    join('', map { sprintf("%s%d.%d %s\n", $trunc_now, rand(10), rand(1000), $_) } @metrics);
+    join('', map { $trunc_now . int(rand(10)) . ($toggle=!$toggle ? ".".int(rand(1000)) : '') . " $_\n" } @metrics);
 }
 
 sub getval {

--- a/bindings/perl/lib/Collectd/MockDaemon.pm
+++ b/bindings/perl/lib/Collectd/MockDaemon.pm
@@ -55,9 +55,9 @@ sub daemon {
 }
 
 sub listval {
-    my $now = time;
+    my $trunc_now = substr(time, 0, -1);
     return print_nvalues(scalar @metrics) .
-    join('', map { "$now $_\n" } @metrics);
+    join('', map { sprintf("%s%d.%d %s\n", $trunc_now, rand(10), rand(1000), $_) } @metrics);
 }
 
 sub getval {

--- a/bindings/perl/lib/Collectd/MockDaemon.pm
+++ b/bindings/perl/lib/Collectd/MockDaemon.pm
@@ -55,10 +55,20 @@ sub daemon {
 }
 
 sub listval {
-    my $trunc_now = substr(time, 0, -1);
-    my $toggle;
+    my @timevals = (
+        1479835353.75,
+        1479835354.434,
+        1479835356,
+        1479835354,
+        1479835354,
+        1479835350.820,
+        1479835351,
+        1479835354.2,
+        1479835353,
+    );
+    my $i = 0;
     return print_nvalues(scalar @metrics) .
-    join('', map { $trunc_now . int(rand(10)) . ($toggle=!$toggle ? ".".int(rand(1000)) : '') . " $_\n" } @metrics);
+    join('', map { $timevals[$i++ % @timevals] . " $_\n" } @metrics);
 }
 
 sub getval {

--- a/bindings/perl/lib/Collectd/Unixsock.pm
+++ b/bindings/perl/lib/Collectd/Unixsock.pm
@@ -383,7 +383,7 @@ sub listval_filter
 	(exists $args{plugin_instance}   ? "-$args{plugin_instance}" : '(?:-[^/]+)?') .
 	(exists $args{type}              ? "/$args{type}"            : '/[^/-]+') .
 	(exists $args{type_instance}     ? "-$args{type_instance}"   : '(?:-[^/]+)?');
-	$pattern = qr/^\d+ $pattern$/;
+	$pattern = qr/^\d+\.\d+ $pattern$/;
 
 	my $msg = $self->_socket_command('LISTVAL') or return;
 	($nresults, $msg) = split / /, $msg, 2;
@@ -410,7 +410,7 @@ sub listval_filter
 	} # for (i = 0 .. $status)
 
 	return @ret;
-} # listval
+} # listval_filter
 
 =item I<$res> = I<$self>-E<gt>B<listval> ()
 

--- a/bindings/perl/lib/Collectd/Unixsock.pm
+++ b/bindings/perl/lib/Collectd/Unixsock.pm
@@ -383,7 +383,7 @@ sub listval_filter
 	(exists $args{plugin_instance}   ? "-$args{plugin_instance}" : '(?:-[^/]+)?') .
 	(exists $args{type}              ? "/$args{type}"            : '/[^/-]+') .
 	(exists $args{type_instance}     ? "-$args{type_instance}"   : '(?:-[^/]+)?');
-	$pattern = qr/^\d+\.\d+ $pattern$/;
+	$pattern = qr/^\d+(?:\.\d+)? $pattern$/;
 
 	my $msg = $self->_socket_command('LISTVAL') or return;
 	($nresults, $msg) = split / /, $msg, 2;

--- a/bindings/perl/lib/Collectd/Unixsock.pm
+++ b/bindings/perl/lib/Collectd/Unixsock.pm
@@ -137,7 +137,7 @@ sub _parse_identifier
 
 sub _escape_argument
 {
-    my $arg = shift;
+	my $arg = shift;
 
 	return $arg if $arg =~ /^\w+$/;
 
@@ -153,19 +153,19 @@ sub _socket_command {
 
 	my $fh = $self->{sock} or confess ('object has no filehandle');
 
-    if($args) {
-        my $identifier = _create_identifier ($args) or return;
-	    $command .= ' ' . _escape_argument ($identifier) . "\n";
-    } else {
-        $command .= "\n";
-    }
+	if($args) {
+		my $identifier = _create_identifier ($args) or return;
+		$command .= ' ' . _escape_argument ($identifier) . "\n";
+	} else {
+		$command .= "\n";
+	}
 	_debug "-> $command";
 	$fh->print($command);
 
 	my $response = $fh->getline;
 	chomp $response;
 	_debug "<- $response\n";
-    return $response;
+	return $response;
 }
 
 # Read any remaining results from a socket and pass them to
@@ -188,7 +188,7 @@ sub _socket_chat
 		my $entry = $fh->getline;
 		chomp $entry;
 		_debug "<- $entry\n";
-        $callback->($entry, $cbdata);
+		$callback->($entry, $cbdata);
 	}
 	return $cbdata;
 }
@@ -260,14 +260,14 @@ sub getval # {{{
 	my %args = @_;
 	my $ret = {};
 
-    my $msg = $self->_socket_command('GETVAL', \%args) or return;
-    $self->_socket_chat($msg, sub {
-            local $_ = shift;
-            my $ret = shift;
-            /^(\w+)=NaN$/ and $ret->{$1} = undef, return;
-            /^(\w+)=(.*)$/ and looks_like_number($2) and $ret->{$1} = 0 + $2, return;
-        }, $ret
-    );
+	my $msg = $self->_socket_command('GETVAL', \%args) or return;
+	$self->_socket_chat($msg, sub {
+			local $_ = shift;
+			my $ret = shift;
+			/^(\w+)=NaN$/ and $ret->{$1} = undef, return;
+			/^(\w+)=(.*)$/ and looks_like_number($2) and $ret->{$1} = 0 + $2, return;
+		}, $ret
+	);
 	return $ret;
 } # }}} sub getval
 
@@ -284,17 +284,17 @@ sub getthreshold # {{{
 	my %args = @_;
 	my $ret = {};
 
-    my $msg = $self->_socket_command('GETTHRESHOLD', \%args) or return;
-    $self->_socket_chat($msg, sub {
-            local $_ = shift;
-            my $ret = shift;
-            my ( $key, $val );
-            ( $key, $val ) = /^\s*([^:]+):\s*(.*)/ and do {
-                  $key =~ s/\s*$//;
-                  $ret->{$key} = $val;
-            };
-        }, $ret
-    );
+	my $msg = $self->_socket_command('GETTHRESHOLD', \%args) or return;
+	$self->_socket_chat($msg, sub {
+			local $_ = shift;
+			my $ret = shift;
+			my ( $key, $val );
+			( $key, $val ) = /^\s*([^:]+):\s*(.*)/ and do {
+				  $key =~ s/\s*$//;
+				  $ret->{$key} = $val;
+			};
+		}, $ret
+	);
 	return $ret;
 } # }}} sub getthreshold
 
@@ -319,7 +319,7 @@ sub putval
 	my $fh = $self->{sock} or confess;
 
 	my $interval = defined $args{interval} ?
-    ' interval=' . _escape_argument ($args{interval}) : '';
+	' interval=' . _escape_argument ($args{interval}) : '';
 
 	$identifier = _create_identifier (\%args) or return;
 	if (!$args{values})
@@ -372,23 +372,23 @@ The returned data is in the same format as from C<listval>.
 sub listval_filter
 {
 	my $self = shift;
-    my %args = @_;
+	my %args = @_;
 	my @ret;
 	my $nresults;
 	my $fh = $self->{sock} or confess;
 
-    my $pattern =
-    (exists $args{host}              ? "$args{host}"             : '[^/]+') .
-    (exists $args{plugin}            ? "/$args{plugin}"          : '/[^/-]+') .
+	my $pattern =
+	(exists $args{host}              ? "$args{host}"             : '[^/]+') .
+	(exists $args{plugin}            ? "/$args{plugin}"          : '/[^/-]+') .
 	(exists $args{plugin_instance}   ? "-$args{plugin_instance}" : '(?:-[^/]+)?') .
 	(exists $args{type}              ? "/$args{type}"            : '/[^/-]+') .
 	(exists $args{type_instance}     ? "-$args{type_instance}"   : '(?:-[^/]+)?');
-    $pattern = qr/^\d+ $pattern$/;
+	$pattern = qr/^\d+ $pattern$/;
 
-    my $msg = $self->_socket_command('LISTVAL') or return;
+	my $msg = $self->_socket_command('LISTVAL') or return;
 	($nresults, $msg) = split / /, $msg, 2;
 
-    # This could use _socket_chat() but doesn't for speed reasons
+	# This could use _socket_chat() but doesn't for speed reasons
 	if ($nresults < 0)
 	{
 		$self->{error} = $msg;
@@ -427,10 +427,10 @@ sub listval
 	my @ret;
 	my $fh = $self->{sock} or confess;
 
-    my $msg = $self->_socket_command('LISTVAL') or return;
+	my $msg = $self->_socket_command('LISTVAL') or return;
 	($nresults, $msg) = split / /, $msg, 2;
 
-    # This could use _socket_chat() but doesn't for speed reasons
+	# This could use _socket_chat() but doesn't for speed reasons
 	if ($nresults < 0)
 	{
 		$self->{error} = $msg;
@@ -497,10 +497,10 @@ sub putnotif
 
 	my $msg; # message sent to the socket
 	
-    for my $arg (qw( message severity ))
-    {
-        cluck ("Need argument `$arg'"), return unless $args{$arg};
-    }
+	for my $arg (qw( message severity ))
+	{
+		cluck ("Need argument `$arg'"), return unless $args{$arg};
+	}
 	$args{severity} = lc $args{severity};
 	if (($args{severity} ne 'failure')
 		&& ($args{severity} ne 'warning')
@@ -554,9 +554,9 @@ sub flush
 
 	my $fh = $self->{sock} or confess;
 
-	my $msg    = "FLUSH";
+	my $msg = "FLUSH";
 
-    $msg .= " timeout=$args{timeout}" if defined $args{timeout};
+	$msg .= " timeout=$args{timeout}" if defined $args{timeout};
 
 	if ($args{plugins})
 	{
@@ -587,11 +587,11 @@ sub flush
 				$self->_send_message($msg) or return;
 				$msg = $pre;
 			}
-            
+
 			$msg .= $ident_str;
 		}
 	}
-    
+
 	return $self->_send_message($msg);
 }
 
@@ -637,4 +637,4 @@ Florian octo Forster E<lt>octo@collectd.orgE<gt>
 
 =cut
 1;
-# vim: set fdm=marker :
+# vim: set fdm=marker noexpandtab:

--- a/bindings/perl/lib/Collectd/Unixsock.pm
+++ b/bindings/perl/lib/Collectd/Unixsock.pm
@@ -404,10 +404,10 @@ sub listval_filter
 		my ($time, $ident) = split / /, $msg, 2;
 
 		$ident = _parse_identifier ($ident);
-		$ident->{time} = int $time;
+		$ident->{time} = 0+$time;
 
 		push (@ret, $ident);
-	} # for (i = 0 .. $status)
+	} # for (i = 0 .. $nresults)
 
 	return @ret;
 } # listval_filter
@@ -446,10 +446,10 @@ sub listval
 		my ($time, $ident) = split / /, $msg, 2;
 
 		$ident = _parse_identifier ($ident);
-		$ident->{time} = int $time;
+		$ident->{time} = 0+$time;
 
 		push (@ret, $ident);
-	} # for (i = 0 .. $status)
+	} # for (i = 0 .. $nresults)
 
 	return @ret;
 } # listval

--- a/bindings/perl/t/01_methods.t
+++ b/bindings/perl/t/01_methods.t
@@ -9,8 +9,6 @@ use Collectd::MockDaemon;
 my $path = mockd_start();
 END { mockd_stop(); }
 
-sub filter_time { return map { delete $_->{time}; $_ } @_ }
-
 sub test_query {
     my ($s, $attr, $results) = @_;
     my ($nresults, $resultdata) = @$results;
@@ -33,24 +31,24 @@ test_query($s, $_, $queries{$_}) for sort keys %queries;
 
 my @values = $s->listval;
 is(scalar @values, 4984, "Correct number of results from LISTVAL");
-delete $values[1234]{time};     # won't be constant
 is_deeply($values[1234], {
         type_instance => 'nice',
         plugin_instance => 21,
         plugin => 'cpu',
         type => 'cpu',
-        host => 'h2gdf6120'
+        host => 'h2gdf6120',
+        time => 1479835354.434,
     }, "Correct data returned for select element");
 @values = ();
 
-is_deeply([ filter_time $s->listval_filter() ] , [ filter_time $s->listval ], "listval_filter() w/o filter equivalent to listval()");
+is_deeply([ $s->listval_filter() ] , [ $s->listval ], "listval_filter() w/o filter equivalent to listval()");
 is_deeply(
-    [ filter_time $s->listval_filter(host => 'a1d8f6310', plugin => 'disk', plugin_instance => 'vda6') ],
+    [ $s->listval_filter(host => 'a1d8f6310', plugin => 'disk', plugin_instance => 'vda6') ],
     [
-        { 'plugin_instance' => 'vda6', 'type' => 'disk_merged', 'plugin' => 'disk', 'host' => 'a1d8f6310' },
-        { 'host' => 'a1d8f6310', 'plugin' => 'disk', 'plugin_instance' => 'vda6', 'type' => 'disk_octets' },
-        { 'type' => 'disk_ops', 'plugin_instance' => 'vda6', 'plugin' => 'disk', 'host' => 'a1d8f6310' },
-        { 'plugin' => 'disk', 'host' => 'a1d8f6310', 'type' => 'disk_time', 'plugin_instance' => 'vda6' }
+        { 'plugin_instance' => 'vda6', 'type' => 'disk_merged', 'plugin' => 'disk', 'host' => 'a1d8f6310', time => 1479835354.434 },
+        { 'host' => 'a1d8f6310', 'plugin' => 'disk', 'plugin_instance' => 'vda6', 'type' => 'disk_octets', time => 1479835356 },
+        { 'type' => 'disk_ops', 'plugin_instance' => 'vda6', 'plugin' => 'disk', 'host' => 'a1d8f6310', time => 1479835354 },
+        { 'plugin' => 'disk', 'host' => 'a1d8f6310', 'type' => 'disk_time', 'plugin_instance' => 'vda6', time => 1479835354 }
     ],
     "Correct result from listval_filter on <host>, <plugin> and <plugin_instance>"
 );


### PR DESCRIPTION
I just noticed that at some point the unixsock module's reporting of fractional seconds broke `Collectd::Unixsock::listval_filter` as the regexp for the data lines didn't match any more so nothing was returned. This fixes this bug.
Also updated the mock daemon to provide realistic values (with fractional parts and without in turn so as to test compatibility with both) and fixed some indentation to use all tabs as the rest of the module does.