### PR TITLE
ipmi plugin: add more analog sensors support

### DIFF
--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -449,9 +449,12 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
       break;
 
     INFO("ipmi plugin: sensor_list_add: Ignore sensor `%s` of `%s`, "
-         "because I don't know how to handle its type (%#x, %s). "
-         "If you need this sensor, please file a bug report.",
-         sensor_name_ptr, st->name, sensor_type,
+         "because I don't know how to handle its units (%#x, %#x, %#x). "
+         "Sensor type: (%#x, %s). If you need this sensor, please file "
+         "a bug report at http://collectd.org/.",
+         sensor_name_ptr, st->name, ipmi_sensor_get_base_unit(sensor),
+         ipmi_sensor_get_modifier_unit(sensor),
+         ipmi_sensor_get_rate_unit(sensor), sensor_type,
          ipmi_sensor_get_sensor_type_string(sensor));
     return -1;
   }


### PR DESCRIPTION
- Add more analog sensors like 'PS1 Input Power', 'System Airflow' etc. The sensor type mapping => collectd db type done using sensor base unit type (+ percentage sensor type). 
- Avoid reading value of discrete sensors by ipmi_sensor_id_get_reading() function.
 
Example of analog sensors:
```
# ipmitool sensor get 'PS1 Input Power'
Locating sensor record...
Sensor ID              : PS1 Input Power (0x54)
 Entity ID             : 10.1
 Sensor Type (Threshold)  : Other
 Sensor Reading        : 0 (+/- 0) Watts
 Status                : ok
 Lower Non-Recoverable : na
 Lower Critical        : na
 Lower Non-Critical    : na
 Upper Non-Critical    : 868.000
 Upper Critical        : 920.000
 Upper Non-Recoverable : na
 Positive Hysteresis   : Unspecified
 Negative Hysteresis   : Unspecified
 Assertion Events      :
 Assertions Enabled    : unc+ ucr+
 Deassertions Enabled  : unc+ ucr+

# ipmitool sensor get 'System Airflow'
Locating sensor record...
Sensor ID              : System Airflow (0x11)
 Entity ID             : 23.1
 Sensor Type (Threshold)  : Other
 Sensor Reading        : 54 (+/- 0) CFM
 Status                : ok
 Lower Non-Recoverable : na
 Lower Critical        : na
 Lower Non-Critical    : na
 Upper Non-Critical    : na
 Upper Critical        : na
 Upper Non-Recoverable : na
 Positive Hysteresis   : Unspecified
 Negative Hysteresis   : Unspecified
 Assertion Events      :
 Assertions Enabled    :
```
Example of discrete sensors which are added to internal ipmi list on init but falied to read using ipmi_sensor_id_get_reading() func:

```
# ipmitool sensor get 'Fan 1 Present'
Locating sensor record...
Sensor ID              : Fan 1 Present (0x40)
 Entity ID             : 29.1
 Sensor Type (Discrete): Fan
 States Asserted       : Availability State
                         [Device Present]

# ipmitool sensor get 'P1 VRD Hot'
Locating sensor record...
Sensor ID              : P1 VRD Hot (0x90)
 Entity ID             : 3.1
 Sensor Type (Discrete): Temperature
```

Regards,
Volodymyr