### PR TITLE
collectd.service: add intel_rdt plugin capability requirement

### DIFF
--- a/contrib/systemd.collectd.service
+++ b/contrib/systemd.collectd.service
@@ -18,6 +18,7 @@ ProtectHome=true
 #   ceph            CAP_DAC_OVERRIDE
 #   dns             CAP_NET_RAW
 #   exec            CAP_SETUID CAP_SETGID
+#   intel_rdt       CAP_SYS_RAWIO
 #   iptables        CAP_NET_ADMIN
 #   ping            CAP_NET_RAW
 #   turbostat       CAP_SYS_RAWIO

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2958,6 +2958,10 @@ allows to monitor instructions per clock (IPC).
 Monitor events are hardware dependant. Monitoring capabilities are detected on
 plugin initialization and only supported events are monitored.
 
+B<Note:> I<intel_rdt> plugin is using model-specific registers (MSRs), which
+require an additional capability to be enabled if collectd is run as a service.
+Please refer to I<contrib/systemd.collectd.service> file for more details.
+
 B<Synopsis:>
 
   <Plugin "intel_rdt">


### PR DESCRIPTION
Intel RDT plugin is using model-specific registers (MSRs), which require an additional capability to be enabled if collectd is run as a service.

Signed-off-by: Przemyslaw Szczerbik <przemyslawx.szczerbik@intel.com>