### PR TITLE
virt: add support for new metrics

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1495,7 +1495,7 @@
 #	InterfaceFormat name
 #	PluginInstanceFormat name
 #	Instances 1
-#	ExtraStats "disk pcpu"
+#	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpupin"
 #</Plugin>
 
 #<Plugin vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8140,11 +8140,11 @@ Collect statistics about worker threads. False by default.
 
 =head2 Plugin C<virt>
 
-This plugin allows CPU, disk and network load to be collected for virtualized
-guests on the machine. This means that these metrics can be collected for guest
-systems without installing any software on them - I<collectd> only runs on the
-host system. The statistics are collected through libvirt
-(L<http://libvirt.org/>).
+This plugin allows CPU, disk, network load and other metrics to be collected for
+virtualized guests on the machine. The statistics are collected through libvirt
+API (L<http://libvirt.org/>). Majority of metrics can be gathered without
+installing any additional software on guests, especially I<collectd>, which runs
+only on the host system.
 
 Only I<Connection> is required.
 
@@ -8294,10 +8294,48 @@ Report additional extra statistics. The default is no extra statistics, preservi
 the previous behaviour of the plugin. If unsure, leave the default. If enabled,
 allows the plugin to reported more detailed statistics about the behaviour of
 Virtual Machines. The argument is a space-separated list of selectors.
+
 Currently supported selectors are:
-B<disk> report extra statistics like number of flush operations and total
-service time for read, write and flush operations.
-B<pcpu> report the physical user/system cpu time consumed by the hypervisor, per-vm.
+
+=over 4
+
+=item B<cpu_util>: report CPU utilization per domain in percentage.
+
+=item B<disk>: report extra statistics like number of flush operations and total
+service time for read, write and flush operations. Requires libvirt API version
+I<0.9.5> or later.
+
+=item B<disk_err>: report disk errors if any occured. Requires libvirt API version
+I<0.9.10> or later.
+
+=item B<domain_state>: report domain state and reason in human-readable format as
+a notification. If libvirt API version I<0.9.2> or later is available, domain
+reason will be included in notification.
+
+=item B<fs_info>: report file system information as a notification. Requires
+libvirt API version I<1.2.11> or later. Can be collected only if I<Guest Agent>
+is installed and configured inside VM. Make sure that installed I<Guest Agent>
+version supports retrieving  file system information.
+
+=item B<job_stats_background>: report statistics about progress of a background
+job on a domain. Only one type of job statistics can be collected at the same time.
+Requires libvirt API version I<1.2.9> or later.
+
+=item B<job_stats_completed>: report statistics about a recently completed job on
+a domain. Only one type of job statistics can be collected at the same time.
+Requires libvirt API version I<1.2.9> or later.
+
+=item B<pcpu>: report the physical user/system cpu time consumed by the hypervisor, per-vm.
+Requires libvirt API version I<0.9.11> or later.
+
+=item B<perf>: report performance monitoring events. To collect performance
+metrics they must be enabled for domain and supported by the platform. Requires
+libvirt API version I<1.3.3> or later.
+B<Note>: I<perf> metrics can't be collected if I<intel_rdt> plugin is enabled.
+
+=item B<vcpupin>: report pinning of domain VCPUs to host physical CPUs.
+
+=back
 
 =back
 

--- a/src/types.db
+++ b/src/types.db
@@ -37,6 +37,7 @@ contextswitch           value:DERIVE:0:U
 count                   value:GAUGE:0:U
 counter                 value:COUNTER:U:U
 cpu                     value:DERIVE:0:U
+cpu_affinity            value:GAUGE:0:1
 cpufreq                 value:GAUGE:0:U
 current                 value:GAUGE:U:U
 current_connections     value:GAUGE:0:U
@@ -47,6 +48,7 @@ df                      used:GAUGE:0:1125899906842623, free:GAUGE:0:112589990684
 df_complex              value:GAUGE:0:U
 df_inodes               value:GAUGE:0:U
 dilution_of_precision   value:GAUGE:0:U
+disk_error              value:GAUGE:0:U
 disk_io_time            io_time:DERIVE:0:U, weighted_io_time:DERIVE:0:U
 disk_latency            read:GAUGE:0:U, write:GAUGE:0:U
 disk_merged             read:DERIVE:0:U, write:DERIVE:0:U
@@ -70,6 +72,7 @@ dns_response            value:DERIVE:0:U
 dns_transfer            value:DERIVE:0:U
 dns_update              value:DERIVE:0:U
 dns_zops                value:DERIVE:0:U
+domain_state            state:GAUGE:0:U, reason:GAUGE:0:U
 drbd_resource           value:DERIVE:0:U
 duration                seconds:GAUGE:0:U
 email_check             value:GAUGE:0:U
@@ -119,6 +122,7 @@ ipc                     value:GAUGE:0:U
 ipt_bytes               value:DERIVE:0:U
 ipt_packets             value:DERIVE:0:U
 irq                     value:DERIVE:0:U
+job_stats               value:DERIVE:0:U
 latency                 value:GAUGE:0:U
 links                   value:GAUGE:0:U
 load                    shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
@@ -168,6 +172,7 @@ pending_operations      value:GAUGE:0:U
 percent                 value:GAUGE:0:100.1
 percent_bytes           value:GAUGE:0:100.1
 percent_inodes          value:GAUGE:0:100.1
+perf                    value:DERIVE:0:U
 pf_counters             value:DERIVE:0:U
 pf_limits               value:DERIVE:0:U
 pf_source               value:DERIVE:0:U

--- a/src/virt.c
+++ b/src/virt.c
@@ -17,6 +17,7 @@
  *
  * Authors:
  *   Richard W.M. Jones <rjones@redhat.com>
+ *   Przemyslaw Szczerbik <przemyslawx.szczerbik@intel.com>
  **/
 
 #include "collectd.h"
@@ -39,12 +40,52 @@
 
 #ifdef LIBVIR_CHECK_VERSION
 
+#if LIBVIR_CHECK_VERSION(0, 9, 2)
+#define HAVE_DOM_REASON 1
+#endif
+
 #if LIBVIR_CHECK_VERSION(0, 9, 5)
 #define HAVE_BLOCK_STATS_FLAGS 1
+#define HAVE_DOM_REASON_PAUSED_SHUTTING_DOWN 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(0, 9, 10)
+#define HAVE_DISK_ERR 1
 #endif
 
 #if LIBVIR_CHECK_VERSION(0, 9, 11)
 #define HAVE_CPU_STATS 1
+#define HAVE_DOM_STATE_PMSUSPENDED 1
+#define HAVE_DOM_REASON_RUNNING_WAKEUP 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 0, 1)
+#define HAVE_DOM_REASON_PAUSED_SNAPSHOT 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 1, 1)
+#define HAVE_DOM_REASON_PAUSED_CRASHED 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 2, 9)
+#define HAVE_JOB_STATS 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 2, 10)
+#define HAVE_DOM_REASON_CRASHED 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 2, 11)
+#define HAVE_FS_INFO 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 2, 15)
+#define HAVE_DOM_REASON_PAUSED_STARTING_UP 1
+#endif
+
+#if LIBVIR_CHECK_VERSION(1, 3, 3)
+#define HAVE_PERF_STATS 1
+#define HAVE_DOM_REASON_POSTCOPY 1
 #endif
 
 #endif /* LIBVIR_CHECK_VERSION */
@@ -67,14 +108,145 @@ static const char *config_keys[] = {"Connection",
 
                                     "Instances",
                                     "ExtraStats",
-
                                     NULL};
+
+const char *domain_states[] = {
+        [VIR_DOMAIN_NOSTATE] = "no state",
+        [VIR_DOMAIN_RUNNING] = "the domain is running",
+        [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
+        [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
+        [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
+        [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
+        [VIR_DOMAIN_CRASHED] = "the domain is crashed",
+#ifdef HAVE_DOM_STATE_PMSUSPENDED
+        [VIR_DOMAIN_PMSUSPENDED] =
+            "the domain is suspended by guest power management",
+#endif
+};
+
+#ifdef HAVE_DOM_REASON
+#define DOMAIN_STATE_REASON_MAX_SIZE 20
+const char *domain_reasons[][DOMAIN_STATE_REASON_MAX_SIZE] = {
+        [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] =
+            "the reason is unknown",
+
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
+            "normal startup from boot",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
+            "migrated from another host",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
+            "restored from a state file",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
+            "restored from snapshot",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
+            "returned from paused state",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
+            "returned from migration",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
+            "returned from failed save process",
+#ifdef HAVE_DOM_REASON_RUNNING_WAKEUP
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
+            "returned from pmsuspended due to wakeup event",
+#endif
+#ifdef HAVE_DOM_REASON_CRASHED
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] =
+            "resumed from crashed",
+#endif
+#ifdef HAVE_DOM_REASON_POSTCOPY
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
+            "running in post-copy migration mode",
+#endif
+
+        [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] =
+            "the reason is unknown",
+
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
+            "paused for offline migration",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
+            "paused for offline core dump",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
+            "paused due to a disk I/O error",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
+            "paused due to a watchdog event",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
+            "paused after restoring from snapshot",
+#ifdef HAVE_DOM_REASON_PAUSED_SHUTTING_DOWN
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
+            "paused during shutdown process",
+#endif
+#ifdef HAVE_DOM_REASON_PAUSED_SNAPSHOT
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
+            "paused while creating a snapshot",
+#endif
+#ifdef HAVE_DOM_REASON_PAUSED_CRASHED
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
+            "paused due to a guest crash",
+#endif
+#ifdef HAVE_DOM_REASON_PAUSED_STARTING_UP
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
+            "the domain is being started",
+#endif
+#ifdef HAVE_DOM_REASON_POSTCOPY
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
+            "paused for post-copy migration",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
+            "paused after failed post-copy",
+#endif
+
+        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
+            "shutting down on user request",
+
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
+            "migrated to another host",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] =
+            "domain failed to start",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
+            "restored from a snapshot which was taken while domain was shutoff",
+
+        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] =
+            "the reason is unknown",
+#ifdef VIR_DOMAIN_CRASHED_PANICKED
+        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
+#endif
+
+#ifdef HAVE_DOM_STATE_PMSUSPENDED
+        [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
+            "the reason is unknown",
+#endif
+};
+#endif /* HAVE_DOM_REASON */
+
 #define NR_CONFIG_KEYS ((sizeof config_keys / sizeof config_keys[0]) - 1)
+#define NANOSEC_IN_SEC 1e9
+
+#define GET_STATS(_f, _name, ...)                                              \
+  do {                                                                         \
+    status = _f(__VA_ARGS__);                                                  \
+    if (status != 0)                                                           \
+      ERROR(PLUGIN_NAME ": Failed to get " _name);                             \
+  } while (0)
 
 /* Connection. */
 static virConnectPtr conn = 0;
 static char *conn_string = NULL;
 static c_complain_t conn_complain = C_COMPLAIN_INIT_STATIC;
+
+/* Node information required for %CPU */
+static virNodeInfo nodeinfo;
 
 /* Seconds between list refreshes, 0 disables completely. */
 static int interval = 60;
@@ -103,9 +275,14 @@ struct interface_device {
   char *number;     /* interface device number */
 };
 
+typedef struct domain_s {
+  virDomainPtr ptr;
+  virDomainInfo info;
+} domain_t;
+
 struct lv_read_state {
   /* Actual list of domains found on last refresh. */
-  virDomainPtr *domains;
+  domain_t *domains;
   int nr_domains;
 
   struct block_device *block_devices;
@@ -172,8 +349,29 @@ enum bd_field { target, source };
 enum if_field { if_address, if_name, if_number };
 
 /* ExtraStats */
-#define EX_STATS_MAX_FIELDS 8
-enum ex_stats { ex_stats_none = 0, ex_stats_disk = 1, ex_stats_pcpu = 2 };
+#define EX_STATS_MAX_FIELDS 15
+enum ex_stats {
+  ex_stats_none = 0,
+  ex_stats_disk = 1 << 0,
+  ex_stats_pcpu = 1 << 1,
+  ex_stats_cpu_util = 1 << 2,
+  ex_stats_domain_state = 1 << 3,
+#ifdef HAVE_PERF_STATS
+  ex_stats_perf = 1 << 4,
+#endif
+  ex_stats_vcpupin = 1 << 5,
+#ifdef HAVE_DISK_ERR
+  ex_stats_disk_err = 1 << 6,
+#endif
+#ifdef HAVE_FS_INFO
+  ex_stats_fs_info = 1 << 7,
+#endif
+#ifdef HAVE_JOB_STATS
+  ex_stats_job_stats_completed = 1 << 8,
+  ex_stats_job_stats_background = 1 << 9,
+#endif
+};
+
 static unsigned int extra_stats = ex_stats_none;
 
 struct ex_stats_item {
@@ -181,7 +379,25 @@ struct ex_stats_item {
   enum ex_stats flag;
 };
 static const struct ex_stats_item ex_stats_table[] = {
-    {"disk", ex_stats_disk}, {"pcpu", ex_stats_pcpu}, {NULL, ex_stats_none},
+    {"disk", ex_stats_disk},
+    {"pcpu", ex_stats_pcpu},
+    {"cpu_util", ex_stats_cpu_util},
+    {"domain_state", ex_stats_domain_state},
+#ifdef HAVE_PERF_STATS
+    {"perf", ex_stats_perf},
+#endif
+    {"vcpupin", ex_stats_vcpupin},
+#ifdef HAVE_DISK_ERR
+    {"disk_err", ex_stats_disk_err},
+#endif
+#ifdef HAVE_FS_INFO
+    {"fs_info", ex_stats_fs_info},
+#endif
+#ifdef HAVE_JOB_STATS
+    {"job_stats_completed", ex_stats_job_stats_completed},
+    {"job_stats_background", ex_stats_job_stats_background},
+#endif
+    {NULL, ex_stats_none},
 };
 
 /* BlockDeviceFormatBasename */
@@ -388,6 +604,34 @@ static void init_value_list(value_list_t *vl, virDomainPtr dom) {
 
 } /* void init_value_list */
 
+static int init_notif(notification_t *notif, const virDomainPtr domain,
+                      int severity, const char *msg, const char *type,
+                      const char *type_instance) {
+  value_list_t vl = VALUE_LIST_INIT;
+
+  if (!notif) {
+    ERROR(PLUGIN_NAME ": init_notif: NULL pointer");
+    return -1;
+  }
+
+  init_value_list(&vl, domain);
+  notification_init(notif, severity, msg, vl.host, vl.plugin,
+                    vl.plugin_instance, type, type_instance);
+  notif->time = cdtime();
+  return 0;
+}
+
+static void submit_notif(const virDomainPtr domain, int severity,
+                         const char *msg, const char *type,
+                         const char *type_instance) {
+  notification_t notif;
+
+  init_notif(&notif, domain, severity, msg, type, type_instance);
+  plugin_dispatch_notification(&notif);
+  if (notif.meta)
+    plugin_notification_meta_free(notif.meta);
+}
+
 static void submit(virDomainPtr dom, char const *type,
                    char const *type_instance, value_t *values,
                    size_t values_len) {
@@ -404,7 +648,7 @@ static void submit(virDomainPtr dom, char const *type,
   plugin_dispatch_values(&vl);
 }
 
-static void memory_submit(gauge_t value, virDomainPtr dom) {
+static void memory_submit(virDomainPtr dom, gauge_t value) {
   submit(dom, "memory", "total", &(value_t){.gauge = value}, 1);
 }
 
@@ -412,7 +656,8 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
                                 int tag_index) {
   static const char *tags[] = {"swap_in",        "swap_out", "major_fault",
                                "minor_fault",    "unused",   "available",
-                               "actual_balloon", "rss"};
+                               "actual_balloon", "rss",      "usable",
+                               "last_update"};
 
   if ((tag_index < 0) || (tag_index >= (int)STATIC_ARRAY_SIZE(tags))) {
     ERROR("virt plugin: Array index out of bounds: tag_index = %d", tag_index);
@@ -439,9 +684,45 @@ static void pcpu_submit(virDomainPtr dom, struct lv_info *info) {
 #endif /* HAVE_CPU_STATS */
 }
 
-static void cpu_submit(unsigned long long value, virDomainPtr dom,
-                       const char *type) {
-  submit(dom, type, NULL, &(value_t){.derive = (derive_t)value}, 1);
+static double cpu_ns_to_percent(unsigned int node_cpus,
+                                unsigned long long cpu_time_old,
+                                unsigned long long cpu_time_new) {
+  double percent = 0.0;
+  unsigned long long cpu_time_diff = 0;
+  double time_diff_sec = CDTIME_T_TO_DOUBLE(plugin_get_interval());
+
+  if (node_cpus != 0 && time_diff_sec != 0 && cpu_time_old != 0) {
+    cpu_time_diff = cpu_time_new - cpu_time_old;
+    percent = ((double)(100 * cpu_time_diff)) /
+              (time_diff_sec * node_cpus * NANOSEC_IN_SEC);
+  }
+
+  DEBUG(PLUGIN_NAME ": node_cpus=%u cpu_time_old=%llu cpu_time_new=%llu"
+                    "cpu_time_diff=%llu time_diff_sec=%f percent=%f",
+        node_cpus, cpu_time_old, cpu_time_new, cpu_time_diff, time_diff_sec,
+        percent);
+
+  return percent;
+}
+
+static void cpu_submit(const domain_t *dom, unsigned long long cpuTime_new) {
+
+  if (!dom)
+    return;
+
+  if (extra_stats & ex_stats_cpu_util) {
+    /* Computing %CPU requires 2 samples of cpuTime */
+    if (dom->info.cpuTime != 0 && cpuTime_new != 0) {
+
+      submit(dom->ptr, "percent", "virt_cpu_total",
+             &(value_t){.gauge = cpu_ns_to_percent(
+                            nodeinfo.cpus, dom->info.cpuTime, cpuTime_new)},
+             1);
+    }
+  }
+
+  submit(dom->ptr, "virt_cpu_total", NULL, &(value_t){.derive = cpuTime_new},
+         1);
 }
 
 static void vcpu_submit(derive_t value, virDomainPtr dom, int vcpu_nr,
@@ -449,14 +730,26 @@ static void vcpu_submit(derive_t value, virDomainPtr dom, int vcpu_nr,
   char type_instance[DATA_MAX_NAME_LEN];
 
   ssnprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
-
   submit(dom, type, type_instance, &(value_t){.derive = value}, 1);
 }
 
 static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
-                        const char *type_instance) {
-  char flush_type_instance[DATA_MAX_NAME_LEN];
+                        const char *dev) {
+  char *dev_copy = strdup(dev);
+  const char *type_instance = dev_copy;
 
+  if (!dev_copy)
+    return;
+
+  if (blockdevice_format_basename && blockdevice_format == source)
+    type_instance = basename(dev_copy);
+
+  if (!type_instance) {
+    sfree(dev_copy);
+    return;
+  }
+
+  char flush_type_instance[DATA_MAX_NAME_LEN];
   ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
             type_instance);
 
@@ -482,6 +775,8 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
              &(value_t){.derive = value}, 1);
     }
   }
+
+  sfree(dev_copy);
 }
 
 static unsigned int parse_ex_stats_flags(char **exstats, int numexstats) {
@@ -494,9 +789,69 @@ static unsigned int parse_ex_stats_flags(char **exstats, int numexstats) {
         ex_stats_flags |= ex_stats_table[j].flag;
         break;
       }
+
+      if (ex_stats_table[j + 1].name == NULL) {
+        ERROR(PLUGIN_NAME ": Unmatched ExtraStats option: %s", exstats[i]);
+      }
     }
   }
   return ex_stats_flags;
+}
+
+static void domain_state_submit(virDomainPtr dom, int state, int reason) {
+
+  if ((state < 0) || (state >= STATIC_ARRAY_SIZE(domain_states))) {
+    ERROR(PLUGIN_NAME ": Array index out of bounds: state=%d", state);
+    return;
+  }
+
+  char msg[DATA_MAX_NAME_LEN];
+  const char *state_str = domain_states[state];
+#ifdef HAVE_DOM_REASON
+  if ((reason < 0) || (reason >= STATIC_ARRAY_SIZE(domain_reasons[0]))) {
+    ERROR(PLUGIN_NAME ": Array index out of bounds: reason=%d", reason);
+    return;
+  }
+
+  const char *reason_str = domain_reasons[state][reason];
+  /* Array size for domain reasons is fixed, but different domain states can
+   * have different number of reasons. We need to check if reason was
+   * successfully parsed */
+  if (!reason_str) {
+    ERROR(PLUGIN_NAME ": Invalid reason (%d) for domain state: %s", reason,
+          state_str);
+    return;
+  }
+#else
+  const char *reason_str = "N/A";
+#endif
+
+  ssnprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
+            reason_str);
+
+  int severity;
+  switch (state) {
+  case VIR_DOMAIN_NOSTATE:
+  case VIR_DOMAIN_RUNNING:
+  case VIR_DOMAIN_SHUTDOWN:
+  case VIR_DOMAIN_SHUTOFF:
+    severity = NOTIF_OKAY;
+    break;
+  case VIR_DOMAIN_BLOCKED:
+  case VIR_DOMAIN_PAUSED:
+#ifdef DOM_STATE_PMSUSPENDED
+  case VIR_DOMAIN_PMSUSPENDED:
+#endif
+    severity = NOTIF_WARNING;
+    break;
+  case VIR_DOMAIN_CRASHED:
+    severity = NOTIF_FAILURE;
+    break;
+  default:
+    ERROR(PLUGIN_NAME ": Unrecognized domain state (%d)", state);
+    return;
+  }
+  submit_notif(dom, severity, msg, "domain_state", NULL);
 }
 
 static int lv_config(const char *key, const char *value) {
@@ -701,6 +1056,16 @@ static int lv_config(const char *key, const char *value) {
           strsplit(localvalue, exstats, STATIC_ARRAY_SIZE(exstats));
       extra_stats = parse_ex_stats_flags(exstats, numexstats);
       sfree(localvalue);
+
+#ifdef HAVE_JOB_STATS
+      if ((extra_stats & ex_stats_job_stats_completed) &&
+          (extra_stats & ex_stats_job_stats_background)) {
+        ERROR(PLUGIN_NAME " plugin: Invalid job stats configuration. Only one "
+                          "type of job statistics can be collected at the same "
+                          "time");
+        return 1;
+      }
+#endif
     }
   }
 
@@ -710,12 +1075,23 @@ static int lv_config(const char *key, const char *value) {
 
 static int lv_connect(void) {
   if (conn == NULL) {
-    /* `conn_string == NULL' is acceptable. */
-    conn = virConnectOpenReadOnly(conn_string);
+/* `conn_string == NULL' is acceptable */
+#ifdef HAVE_FS_INFO
+    /* virDomainGetFSInfo requires full read-write access connection */
+    if (extra_stats & ex_stats_fs_info)
+      conn = virConnectOpen(conn_string);
+    else
+#endif
+      conn = virConnectOpenReadOnly(conn_string);
     if (conn == NULL) {
       c_complain(LOG_ERR, &conn_complain,
                  PLUGIN_NAME " plugin: Unable to connect: "
-                             "virConnectOpenReadOnly failed.");
+                             "virConnectOpen failed.");
+      return -1;
+    }
+    int status = virNodeGetInfo(conn, &nodeinfo);
+    if (status != 0) {
+      ERROR(PLUGIN_NAME ": virNodeGetInfo failed");
       return -1;
     }
   }
@@ -765,6 +1141,445 @@ done:
 #endif /* HAVE_BLOCK_STATS_FLAGS */
 }
 
+#ifdef HAVE_PERF_STATS
+static void perf_submit(virDomainStatsRecordPtr stats) {
+  for (int i = 0; i < stats->nparams; ++i) {
+    /* Replace '.' with '_' in event field to match other metrics' naming
+     * convention */
+    char *c = strchr(stats->params[i].field, '.');
+    if (c)
+      *c = '_';
+    submit(stats->dom, "perf", stats->params[i].field,
+           &(value_t){.derive = stats->params[i].value.ul}, 1);
+  }
+}
+
+static int get_perf_events(virDomainPtr domain) {
+  virDomainStatsRecordPtr *stats = NULL;
+  /* virDomainListGetStats requires a NULL terminated list of domains */
+  virDomainPtr domain_array[] = {domain, NULL};
+
+  int status =
+      virDomainListGetStats(domain_array, VIR_DOMAIN_STATS_PERF, &stats, 0);
+  if (status == -1) {
+    ERROR("virt plugin: virDomainListGetStats failed with status %i.", status);
+    return status;
+  }
+
+  for (int i = 0; i < status; ++i)
+    perf_submit(stats[i]);
+
+  virDomainStatsRecordListFree(stats);
+  return 0;
+}
+#endif /* HAVE_PERF_STATS */
+
+static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
+                            unsigned char *cpu_maps, int cpu_map_len) {
+  for (int cpu = 0; cpu < max_cpus; ++cpu) {
+    char type_instance[DATA_MAX_NAME_LEN];
+    _Bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? 1 : 0;
+
+    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
+              cpu);
+    submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
+  }
+}
+
+static int get_vcpu_stats(virDomainPtr domain, unsigned short nr_virt_cpu) {
+  int max_cpus = VIR_NODEINFO_MAXCPUS(nodeinfo);
+  int cpu_map_len = VIR_CPU_MAPLEN(max_cpus);
+
+  virVcpuInfoPtr vinfo = calloc(nr_virt_cpu, sizeof(vinfo[0]));
+  if (vinfo == NULL) {
+    ERROR(PLUGIN_NAME " plugin: malloc failed.");
+    return -1;
+  }
+
+  unsigned char *cpumaps = calloc(nr_virt_cpu, cpu_map_len);
+  if (cpumaps == NULL) {
+    ERROR(PLUGIN_NAME " plugin: malloc failed.");
+    sfree(vinfo);
+    return -1;
+  }
+
+  int status =
+      virDomainGetVcpus(domain, vinfo, nr_virt_cpu, cpumaps, cpu_map_len);
+  if (status < 0) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetVcpus failed with status %i.",
+          status);
+    sfree(cpumaps);
+    sfree(vinfo);
+    return status;
+  }
+
+  for (int i = 0; i < nr_virt_cpu; ++i) {
+    vcpu_submit(vinfo[i].cpuTime, domain, vinfo[i].number, "virt_vcpu");
+    if (extra_stats & ex_stats_vcpupin)
+      vcpu_pin_submit(domain, max_cpus, i, cpumaps, cpu_map_len);
+  }
+
+  sfree(cpumaps);
+  sfree(vinfo);
+  return 0;
+}
+
+#ifdef HAVE_DOM_REASON
+static int get_domain_state(virDomainPtr domain) {
+  int domain_state = 0;
+  int domain_reason = 0;
+
+  int status = virDomainGetState(domain, &domain_state, &domain_reason, 0);
+  if (status != 0) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetState failed with status %i.",
+          status);
+    return status;
+  }
+
+  domain_state_submit(domain, domain_state, domain_reason);
+  return status;
+}
+#endif /* HAVE_DOM_REASON */
+
+static int get_memory_stats(virDomainPtr domain) {
+  virDomainMemoryStatPtr minfo =
+      calloc(VIR_DOMAIN_MEMORY_STAT_NR, sizeof(virDomainMemoryStatStruct));
+  if (minfo == NULL) {
+    ERROR("virt plugin: malloc failed.");
+    return -1;
+  }
+
+  int mem_stats =
+      virDomainMemoryStats(domain, minfo, VIR_DOMAIN_MEMORY_STAT_NR, 0);
+  if (mem_stats < 0) {
+    ERROR("virt plugin: virDomainMemoryStats failed with mem_stats %i.",
+          mem_stats);
+    sfree(minfo);
+    return mem_stats;
+  }
+
+  for (int i = 0; i < mem_stats; i++)
+    memory_stats_submit((gauge_t)minfo[i].val * 1024, domain, minfo[i].tag);
+
+  sfree(minfo);
+  return 0;
+}
+
+#ifdef HAVE_DISK_ERR
+static void disk_err_submit(virDomainPtr domain,
+                            virDomainDiskErrorPtr disk_err) {
+  submit(domain, "disk_error", disk_err->disk,
+         &(value_t){.gauge = disk_err->error}, 1);
+}
+
+static int get_disk_err(virDomainPtr domain) {
+  /* Get preferred size of disk errors array */
+  int disk_err_count = virDomainGetDiskErrors(domain, NULL, 0, 0);
+  if (disk_err_count == -1) {
+    ERROR(PLUGIN_NAME
+          " plugin: failed to get preferred size of disk errors array");
+    return -1;
+  }
+
+  DEBUG(PLUGIN_NAME
+        " plugin: preferred size of disk errors array: %d for domain %s",
+        disk_err_count, virDomainGetName(domain));
+  virDomainDiskError disk_err[disk_err_count];
+
+  disk_err_count = virDomainGetDiskErrors(domain, disk_err, disk_err_count, 0);
+  if (disk_err_count == -1) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetDiskErrors failed with status %d",
+          disk_err_count);
+    return -1;
+  }
+
+  DEBUG(PLUGIN_NAME " plugin: detected %d disk errors in domain %s",
+        disk_err_count, virDomainGetName(domain));
+
+  for (int i = 0; i < disk_err_count; ++i) {
+    disk_err_submit(domain, &disk_err[i]);
+    sfree(disk_err[i].disk);
+  }
+
+  return 0;
+}
+#endif /* HAVE_DISK_ERR */
+
+static int get_block_stats(struct block_device *block_dev) {
+
+  if (!block_dev) {
+    ERROR(PLUGIN_NAME " plugin: get_block_stats NULL pointer");
+    return -1;
+  }
+
+  struct lv_block_info binfo;
+  init_block_info(&binfo);
+
+  if (lv_domain_block_info(block_dev->dom, block_dev->path, &binfo) < 0) {
+    ERROR(PLUGIN_NAME " plugin: lv_domain_block_info failed");
+    return -1;
+  }
+
+  disk_submit(&binfo, block_dev->dom, block_dev->path);
+  return 0;
+}
+
+#ifdef HAVE_FS_INFO
+
+#define NM_ADD_ITEM(_fun, _name, _val)                                         \
+  do {                                                                         \
+    ret = _fun(&notif, _name, _val);                                           \
+    if (ret != 0) {                                                            \
+      ERROR(PLUGIN_NAME " plugin: failed to add notification metadata");       \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+#define NM_ADD_STR_ITEMS(_items, _size)                                        \
+  do {                                                                         \
+    for (int _i = 0; _i < _size; ++_i) {                                       \
+      DEBUG(PLUGIN_NAME                                                        \
+            " plugin: Adding notification metadata name=%s value=%s",          \
+            _items[_i].name, _items[_i].value);                                \
+      NM_ADD_ITEM(plugin_notification_meta_add_string, _items[_i].name,        \
+                  _items[_i].value);                                           \
+    }                                                                          \
+  } while (0)
+
+static int fs_info_notify(virDomainPtr domain, virDomainFSInfoPtr fs_info) {
+  notification_t notif;
+  int ret = 0;
+
+  /* Local struct, just for the purpose of this function. */
+  typedef struct nm_str_item_s {
+    const char *name;
+    const char *value;
+  } nm_str_item_t;
+
+  nm_str_item_t fs_dev_alias[fs_info->ndevAlias];
+  nm_str_item_t fs_str_items[] = {
+      {.name = "mountpoint", .value = fs_info->mountpoint},
+      {.name = "name", .value = fs_info->name},
+      {.name = "fstype", .value = fs_info->fstype}};
+
+  for (int i = 0; i < fs_info->ndevAlias; ++i) {
+    fs_dev_alias[i].name = "devAlias";
+    fs_dev_alias[i].value = fs_info->devAlias[i];
+  }
+
+  init_notif(&notif, domain, NOTIF_OKAY, "File system information",
+             "file_system", NULL);
+  NM_ADD_STR_ITEMS(fs_str_items, STATIC_ARRAY_SIZE(fs_str_items));
+  NM_ADD_ITEM(plugin_notification_meta_add_unsigned_int, "ndevAlias",
+              fs_info->ndevAlias);
+  NM_ADD_STR_ITEMS(fs_dev_alias, fs_info->ndevAlias);
+
+  plugin_dispatch_notification(&notif);
+
+cleanup:
+  if (notif.meta)
+    plugin_notification_meta_free(notif.meta);
+  return ret;
+}
+
+#undef RETURN_ON_ERR
+#undef NM_ADD_STR_ITEMS
+
+static int get_fs_info(virDomainPtr domain) {
+  virDomainFSInfoPtr *fs_info = NULL;
+  int ret = 0;
+
+  int mount_points_cnt = virDomainGetFSInfo(domain, &fs_info, 0);
+  if (mount_points_cnt == -1) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetFSInfo failed: %d",
+          mount_points_cnt);
+    return mount_points_cnt;
+  }
+
+  for (int i = 0; i < mount_points_cnt; ++i) {
+    if (fs_info_notify(domain, fs_info[i]) != 0) {
+      ERROR(PLUGIN_NAME " plugin: failed to send file system notification "
+                        "for mount point %s",
+            fs_info[i]->mountpoint);
+      ret = -1;
+    }
+    virDomainFSInfoFree(fs_info[i]);
+  }
+
+  sfree(fs_info);
+  return ret;
+}
+
+#endif /* HAVE_FS_INFO */
+
+#ifdef HAVE_JOB_STATS
+static void job_stats_submit(virDomainPtr domain, virTypedParameterPtr param) {
+  value_t vl = {0};
+
+  if (param->type == VIR_TYPED_PARAM_INT)
+    vl.derive = param->value.i;
+  else if (param->type == VIR_TYPED_PARAM_UINT)
+    vl.derive = param->value.ui;
+  else if (param->type == VIR_TYPED_PARAM_LLONG)
+    vl.derive = param->value.l;
+  else if (param->type == VIR_TYPED_PARAM_ULLONG)
+    vl.derive = param->value.ul;
+  else if (param->type == VIR_TYPED_PARAM_DOUBLE)
+    vl.derive = param->value.d;
+  else if (param->type == VIR_TYPED_PARAM_BOOLEAN)
+    vl.derive = param->value.b;
+  else if (param->type == VIR_TYPED_PARAM_STRING) {
+    submit_notif(domain, NOTIF_OKAY, param->value.s, "job_stats", param->field);
+    return;
+  } else {
+    ERROR(PLUGIN_NAME " plugin: unrecognized virTypedParameterType");
+    return;
+  }
+
+  submit(domain, "job_stats", param->field, &vl, 1);
+}
+
+static int get_job_stats(virDomainPtr domain) {
+  int ret = 0;
+  int job_type = 0;
+  int nparams = 0;
+  virTypedParameterPtr params = NULL;
+  int flags = (extra_stats & ex_stats_job_stats_completed)
+                  ? VIR_DOMAIN_JOB_STATS_COMPLETED
+                  : 0;
+
+  ret = virDomainGetJobStats(domain, &job_type, &params, &nparams, flags);
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetJobStats failed: %d", ret);
+    return ret;
+  }
+
+  DEBUG(PLUGIN_NAME " plugin: job_type=%d nparams=%d", job_type, nparams);
+
+  for (int i = 0; i < nparams; ++i) {
+    DEBUG(PLUGIN_NAME " plugin: param[%d] field=%s type=%d", i, params[i].field,
+          params[i].type);
+    job_stats_submit(domain, &params[i]);
+  }
+
+  virTypedParamsFree(params, nparams);
+  return ret;
+}
+#endif /* HAVE_JOB_STATS */
+
+static int get_domain_metrics(domain_t *domain) {
+  struct lv_info info;
+
+  if (!domain || !domain->ptr) {
+    ERROR(PLUGIN_NAME ": get_domain_metrics: NULL pointer");
+    return -1;
+  }
+
+  init_lv_info(&info);
+  int status = lv_domain_info(domain->ptr, &info);
+  if (status != 0) {
+    ERROR(PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
+          status);
+    return -1;
+  }
+
+  if (extra_stats & ex_stats_domain_state) {
+#ifdef HAVE_DOM_REASON
+    /* At this point we already know domain's state from virDomainGetInfo call,
+     * however it doesn't provide a reason for entering particular state.
+     * We need to get it from virDomainGetState.
+     */
+    GET_STATS(get_domain_state, "domain reason", domain->ptr);
+#else
+    /* virDomainGetState is not available. Submit 0, which corresponds to
+     * unknown reason. */
+    domain_state_submit(domain->ptr, info.di.state, 0);
+#endif
+  }
+
+  /* Gather remaining stats only for running domains */
+  if (info.di.state != VIR_DOMAIN_RUNNING)
+    return 0;
+
+  pcpu_submit(domain->ptr, &info);
+  cpu_submit(domain, info.di.cpuTime);
+
+  memory_submit(domain->ptr, (gauge_t)info.di.memory * 1024);
+
+  GET_STATS(get_vcpu_stats, "vcpu stats", domain->ptr, info.di.nrVirtCpu);
+  GET_STATS(get_memory_stats, "memory stats", domain->ptr);
+
+#ifdef HAVE_PERF_STATS
+  if (extra_stats & ex_stats_perf)
+    GET_STATS(get_perf_events, "performance monitoring events", domain->ptr);
+#endif
+
+#ifdef HAVE_FS_INFO
+  if (extra_stats & ex_stats_fs_info)
+    GET_STATS(get_fs_info, "file system info", domain->ptr);
+#endif
+
+#ifdef HAVE_DISK_ERR
+  if (extra_stats & ex_stats_disk_err)
+    GET_STATS(get_disk_err, "disk errors", domain->ptr);
+#endif
+
+#ifdef HAVE_JOB_STATS
+  if (extra_stats &
+      (ex_stats_job_stats_completed | ex_stats_job_stats_background))
+    GET_STATS(get_job_stats, "job stats", domain->ptr);
+#endif
+
+  /* Update cached virDomainInfo. It has to be done after cpu_submit */
+  memcpy(&domain->info, &info.di, sizeof(domain->info));
+  return 0;
+}
+
+static int get_if_dev_stats(struct interface_device *if_dev) {
+  virDomainInterfaceStatsStruct stats = {0};
+  char *display_name = NULL;
+
+  if (!if_dev) {
+    ERROR(PLUGIN_NAME " plugin: get_if_dev_stats: NULL pointer");
+    return -1;
+  }
+
+  switch (interface_format) {
+  case if_address:
+    display_name = if_dev->address;
+    break;
+  case if_number:
+    display_name = if_dev->number;
+    break;
+  case if_name:
+  default:
+    display_name = if_dev->path;
+  }
+
+  if (virDomainInterfaceStats(if_dev->dom, if_dev->path, &stats,
+                              sizeof(stats)) != 0) {
+    ERROR(PLUGIN_NAME " plugin: virDomainInterfaceStats failed");
+    return -1;
+  }
+
+  if ((stats.rx_bytes != -1) && (stats.tx_bytes != -1))
+    submit_derive2("if_octets", (derive_t)stats.rx_bytes,
+                   (derive_t)stats.tx_bytes, if_dev->dom, display_name);
+
+  if ((stats.rx_packets != -1) && (stats.tx_packets != -1))
+    submit_derive2("if_packets", (derive_t)stats.rx_packets,
+                   (derive_t)stats.tx_packets, if_dev->dom, display_name);
+
+  if ((stats.rx_errs != -1) && (stats.tx_errs != -1))
+    submit_derive2("if_errors", (derive_t)stats.rx_errs,
+                   (derive_t)stats.tx_errs, if_dev->dom, display_name);
+
+  if ((stats.rx_drop != -1) && (stats.tx_drop != -1))
+    submit_derive2("if_dropped", (derive_t)stats.rx_drop,
+                   (derive_t)stats.tx_drop, if_dev->dom, display_name);
+  return 0;
+}
+
 static int lv_read(user_data_t *ud) {
   time_t t;
   struct lv_read_instance *inst = NULL;
@@ -798,7 +1613,7 @@ static int lv_read(user_data_t *ud) {
 
 #if 0
     for (int i = 0; i < nr_domains; ++i)
-        fprintf (stderr, "domain %s\n", virDomainGetName (domains[i]));
+        fprintf (stderr, "domain %s\n", virDomainGetName (state->domains[i].ptr));
     for (int i = 0; i < nr_block_devices; ++i)
         fprintf  (stderr, "block device %d %s:%s\n",
                   i, virDomainGetName (block_devices[i].dom),
@@ -809,139 +1624,33 @@ static int lv_read(user_data_t *ud) {
                  interface_devices[i].path);
 #endif
 
-  /* Get CPU usage, memory, VCPU usage for each domain. */
+  /* Get domains' metrics */
   for (int i = 0; i < state->nr_domains; ++i) {
-    struct lv_info info;
-    virVcpuInfoPtr vinfo = NULL;
-    virDomainMemoryStatPtr minfo = NULL;
-    int status;
-
-    init_lv_info(&info);
-    status = lv_domain_info(state->domains[i], &info);
-    if (status != 0) {
-      ERROR(PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
-            status);
-      continue;
-    }
-
-    pcpu_submit(state->domains[i], &info);
-    cpu_submit(info.di.cpuTime, state->domains[i], "virt_cpu_total");
-    memory_submit((gauge_t)info.di.memory * 1024, state->domains[i]);
-
-    vinfo = malloc(info.di.nrVirtCpu * sizeof(vinfo[0]));
-    if (vinfo == NULL) {
-      ERROR(PLUGIN_NAME " plugin: malloc failed.");
-      continue;
-    }
-
-    status = virDomainGetVcpus(state->domains[i], vinfo, info.di.nrVirtCpu,
-                               /* cpu map = */ NULL, /* cpu map length = */ 0);
-    if (status < 0) {
-      ERROR(PLUGIN_NAME " plugin: virDomainGetVcpus failed with status %i.",
-            status);
-      sfree(vinfo);
-      continue;
-    }
-
-    for (int j = 0; j < info.di.nrVirtCpu; ++j)
-      vcpu_submit(vinfo[j].cpuTime, state->domains[i], vinfo[j].number,
-                  "virt_vcpu");
-
-    sfree(vinfo);
-
-    minfo =
-        malloc(VIR_DOMAIN_MEMORY_STAT_NR * sizeof(virDomainMemoryStatStruct));
-    if (minfo == NULL) {
-      ERROR("virt plugin: malloc failed.");
-      continue;
-    }
-
-    status = virDomainMemoryStats(state->domains[i], minfo,
-                                  VIR_DOMAIN_MEMORY_STAT_NR, 0);
-
-    if (status < 0) {
-      ERROR("virt plugin: virDomainMemoryStats failed with status %i.", status);
-      sfree(minfo);
-      continue;
-    }
-
-    for (int j = 0; j < status; j++) {
-      memory_stats_submit((gauge_t)minfo[j].val * 1024, state->domains[i],
-                          minfo[j].tag);
-    }
-
-    sfree(minfo);
+    int status = get_domain_metrics(&state->domains[i]);
+    if (status != 0)
+      ERROR(PLUGIN_NAME " failed to get metrics for domain=%s",
+            virDomainGetName(state->domains[i].ptr));
   }
 
   /* Get block device stats for each domain. */
   for (int i = 0; i < state->nr_block_devices; ++i) {
-    struct block_device *bdev = &(state->block_devices[i]);
-    struct lv_block_info binfo;
-    init_block_info(&binfo);
-
-    if (lv_domain_block_info(bdev->dom, bdev->path, &binfo) < 0)
-      continue;
-
-    char *type_instance = bdev->path;
-    char *path = NULL;
-    if (blockdevice_format_basename && blockdevice_format == source) {
-      path = strdup(bdev->path);
-      if (path == NULL) {
-        WARNING(PLUGIN_NAME
-                " plugin: error extracting the basename for '%s', skipped",
-                bdev->path);
-        continue;
-      }
-      type_instance = basename(path);
-    }
-
-    disk_submit(&binfo, bdev->dom, type_instance);
-
-    sfree(path);
-  } /* for (nr_block_devices) */
+    int status = get_block_stats(&state->block_devices[i]);
+    if (status != 0)
+      ERROR(PLUGIN_NAME
+            " failed to get stats for block device (%s) in domain %s",
+            state->block_devices[i].path,
+            virDomainGetName(state->domains[i].ptr));
+  }
 
   /* Get interface stats for each domain. */
   for (int i = 0; i < state->nr_interface_devices; ++i) {
-    struct _virDomainInterfaceStats stats;
-    char *display_name = NULL;
-
-    switch (interface_format) {
-    case if_address:
-      display_name = state->interface_devices[i].address;
-      break;
-    case if_number:
-      display_name = state->interface_devices[i].number;
-      break;
-    case if_name:
-    default:
-      display_name = state->interface_devices[i].path;
-    }
-
-    if (virDomainInterfaceStats(state->interface_devices[i].dom,
-                                state->interface_devices[i].path, &stats,
-                                sizeof stats) != 0)
-      continue;
-
-    if ((stats.rx_bytes != -1) && (stats.tx_bytes != -1))
-      submit_derive2("if_octets", (derive_t)stats.rx_bytes,
-                     (derive_t)stats.tx_bytes, state->interface_devices[i].dom,
-                     display_name);
-
-    if ((stats.rx_packets != -1) && (stats.tx_packets != -1))
-      submit_derive2("if_packets", (derive_t)stats.rx_packets,
-                     (derive_t)stats.tx_packets,
-                     state->interface_devices[i].dom, display_name);
-
-    if ((stats.rx_errs != -1) && (stats.tx_errs != -1))
-      submit_derive2("if_errors", (derive_t)stats.rx_errs,
-                     (derive_t)stats.tx_errs, state->interface_devices[i].dom,
-                     display_name);
-
-    if ((stats.rx_drop != -1) && (stats.tx_drop != -1))
-      submit_derive2("if_dropped", (derive_t)stats.rx_drop,
-                     (derive_t)stats.tx_drop, state->interface_devices[i].dom,
-                     display_name);
-  } /* for (nr_interface_devices) */
+    int status = get_if_dev_stats(&state->interface_devices[i]);
+    if (status != 0)
+      ERROR(PLUGIN_NAME
+            " failed to get interface stats for device (%s) in domain %s",
+            state->interface_devices[i].path,
+            virDomainGetName(state->interface_devices[i].dom));
+  }
 
   return 0;
 }
