### PR TITLE
src/Makefile.am: Fix dependencies for the "tail" and "match" utilities.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ endif
 
 noinst_LTLIBRARIES += liblatency.la
 liblatency_la_SOURCES = utils_latency.c utils_latency.h utils_latency_config.c utils_latency_config.h
-liblatency_la_LIBADD = daemon/libcommon.la
+liblatency_la_LIBADD = daemon/libcommon.la -lm
 check_PROGRAMS += test_utils_latency
 TESTS += test_utils_latency
 test_utils_latency_SOURCES = utils_latency_test.c testing.h
@@ -334,11 +334,11 @@ endif
 if BUILD_PLUGIN_CURL
 pkglib_LTLIBRARIES += curl.la
 curl_la_SOURCES = curl.c \
-		  utils_curl_stats.c utils_curl_stats.h \
-		  utils_match.c utils_match.h
+                  utils_curl_stats.c utils_curl_stats.h \
+                  utils_match.c utils_match.h
 curl_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 curl_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBCURL_CFLAGS)
-curl_la_LIBADD = $(BUILD_WITH_LIBCURL_LIBS)
+curl_la_LIBADD = $(BUILD_WITH_LIBCURL_LIBS) liblatency.la
 endif
 
 if BUILD_PLUGIN_CURL_JSON
@@ -687,10 +687,11 @@ endif
 
 if BUILD_PLUGIN_MEMCACHEC
 pkglib_LTLIBRARIES += memcachec.la
-memcachec_la_SOURCES = memcachec.c utils_match.c utils_match.h
+memcachec_la_SOURCES = memcachec.c \
+                       utils_match.c utils_match.h
 memcachec_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMEMCACHED_LDFLAGS)
 memcachec_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBMEMCACHED_CPPFLAGS)
-memcachec_la_LIBADD = $(BUILD_WITH_LIBMEMCACHED_LIBS)
+memcachec_la_LIBADD = $(BUILD_WITH_LIBMEMCACHED_LIBS) liblatency.la
 endif
 
 if BUILD_PLUGIN_MEMCACHED
@@ -1073,7 +1074,7 @@ if BUILD_PLUGIN_STATSD
 pkglib_LTLIBRARIES += statsd.la
 statsd_la_SOURCES = statsd.c
 statsd_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-statsd_la_LIBADD = liblatency.la -lm
+statsd_la_LIBADD = liblatency.la
 endif
 
 if BUILD_PLUGIN_SWAP
@@ -1115,14 +1116,18 @@ endif
 
 if BUILD_PLUGIN_TAIL
 pkglib_LTLIBRARIES += tail.la
-tail_la_SOURCES = tail.c utils_tail_match.c utils_tail_match.h
+tail_la_SOURCES = tail.c \
+                  utils_match.c utils_match.h \
+                  utils_tail.c utils_tail.h \
+                  utils_tail_match.c utils_tail_match.h
 tail_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 tail_la_LIBADD = liblatency.la
 endif
 
 if BUILD_PLUGIN_TAIL_CSV
 pkglib_LTLIBRARIES += tail_csv.la
-tail_csv_la_SOURCES = tail_csv.c utils_tail.c utils_tail.h
+tail_csv_la_SOURCES = tail_csv.c \
+                      utils_tail.c utils_tail.h
 tail_csv_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 


### PR DESCRIPTION
Since being pulled out of the core daemon, the daemon no longer provides
all the required symbols for these shared objects. The "tail", "match"
and "tail_match" utils need to be compiled in explicitly. Also, we need
to link with the liblatency.la convenience library for the
"Distribution" handling in the "match" util.

Issue: #2067