### PR TITLE
protocols.c: Read /proc/net/snmp6 for IPv6 stats

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -301,6 +301,11 @@ ssize_t swrite(int fd, const void *buf, size_t count) {
   return (0);
 }
 
+int strstartswith(const char *pre, const char *str){   
+    size_t lenpre = strlen(pre);
+    return strncmp(pre, str, lenpre) == 0;
+}
+
 int strsplit(char *string, char **fields, size_t size) {
   size_t i;
   char *ptr;

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -117,6 +117,22 @@ ssize_t swrite(int fd, const void *buf, size_t count);
 
 /*
  * NAME
+ *   strstartswith
+ *
+ * DESCRIPTION
+ *   Checks if a string starts with a substring.
+ *
+ * PARAMETERS
+ *   `pre'         The prefix to look for.
+ *   `str'         The string that will be examined for a prefix.
+ *
+ * RETURN VALUE
+ *    Returns 1 if str starts with pre. 0 otherwise.
+*/
+int strstartswith(const char *pre, const char *str);
+
+/*
+ * NAME
  *   strsplit
  *
  * DESCRIPTION


### PR DESCRIPTION
Currently protocols.c reads /proc/net/snmp but ignores /proc/net/snmp6 for the equivalent ipv6 stats. This patch adds support for reading /proc/net/snmp6. Example config:

LoadPlugin protocols
<Plugin protocols>
    Value "Udp:InErrors"
    Value "Udp:InCsumErrors"
    Value "Udp6:InErrors"
    Value "Udp6:InCsumErrors"
</Plugin>