### PR TITLE
chrony: add missing build flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -609,6 +609,7 @@ if BUILD_PLUGIN_CHRONY
 pkglib_LTLIBRARIES += chrony.la
 chrony_la_SOURCES = src/chrony.c
 chrony_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+chrony_la_LIBADD = -lm
 endif
 
 if BUILD_PLUGIN_CONNTRACK


### PR DESCRIPTION
The chrony plugin uses the `pow()` math function so it needs to be built with `-lm`. Otherwise collectd crashes with `symbol lookup error: /usr/lib/collectd/chrony.so: undefined symbol: pow`.