### PR TITLE
chrony plugin bug fixing

### DIFF
--- a/src/chrony.c
+++ b/src/chrony.c
@@ -584,9 +584,10 @@ static double ntohf(tFloat p_float) {
   uint32_t uval;
 
   uval = ntohl(p_float.value);
-  exp = (uval >> FLOAT_COEF_BITS) - FLOAT_COEF_BITS;
+  exp = (uval >> FLOAT_COEF_BITS);
   if (exp >= 1 << (FLOAT_EXP_BITS - 1))
     exp -= 1 << FLOAT_EXP_BITS;
+  exp -= FLOAT_COEF_BITS;
 
   /* coef = (x << FLOAT_EXP_BITS) >> FLOAT_EXP_BITS; */
   coef = uval % (1U << FLOAT_COEF_BITS);

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -892,6 +892,8 @@ static int chrony_request_source_data(int p_src_idx, char *src_addr,
                          ntohs(chrony_resp.body.source_data.f_reachability));
   chrony_push_data_valid("clock_last_meas", src_addr, is_reachable,
                          ntohl(chrony_resp.body.source_data.f_since_sample));
+  chrony_push_data_valid("time_offset", src_addr, is_reachable,
+                  ntohf(chrony_resp.body.source_data.f_origin_latest_meas));
 
   return CHRONY_RC_OK;
 }
