### PR TITLE
notify_email: don't explicitly link against libssl and libcrypto

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -825,7 +825,7 @@ if BUILD_PLUGIN_NOTIFY_EMAIL
 pkglib_LTLIBRARIES += notify_email.la
 notify_email_la_SOURCES = notify_email.c
 notify_email_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-notify_email_la_LIBADD = -lesmtp -lssl -lcrypto
+notify_email_la_LIBADD = -lesmtp
 endif
 
 if BUILD_PLUGIN_NOTIFY_NAGIOS


### PR DESCRIPTION
libesmtp takes care of this.

Pointed out by https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852924