### PR TITLE
ovs_stats: Increase devname buffer

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -875,7 +875,7 @@ static int ovs_stats_plugin_init(void) {
 static int ovs_stats_plugin_read(__attribute__((unused)) user_data_t *ud) {
   bridge_list_t *bridge;
   port_list_t *port;
-  char devname[PORT_NAME_SIZE_MAX];
+  char devname[PORT_NAME_SIZE_MAX * 2];
 
   pthread_mutex_lock(&g_stats_lock);
   for (bridge = g_bridge_list_head; bridge != NULL; bridge = bridge->next) {


### PR DESCRIPTION
Increase devname buffer to ensure that snprintf output would not be truncated before the last format character
Fix for #2201 
Signed-off-by: Taras Chornyi <tarasx.chornyi@intel.com>