### PR TITLE
Add support for 'Attribute' option on KAIROSDB output format

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1535,6 +1535,7 @@
 #		Header "X-Custom-Header: custom_value"
 #		SSLVersion "TLSv1"
 #		Format "Command"
+#		Attribute "key" "value"     # only available for KAIROSDB format
 #		Metrics true
 #		Notifications false
 #		StoreRates false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8725,6 +8725,15 @@ create output in the I<JavaScript Object Notation> (JSON). When set to KAIROSDB
 
 Defaults to B<Command>.
 
+=item B<Attribute> I<String> I<String>
+
+Only available for KAIROSDB output format.
+
+Consider the two given strings to be the key and value of an additional tag for
+each metric being sent out.
+
+You can add multiple B<Attribute>.
+
 =item B<Metrics> B<true>|B<false>
 
 Controls whether I<metrics> are POSTed to this location. Defaults to B<true>.

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -183,7 +183,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
                                   const data_set_t *ds, const value_list_t *vl,
                                   int store_rates,
                                   char const *const *http_attrs,
-                                  const int http_attrs_num) {
+                                  size_t http_attrs_num) {
   char temp[512];
   size_t offset = 0;
   int status;
@@ -233,7 +233,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
     BUFFER_ADD(", \"tags\":\{");
 
     BUFFER_ADD("\"host\": \"%s\"", vl->host);
-    for (int j = 0; j < http_attrs_num; j += 2) {
+    for (size_t j = 0; j < http_attrs_num; j += 2) {
       BUFFER_ADD(", \"%s\":", http_attrs[j]);
       BUFFER_ADD(" \"%s\"", http_attrs[j + 1]);
     }
@@ -260,7 +260,7 @@ static int format_kairosdb_value_list_nocheck(
     char *buffer, /* {{{ */
     size_t *ret_buffer_fill, size_t *ret_buffer_free, const data_set_t *ds,
     const value_list_t *vl, int store_rates, size_t temp_size,
-    char const *const *http_attrs, const int http_attrs_num) {
+    char const *const *http_attrs, size_t http_attrs_num) {
   char temp[temp_size];
   int status;
 
@@ -334,7 +334,7 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
                                size_t *ret_buffer_fill, size_t *ret_buffer_free,
                                const data_set_t *ds, const value_list_t *vl,
                                int store_rates, char const *const *http_attrs,
-                               const int http_attrs_num) {
+                               size_t http_attrs_num) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
     return (-EINVAL);

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -181,7 +181,9 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
 static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
                                   const data_set_t *ds, const value_list_t *vl,
-                                  int store_rates) {
+                                  int store_rates,
+                                  char const *const *http_attrs,
+                                  const int http_attrs_num) {
   char temp[512];
   size_t offset = 0;
   int status;
@@ -231,6 +233,11 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
     BUFFER_ADD(", \"tags\":\{");
 
     BUFFER_ADD("\"host\": \"%s\"", vl->host);
+    for (int j = 0; j < http_attrs_num; j += 2) {
+      BUFFER_ADD(", \"%s\":", http_attrs[j]);
+      BUFFER_ADD(" \"%s\"", http_attrs[j + 1]);
+    }
+
     if (strlen(vl->plugin_instance))
       BUFFER_ADD_KEYVAL("plugin_instance", vl->plugin_instance);
     BUFFER_ADD_KEYVAL("type", vl->type);
@@ -252,11 +259,13 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 static int format_kairosdb_value_list_nocheck(
     char *buffer, /* {{{ */
     size_t *ret_buffer_fill, size_t *ret_buffer_free, const data_set_t *ds,
-    const value_list_t *vl, int store_rates, size_t temp_size) {
+    const value_list_t *vl, int store_rates, size_t temp_size,
+    char const *const *http_attrs, const int http_attrs_num) {
   char temp[temp_size];
   int status;
 
-  status = value_list_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates);
+  status = value_list_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates,
+                                  http_attrs, http_attrs_num);
   if (status != 0)
     return (status);
   temp_size = strlen(temp);
@@ -324,7 +333,8 @@ int format_kairosdb_finalize(char *buffer, /* {{{ */
 int format_kairosdb_value_list(char *buffer, /* {{{ */
                                size_t *ret_buffer_fill, size_t *ret_buffer_free,
                                const data_set_t *ds, const value_list_t *vl,
-                               int store_rates) {
+                               int store_rates, char const *const *http_attrs,
+                               const int http_attrs_num) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
     return (-EINVAL);
@@ -334,5 +344,7 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
 
   return (format_kairosdb_value_list_nocheck(
       buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
-      (*ret_buffer_free) - 2));
+      (*ret_buffer_free) - 2, http_attrs, http_attrs_num));
 } /* }}} int format_kairosdb_value_list */
