### PR TITLE
write_prometheus plugin: Add "total" suffix to the counters only

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -665,8 +665,7 @@ static char *metric_family_name(data_set_t const *ds, value_list_t const *vl,
 
   /* Prometheus best practices:
    * cumulative metrics should have a "total" suffix. */
-  if ((ds->ds[ds_index].type == DS_TYPE_COUNTER) ||
-      (ds->ds[ds_index].type == DS_TYPE_DERIVE)) {
+  if (ds->ds[ds_index].type == DS_TYPE_COUNTER) {
     fields[fields_num] = "total";
     fields_num++;
   }


### PR DESCRIPTION
collectd_exporter adds "total" suffix to the counters only: 

https://github.com/prometheus/collectd_exporter/blob/master/main.go#L70-L73.

As write_prometheus plugins is meant to be a direct replacement for collectd_exporter, it makes sense not to break a lot of metrics/dashboards/etc for a current collectd_exporter users.