### PR TITLE
contrib/docker: cleanup wrapper a bit

### DIFF
--- a/contrib/docker/rootfs_prefix/.gitignore
+++ b/contrib/docker/rootfs_prefix/.gitignore
@@ -1,0 +1,1 @@
+rootprefix.so

--- a/contrib/docker/rootfs_prefix/rootfs_prefix.c
+++ b/contrib/docker/rootfs_prefix/rootfs_prefix.c
@@ -11,28 +11,22 @@
 #define BUFSIZE 256
 
 const char *add_prefix(const char *orig, char *prefixed) {
-  int status;
-  int errno;
-
-  if ((strncmp(orig, "/proc", 5) == 0) || (strncmp(orig, "/sys", 4) == 0)) {
-
-    status = snprintf(prefixed, BUFSIZE, "%s%s", PREFIX, orig);
-    if ((unsigned int)status >= BUFSIZE) {
-      error(status, ENAMETOOLONG,
-            "'%s' got truncated when adding '%s' prefix: '%s'", orig, PREFIX,
-            prefixed);
-      return orig;
-    } else if (status < 1) {
-      error(status, errno,
-            "adding '%s' prefix to file path failed: '%s' -> '%s'", PREFIX,
-            orig, prefixed);
-      return orig;
-    } else {
-      return (const char *)prefixed;
-    }
-
-  } else {
+  if ((strncmp(orig, "/proc", 5) != 0) && (strncmp(orig, "/sys", 4) != 0))
     return orig;
+
+  int status = snprintf(prefixed, BUFSIZE, "%s%s", PREFIX, orig);
+  if ((unsigned int)status >= BUFSIZE) {
+    error(status, ENAMETOOLONG,
+          "'%s' got truncated when adding '%s' prefix: '%s'", orig, PREFIX,
+          prefixed);
+    return orig;
+  } else if (status < 1) {
+    error(status, errno,
+          "adding '%s' prefix to file path failed: '%s' -> '%s'", PREFIX,
+          orig, prefixed);
+    return orig;
+  } else {
+    return (const char *)prefixed;
   }
 }
 

--- a/contrib/docker/rootfs_prefix/rootfs_prefix.c
+++ b/contrib/docker/rootfs_prefix/rootfs_prefix.c
@@ -11,19 +11,19 @@
 #define BUFSIZE 256
 
 const char *add_prefix(const char *orig, char *prefixed) {
-  if ((strncmp(orig, "/proc", 5) != 0) && (strncmp(orig, "/sys", 4) != 0))
+  if ((strncmp(orig, "/proc", strlen("/proc")) != 0) &&
+      (strncmp(orig, "/sys", strlen("/sys")) != 0))
     return orig;
 
   int status = snprintf(prefixed, BUFSIZE, "%s%s", PREFIX, orig);
-  if ((unsigned int)status >= BUFSIZE) {
+  if (status < 1) {
+    error(status, errno, "adding '%s' prefix to file path failed: '%s' -> '%s'",
+          PREFIX, orig, prefixed);
+    return orig;
+  } else if ((unsigned int)status >= BUFSIZE) {
     error(status, ENAMETOOLONG,
           "'%s' got truncated when adding '%s' prefix: '%s'", orig, PREFIX,
           prefixed);
-    return orig;
-  } else if (status < 1) {
-    error(status, errno,
-          "adding '%s' prefix to file path failed: '%s' -> '%s'", PREFIX,
-          orig, prefixed);
     return orig;
   } else {
     return (const char *)prefixed;


### PR DESCRIPTION
- No need to declare errno
- Remove one level of indentation