### PR TITLE
unixsock.so: undefined symbol: handle_getthreshold -> link unixsock against libcmds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1616,7 +1616,7 @@ if BUILD_PLUGIN_UNIXSOCK
 pkglib_LTLIBRARIES += unixsock.la
 unixsock_la_SOURCES = src/unixsock.c
 unixsock_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-unixsock_la_LIBS = libcmds.la
+unixsock_la_LIBADD = libcmds.la
 endif
 
 if BUILD_PLUGIN_UPTIME


### PR DESCRIPTION
unixsock_la_LIBS is not being processed by automake and thus being incorrectly linked. This results in an symbol error when loading the module. Changing unixsock_la_LIBS to unixsock_la_LIBADD fixes this on my system (Fedora 25).

Error message:
> Jan 14 01:15:18 fedora collectd[20351]: dlopen ("/home/piotr/collectd/lib/collectd/unixsock.so") failed: /home/piotr/collectd/lib/collectd/unixsock.so: undefined symbol: handle_getthreshold. The most common cause for this problem is missing dependencies. Use ldd(1) to check the dependencies of the plugin / shared object.