@@ -1287,7 +1996,7 @@ static int refresh_lists(struct lv_read_instance *inst) {
 static void free_domains(struct lv_read_state *state) {
   if (state->domains) {
     for (int i = 0; i < state->nr_domains; ++i)
-      virDomainFree(state->domains[i]);
+      virDomainFree(state->domains[i].ptr);
     sfree(state->domains);
   }
   state->domains = NULL;
@@ -1295,7 +2004,7 @@ static void free_domains(struct lv_read_state *state) {
 }
 
 static int add_domain(struct lv_read_state *state, virDomainPtr dom) {
-  virDomainPtr *new_ptr;
+  domain_t *new_ptr;
   int new_size = sizeof(state->domains[0]) * (state->nr_domains + 1);
 
   if (state->domains)
@@ -1307,7 +2016,10 @@ static int add_domain(struct lv_read_state *state, virDomainPtr dom) {
     return -1;
 
   state->domains = new_ptr;
-  state->domains[state->nr_domains] = dom;
+  state->domains[state->nr_domains].ptr = dom;
+  memset(&state->domains[state->nr_domains].info, 0,
+         sizeof(state->domains[state->nr_domains].info));
+
   return state->nr_domains++;
 }
 


### PR DESCRIPTION
Extend virt plugin functionality to support new statistics:

- Performance monitoring events
- Domain state & reason
- Percentage CPU usage
- CPU pinning (affinity)
- Disk errors
- File system information
- Job statistics

Leverage recently added 'ExtraStats' logic to allow user to enable or disable new metrics.
Plugin decodes domain state and reason enum values to human-readable string format, which will make it easier to interpret notifications.

Known limitation:
Missing CPU utilization metric is expected in some cases. In order to compute %CPU, we require 2 samples of CPU time. However, connection to libvirt is periodically refreshed, by default every 60 seconds. This interval can be changed with RefreshInterval virt plugin configuration option. Whenever connection is refreshed, we lose previous readings of CPU time, which means that we are unable to dispatch %CPU at next dispatch. With default settings - Plugin Interval 10 sec and RefreshInterval 60 sec CPU utilization will be missing every 6th dispatch. We are already working on solution for this issue, fix coming soon.