### PR TITLE
network plugin: Fix endless loop DOS in parse_packet()

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1050,14 +1050,6 @@ static int parse_part_sign_sha256 (sockent_t *se, /* {{{ */
   buffer_len = *ret_buffer_len;
   buffer_offset = 0;
 
-  if (se->data.server.userdb == NULL)
-  {
-    c_complain (LOG_NOTICE, &complain_no_users,
-        "network plugin: Received signed network packet but can't verify it "
-        "because no user DB has been configured. Will accept it.");
-    return (0);
-  }
-
   /* Check if the buffer has enough data for this structure. */
   if (buffer_len <= PART_SIGNATURE_SHA256_SIZE)
     return (-ENOMEM);
@@ -1073,6 +1065,18 @@ static int parse_part_sign_sha256 (sockent_t *se, /* {{{ */
   {
     ERROR ("network plugin: HMAC-SHA-256 with invalid length received.");
     return (-1);
+  }
+
+  if (se->data.server.userdb == NULL) 
+  {
+    c_complain (LOG_NOTICE, &complain_no_users,
+        "network plugin: Received signed network packet but can't verify it "
+        "because no user DB has been configured. Will accept it.");
+
+    *ret_buffer = buffer + pss_head_length;
+    *ret_buffer_len -= pss_head_length;
+
+    return (0);
   }
 
   /* Copy the hash. */


### PR DESCRIPTION
When correct 'Signature part' is received by Collectd, configured without
AuthFile option, condition for endless loop occurs due to missing increase
of pointer to next unprocessed part.

Closes: #2174
CVE:  CVE-2017-7401.