### PR TITLE
dpdkstat: Enable all ports by default.

### DIFF
--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -103,6 +103,8 @@ static void dpdk_stats_default_config(void) {
   for (int i = 0; i < RTE_MAX_ETHPORTS; i++) {
     ec->config.port_name[i][0] = 0;
   }
+  /* Enable all ports by default */
+  ec->config.enabled_port_mask = ~0;
 }
 
 static int dpdk_stats_preinit(void) {


### PR DESCRIPTION
If "EnabledPortMask" option is not set
all DPDK ports will be monitored.

Signed-off-by: Taras Chornyi <tarasx.chornyi@intel.com>