### PR TITLE
ovs_events: change configuration option defaults

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1027,8 +1027,8 @@
 #  Address "127.0.0.1"
 #  Socket "/var/run/openvswitch/db.sock"
 #  Interfaces "br0" "veth0"
-#  SendNotification false
-#  DispatchValues true
+#  SendNotification true
+#  DispatchValues false
 #</Plugin>
 
 #<Plugin ovs_stats>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5637,8 +5637,8 @@ B<Synopsis:>
    Address "127.0.0.1"
    Socket "/var/run/openvswitch/db.sock"
    Interfaces "br0" "veth0"
-   SendNotification false
-   DispatchValues true
+   SendNotification true
+   DispatchValues false
  </Plugin>
 
 The plugin provides the following configuration options:
@@ -5676,12 +5676,12 @@ Default: empty (all interfaces on all bridges are monitored)
 =item B<SendNotification> I<true|false>
 
 If set to true, OVS link notifications (interface status and OVS DB connection
-terminate) are sent to collectd. Default value is false.
+terminate) are sent to collectd. Default value is true.
 
 =item B<DispatchValues> I<true|false>
 
 Dispatch the OVS DB interface link status value with configured plugin interval.
-Defaults to true. Please note, if B<SendNotification> and B<DispatchValues>
+Defaults to false. Please note, if B<SendNotification> and B<DispatchValues>
 options are false, no OVS information will be provided by the plugin.
 
 =back

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -86,7 +86,8 @@ typedef struct ovs_events_ctx_s ovs_events_ctx_t;
  */
 static ovs_events_ctx_t ovs_events_ctx = {
     .mutex = PTHREAD_MUTEX_INITIALIZER,
-    .config = {.ovs_db_node = "localhost", /* use default OVS DB node */
+    .config = {.send_notification = 1,     /* send notification by default */
+               .ovs_db_node = "localhost", /* use default OVS DB node */
                .ovs_db_serv = "6640"}      /* use default OVS DB service */
 };
 
@@ -227,7 +228,7 @@ static int ovs_events_config_get_interfaces(const oconfig_item_t *ci) {
  * in allocated memory. Returns negative value in case of error.
  */
 static int ovs_events_plugin_config(oconfig_item_t *ci) {
-  _Bool dispatch_values = 1;
+  _Bool dispatch_values = 0;
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
     if (strcasecmp("SendNotification", child->key) == 0) {


### PR DESCRIPTION
Right now, the plugin dispatches values by default and doesn't send any notification messages. The expected behaviour of the event plugin is to send notification by default. So, changed default value of
SendNotification & DispatchValues options to opposite.