### PR TITLE
ntpd: Correct loop offset and error calculation

### DIFF
--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -847,9 +847,9 @@ static int ntpd_read(void) {
   }
 
   /* kerninfo -> estimated error */
-  offset_loop = scale_loop * ((gauge_t)ntohl(ik->offset));
+  offset_loop = (gauge_t)((int32_t)ntohl(ik->offset) * scale_loop);
   freq_loop = ntpd_read_fp(ik->freq);
-  offset_error = scale_error * ((gauge_t)ntohl(ik->esterror));
+  offset_error = (gauge_t)((int32_t)ntohl(ik->esterror) * scale_error);
 
   DEBUG("info_kernel:\n"
         "  pll offset    = %.8g\n"


### PR DESCRIPTION
Stop the scaling calculation dropping the sign of the underlying value

Fixes: 2188