### PR TITLE
Check for the CAP_IS_SUPPORTED macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -818,6 +818,12 @@ AC_CHECK_LIB(cap, cap_get_proc,
                  [have_capability="no (cap_get_proc() not found)"])
 fi
 if test "x$have_capability" = "xyes"; then
+AC_CHECK_DECL([CAP_IS_SUPPORTED],
+                 [have_capability="yes"],
+                 [have_capability="no (CAP_IS_SUPPORTED not found)"],
+                 [[#include <sys/capability.h>]])
+fi
+if test "x$have_capability" = "xyes"; then
   AC_DEFINE(HAVE_CAPABILITY, 1, [Define to 1 if you have cap_get_proc() (-lcap).])
 fi
 AM_CONDITIONAL(BUILD_WITH_CAPABILITY, test "x$have_capability" = "xyes")


### PR DESCRIPTION
On EPEL6:
src/daemon/common.c: In function 'check_capability':
src/daemon/common.c:1571: error: implicit declaration of function 'CAP_IS_SUPPORTED'
make[1]: *** [src/daemon/common.lo] Error 1