### PR TITLE
Fix rpm spec file for 5.7.1

### DIFF
--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -237,7 +237,7 @@
 Summary:	Statistics collection and monitoring daemon
 Name:		collectd
 Version:	5.7.1
-Release:	2%{?dist}
+Release:	1%{?dist}
 URL:		https://collectd.org
 Source:		https://collectd.org/files/%{name}-%{version}.tar.bz2
 License:	GPLv2

--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -236,7 +236,7 @@
 
 Summary:	Statistics collection and monitoring daemon
 Name:		collectd
-Version:	5.7.0
+Version:	5.7.1
 Release:	2%{?dist}
 URL:		https://collectd.org
 Source:		https://collectd.org/files/%{name}-%{version}.tar.bz2
@@ -2588,6 +2588,9 @@ fi
 %doc contrib/
 
 %changelog
+* Tue Jan 01 2017 Marc Fournier <marc.fournier@camptocamp.com> - 5.7.1-1
+- New upstream version
+
 * Tue Nov 29 2016 Ruben Kerkhof <ruben@rubenkerkhof.com> - 5.7.0-2
 - Disable redis plugin on RHEL 6, hiredis has been retired from EPEL6
 


### PR DESCRIPTION
Update version in redhat rpm spec file to fix error building rpm package for 5.7.1 version.
