### PR TITLE
daemon/common.c: Fix check_capability() by using cap_get_proc()

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -1527,16 +1527,26 @@ void strarray_free(char **array, size_t array_len) /* {{{ */
 #if HAVE_CAPABILITY
 int check_capability(int arg) /* {{{ */
 {
-  cap_value_t cap = (cap_value_t)arg;
+  cap_value_t cap_value = (cap_value_t)arg;
+  cap_t cap;
+  cap_flag_value_t cap_flag_value;
 
-  if (!CAP_IS_SUPPORTED(cap))
+  if (!CAP_IS_SUPPORTED(cap_value))
     return (-1);
 
-  int have_cap = cap_get_bound(cap);
-  if (have_cap != 1)
+  if (!(cap = cap_get_proc())) {
+    ERROR("check_capability: cap_get_proc failed.");
     return (-1);
+  }
 
-  return (0);
+  if (cap_get_flag(cap, cap_value, CAP_EFFECTIVE, &cap_flag_value) < 0) {
+    ERROR("check_capability: cap_get_flag failed.");
+    cap_free(cap);
+    return (-1);
+  }
+  cap_free(cap);
+
+  return (cap_flag_value != CAP_SET);
 } /* }}} int check_capability */
 #else
 int check_capability(__attribute__((unused)) int arg) /* {{{ */

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -376,7 +376,7 @@ void strarray_free(char **array, size_t array_len);
  * argument. Returns zero if it does, less than zero if it doesn't or on error.
  * See capabilities(7) for the list of possible capabilities.
  * */
-int check_capability(int capability);
+int check_capability(int arg);
 #endif /* HAVE_SYS_CAPABILITY_H */
 
 #endif /* COMMON_H */


### PR DESCRIPTION
So it seems #2010 broke `check_capability()`. Reading `cap_get_bound(3)` doesn't really enlighten me on the purpose and use of this function. But the fact is, the way it was used in `check_capability()` always returned 1, whatever the effective capabilities were set to.

I came accross https://github.com/maximk/diod-ether/blob/master/tests/misc/tcap.c which's author was smart enough to decipher the manpage, and I rewrote `check_capability()` based on his code.

From what I tested, the function now works as expected:
```
$ getcap /opt/collectd/sbin/collectd
/opt/collectd/sbin/collectd =

$ /opt/collectd/sbin/collectd -T
option = ReadThreads; value = -1;
Created new plugin context.
[info] plugin_load: plugin "ping" successfully loaded.
[info] plugin_load: plugin "write_log" successfully loaded.
[warning] ping plugin: collectd doesn't have the CAP_NET_RAW capability. If you don't want to run collectd as root, try running "setcap cap_net_raw=ep" on the collectd binary.
[warning] ping plugin: ping_host_add (localhost) failed: Operation not permitted
[error] ping plugin: No host could be added to ping object. Giving up.
[info] Exiting normally.
[info] collectd: Stopping 5 write threads.
[info] ping plugin: Shutting down thread.
```

```
$ sudo setcap cap_net_raw=ep /opt/collectd/sbin/collectd
$ getcap /opt/collectd/sbin/collectd
/opt/collectd/sbin/collectd = cap_net_raw+ep

$ /opt/collectd/sbin/collectd -f
Created new plugin context.
[info] plugin_load: plugin "ping" successfully loaded.
[info] plugin_load: plugin "write_log" successfully loaded.
[info] Initialization complete, entering read-loop.
[info] write_log values:
collectd.ping.ping_stddev-localhost 0.0359975307795163 1485327717
[info] write_log values:
collectd.ping.ping_droprate-localhost 0 1485327717
[info] write_log values:
collectd.ping.ping-localhost 0.1036 1485327717

^C[info] Exiting normally.
[info] collectd: Stopping 5 read threads.
[info] collectd: Stopping 5 write threads.
[info] ping plugin: Shutting down thread.
```