### PR TITLE
virt plugin: Open connection on init()

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -740,7 +740,8 @@ static int lv_init(void) {
   if (virInitialize() != 0)
     return -1;
 
-  lv_connect();
+  if (lv_connect() != 0)
+    return -1;
 
   DEBUG(PLUGIN_NAME " plugin: starting %i instances", nr_instances);
 


### PR DESCRIPTION
If we use more than one reader instance, we can spot errors like
this in the system logs:

Dec 12 09:59:24 $HOST collectd[19338]: reading number of
domains: invalid connection pointer in virConnectNumOfDomains
Dec 12 09:59:24 benji.rokugan.lan collectd[19338]: read-function of
plugin `virt-2' failed. Will suspend it for 20.000 seconds.

This causes unnecessary delay in the sampling of libvirt.
The reason for this is just one instance (always #0) takes care
of establishing the libvirt connection.

But this could be done safely in the plugin init callback: according
to doc, this function is called at least once before all the read
instances.

Signed-off-by: Francesco Romani <fromani@redhat.com>