### PR TITLE
virt plugin: support virDomainBlockStatsFlags

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1459,6 +1459,7 @@
 #	InterfaceFormat name
 #	PluginInstanceFormat name
 #	Instances 1
+#	ExtraStats "disk"
 #</Plugin>
 
 #<Plugin vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8076,6 +8076,12 @@ How many read instances you want to use for this plugin. The default is one,
 and the sensible setting is a multiple of the B<ReadThreads> value.
 If you are not sure, just use the default setting.
 
+=item B<ExtraStats> B<string>
+
+Enable extra statistics. This allows the plugin to reported more detailed
+statistics about the behaviour of Virtual Machines. The argument is a
+space-separated list of selectors. Currently only B<disk> is supported.
+
 =back
 
 =head2 Plugin C<vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8078,9 +8078,13 @@ If you are not sure, just use the default setting.
 
 =item B<ExtraStats> B<string>
 
-Enable extra statistics. This allows the plugin to reported more detailed
-statistics about the behaviour of Virtual Machines. The argument is a
-space-separated list of selectors. Currently only B<disk> is supported.
+Report additional extra statistics. The default is no extra statistics, preserving
+the previous behaviour of the plugin. If unsure, leave the default. If enabled,
+allows the plugin to reported more detailed statistics about the behaviour of
+Virtual Machines. The argument is a space-separated list of selectors.
+Currently supported selectors are:
+B<disk> report extra statistics like number of flush operations and total
+service time for read, write and flush operations.
 
 =back
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -380,6 +380,10 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
   if ((binfo->bi.rd_bytes != -1) && (binfo->bi.wr_bytes != -1))
     submit_derive2("disk_octets", (derive_t)binfo->bi.rd_bytes,
                    (derive_t)binfo->bi.wr_bytes, dom, type_instance);
+
+  if ((binfo->rd_total_times != -1) && (binfo->wr_total_times != -1))
+    submit_derive2("disk_time", (derive_t)binfo->rd_total_times,
+                   (derive_t)binfo->wr_total_times, dom, type_instance);
 }
 
 static int lv_config(const char *key, const char *value) {

--- a/src/virt.c
+++ b/src/virt.c
@@ -60,6 +60,7 @@ static const char *config_keys[] = {"Connection",
                                     "PluginInstanceFormat",
 
                                     "Instances",
+                                    "ExtraStats",
 
                                     NULL};
 #define NR_CONFIG_KEYS ((sizeof config_keys / sizeof config_keys[0]) - 1)
@@ -163,6 +164,12 @@ enum bd_field { target, source };
 
 /* InterfaceFormat. */
 enum if_field { if_address, if_name, if_number };
+
+/* ExtraStats */
+#define EX_STATS_MAX_FIELDS 8
+#define EX_STATS_DISK "disk"
+enum ex_stats { ex_stats_none = 0, ex_stats_disk = 1 };
+static enum ex_stats extra_stats = ex_stats_none;
 
 /* BlockDeviceFormatBasename */
 _Bool blockdevice_format_basename = 0;
@@ -386,17 +393,19 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
     submit_derive2("disk_octets", (derive_t)binfo->bi.rd_bytes,
                    (derive_t)binfo->bi.wr_bytes, dom, type_instance);
 
-  if ((binfo->rd_total_times != -1) && (binfo->wr_total_times != -1))
-    submit_derive2("disk_time", (derive_t)binfo->rd_total_times,
-                   (derive_t)binfo->wr_total_times, dom, type_instance);
+  if (extra_stats & ex_stats_disk) {
+    if ((binfo->rd_total_times != -1) && (binfo->wr_total_times != -1))
+      submit_derive2("disk_time", (derive_t)binfo->rd_total_times,
+                     (derive_t)binfo->wr_total_times, dom, type_instance);
 
-  if (binfo->fl_req != -1)
-    submit(dom, "total_requests", flush_type_instance,
-           &(value_t){.derive = (derive_t)binfo->fl_req}, 1);
-  if (binfo->fl_total_times != -1) {
-    derive_t value = binfo->fl_total_times / 1000; // ns -> ms
-    submit(dom, "total_time_in_ms", flush_type_instance,
-           &(value_t){.derive = value}, 1);
+    if (binfo->fl_req != -1)
+      submit(dom, "total_requests", flush_type_instance,
+             &(value_t){.derive = (derive_t)binfo->fl_req}, 1);
+    if (binfo->fl_total_times != -1) {
+      derive_t value = binfo->fl_total_times / 1000; // ns -> ms
+      submit(dom, "total_time_in_ms", flush_type_instance,
+             &(value_t){.derive = value}, 1);
+    }
   }
 }
 
@@ -592,6 +601,24 @@ static int lv_config(const char *key, const char *value) {
     nr_instances = (int)val;
     DEBUG(PLUGIN_NAME " plugin: configured %i instances", nr_instances);
     return 0;
+  }
+
+  if (strcasecmp(key, "ExtraStats") == 0) {
+    char *localvalue = sstrdup(value);
+    if (localvalue != NULL) {
+      char *exstats[EX_STATS_MAX_FIELDS];
+      int numexstats;
+
+      numexstats = strsplit(localvalue, exstats, STATIC_ARRAY_SIZE(exstats));
+      for (int i = 0; i < numexstats; i++) {
+        if (strcasecmp(exstats[i], EX_STATS_DISK) == 0) {
+          DEBUG(PLUGIN_NAME " plugin: enabling extra stats for '%s'",
+                EX_STATS_DISK);
+          extra_stats |= ex_stats_disk;
+        }
+      }
+      sfree(localvalue);
+    }
   }
 
   /* Unrecognised option. */

--- a/src/virt.c
+++ b/src/virt.c
@@ -373,6 +373,11 @@ static void submit_derive2(const char *type, derive_t v0, derive_t v1,
 
 static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
                         const char *type_instance) {
+  char flush_type_instance[DATA_MAX_NAME_LEN];
+
+  ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
+            type_instance);
+
   if ((binfo->bi.rd_req != -1) && (binfo->bi.wr_req != -1))
     submit_derive2("disk_ops", (derive_t)binfo->bi.rd_req,
                    (derive_t)binfo->bi.wr_req, dom, type_instance);
@@ -384,6 +389,15 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
   if ((binfo->rd_total_times != -1) && (binfo->wr_total_times != -1))
     submit_derive2("disk_time", (derive_t)binfo->rd_total_times,
                    (derive_t)binfo->wr_total_times, dom, type_instance);
+
+  if (binfo->fl_req != -1)
+    submit(dom, "total_requests", flush_type_instance,
+           &(value_t){.derive = (derive_t)binfo->fl_req}, 1);
+  if (binfo->fl_total_times != -1) {
+    derive_t value = binfo->fl_total_times / 1000; // ns -> ms
+    submit(dom, "total_time_in_ms", flush_type_instance,
+           &(value_t){.derive = value}, 1);
+  }
 }
 
 static int lv_config(const char *key, const char *value) {


### PR DESCRIPTION
We want to export more disk stats, like disk_time.
To do so, we must use the virDomainBlockStatsFlags API, but it
could not be available on all the platforms collectd supports.
To cope with that, we add a minimal layer around the API, and
we use virDomainBlockStatsFlags only if available.

This patch adds the code to use the new API and the fallback code
in the case the platform' libvirt is too old.

Signed-off-by: Francesco Romani <fromani@redhat.com>