@@ -903,12 +905,11 @@ static int chrony_request_source_stats(int p_src_idx, const char *src_addr,
   size_t chrony_resp_size;
   tChrony_Request chrony_req;
   tChrony_Response chrony_resp;
-  double skew_ppm, frequency_error, time_offset;
+  double skew_ppm, frequency_error;
 
   if (*p_is_reachable == 0) {
     skew_ppm = 0;
     frequency_error = 0;
-    time_offset = 0;
   } else {
     chrony_init_req(&chrony_req);
     chrony_req.body.source_stats.f_index = htonl(p_src_idx);
@@ -923,7 +924,6 @@ static int chrony_request_source_stats(int p_src_idx, const char *src_addr,
 
     skew_ppm = ntohf(chrony_resp.body.source_stats.f_skew_ppm);
     frequency_error = ntohf(chrony_resp.body.source_stats.f_rtc_gain_rate_ppm);
-    time_offset = ntohf(chrony_resp.body.source_stats.f_est_offset);
 
     DEBUG(PLUGIN_NAME
           ": Source[%d] stat: .addr = %s, .ref_id= %u, .n_samples = %u, "
@@ -935,7 +935,8 @@ static int chrony_request_source_stats(int p_src_idx, const char *src_addr,
           ntohl(chrony_resp.body.source_stats.f_n_runs),
           ntohl(chrony_resp.body.source_stats.f_span_seconds),
           ntohf(chrony_resp.body.source_stats.f_rtc_seconds_fast),
-          frequency_error, skew_ppm, time_offset,
+          frequency_error, skew_ppm,
+          ntohf(chrony_resp.body.source_stats.f_est_offset),
           ntohf(chrony_resp.body.source_stats.f_est_offset_err));
 
   } /* if (*is_reachable) */
@@ -944,8 +945,6 @@ static int chrony_request_source_stats(int p_src_idx, const char *src_addr,
   chrony_push_data_valid("clock_skew_ppm", src_addr, *p_is_reachable, skew_ppm);
   chrony_push_data_valid("frequency_error", src_addr, *p_is_reachable,
                          frequency_error); /* unit: ppm */
-  chrony_push_data_valid("time_offset", src_addr, *p_is_reachable,
-                         time_offset); /* unit: s */
 
   return CHRONY_RC_OK;
 }

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -186,13 +186,11 @@ typedef struct ATTRIB_PACKED {
     uint8_t ip6[16];
   } addr;
   uint16_t f_family;
+  uint16_t padding;
 } tChrony_IPAddr;
 
 typedef struct ATTRIB_PACKED {
   tChrony_IPAddr addr;
-  uint16_t
-      dummy; /* FIXME: Strange dummy space. Needed on gcc 4.8.3/clang 3.4.1 on
-                x86_64 */
   int16_t f_poll;     /* 2^f_poll = Time between polls (s) */
   uint16_t f_stratum; /* Remote clock stratum */
   uint16_t f_state;   /* 0 = RPY_SD_ST_SYNC,    1 = RPY_SD_ST_UNREACH,   2 =
@@ -213,9 +211,6 @@ typedef struct ATTRIB_PACKED {
 typedef struct ATTRIB_PACKED {
   uint32_t f_ref_id;
   tChrony_IPAddr addr;
-  uint16_t
-      dummy; /* FIXME: Strange dummy space. Needed on gcc 4.8.3/clang 3.4.1 on
-                x86_64 */
   uint32_t f_n_samples;       /* Number of measurements done   */
   uint32_t f_n_runs;          /* How many measurements to come */
   uint32_t f_span_seconds;    /* For how long we're measuring  */
@@ -230,9 +225,6 @@ typedef struct ATTRIB_PACKED {
 typedef struct ATTRIB_PACKED {
   uint32_t f_ref_id;
   tChrony_IPAddr addr;
-  uint16_t
-      dummy; /* FIXME: Strange dummy space. Needed on gcc 4.8.3/clang 3.4.1 on
-                x86_64 */
   uint16_t f_stratum;
   uint16_t f_leap_status;
   tTimeval f_ref_time;

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -881,7 +881,7 @@ static int chrony_request_source_data(int p_src_idx, int *p_is_reachable) {
   chrony_push_data_valid("clock_reachability", src_addr, is_reachable,
                          ntohs(chrony_resp.body.source_data.f_reachability));
   chrony_push_data_valid("clock_last_meas", src_addr, is_reachable,
-                         ntohs(chrony_resp.body.source_data.f_since_sample));
+                         ntohl(chrony_resp.body.source_data.f_since_sample));
 
   return CHRONY_RC_OK;
 }

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -892,8 +892,9 @@ static int chrony_request_source_data(int p_src_idx, char *src_addr,
                          ntohs(chrony_resp.body.source_data.f_reachability));
   chrony_push_data_valid("clock_last_meas", src_addr, is_reachable,
                          ntohl(chrony_resp.body.source_data.f_since_sample));
-  chrony_push_data_valid("time_offset", src_addr, is_reachable,
-                  ntohf(chrony_resp.body.source_data.f_origin_latest_meas));
+  chrony_push_data_valid(
+      "time_offset", src_addr, is_reachable,
+      ntohf(chrony_resp.body.source_data.f_origin_latest_meas));
 
   return CHRONY_RC_OK;
 }

--- a/src/types.db
+++ b/src/types.db
@@ -26,7 +26,7 @@ clock_last_meas         value:GAUGE:0:U
 clock_last_update       value:GAUGE:U:U
 clock_mode              value:GAUGE:0:U
 clock_reachability      value:GAUGE:0:U
-clock_skew_ppm          value:GAUGE:-2:2
+clock_skew_ppm          value:GAUGE:0:1000000
 clock_state             value:GAUGE:0:U
 clock_stratum           value:GAUGE:0:U
 compression             uncompressed:DERIVE:0:U, compressed:DERIVE:0:U
@@ -89,7 +89,7 @@ filter_result           value:DERIVE:0:U
 flow                    value:GAUGE:0:U
 fork_rate               value:DERIVE:0:U
 frequency               value:GAUGE:0:U
-frequency_error         value:GAUGE:-2:2 
+frequency_error         value:GAUGE:-1000000:1000000
 frequency_offset        value:GAUGE:-1000000:1000000
 fscache_stat            value:DERIVE:0:U
 gauge                   value:GAUGE:U:U


### PR DESCRIPTION
These are fixes for some issues I noticed on a machine operating as a stratum-1 server using chrony. One commit changes the time_offset value to use the last measured offset from the source report instead of current estimated offset from the sourcestats report. I think that's what most users are interested in monitoring, but if @bbczeuz or anyone else thinks the sourcestats offset would still be useful, I can rework the patch to add a new type instead.

Is there a guideline on renaming values of existing plugins, which would break compatibility? If there is interest, I think we could try to reduce the number of types specific to this plugin and maybe make the naming a bit more consistent.