+
+/* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -35,7 +35,6 @@
 #define JSON_GAUGE_FORMAT GAUGE_FORMAT
 #endif
 
-
 int format_kairosdb_initialize(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free);
 int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -41,7 +41,7 @@ int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free, const data_set_t *ds,
                                const value_list_t *vl, int store_rates,
                                char const *const *http_attrs,
-                               const int http_attrs_num);
+                               size_t http_attrs_num);
 int format_kairosdb_finalize(char *buffer, size_t *ret_buffer_fill,
                              size_t *ret_buffer_free);
 

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -35,11 +35,14 @@
 #define JSON_GAUGE_FORMAT GAUGE_FORMAT
 #endif
 
+
 int format_kairosdb_initialize(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free);
 int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free, const data_set_t *ds,
-                               const value_list_t *vl, int store_rates);
+                               const value_list_t *vl, int store_rates,
+                               char const *const *http_attrs,
+                               const int http_attrs_num);
 int format_kairosdb_finalize(char *buffer, size_t *ret_buffer_fill,
                              size_t *ret_buffer_free);
 

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -81,6 +81,9 @@ struct wh_callback_s {
 };
 typedef struct wh_callback_s wh_callback_t;
 
+static char **http_attrs;
+static size_t http_attrs_num;
+
 static void wh_log_http_error(wh_callback_t *cb) {
   if (!cb->log_http_error)
     return;
@@ -468,9 +471,9 @@ static int wh_write_kairosdb(const data_set_t *ds,
     }
   }
 
-  status = format_kairosdb_value_list(cb->send_buffer, &cb->send_buffer_fill,
-                                      &cb->send_buffer_free, ds, vl,
-                                      cb->store_rates);
+  status = format_kairosdb_value_list(
+      cb->send_buffer, &cb->send_buffer_fill, &cb->send_buffer_free, ds, vl,
+      cb->store_rates, (char const *const *)http_attrs, http_attrs_num);
   if (status == -ENOMEM) {
     status = wh_flush_nolock(/* timeout = */ 0, cb);
     if (status != 0) {
@@ -479,9 +482,9 @@ static int wh_write_kairosdb(const data_set_t *ds,
       return (status);
     }
 
-    status = format_kairosdb_value_list(cb->send_buffer, &cb->send_buffer_fill,
-                                        &cb->send_buffer_free, ds, vl,
-                                        cb->store_rates);
+    status = format_kairosdb_value_list(
+        cb->send_buffer, &cb->send_buffer_fill, &cb->send_buffer_free, ds, vl,
+        cb->store_rates, (char const *const *)http_attrs, http_attrs_num);
   }
   if (status != 0) {
     pthread_mutex_unlock(&cb->send_lock);
@@ -703,7 +706,34 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
       status = cf_util_get_boolean(child, &cb->log_http_error);
     else if (strcasecmp("Header", child->key) == 0)
       status = wh_config_append_string("Header", &cb->headers, child);
-    else {
+    else if (strcasecmp("Attribute", child->key) == 0) {
+      char *key = NULL;
+      char *val = NULL;
+
+      if (child->values_num != 2) {
+        WARNING("write_http plugins: Attribute need both a key and a value.");
+        break;
+      }
+      if (child->values[0].type != OCONFIG_TYPE_STRING ||
+          child->values[1].type != OCONFIG_TYPE_STRING) {
+        WARNING("write_http plugins: Attribute needs string arguments.");
+        break;
+      }
+      if ((key = strdup(child->values[0].value.string)) == NULL) {
+        WARNING("cannot allocate memory for attribute key.");
+        break;
+      }
+      if ((val = strdup(child->values[1].value.string)) == NULL) {
+        WARNING("cannot allocate memory for attribute value.");
+        sfree(key);
+        break;
+      }
+      strarray_add(&http_attrs, &http_attrs_num, key);
+      strarray_add(&http_attrs, &http_attrs_num, val);
+      DEBUG("write_http plugins: got attribute: %s => %s", key, val);
+      sfree(key);
+      sfree(val);
+    } else {
       ERROR("write_http plugin: Invalid configuration "
             "option: %s.",
             child->key);

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -730,7 +730,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
       }
       strarray_add(&http_attrs, &http_attrs_num, key);
       strarray_add(&http_attrs, &http_attrs_num, val);
-      DEBUG("write_http plugins: got attribute: %s => %s", key, val);
+      DEBUG("write_http plugin: got attribute: %s => %s", key, val);
       sfree(key);
       sfree(val);
     } else {

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -711,12 +711,12 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
       char *val = NULL;
 
       if (child->values_num != 2) {
-        WARNING("write_http plugins: Attribute need both a key and a value.");
+        WARNING("write_http plugin: Attribute need both a key and a value.");
         break;
       }
       if (child->values[0].type != OCONFIG_TYPE_STRING ||
           child->values[1].type != OCONFIG_TYPE_STRING) {
-        WARNING("write_http plugins: Attribute needs string arguments.");
+        WARNING("write_http plugin: Attribute needs string arguments.");
         break;
       }
       if ((key = strdup(child->values[0].value.string)) == NULL) {


### PR DESCRIPTION
Support attributes on write_http module specificly on kairosdb format.