### PR TITLE
processes: Show real disk IO in addition to process IO (Linux only)

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -185,6 +185,8 @@ typedef struct process_entry_s {
   derive_t io_wchar;
   derive_t io_syscr;
   derive_t io_syscw;
+  derive_t io_diskr;
+  derive_t io_diskw;
   _Bool has_io;
 
   derive_t cswitch_vol;
@@ -209,6 +211,8 @@ typedef struct procstat_entry_s {
   derive_t io_wchar;
   derive_t io_syscr;
   derive_t io_syscw;
+  derive_t io_diskr;
+  derive_t io_diskw;
 
   derive_t cswitch_vol;
   derive_t cswitch_invol;
@@ -242,6 +246,8 @@ typedef struct procstat {
   derive_t io_wchar;
   derive_t io_syscr;
   derive_t io_syscw;
+  derive_t io_diskr;
+  derive_t io_diskw;
 
   derive_t cswitch_vol;
   derive_t cswitch_invol;
@@ -310,6 +316,8 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
   new->io_wchar = -1;
   new->io_syscr = -1;
   new->io_syscw = -1;
+  new->io_diskr = -1;
+  new->io_diskw = -1;
   new->cswitch_vol = -1;
   new->cswitch_invol = -1;
 
@@ -478,6 +486,11 @@ static void ps_list_add(const char *name, const char *cmdline,
     if ((entry->io_syscr != -1) && (entry->io_syscw != -1)) {
       ps_update_counter(&ps->io_syscr, &pse->io_syscr, entry->io_syscr);
       ps_update_counter(&ps->io_syscw, &pse->io_syscw, entry->io_syscw);
+    }
+
+    if ((entry->io_diskr != -1) && (entry->io_diskw != -1)) {
+      ps_update_counter(&ps->io_diskr, &pse->io_diskr, entry->io_diskr);
+      ps_update_counter(&ps->io_diskw, &pse->io_diskw, entry->io_diskw);
     }
 
     if ((entry->cswitch_vol != -1) && (entry->cswitch_vol != -1)) {
@@ -725,7 +738,7 @@ static void ps_submit_proc_list(procstat_t *ps) {
   plugin_dispatch_values(&vl);
 
   if ((ps->io_rchar != -1) && (ps->io_wchar != -1)) {
-    sstrncpy(vl.type, "ps_disk_octets", sizeof(vl.type));
+    sstrncpy(vl.type, "io_octets", sizeof(vl.type));
     vl.values[0].derive = ps->io_rchar;
     vl.values[1].derive = ps->io_wchar;
     vl.values_len = 2;
@@ -733,9 +746,17 @@ static void ps_submit_proc_list(procstat_t *ps) {
   }
 
   if ((ps->io_syscr != -1) && (ps->io_syscw != -1)) {
-    sstrncpy(vl.type, "ps_disk_ops", sizeof(vl.type));
+    sstrncpy(vl.type, "io_ops", sizeof(vl.type));
     vl.values[0].derive = ps->io_syscr;
     vl.values[1].derive = ps->io_syscw;
+    vl.values_len = 2;
+    plugin_dispatch_values(&vl);
+  }
+
+  if ((ps->io_diskr != -1) && (ps->io_diskw != -1)) {
+    sstrncpy(vl.type, "disk_octets", sizeof(vl.type));
+    vl.values[0].derive = ps->io_diskr;
+    vl.values[1].derive = ps->io_diskw;
     vl.values_len = 2;
     plugin_dispatch_values(&vl);
   }
@@ -768,12 +789,13 @@ static void ps_submit_proc_list(procstat_t *ps) {
         "cpu_user_counter = %" PRIi64 "; cpu_system_counter = %" PRIi64 "; "
         "io_rchar = %" PRIi64 "; io_wchar = %" PRIi64 "; "
         "io_syscr = %" PRIi64 "; io_syscw = %" PRIi64 "; "
+        "io_diskr = %" PRIi64 "; io_diskw = %" PRIi64 "; "
         "cswitch_vol = %" PRIi64 "; cswitch_invol = %" PRIi64 ";",
         ps->name, ps->num_proc, ps->num_lwp, ps->num_fd, ps->vmem_size,
         ps->vmem_rss, ps->vmem_data, ps->vmem_code, ps->vmem_minflt_counter,
         ps->vmem_majflt_counter, ps->cpu_user_counter, ps->cpu_system_counter,
-        ps->io_rchar, ps->io_wchar, ps->io_syscr, ps->io_syscw, ps->cswitch_vol,
-        ps->cswitch_invol);
+        ps->io_rchar, ps->io_wchar, ps->io_syscr, ps->io_syscw, ps->io_diskr,
+        ps->io_diskw, ps->cswitch_vol, ps->cswitch_invol);
 } /* void ps_submit_proc_list */
 
 #if KERNEL_LINUX || KERNEL_SOLARIS
@@ -950,6 +972,10 @@ static int ps_read_io(process_entry_t *ps) {
       val = &(ps->io_syscr);
     else if (strncasecmp(buffer, "syscw:", 6) == 0)
       val = &(ps->io_syscw);
+    else if (strncasecmp(buffer, "read_bytes:", 11) == 0)
+      val = &(ps->io_diskr);
+    else if (strncasecmp(buffer, "write_bytes:", 12) == 0)
+      val = &(ps->io_diskw);
     else
       continue;
 
@@ -1145,6 +1171,8 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   ps->io_wchar = -1;
   ps->io_syscr = -1;
   ps->io_syscw = -1;
+  ps->io_diskr = -1;
+  ps->io_diskw = -1;
 
   ps->cswitch_vol = -1;
   ps->cswitch_invol = -1;
@@ -1403,6 +1431,8 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   ps->io_wchar = myUsage->pr_oublk * chars_per_block;
   ps->io_syscr = myUsage->pr_sysc;
   ps->io_syscw = myUsage->pr_sysc;
+  ps->io_diskr = -1;
+  ps->io_diskw = -1;
 
   /*
    * TODO: context switch counters for Solaris
@@ -1616,6 +1646,8 @@ static int ps_read(void) {
         pse.io_wchar = -1;
         pse.io_syscr = -1;
         pse.io_syscw = -1;
+        pse.io_diskr = -1;
+        pse.io_diskw = -1;
 
         /* File descriptor count not implemented */
         pse.num_fd = 0;
@@ -1919,6 +1951,8 @@ static int ps_read(void) {
       pse.io_wchar = -1;
       pse.io_syscr = -1;
       pse.io_syscw = -1;
+      pse.io_diskr = -1;
+      pse.io_diskw = -1;
 
       /* file descriptor count not implemented */
       pse.num_fd = 0;
@@ -2058,6 +2092,8 @@ static int ps_read(void) {
       pse.io_wchar = -1;
       pse.io_syscr = -1;
       pse.io_syscw = -1;
+      pse.io_diskr = -1;
+      pse.io_diskw = -1;
 
       /* file descriptor count not implemented */
       pse.num_fd = 0;
@@ -2221,6 +2257,8 @@ static int ps_read(void) {
       pse.io_wchar = -1;
       pse.io_syscr = -1;
       pse.io_syscw = -1;
+      pse.io_diskr = -1;
+      pse.io_diskw = -1;
 
       pse.num_fd = 0;
 

--- a/src/types.db
+++ b/src/types.db
@@ -114,6 +114,7 @@ if_tx_octets            value:DERIVE:0:U
 if_tx_packets           value:DERIVE:0:U
 invocations             value:DERIVE:0:U
 io_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
+io_ops                  read:DERIVE:0:U, write:DERIVE:0:U
 io_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
 ipc                     value:GAUGE:0:U
 ipt_bytes               value:DERIVE:0:U


### PR DESCRIPTION
Collectd reports `/proc/PID/io` fields `io_rchar/io_wchar` as `ps_disk_octets` type and `io_syscr/io_syscw` as `ps_disk_ops` type.
The names of these types do not match values they represent. 

1) For `io_rchar/io_wchar` data type should be named as `ps_io_octets`. In Linux, these values represent any I/O of process, not disk I/O only: they include sockets, pipes, console I/O, etc.
The `ps_io_octets` type can be added in addition to the existing `ps_disk_octets` for which values can be obtained from `read_bytes/write_bytes` of /proc/PID/io. These values will be much more correct for reporting as `ps_disk_octets` than existing `io_rchar/io_wchar`. Please note what `read_bytes/write_bytes` is _real_ disk I/O, it does not account file I/O from cache.

2) For `io_syscr/io_syscw` correct type should be named `ps_io_ops`.
Reported values do not match any real disk ops. 

My proposal is to fix these issues.

New, correct mapping implemented:
```
 io_rchar/io_wchar      -> ps_io_octets   (renamed from ps_disk_octets)
 io_syscr/io_syscw      -> ps_io_ops      (renamed from ps_disk_ops)
 read_bytes/write_bytes -> ps_disk_octets (new data collected to existing type)
```

Related documentation: http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt?id=HEAD#n1558

Issues: #1990, #1225


