### PR TITLE
ovs_events: Make dispatch link status configurable

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1004,6 +1004,7 @@
 #  Socket "/var/run/openvswitch/db.sock"
 #  Interfaces "br0" "veth0"
 #  SendNotification false
+#  DispatchValues true
 #</Plugin>
 
 #<Plugin perl>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5516,6 +5516,7 @@ B<Synopsis:>
    Socket "/var/run/openvswitch/db.sock"
    Interfaces "br0" "veth0"
    SendNotification false
+   DispatchValues true
  </Plugin>
 
 The plugin provides the following configuration options:
@@ -5554,6 +5555,12 @@ Default: empty (all interfaces on all bridges are monitored)
 
 If set to true, OVS link notifications (interface status and OVS DB connection
 terminate) are sent to collectd. Default value is false.
+
+=item B<DispatchValues> I<true|false>
+
+Dispatch the OVS DB interface link status value with configured plugin interval.
+Defaults to true. Please note, if B<SendNotification> and B<DispatchValues>
+options are false, no OVS information will be provided by the plugin.
 
 =back
 


### PR DESCRIPTION
Added new `DispatchValues` config option to the plugin to make the dispatching of link status value configurable. Also, the sending notification option is enabled by default.