### PR TITLE
netlink plugin: Adding support of drops value monitoring

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -539,7 +539,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
         submit_one(dev, "ipt_packets", type_instance, bs->packets);
       }
       if (qs != NULL) {
-        submit_one(dev, "if_tx_errors", type_instance, qs->drops);
+        submit_one(dev, "if_tx_dropped", type_instance, qs->drops);
       }
     }
 

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -86,8 +86,8 @@ typedef struct ir_ignorelist_s {
 } ir_ignorelist_t;
 
 struct qos_stats {
-  struct gnet_stats_basic **bs;
-  struct gnet_stats_queue **qs;
+  struct gnet_stats_basic *bs;
+  struct gnet_stats_queue *qs;
 };
 
 static int ir_ignorelist_invert = 1;
@@ -393,30 +393,30 @@ static int link_filter_cb(const struct nlmsghdr *nlh,
 #if HAVE_TCA_STATS2
 static int qos_attr_cb(const struct nlattr *attr, void *data) {
   struct qos_stats *qdisc = (struct qos_stats *)data;
-  struct gnet_stats_basic **bs = qdisc->bs;
-  struct gnet_stats_queue **qs = qdisc->qs;
+  struct gnet_stats_basic *bs = qdisc->bs;
+  struct gnet_stats_queue *qs = qdisc->qs;
 
   /* skip unsupported attribute in user-space */
   if (mnl_attr_type_valid(attr, TCA_STATS_MAX) < 0)
     return MNL_CB_OK;
 
   if (mnl_attr_get_type(attr) == TCA_STATS_BASIC) {
-    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(**bs)) < 0) {
+    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*bs)) < 0) {
       ERROR("netlink plugin: qos_attr_cb: TCA_STATS_BASIC mnl_attr_validate2 "
             "failed.");
       return MNL_CB_ERROR;
     }
-    *bs = mnl_attr_get_payload(attr);
+    bs = mnl_attr_get_payload(attr);
     return MNL_CB_OK;
   }
 
   if (mnl_attr_get_type(attr) == TCA_STATS_QUEUE) {
-    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(**qs)) < 0) {
+    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*qs)) < 0) {
       ERROR("netlink plugin: qos_attr_cb: TCA_STATS_QUEUE mnl_attr_validate2 "
             "failed.");
       return MNL_CB_ERROR;
     }
-    *qs = mnl_attr_get_payload(attr);
+    qs = mnl_attr_get_payload(attr);
     return MNL_CB_OK;
   }
 
@@ -512,8 +512,8 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     struct gnet_stats_basic *bs = NULL;
     struct gnet_stats_queue *qs = NULL;
     struct qos_stats q_stats;
-    q_stats.bs = &bs;
-    q_stats.qs = &qs;
+    q_stats.bs = bs;
+    q_stats.qs = qs;
 
     if (mnl_attr_get_type(attr) != TCA_STATS2)
       continue;

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -392,31 +392,29 @@ static int link_filter_cb(const struct nlmsghdr *nlh,
 
 #if HAVE_TCA_STATS2
 static int qos_attr_cb(const struct nlattr *attr, void *data) {
-  struct qos_stats *qdisc = (struct qos_stats *)data;
-  struct gnet_stats_basic *bs = qdisc->bs;
-  struct gnet_stats_queue *qs = qdisc->qs;
+  struct qos_stats *q_stats = (struct qos_stats *)data;
 
   /* skip unsupported attribute in user-space */
   if (mnl_attr_type_valid(attr, TCA_STATS_MAX) < 0)
     return MNL_CB_OK;
 
   if (mnl_attr_get_type(attr) == TCA_STATS_BASIC) {
-    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*bs)) < 0) {
+    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*q_stats->bs)) < 0) {
       ERROR("netlink plugin: qos_attr_cb: TCA_STATS_BASIC mnl_attr_validate2 "
             "failed.");
       return MNL_CB_ERROR;
     }
-    bs = mnl_attr_get_payload(attr);
+    q_stats->bs = mnl_attr_get_payload(attr);
     return MNL_CB_OK;
   }
 
   if (mnl_attr_get_type(attr) == TCA_STATS_QUEUE) {
-    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*qs)) < 0) {
+    if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*q_stats->qs)) < 0) {
       ERROR("netlink plugin: qos_attr_cb: TCA_STATS_QUEUE mnl_attr_validate2 "
             "failed.");
       return MNL_CB_ERROR;
     }
-    qs = mnl_attr_get_payload(attr);
+    q_stats->qs = mnl_attr_get_payload(attr);
     return MNL_CB_OK;
   }
 
@@ -509,11 +507,9 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
 #if HAVE_TCA_STATS2
   mnl_attr_for_each(attr, nlh, sizeof(*tm)) {
-    struct gnet_stats_basic *bs = NULL;
-    struct gnet_stats_queue *qs = NULL;
     struct qos_stats q_stats;
-    q_stats.bs = bs;
-    q_stats.qs = qs;
+
+    memset(&q_stats, 0x0, sizeof(q_stats));
 
     if (mnl_attr_get_type(attr) != TCA_STATS2)
       continue;
@@ -526,7 +522,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
     mnl_attr_parse_nested(attr, qos_attr_cb, &q_stats);
 
-    if (bs != NULL || qs != NULL) {
+    if (q_stats.bs != NULL || q_stats.qs != NULL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
       stats_submitted = 1;
@@ -534,12 +530,12 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                 tc_inst);
 
-      if (bs != NULL) {
-        submit_one(dev, "ipt_bytes", type_instance, bs->bytes);
-        submit_one(dev, "ipt_packets", type_instance, bs->packets);
+      if (q_stats.bs != NULL) {
+        submit_one(dev, "ipt_bytes", type_instance, q_stats.bs->bytes);
+        submit_one(dev, "ipt_packets", type_instance, q_stats.bs->packets);
       }
-      if (qs != NULL) {
-        submit_one(dev, "if_tx_dropped", type_instance, qs->drops);
+      if (q_stats.qs != NULL) {
+        submit_one(dev, "if_tx_dropped", type_instance, q_stats.qs->drops);
       }
     }
 


### PR DESCRIPTION
Monitoring drops is very handy to see drop rate of qdisc/class (to adjust length of queue and to estimate how much data are exceeding limit), and in some cases to limit interface drops that doesn't reach ethstat and other statistics.
