### PR TITLE
Treewide: remove vim modelines from C code files

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -752,5 +752,3 @@ void module_register(void) {
   plugin_register_read("aggregation", agg_read);
   plugin_register_write("aggregation", agg_write, /* user_data = */ NULL);
 }
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -1022,5 +1022,3 @@ void module_register(void) {
   plugin_register_complex_config("amqp", camqp_config);
   plugin_register_shutdown("amqp", camqp_shutdown);
 } /* void module_register */
-
-/* vim: set sw=4 sts=4 et fdm=marker : */

--- a/src/apache.c
+++ b/src/apache.c
@@ -573,5 +573,3 @@ void module_register(void) {
   plugin_register_complex_config("apache", config);
   plugin_register_init("apache", apache_init);
 } /* void module_register */
-
-/* vim: set sw=8 noet fdm=marker : */

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -161,5 +161,3 @@ void module_register(void) {
   plugin_register_read("aquaero", aquaero_read);
   plugin_register_shutdown("aquaero", aquaero_shutdown);
 } /* void module_register */
-
-/* vim: set sw=8 sts=8 noet : */

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -571,5 +571,3 @@ void module_register(void) {
   plugin_register_init("ascent", ascent_init);
   plugin_register_read("ascent", ascent_read);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 et fdm=marker : */

--- a/src/bind.c
+++ b/src/bind.c
@@ -1613,5 +1613,3 @@ void module_register(void) {
   plugin_register_read("bind", bind_read);
   plugin_register_shutdown("bind", bind_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 et fdm=marker : */

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1446,4 +1446,3 @@ void module_register(void) {
   plugin_register_read("ceph", ceph_read);
   plugin_register_shutdown("ceph", ceph_shutdown);
 }
-/* vim: set sw=4 sts=4 et : */

--- a/src/ceph_test.c
+++ b/src/ceph_test.c
@@ -187,5 +187,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/collectd-tg.c
+++ b/src/collectd-tg.c
@@ -423,5 +423,3 @@ int main(int argc, char **argv) /* {{{ */
   lcc_network_destroy(net);
   exit(EXIT_SUCCESS);
 } /* }}} int main */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -585,5 +585,3 @@ int main(int argc, char **argv) {
     return (status);
   return (0);
 } /* main */
-
-/* vim: set sw=2 ts=2 tw=78 expandtab : */

--- a/src/collectdmon.c
+++ b/src/collectdmon.c
@@ -386,5 +386,3 @@ int main(int argc, char **argv) {
   free(collectd_argv);
   return 0;
 } /* main */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -862,5 +862,3 @@ void module_register(void) {
   plugin_register_config("cpu", cpu_config, config_keys, config_keys_num);
   plugin_register_read("cpu", cpu_read);
 } /* void module_register */
-
-/* vim: set sw=8 sts=8 noet fdm=marker : */

--- a/src/curl.c
+++ b/src/curl.c
@@ -679,5 +679,3 @@ void module_register(void) {
   plugin_register_read("curl", cc_read);
   plugin_register_shutdown("curl", cc_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -940,5 +940,3 @@ void module_register(void) {
   plugin_register_complex_config("curl_json", cj_config);
   plugin_register_init("curl_json", cj_init);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -1026,5 +1026,3 @@ void module_register(void) {
   plugin_register_complex_config("curl_xml", cx_config);
   plugin_register_init("curl_xml", cx_init);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -392,5 +392,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/filter_chain.c
+++ b/src/daemon/filter_chain.c
@@ -942,5 +942,3 @@ int fc_configure(const oconfig_item_t *ci) /* {{{ */
 
   return (-1);
 } /* }}} int fc_configure */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/filter_chain.h
+++ b/src/daemon/filter_chain.h
@@ -101,4 +101,3 @@ int fc_default_action(const data_set_t *ds, value_list_t *vl);
 int fc_configure(const oconfig_item_t *ci);
 
 #endif /* FILTER_CHAIN_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -746,5 +746,3 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
 
   return (0);
 } /* }}} int meta_data_as_string */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/meta_data.h
+++ b/src/daemon/meta_data.h
@@ -69,4 +69,3 @@ int meta_data_get_boolean(meta_data_t *md, const char *key, _Bool *value);
 int meta_data_as_string(meta_data_t *md, const char *key, char **value);
 
 #endif /* META_DATA_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/meta_data_test.c
+++ b/src/daemon/meta_data_test.c
@@ -114,5 +114,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2578,5 +2578,3 @@ int plugin_thread_create(pthread_t *thread, const pthread_attr_t *attr,
 
   return 0;
 } /* int plugin_thread_create */
-
-/* vim: set sw=8 ts=8 noet fdm=marker : */

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -89,5 +89,3 @@ void plugin_log(int level, char const *format, ...) {
 }
 
 cdtime_t plugin_get_interval(void) { return TIME_T_TO_CDTIME_T(10); }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -191,7 +191,3 @@ int read_types_list(const char *file) {
 
   return (0);
 } /* int read_types_list */
-
-/*
- * vim: shiftwidth=2:softtabstop=2:tabstop=8
- */

--- a/src/daemon/utils_avltree_test.c
+++ b/src/daemon/utils_avltree_test.c
@@ -135,5 +135,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -938,5 +938,3 @@ int uc_meta_data_exists(const value_list_t *vl,
                                                 const char *key, _Bool *value)
                                                 UC_WRAP(meta_data_get_boolean)
 #undef UC_WRAP
-
-    /* vim: set sw=2 ts=8 sts=2 tw=78 : */

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -133,5 +133,4 @@ int uc_meta_data_get_double(const value_list_t *vl, const char *key,
 int uc_meta_data_get_boolean(const value_list_t *vl, const char *key,
                              _Bool *value);
 
-/* vim: set shiftwidth=2 softtabstop=2 tabstop=8 : */
 #endif /* !UTILS_CACHE_H */

--- a/src/daemon/utils_complain.c
+++ b/src/daemon/utils_complain.c
@@ -97,5 +97,3 @@ void c_do_release(int level, c_complain_t *c, const char *format, ...) {
 
   plugin_log(level, "%s", message);
 } /* c_release */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/daemon/utils_complain.h
+++ b/src/daemon/utils_complain.h
@@ -113,5 +113,3 @@ c_do_release(int level, c_complain_t *c, const char *format, ...);
   } while (0)
 
 #endif /* UTILS_COMPLAIN_H */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/daemon/utils_heap.c
+++ b/src/daemon/utils_heap.c
@@ -203,5 +203,3 @@ void *c_heap_get_root(c_heap_t *h) {
 
   return (ret);
 } /* void *c_heap_get_root */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/utils_heap.h
+++ b/src/daemon/utils_heap.h
@@ -97,4 +97,3 @@ int c_heap_insert(c_heap_t *h, void *ptr);
 void *c_heap_get_root(c_heap_t *h);
 
 #endif /* UTILS_HEAP_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_heap_test.c
+++ b/src/daemon/utils_heap_test.c
@@ -76,5 +76,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_subst.c
+++ b/src/daemon/utils_subst.c
@@ -159,5 +159,3 @@ char *subst_string(char *buf, size_t buflen, const char *string,
 
   return (buf);
 } /* char *subst_string */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/daemon/utils_subst.h
+++ b/src/daemon/utils_subst.h
@@ -100,5 +100,3 @@ char *subst_string(char *buf, size_t buflen, const char *string,
                    const char *needle, const char *replacement);
 
 #endif /* UTILS_SUBST_H */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -132,5 +132,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_threshold.h
+++ b/src/daemon/utils_threshold.h
@@ -61,5 +61,3 @@ threshold_t *threshold_search(const value_list_t *vl);
 int ut_search_threshold(const value_list_t *vl, threshold_t *ret_threshold);
 
 #endif /* UTILS_THRESHOLD_H */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -240,5 +240,3 @@ int rfc3339nano_local(char *buffer, size_t buffer_size, cdtime_t t) /* {{{ */
 
   return format_rfc3339_local(buffer, buffer_size, t, 1);
 } /* }}} int rfc3339nano */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/daemon/utils_time.h
+++ b/src/daemon/utils_time.h
@@ -130,4 +130,3 @@ int rfc3339_local(char *buffer, size_t buffer_size, cdtime_t t);
 int rfc3339nano_local(char *buffer, size_t buffer_size, cdtime_t t);
 
 #endif /* UTILS_TIME_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/daemon/utils_time_test.c
+++ b/src/daemon/utils_time_test.c
@@ -167,5 +167,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -780,7 +780,3 @@ void module_register(void) /* {{{ */
   plugin_register_init("dbi", cdbi_init);
   plugin_register_shutdown("dbi", cdbi_shutdown);
 } /* }}} void module_register */
-
-/*
- * vim: shiftwidth=2 softtabstop=2 et fdm=marker
- */

--- a/src/email.c
+++ b/src/email.c
@@ -719,5 +719,3 @@ void module_register(void) {
   plugin_register_read("email", email_read);
   plugin_register_shutdown("email", email_shutdown);
 } /* void module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/ethstat.c
+++ b/src/ethstat.c
@@ -325,5 +325,3 @@ void module_register(void) {
   plugin_register_read("ethstat", ethstat_read);
   plugin_register_shutdown("ethstat", ethstat_shutdown);
 }
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/exec.c
+++ b/src/exec.c
@@ -866,7 +866,3 @@ void module_register(void) {
                                /* user_data = */ NULL);
   plugin_register_shutdown("exec", exec_shutdown);
 } /* void module_register */
