### PR TITLE
configfile: Reintroduce support for boolean string config values.

### DIFF
--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -1119,14 +1119,36 @@ int cf_util_get_boolean(const oconfig_item_t *ci, _Bool *ret_bool) /* {{{ */
   if ((ci == NULL) || (ret_bool == NULL))
     return (EINVAL);
 
-  if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_BOOLEAN)) {
+  if ((ci->values_num != 1) || ((ci->values[0].type != OCONFIG_TYPE_BOOLEAN) &&
+                                (ci->values[0].type != OCONFIG_TYPE_STRING))) {
     ERROR("cf_util_get_boolean: The %s option requires "
           "exactly one boolean argument.",
           ci->key);
     return (-1);
   }
 
-  *ret_bool = ci->values[0].value.boolean ? 1 : 0;
+  switch (ci->values[0].type) {
+  case OCONFIG_TYPE_BOOLEAN:
+    *ret_bool = ci->values[0].value.boolean ? 1 : 0;
+    break;
+  case OCONFIG_TYPE_STRING:
+    WARNING("cf_util_get_boolean: Using string value `%s' for boolean option "
+            "`%s' is deprecated and will be removed in future releases. "
+            "Use unquoted true or false instead.",
+            ci->values[0].value.string, ci->key);
+
+    if (IS_TRUE(ci->values[0].value.string))
+      *ret_bool = 1;
+    else if (IS_FALSE(ci->values[0].value.string))
+      *ret_bool = 0;
+    else {
+      ERROR("cf_util_get_boolean: Cannot parse string value `%s' of the `%s' "
+            "option as a boolean value.",
+            ci->values[0].value.string, ci->key);
+      return (-1);
+    }
+    break;
+  }
 
   return (0);
 } /* }}} int cf_util_get_boolean */


### PR DESCRIPTION
For the network plugin, this was changed in ac73c75aed7 (which landed in 5.6)
which was a backward incompatible change breaking user configuration. Adding
support back in a central location ensures a more consistent behavior across
plugins. At the same time, we issue a warning message that this behavior is
deprecated.

GH #2083, #2098