### PR TITLE
dpdkstat: fix retrieval of statistics

### DIFF
--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -38,6 +38,7 @@
 
 #include <rte_config.h>
 #include <rte_eal.h>
+#include <rte_ethdev.h>
 
 #include "common.h"
 #include "utils_dpdk.h"
@@ -849,4 +850,23 @@ uint128_t str_to_uint128(const char *str, int len) {
     }
   }
   return lcore_mask;
+}
+
+uint8_t dpdk_helper_eth_dev_count() {
+  uint8_t ports = rte_eth_dev_count();
+  if (ports == 0) {
+    ERROR(
+        "%s:%d: No DPDK ports available. Check bound devices to DPDK driver.\n",
+        __FUNCTION__, __LINE__);
+    return ports;
+  }
+
+  if (ports > RTE_MAX_ETHPORTS) {
+    ERROR("%s:%d: Number of DPDK ports (%u) is greater than "
+          "RTE_MAX_ETHPORTS=%d. Ignoring extra ports\n",
+          __FUNCTION__, __LINE__, ports, RTE_MAX_ETHPORTS);
+    ports = RTE_MAX_ETHPORTS;
+  }
+
+  return ports;
 }

--- a/src/utils_dpdk.h
+++ b/src/utils_dpdk.h
@@ -73,6 +73,7 @@ int dpdk_helper_command(dpdk_helper_ctx_t *phc, enum DPDK_CMD cmd, int *result,
                         cdtime_t cmd_wait_time);
 void *dpdk_helper_priv_get(dpdk_helper_ctx_t *phc);
 int dpdk_helper_data_size_get(dpdk_helper_ctx_t *phc);
+uint8_t dpdk_helper_eth_dev_count();
 
 /* forward declaration of handler function that is called by helper from
  * child process. not implemented in helper. must be provided by client. */


### PR DESCRIPTION
This change forces dpdkstat plugin to check if memory needs to be resized on
every DPDK_CMD_GET_STATS command, rather than resizing it only once at
initialization. Additionally it fixes incorrect metric retrieval logic, which
allows plugin to dispatch metrics only if number of retrieved extended statistics
is equal to allocated stats array size for port. Based on DPDK API documentation
rte_eth_xstats_get (and rte_eth_xstats_get_names) function can return positive
value lower than array size, which isn't considered a failure.

If primary DPDK process is restarted with a greater number of ports bound to
DPDK driver while collectd dpdkstat plugin is running, then memory isn't resized.
Due to insufficient memory allocation dpdkstat plugin is unable to gather metrics
from new ports.

Signed-off-by: Przemyslaw Szczerbik <przemyslawx.szczerbik@intel.com>