### PR TITLE
write_kafka plugin: Use 32bit random number when formatting a random key.

### DIFF
--- a/src/daemon/utils_random.c
+++ b/src/daemon/utils_random.c
@@ -50,7 +50,7 @@ static void cdrand_seed(void) {
   have_seed = 1;
 }
 
-double cdrand_d(void) {
+double cdrand_d() {
   double r;
 
   pthread_mutex_lock(&lock);
@@ -59,6 +59,17 @@ double cdrand_d(void) {
   pthread_mutex_unlock(&lock);
 
   return (r);
+}
+
+uint32_t cdrand_u() {
+  long r;
+
+  pthread_mutex_lock(&lock);
+  cdrand_seed();
+  r = jrand48(seed);
+  pthread_mutex_unlock(&lock);
+
+  return (uint32_t)r;
 }
 
 long cdrand_range(long min, long max) {

--- a/src/daemon/utils_random.h
+++ b/src/daemon/utils_random.h
@@ -29,7 +29,15 @@
  *
  * This function is thread- and reentrant-safe.
  */
-double cdrand_d(void);
+double cdrand_d();
+
+/**
+ * cdrand_u returns a random uint32_t value uniformly distributed in the range
+ * [0-2^32).
+ *
+ * This function is thread- and reentrant-safe.
+ */
+uint32_t cdrand_u();
 
 /**
  * Returns a random long between min and max, inclusively.

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -31,6 +31,7 @@
 #include "utils_cmd_putval.h"
 #include "utils_format_graphite.h"
 #include "utils_format_json.h"
+#include "utils_random.h"
 
 #include <errno.h>
 #include <librdkafka/rdkafka.h>
@@ -88,7 +89,7 @@ static uint32_t kafka_hash(const char *keydata, size_t keylen) {
 #define KAFKA_RANDOM_KEY_BUFFER                                                \
   (char[KAFKA_RANDOM_KEY_SIZE]) { "" }
 static char *kafka_random_key(char buffer[static KAFKA_RANDOM_KEY_SIZE]) {
-  ssnprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08lX", (unsigned long)mrand48());
+  ssnprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
   return buffer;
 }
 


### PR DESCRIPTION
Previously, negative numbers would be truncated to `ffffffff` by the buffer length on architectures where longs are 64 bit.

Fixes: #2074
