### PR TITLE
Add SFP signal power to types.db

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -212,6 +212,7 @@ routes                  value:GAUGE:0:U
 satellites              value:GAUGE:0:U
 segments                value:GAUGE:0:65535
 serial_octets           rx:DERIVE:0:U, tx:DERIVE:0:U
+sfp_optical_power       rx:GAUGE:-100:100, tx:GAUGE:-100:100
 signal_noise            value:GAUGE:U:0
 signal_power            value:GAUGE:U:0
 signal_quality          value:GAUGE:0:U


### PR DESCRIPTION
This adds a SFP optical power data type.

If it is more appropriate to make separate Data entries in my snmp conf. for rx and tx power, please tell me.

Example of how im using it with the snmp plugin:

    <Data "juniper_optical_power">
      Type "sfp_signal_power"
      Table true
      InstancePrefix "int-snmp-"
      Values "JUNIPER-DOM-MIB::jnxDomCurrentLaneRxLaserPower" "JUNIPER-DOM-MIB::jnxDomCurrentLaneTxLaserOutputPower"
    </Data>