### PR TITLE
Java bindings - Adding Atomic* support

### DIFF
--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.Iterator;
 import java.util.ArrayList;
 
@@ -127,6 +129,14 @@ class GenericJMXConfValue
     else if (obj instanceof BigInteger)
     {
       return (BigInteger.ZERO.add ((BigInteger) obj));
+    }
+    else if (obj instanceof AtomicInteger)
+    {
+        return (new Integer(((AtomicInteger) obj).get()));
+    }
+    else if (obj instanceof AtomicLong)
+    {
+        return (new Long(((AtomicLong) obj).get()));
     }
 
     return (null);


### PR DESCRIPTION
AtomicIntegers are used to address some concurrency problems in Java, and this is advised by some metrics libraries like Netflix's servo:

https://github.com/Netflix/servo/wiki#jmx

Unfortunately, the GenericJMXConfValue.java class is not able to get the values from such types, hence this PR.

I scanned the Java doc for the Java package:
https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html
I think I have not forgotten any types.

Tests: tested at runtime