### PR TITLE
virt plugin: handle disconnect on inst#0

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -520,6 +520,13 @@ static int lv_connect(void) {
   return 0;
 }
 
+static void lv_disconnect(void) {
+  if (conn != NULL)
+    virConnectClose(conn);
+  conn = NULL;
+  WARNING(PLUGIN_NAME " plugin: closed connection to libvirt");
+}
+
 static int lv_read(user_data_t *ud) {
   time_t t;
   struct lv_read_instance *inst = NULL;
@@ -544,9 +551,8 @@ static int lv_read(user_data_t *ud) {
   if ((last_refresh == (time_t)0) ||
       ((interval > 0) && ((last_refresh + interval) <= t))) {
     if (refresh_lists(inst) != 0) {
-      if (conn != NULL)
-        virConnectClose(conn);
-      conn = NULL;
+      if (inst->id == 0)
+        lv_disconnect();
       return -1;
     }
     last_refresh = t;

--- a/src/virt.c
+++ b/src/virt.c
@@ -1178,9 +1178,7 @@ static int lv_shutdown(void) {
     lv_fini_instance(i);
   }
 
-  if (conn != NULL)
-    virConnectClose(conn);
-  conn = NULL;
+  lv_disconnect();
 
   ignorelist_free(il_domains);
   il_domains = NULL;


### PR DESCRIPTION
Only one virt reader instance should take care of connection
handling (connection/disconnection) to avoid races and plugin
data corruption, potentially crashing collectd.

This bug cannot be triggered with instances=1 (default settings).

Signed-off-by: Francesco Romani <fromani@redhat.com>