### PR TITLE
Bugfix/issue 2239 java target match config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,11 +62,15 @@ bindings/.perl-directory-stamp
 bindings/perl/Collectd/pm_to_blib
 bindings/perl/blib/
 bindings/perl/pm_to_blib
+bindings/buildperl/
 
 # java stuff
 bindings/java/java-build-stamp
 bindings/java/org/collectd/api/*.class
 bindings/java/org/collectd/java/*.class
+# java IDE stuff
+**/*.idea
+**/*.iml
 
 # python stuff
 *.pyc
@@ -76,3 +80,5 @@ src/tags
 
 # backup stuff
 *~
+
+


### PR DESCRIPTION
* Moves JVM initialization to the `cjni_config_callback`.
    * Appends things to the config_block, or initializes on first invocation.
    * Shuts down any previously initialized JVM (if more than one invocation occurs).
    * Starts a new JVM with the full contents of the config_block.
* Adds a few ignore patterns (IntelliJ IDEA, and some stuff from building on Mac OS X)
