### PR TITLE
processes plugin: Fix broken compilation on AIX

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -2127,7 +2127,6 @@ static int ps_read(void) {
       pse.cpu_user_counter = procentry[i].pi_ru.ru_utime.tv_sec * 1000000 +
                              procentry[i].pi_ru.ru_utime.tv_usec / 1000;
 
-      pse.cpu_system = 0;
       /* tv_usec is nanosec ??? */
       pse.cpu_system_counter = procentry[i].pi_ru.ru_stime.tv_sec * 1000000 +
                                procentry[i].pi_ru.ru_stime.tv_usec / 1000;


### PR DESCRIPTION
After a bb0000acfc57e230fc1c26099bc7acb913680f1a an extra pse.cpu_system statement was left in the AIX / elif HAVE_PROCINFO_H section, which causes the compilation to fail.

Noticed by @tbendiksen in https://github.com/collectd/collectd/pull/1981#issuecomment-283597731

bb0000acfc57e230fc1c26099bc7acb913680f1a was merged before collectd-5.7, so this PR is against 5.7 branch.