### PR TITLE
dpdkstats: fix detection of local libdpdk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2592,8 +2592,6 @@ fi
 # }}}
 
 # --with-libdpdk {{{
-LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
-LIBDPDK_LDFLAGS=""
 AC_ARG_VAR([LIBDPDK_CPPFLAGS], [Preprocessor flags for libdpdk])
 AC_ARG_VAR([LIBDPDK_LDFLAGS], [Linker flags for libdpdk])
 
@@ -2601,6 +2599,10 @@ AC_ARG_WITH([libdpdk], [AS_HELP_STRING([--without-libdpdk], [Disable libdpdk.])]
 
 if test "x$with_libdpdk" != "xno"
 then
+	if test "x$LIBDPDK_CPPFLAGS" = "x"
+	then
+		LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
+	fi
 	SAVE_CPPFLAGS="$CPPFLAGS"
 	CPPFLAGS="$LIBDPDK_CPPFLAGS $CPPFLAGS"
 	AC_CHECK_HEADERS([rte_config.h],
@@ -2615,7 +2617,7 @@ then
 	SAVE_LDFLAGS="$LDFLAGS"
 	LDFLAGS="$LIBDPDK_LDFLAGS $LDFLAGS"
 	AC_CHECK_LIB([dpdk], [rte_eal_init],
-		[with_libdpkd="yes"],
+		[with_libdpdk="yes"],
 		[with_libdpdk="no (symbol 'rte_eal_init' not found)"]
 	)
 	LDFLAGS="$SAVE_LDFLAGS"
@@ -6318,7 +6320,7 @@ then
   plugin_xencpu="yes"
 fi
 
-if test "x$with_libdpkd" = "xyes"
+if test "x$with_libdpdk" = "xyes"
 then
   plugin_dpdkstat="yes"
 fi


### PR DESCRIPTION
- Fix detection of DPDK Library when user provides custom path. E.g.:
`./configure LIBDPDK_CPPFLAGS="-I/dpdk-16.07/install/include/dpdk" LIBDPDK_LDFLAGS="-L/dpdk-16.07/install/lib"`
Current behavior: the DPDK path always stays the same. E.g.:`LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"`.
- Fix typo.