-
-/*
- * vim:shiftwidth=2:softtabstop=2:tabstop=8:fdm=marker
- */

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -511,7 +511,3 @@ void module_register(void) {
   plugin_register_init("filecount", fc_init);
   plugin_register_read("filecount", fc_read);
 } /* void module_register */
-
-/*
- * vim: set sw=2 sts=2 et :
- */

--- a/src/fscache.c
+++ b/src/fscache.c
@@ -217,5 +217,3 @@ static int fscache_read(void) {
 void module_register(void) {
   plugin_register_read("fscache", fscache_read);
 } /* void module_register */
-
-/* vim: set sw=4 sts=4 et : */

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -1030,5 +1030,3 @@ void module_register(void) {
   plugin_register_init("gmond", gmond_init);
   plugin_register_shutdown("gmond", gmond_shutdown);
 }
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/grpc.cc
+++ b/src/grpc.cc
@@ -676,5 +676,3 @@ extern "C" {
 		plugin_register_shutdown("grpc", c_grpc_shutdown);
 	} /* module_register() */
 } /* extern "C" */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -319,5 +319,3 @@ void module_register(void) /* {{{ */
   plugin_register_read("ipc", ipc_read);
 }
 /* }}} */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -621,5 +621,3 @@ void module_register(void) {
   plugin_register_read("ipmi", c_ipmi_read);
   plugin_register_shutdown("ipmi", c_ipmi_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 fdm=marker et : */

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -321,5 +321,3 @@ void module_register(void) {
   plugin_register_shutdown("ipvs", cipvs_shutdown);
   return;
 } /* module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/java.c
+++ b/src/java.c
@@ -2841,5 +2841,3 @@ void module_register(void) {
   plugin_register_init("java", cjni_init);
   plugin_register_shutdown("java", cjni_shutdown);
 } /* void module_register (void) */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -1021,5 +1021,3 @@ int lcc_sort_identifiers(lcc_connection_t *c, /* {{{ */
   qsort(idents, idents_num, sizeof(*idents), lcc_identifier_compare);
   return (0);
 } /* }}} int lcc_sort_identifiers */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/libcollectdclient/collectd/client.h
+++ b/src/libcollectdclient/collectd/client.h
@@ -139,5 +139,4 @@ int lcc_sort_identifiers(lcc_connection_t *c, lcc_identifier_t *idents,
 
 LCC_END_DECLS
 
-/* vim: set sw=2 sts=2 et : */
 #endif /* LIBCOLLECTD_COLLECTDCLIENT_H */

--- a/src/libcollectdclient/collectd/lcc_features.h.in
+++ b/src/libcollectdclient/collectd/lcc_features.h.in
@@ -62,6 +62,3 @@ const char *lcc_version_extra (void);
 LCC_END_DECLS
 
 #endif /* ! LIBCOLLECTD_LCC_FEATURES_H */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */
-

--- a/src/libcollectdclient/collectd/network.h
+++ b/src/libcollectdclient/collectd/network.h
@@ -73,5 +73,4 @@ int lcc_network_notification_send (lcc_network_t *net,
     const lcc_notification_t *notif);
 #endif
 
-/* vim: set sw=2 sts=2 et : */
 #endif /* LIBCOLLECTDCLIENT_NETWORK_H */

--- a/src/libcollectdclient/collectd/network_buffer.h
+++ b/src/libcollectdclient/collectd/network_buffer.h
@@ -55,4 +55,3 @@ int lcc_network_buffer_get(lcc_network_buffer_t *nb, void *buffer,
                            size_t *buffer_size);
 
 #endif /* LIBCOLLECTDCLIENT_NETWORK_BUFFER_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/libcollectdclient/network.c
+++ b/src/libcollectdclient/network.c
@@ -446,5 +446,3 @@ int lcc_network_values_send(lcc_network_t *net, /* {{{ */
 
   return (0);
 } /* }}} int lcc_network_values_send */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -779,5 +779,3 @@ int lcc_network_buffer_get(lcc_network_buffer_t *nb, /* {{{ */
 
   return (0);
 } /* }}} int lcc_network_buffer_get */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -196,7 +196,3 @@ void oconfig_free(oconfig_item_t *ci) {
   oconfig_free_all(ci);
   free(ci);
 }
-
-/*
- * vim:shiftwidth=2:tabstop=8:softtabstop=2:fdm=marker
- */

--- a/src/liboconfig/oconfig.h
+++ b/src/liboconfig/oconfig.h
@@ -67,7 +67,4 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci);
 
 void oconfig_free(oconfig_item_t *ci);
 
-/*
- * vim: shiftwidth=2:tabstop=8:softtabstop=2
- */
 #endif /* OCONFIG_H */

--- a/src/log_logstash.c
+++ b/src/log_logstash.c
@@ -343,5 +343,3 @@ void module_register(void) {
   plugin_register_notification("log_logstash", log_logstash_notification,
                                /* user_data = */ NULL);
 } /* void module_register (void) */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -208,5 +208,3 @@ void module_register(void) {
   plugin_register_notification("logfile", logfile_notification,
                                /* user_data = */ NULL);
 } /* void module_register (void) */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -243,5 +243,3 @@ void module_register(void) {
   plugin_register_init("lpar", lpar_init);
   plugin_register_read("lpar", lpar_read);
 } /* void module_register */
-
-/* vim: set sw=8 noet : */

--- a/src/lua.c
+++ b/src/lua.c
@@ -583,5 +583,3 @@ void module_register(void) {
   plugin_register_complex_config("lua", lua_config);
   plugin_register_shutdown("lua", lua_shutdown);
 }
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/match_empty_counter.c
+++ b/src/match_empty_counter.c
@@ -79,5 +79,3 @@ void module_register(void) {
           .create = mec_create, .destroy = mec_destroy, .match = mec_match,
       });
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/match_hashed.c
+++ b/src/match_hashed.c
@@ -166,5 +166,3 @@ void module_register(void) {
   mproc.match = mh_match;
   fc_register_match("hashed", mproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/match_regex.c
+++ b/src/match_regex.c
@@ -364,5 +364,3 @@ void module_register(void) {
   mproc.match = mr_match;
   fc_register_match("regex", mproc);
 } /* module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab fdm=marker : */

--- a/src/match_timediff.c
+++ b/src/match_timediff.c
@@ -141,5 +141,3 @@ void module_register(void) {
   mproc.match = mt_match;
   fc_register_match("timediff", mproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/match_value.c
+++ b/src/match_value.c
@@ -316,5 +316,3 @@ void module_register(void) {
   mproc.match = mv_match;
   fc_register_match("value", mproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -479,5 +479,3 @@ void module_register(void) {
   plugin_register_read("memcachec", cmc_read);
   plugin_register_shutdown("memcachec", cmc_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/mic.c
+++ b/src/mic.c
@@ -366,7 +366,3 @@ void module_register(void) {
   plugin_register_read("mic", mic_read);
   plugin_register_config("mic", mic_config, config_keys, config_keys_num);
 } /* void module_register */
-
-/*
- * vim: set shiftwidth=8 softtabstop=8 noet textwidth=78 :
- */

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -982,5 +982,3 @@ void module_register(void) {
   plugin_register_complex_config("modbus", mb_config);
   plugin_register_shutdown("modbus", mb_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -751,5 +751,3 @@ void module_register(void) {
   plugin_register_complex_config("mqtt", mqtt_config);
   plugin_register_init("mqtt", mqtt_init);
 } /* void module_register */
-
-/* vim: set sw=4 sts=4 et fdm=marker : */

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -3111,5 +3111,3 @@ void module_register(void) {
   plugin_register_init("netapp", cna_init);
   plugin_register_shutdown("netapp", cna_shutdown);
 }
-
-/* vim: set sw=2 ts=2 noet fdm=marker : */

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -736,7 +736,3 @@ void module_register(void) {
   plugin_register_read("netlink", ir_read);
   plugin_register_shutdown("netlink", ir_shutdown);
 } /* void module_register */
-
-/*
- * vim: set shiftwidth=2 softtabstop=2 tabstop=8 :
- */

--- a/src/network.c
+++ b/src/network.c
@@ -3223,5 +3223,3 @@ void module_register(void) {
   plugin_register_flush("network", network_flush,
                         /* user_data = */ NULL);
 } /* void module_register */
-
-/* vim: set fdm=marker : */

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -267,7 +267,3 @@ void module_register(void) {
   plugin_register_init("nginx", init);
   plugin_register_read("nginx", nginx_read);
 } /* void module_register */
-
-/*
- * vim: set shiftwidth=2 softtabstop=2 tabstop=8 :
- */

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -166,5 +166,3 @@ void module_register(void) {
   plugin_register_init("notify_desktop", c_notify_init);
   return;
 } /* module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -290,5 +290,3 @@ void module_register(void) {
   plugin_register_notification("notify_email", notify_email_notification,
                                /* user_data = */ NULL);
 } /* void module_register (void) */
-
-/* vim: set sw=2 sts=2 ts=8 et : */

--- a/src/notify_nagios.c
+++ b/src/notify_nagios.c
@@ -153,5 +153,3 @@ void module_register(void) {
   plugin_register_complex_config("notify_nagios", nagios_config);
   plugin_register_notification("notify_nagios", nagios_notify, NULL);
 } /* void module_register (void) */
-
-/* vim: set sw=2 sts=2 ts=8 et : */

--- a/src/numa.c
+++ b/src/numa.c
@@ -152,5 +152,3 @@ void module_register(void) {
   plugin_register_init("numa", numa_init);
   plugin_register_read("numa", numa_read);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/nut.c
+++ b/src/nut.c
@@ -255,5 +255,3 @@ void module_register(void) {
   plugin_register_read("nut", nut_read);
   plugin_register_shutdown("nut", nut_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 ts=8 sts=2 tw=78 : */

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -631,5 +631,3 @@ void module_register(void) {
   plugin_register_read("olsrd", olsrd_read);
   plugin_register_shutdown("olsrd", olsrd_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -534,5 +534,3 @@ void module_register(void) {
   plugin_register_config("onewire", cow_load_config, config_keys,
                          config_keys_num);
 }
-
-/* vim: set sw=2 sts=2 ts=8 et fdm=marker cindent : */

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -715,5 +715,3 @@ void module_register(void) {
                          config_keys_num);
   plugin_register_init("openvpn", openvpn_init);
 } /* void module_register */
-
-/* vim: set sw=2 ts=2 : */

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -706,7 +706,3 @@ void module_register(void) /* {{{ */
   plugin_register_read("oracle", o_read);
   plugin_register_shutdown("oracle", o_shutdown);
 } /* }}} void module_register */
-
-/*
- * vim: shiftwidth=2 softtabstop=2 et fdm=marker
- */

--- a/src/perl.c
+++ b/src/perl.c
@@ -2711,5 +2711,3 @@ void module_register(void) {
   plugin_register_complex_config("perl", perl_config);
   return;
 } /* void module_register (void) */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -685,5 +685,3 @@ void module_register(void) /* {{{ */
   plugin_register_read("pinba", plugin_read);
   plugin_register_shutdown("pinba", plugin_shutdown);
 } /* }}} void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/ping.c
+++ b/src/ping.c
@@ -679,5 +679,3 @@ void module_register(void) {
   plugin_register_read("ping", ping_read);
   plugin_register_shutdown("ping", ping_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -1265,5 +1265,3 @@ void module_register(void) {
   plugin_register_complex_config("postgresql", c_psql_config);
   plugin_register_shutdown("postgresql", c_psql_shutdown);
 } /* module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -960,5 +960,3 @@ void module_register(void) {
   plugin_register_read("powerdns", powerdns_read);
   plugin_register_shutdown("powerdns", powerdns_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 fdm=marker : */

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -213,5 +213,3 @@ void module_register(void) {
                          config_keys_num);
   plugin_register_read("protocols", protocols_read);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/redis.c
+++ b/src/redis.c
@@ -451,5 +451,3 @@ void module_register(void) /* {{{ */
    * X elements */
 }
 /* }}} */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -409,5 +409,3 @@ static int cr_config(oconfig_item_t *ci) {
 void module_register(void) {
   plugin_register_complex_config("routeros", cr_config);
 } /* void module_register */
-
-/* vim: set sw=2 noet fdm=marker : */

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -529,7 +529,3 @@ void module_register(void) {
   plugin_register_init("rrdcached", rc_init);
   plugin_register_shutdown("rrdcached", rc_shutdown);
 } /* void module_register */
-
-/*
- * vim: set sw=2 sts=2 et :
- */

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1695,7 +1695,3 @@ void module_register(void) {
   plugin_register_init("snmp", csnmp_init);
   plugin_register_shutdown("snmp", csnmp_shutdown);
 } /* void module_register */
-
-/*
- * vim: shiftwidth=2 softtabstop=2 tabstop=8 fdm=marker
- */

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -914,5 +914,3 @@ void module_register(void) {
   plugin_register_read("statsd", statsd_read);
   plugin_register_shutdown("statsd", statsd_shutdown);
 }
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/swap.c
+++ b/src/swap.c
@@ -738,5 +738,3 @@ void module_register(void) {
   plugin_register_init("swap", swap_init);
   plugin_register_read("swap", swap_read);
 } /* void module_register */
-
-/* vim: set fdm=marker : */

--- a/src/table.c
+++ b/src/table.c
@@ -520,5 +520,3 @@ void module_register(void) {
   plugin_register_complex_config("table", tbl_config);
   plugin_register_init("table", tbl_init);
 } /* module_register */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/tail.c
+++ b/src/tail.c
@@ -337,5 +337,3 @@ void module_register(void) {
   plugin_register_init("tail", ctail_init);
   plugin_register_shutdown("tail", ctail_shutdown);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -551,5 +551,3 @@ void module_register(void) {
   plugin_register_init("tail_csv", tcsv_init);
   plugin_register_shutdown("tail_csv", tcsv_shutdown);
 }
-
-/* vim: set sw=4 sts=4 et : */

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -260,5 +260,3 @@ void module_register(void) {
   tproc.invoke = tn_invoke;
   fc_register_target("notification", tproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/target_replace.c
+++ b/src/target_replace.c
@@ -561,5 +561,3 @@ void module_register(void) {
   tproc.invoke = tr_invoke;
   fc_register_target("replace", tproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -457,5 +457,3 @@ void module_register(void) {
   tproc.invoke = ts_invoke;
   fc_register_target("scale", tproc);
 } /* module_register */
-
-/* vim: set sw=2 ts=2 tw=78 fdm=marker : */

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -415,5 +415,3 @@ void module_register(void) {
   tproc.invoke = ts_invoke;
   fc_register_target("set", tproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -451,5 +451,3 @@ void module_register(void) {
   tproc.invoke = v5_invoke;
   fc_register_target("v5upgrade", tproc);
 } /* module_register */
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -958,7 +958,3 @@ void module_register(void) {
 #endif
   plugin_register_read("tcpconns", conn_read);
 } /* void module_register */
-
-/*
- * vim: set shiftwidth=2 softtabstop=2 tabstop=8 fdm=marker :
- */

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -728,5 +728,3 @@ void module_register(void) {
   plugin_register_read("teamspeak2", tss2_read);
   plugin_register_shutdown("teamspeak2", tss2_shutdown);
 } /* void module_register */
-
-/* vim: set sw=4 ts=4 : */

--- a/src/ted.c
+++ b/src/ted.c
@@ -299,5 +299,3 @@ void module_register(void) {
   plugin_register_read("ted", ted_read);
   plugin_register_shutdown("ted", ted_shutdown);
 } /* void module_register */
-
-/* vim: set sw=4 et : */

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -834,5 +834,3 @@ static int ut_config(oconfig_item_t *ci) { /* {{{ */
 void module_register(void) {
   plugin_register_complex_config("threshold", ut_config);
 }
-
-/* vim: set sw=2 ts=8 sts=2 tw=78 et fdm=marker : */

--- a/src/tokyotyrant.c
+++ b/src/tokyotyrant.c
@@ -150,5 +150,3 @@ void module_register(void) {
   plugin_register_read("tokyotyrant", tt_read);
   plugin_register_shutdown("tokyotyrant", tt_shutdown);
 }
-
-/* vim: set sw=8 ts=8 tw=78 : */

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -429,5 +429,3 @@ void module_register(void) {
   plugin_register_init("unixsock", us_init);
   plugin_register_shutdown("unixsock", us_shutdown);
 } /* void module_register (void) */
-
-/* vim: set sw=4 ts=4 sts=4 tw=78 : */

--- a/src/utils_cmd_flush.c
+++ b/src/utils_cmd_flush.c
@@ -178,5 +178,3 @@ void cmd_destroy_flush(cmd_flush_t *flush) {
   sfree(flush->identifiers);
   flush->identifiers_num = 0;
 } /* void cmd_destroy_flush */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/utils_cmd_flush.h
+++ b/src/utils_cmd_flush.h
@@ -40,5 +40,3 @@ cmd_status_t cmd_handle_flush(FILE *fh, char *buffer);
 void cmd_destroy_flush(cmd_flush_t *flush);
 
 #endif /* UTILS_CMD_FLUSH_H */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/utils_cmd_getthreshold.c
+++ b/src/utils_cmd_getthreshold.c
@@ -198,5 +198,3 @@ int handle_getthreshold(FILE *fh, char *buffer) {
 
                                             return (0);
 } /* int handle_getthreshold */
-
-/* vim: set sw=2 sts=2 ts=8 et : */

--- a/src/utils_cmd_getthreshold.h
+++ b/src/utils_cmd_getthreshold.h
@@ -32,5 +32,3 @@
 int handle_getthreshold(FILE *fh, char *buffer);
 
 #endif /* UTILS_CMD_GETTHRESHOLD_H */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -164,5 +164,3 @@ void cmd_destroy_getval(cmd_getval_t *getval) {
 
   sfree(getval->raw_identifier);
 } /* void cmd_destroy_getval */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_cmd_getval.h
+++ b/src/utils_cmd_getval.h
@@ -41,5 +41,3 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer);
 void cmd_destroy_getval(cmd_getval_t *getval);
 
 #endif /* UTILS_CMD_GETVAL_H */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_cmd_listval.c
+++ b/src/utils_cmd_listval.c
@@ -108,5 +108,3 @@ cmd_status_t cmd_handle_listval(FILE *fh, char *buffer) {
 void cmd_destroy_listval(cmd_listval_t *listval __attribute__((unused))) {
   /* nothing to do */
 } /* void cmd_destroy_listval */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_cmd_listval.h
+++ b/src/utils_cmd_listval.h
@@ -41,5 +41,3 @@ cmd_status_t cmd_handle_listval(FILE *fh, char *buffer);
 void cmd_destroy_listval(cmd_listval_t *listval);
 
 #endif /* UTILS_CMD_LISTVAL_H */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_cmd_putnotif.c
+++ b/src/utils_cmd_putnotif.c
@@ -180,5 +180,3 @@ int handle_putnotif(FILE *fh, char *buffer) {
 
   return (0);
 } /* int handle_putnotif */
-
-/* vim: set shiftwidth=2 softtabstop=2 tabstop=8 : */

--- a/src/utils_cmd_putnotif.h
+++ b/src/utils_cmd_putnotif.h
@@ -31,6 +31,4 @@
 
 int handle_putnotif(FILE *fh, char *buffer);
 
-/* vim: set shiftwidth=2 softtabstop=2 tabstop=8 : */
-
 #endif /* UTILS_CMD_PUTNOTIF_H */

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -309,5 +309,3 @@ void cmd_error_fh(void *ud, cmd_status_t status, const char *format,
 
   fflush(fh);
 } /* void cmd_error_fh */
-
-/* vim: set sw=4 ts=4 tw=78 noexpandtab : */

--- a/src/utils_db_query.c
+++ b/src/utils_db_query.c
@@ -1059,5 +1059,3 @@ void udb_query_delete_preparation_area(
 
   free(q_area);
 } /* }}} void udb_query_delete_preparation_area */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_db_query.h
+++ b/src/utils_db_query.h
@@ -83,4 +83,3 @@ udb_query_allocate_preparation_area(udb_query_t *q);
 void udb_query_delete_preparation_area(udb_query_preparation_area_t *q_area);
 
 #endif /* UTILS_DB_QUERY_H */
-/* vim: set sw=2 sts=2 et : */

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -1169,6 +1169,3 @@ main(int argc, char *argv[])
     return 0;
 } /* static int main(int argc, char *argv[]) */
 #endif
-/*
- * vim:shiftwidth=4:tabstop=8:softtabstop=4
- */

--- a/src/utils_fbhash.c
+++ b/src/utils_fbhash.c
@@ -255,5 +255,3 @@ char *fbh_get(fbhash_t *h, const char *key) /* {{{ */
 
   return (value_copy);
 } /* }}} char *fbh_get */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_fbhash.h
+++ b/src/utils_fbhash.h
@@ -48,5 +48,3 @@ void fbh_destroy(fbhash_t *h);
 char *fbh_get(fbhash_t *h, const char *key);
 
 #endif /* UTILS_FBHASH_H */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -237,5 +237,3 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
   sfree(rates);
   return (status);
 } /* int format_graphite */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -685,5 +685,3 @@ int format_json_notification(char *buffer, size_t buffer_size, /* {{{ */
   return ENOTSUP;
 } /* }}} int format_json_notification */
 #endif
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -336,5 +336,3 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
       buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
       (*ret_buffer_free) - 2));
 } /* }}} int format_kairosdb_value_list */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -342,5 +342,3 @@ double latency_counter_get_rate(const latency_counter_t *lc, /* {{{ */
 
   return sum / (CDTIME_T_TO_DOUBLE(now - lc->start_time));
 } /* }}} double latency_counter_get_rate */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_latency.h
+++ b/src/utils_latency.h
@@ -61,5 +61,3 @@ cdtime_t latency_counter_get_percentile(latency_counter_t *lc, double percent);
  */
 double latency_counter_get_rate(const latency_counter_t *lc, cdtime_t lower,
                                 cdtime_t upper, const cdtime_t now);
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/utils_latency_test.c
+++ b/src/utils_latency_test.c
@@ -232,5 +232,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/utils_lua.c
+++ b/src/utils_lua.c
@@ -317,5 +317,3 @@ int luaC_pushvaluelist(lua_State *L, const data_set_t *ds,
 
   return (0);
 } /* }}} int luaC_pushvaluelist */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_lua.h
+++ b/src/utils_lua.h
@@ -53,4 +53,3 @@ int luaC_pushvaluelist(lua_State *L, const data_set_t *ds,
                        const value_list_t *vl);
 
 #endif /* UTILS_LUA_H */
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_match.c
+++ b/src/utils_match.c
@@ -368,5 +368,3 @@ void *match_get_user_data(cu_match_t *obj) {
     return (NULL);
   return (obj->user_data);
 } /* void *match_get_user_data */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_match.h
+++ b/src/utils_match.h
@@ -177,5 +177,3 @@ int match_apply(cu_match_t *obj, const char *str);
 void *match_get_user_data(cu_match_t *obj);
 
 #endif /* UTILS_MATCH_H */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_mount_test.c
+++ b/src/utils_mount_test.c
@@ -109,5 +109,3 @@ int main(void) {
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/utils_parse_option.c
+++ b/src/utils_parse_option.c
@@ -146,5 +146,3 @@ int parse_option(char **ret_buffer, char **ret_key, char **ret_value) {
 
   return (0);
 } /* int parse_option */
-
-/* vim: set sw=2 ts=8 tw=78 et : */

--- a/src/utils_parse_option.h
+++ b/src/utils_parse_option.h
@@ -31,5 +31,3 @@ int parse_string(char **ret_buffer, char **ret_string);
 int parse_option(char **ret_buffer, char **ret_key, char **ret_value);
 
 #endif /* UTILS_PARSE_OPTION */
-
-/* vim: set sw=2 ts=8 tw=78 et : */

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -664,5 +664,3 @@ int cu_rrd_create_file(const char *filename, /* {{{ */
 
   return (status);
 } /* }}} int cu_rrd_create_file */
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_rrdcreate.h
+++ b/src/utils_rrdcreate.h
@@ -51,5 +51,3 @@ int cu_rrd_create_file(const char *filename, const data_set_t *ds,
                        const value_list_t *vl, const rrdcreate_config_t *cfg);
 
 #endif /* UTILS_RRDCREATE_H */
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -336,5 +336,3 @@ int tail_match_read(cu_tail_match_t *obj) {
 
   return (0);
 } /* int tail_match_read */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/utils_tail_match.h
+++ b/src/utils_tail_match.h
@@ -137,5 +137,3 @@ int tail_match_add_match_simple(cu_tail_match_t *obj, const char *regex,
  *   Zero on success, nonzero on failure.
 */
 int tail_match_read(cu_tail_match_t *obj);
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -262,17 +262,3 @@ void module_register(void) {
                          STATIC_ARRAY_SIZE(config_keys));
   plugin_register_init("uuid", uuid_init);
 }
-
-/*
- * vim: set tabstop=4:
- * vim: set shiftwidth=4:
- * vim: set expandtab:
- */
-/*
- * Local variables:
- *  indent-tabs-mode: nil
- *  c-indent-level: 4
- *  c-basic-offset: 4
- *  tab-width: 4
- * End:
- */

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -1331,5 +1331,3 @@ void module_register(void) /* {{{ */
   plugin_register_complex_config("varnish", varnish_config);
   plugin_register_init("varnish", varnish_init);
 } /* }}} */
-
-/* vim: set sw=8 noet fdm=marker : */

--- a/src/virt.c
+++ b/src/virt.c
@@ -1172,7 +1172,3 @@ void module_register(void) {
   plugin_register_init(PLUGIN_NAME, lv_init);
   plugin_register_shutdown(PLUGIN_NAME, lv_shutdown);
 }
-
-/*
- * vim: shiftwidth=4 tabstop=8 softtabstop=4 expandtab fdm=marker
- */

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -260,5 +260,3 @@ void module_register(void) {
   plugin_register_config("vmem", vmem_config, config_keys, config_keys_num);
   plugin_register_read("vmem", vmem_read);
 } /* void module_register */
-
-/* vim: set sw=2 sts=2 ts=8 : */

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -321,5 +321,3 @@ void module_register(void) {
   plugin_register_init("vserver", vserver_init);
   plugin_register_read("vserver", vserver_read);
 } /* void module_register(void) */
-
-/* vim: set ts=4 sw=4 noexpandtab : */

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -583,5 +583,3 @@ static int wg_config(oconfig_item_t *ci) {
 void module_register(void) {
   plugin_register_complex_config("write_graphite", wg_config);
 }
-
-/* vim: set sw=4 ts=4 sts=4 tw=78 et : */

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -812,5 +812,3 @@ void module_register(void) /* {{{ */
   plugin_register_complex_config("write_http", wh_config);
   plugin_register_init("write_http", wh_init);
 } /* }}} void module_register */
-
-/* vim: set fdm=marker sw=8 ts=8 tw=78 et : */

--- a/src/write_log.c
+++ b/src/write_log.c
@@ -136,5 +136,3 @@ void module_register(void) {
   /* If config is supplied, the global wl_format will be set. */
   plugin_register_write("write_log", wl_write, NULL);
 }
-
-/* vim: set sw=4 ts=4 sts=4 tw=78 et : */

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -344,5 +344,3 @@ static int wm_config(oconfig_item_t *ci) /* {{{ */
 void module_register(void) {
   plugin_register_complex_config("write_mongodb", wm_config);
 }
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -868,5 +868,3 @@ void module_register() {
                           /* user data = */ NULL);
   plugin_register_shutdown("write_prometheus", prom_shutdown);
 }
-
-/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -252,5 +252,3 @@ static int wr_config(oconfig_item_t *ci) /* {{{ */
 void module_register(void) {
   plugin_register_complex_config("write_redis", wr_config);
 }
-
-/* vim: set sw=2 sts=2 tw=78 et fdm=marker : */

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -895,5 +895,3 @@ static int wrr_config(oconfig_item_t *ci) /* {{{ */
 void module_register(void) {
   plugin_register_complex_config("write_riemann", wrr_config);
 }
-
-/* vim: set sw=8 sts=8 ts=8 noet : */

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -225,5 +225,3 @@ int write_riemann_threshold_check(const data_set_t *ds, const value_list_t *vl,
 
   return (0);
 } /* }}} int ut_check_threshold */
-
-/* vim: set sw=2 ts=8 sts=2 tw=78 et fdm=marker : */

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -1248,5 +1248,3 @@ static int sensu_config(oconfig_item_t *ci) /* {{{ */
 void module_register(void) {
   plugin_register_complex_config("write_sensu", sensu_config);
 }
-
-/* vim: set sw=8 sts=8 ts=8 noet : */

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -582,5 +582,3 @@ static int wt_config(oconfig_item_t *ci) {
 void module_register(void) {
   plugin_register_complex_config("write_tsdb", wt_config);
 }
-
-/* vim: set sw=4 ts=4 sts=4 tw=78 et : */

--- a/src/xmms.c
+++ b/src/xmms.c
@@ -66,7 +66,3 @@ static int cxmms_read(void) {
 void module_register(void) {
   plugin_register_read("xmms", cxmms_read);
 } /* void module_register */
-
-/*
- * vim: shiftwidth=2:softtabstop=2:textwidth=78
- */


### PR DESCRIPTION
They often conflict with the formatting we do with clang-format.