### PR TITLE
dpdkstat: fix fixed shared mem object name

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -532,6 +532,7 @@
 #    ProcessType "secondary"
 #    FilePrefix "rte"
 #  </EAL>
+#  SharedMemObj "dpdk_collectd_stats_0"
 #  EnabledPortMask 0xffff
 #  PortName "interface1"
 #  PortName "interface2"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2398,6 +2398,7 @@ B<Synopsis:>
      FilePrefix "rte"
      SocketMemory "1024"
    </EAL>
+   SharedMemObj "dpdk_collectd_stats_0"
    EnabledPortMask 0xffff
    PortName "interface1"
    PortName "interface2"
@@ -2434,7 +2435,12 @@ sockets in MB. This is an optional value.
 
 =back
 
-=over 4
+=over 3
+
+=item B<SharedMemObj> I<Mask>
+A string containing the name of the shared memory object that should be used to
+share stats from the DPDK secondary process to the collectd dpdkstat plugin.
+Defaults to dpdk_collectd_stats if no other value is configured.
 
 =item B<EnabledPortMask> I<Mask>
 


### PR DESCRIPTION
Fix the shared memory object name so that it's configurable. This way multiple
DPDK applications running in containers can be monitored at the same time
(assuming collectd is also running in that container).

Signed-off-by: Maryam Tahhan <maryam.tahhan@intel.com>