### PR TITLE
zfs_arc updates for linux

### DIFF
--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -212,6 +212,21 @@ static int za_read(void) {
     return (-1);
   }
 
+  // Ignore the first two lines because they contain information about
+  // the rest of the file.
+  // See kstat_seq_show_headers module/spl/spl-kstat.c of the spl kernel
+  // module.
+  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
+    ERROR("zfs_arc plugin: \"%s\" does not contain a single line.", ZOL_ARCSTATS_FILE);
+    fclose(fh);
+    return (-1);
+  }
+  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
+    ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.", ZOL_ARCSTATS_FILE);
+    fclose(fh);
+    return (-1);
+  }
+
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
     char *fields[3];
     value_t v;

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -75,7 +75,6 @@ static long long get_zfs_value(kstat_t *ksp, const char *key) {
 
   e = llist_search(ksp, key);
   if (e == NULL) {
-    ERROR("zfs_arc plugin: `llist_search` failed for key: '%s'.", key);
     return (-1);
   }
 
@@ -152,7 +151,7 @@ static int za_read_derive(kstat_t *ksp, const char *kstat_value,
                           const char *type, const char *type_instance) {
   long long tmp = get_zfs_value(ksp, (char *)kstat_value);
   if (tmp == -1LL) {
-    WARNING("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
+    DEBUG("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
     return (-1);
   }
 
@@ -165,7 +164,7 @@ static int za_read_gauge(kstat_t *ksp, const char *kstat_value,
                          const char *type, const char *type_instance) {
   long long tmp = get_zfs_value(ksp, (char *)kstat_value);
   if (tmp == -1LL) {
-    WARNING("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
+    DEBUG("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
     return (-1);
   }
 


### PR DESCRIPTION
Linux seems to have changed the layout of the statistics file. The first commit skips the first two lines of the file as they contain two headers and no statistics. The second commit removes the "other_size" gauge for Linux because it is not available (anymore).