### PR TITLE
Feat mcelog notification bugfixes

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -720,8 +720,11 @@
 #</Plugin>
 
 #<Plugin mcelog>
-#	McelogClientSocket "/var/run/mcelog-client"
-#	McelogLogfile "/var/log/mcelog"
+#  <Memory>
+#    McelogClientSocket "/var/run/mcelog-client"
+#    PersistentNotification false
+#  </Memory>
+#  McelogLogfile "/var/log/mcelog"
 #</Plugin>
 
 #<Plugin md>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3471,7 +3471,9 @@ By default the plugin connects to B<"/var/run/mcelog-client"> to check if the
 mcelog server is running. When the server is running, the plugin will tail the
 specified logfile to retrieve machine check exception information and send a
 notification with the details from the logfile. The plugin will use the mcelog
-client protocol to retrieve memory related machine check exceptions.
+client protocol to retrieve memory related machine check exceptions. Note that
+for memory exceptions, notifications are only sent when there is a change in
+the number of corrected/uncorrected memory errors.
 
 =over 4
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3475,11 +3475,23 @@ client protocol to retrieve memory related machine check exceptions. Note that
 for memory exceptions, notifications are only sent when there is a change in
 the number of corrected/uncorrected memory errors.
 
-=over 4
+=head3 The Memory block
+
+=over 3
 
 =item B<McelogClientSocket> I<Path>
 Connect to the mcelog client socket using the UNIX domain socket at I<Path>.
 Defaults to B<"/var/run/mcelog-client">.
+
+=item B<PersistentNotification> B<true>|B<false>
+Override default configuration to only send notifications when sent when there
+is a change in the number of corrected/uncorrected memory errors. When set to
+true notifications will be sent for every read cycle. Default is false. Does
+not affect the stats being dispatched.
+
+=back
+
+=over 4
 
 =item B<McelogLogfile> I<Path>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3477,6 +3477,9 @@ the number of corrected/uncorrected memory errors.
 
 =head3 The Memory block
 
+Note: these options cannot be used in conjunction with the logfile options, they are mutually
+exclusive.
+
 =over 3
 
 =item B<McelogClientSocket> I<Path>
@@ -3495,7 +3498,9 @@ not affect the stats being dispatched.
 
 =item B<McelogLogfile> I<Path>
 
-The mcelog file to parse. Defaults to B<"/var/log/mcelog">.
+The mcelog file to parse. Defaults to B<"/var/log/mcelog">. Note: this option
+cannot be used in conjunction with the memory block options, they are mutually
+exclusive.
 
 =back
 

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -115,17 +115,6 @@ static void mcelog_free_dimms_list_records(llist_t *dimms_list) {
 
 }
 
-static llentry_t *mcelog_get_dimm(const char *name, llist_t *dimms_list) {
-  if (dimms_list == NULL)
-    return NULL;
-
-  llentry_t *le = llist_search(g_mcelog_config.dimms_list, name);
-  if (le != NULL)
-    return le;
-
-  return NULL;
-}
-
 /* Create or get dimm by dimm name/location */
 static llentry_t *mcelog_dimm(const mcelog_memory_rec_t *rec,
                               llist_t *dimms_list) {
@@ -138,7 +127,7 @@ static llentry_t *mcelog_dimm(const mcelog_memory_rec_t *rec,
   } else
     sstrncpy(dimm_name, rec->location, sizeof(dimm_name));
 
-  llentry_t *dimm_le = mcelog_get_dimm(dimm_name, dimms_list);
+  llentry_t *dimm_le = llist_search(g_mcelog_config.dimms_list, dimm_name);
 
   if (dimm_le == NULL) {
     mcelog_memory_rec_t *dimm_mr = calloc(1, sizeof(*dimm_mr));

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -380,6 +380,7 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
 
       if (n.meta)
         plugin_notification_meta_free(n.meta);
+        n.meta = NULL;
     }
   }
 
@@ -404,9 +405,9 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
                sizeof(n.type_instance));
       n.severity = NOTIF_FAILURE;
       plugin_dispatch_notification(&n);
-
       if (n.meta)
         plugin_notification_meta_free(n.meta);
+        n.meta = NULL;
     }
   }
 


### PR DESCRIPTION
For mcelog's unix socked data source (default /var/run/mcelog-client), mcelog plugin generates collectd notifications that merge both corrected and uncorrected memory error info. This is incorrect behaviour. Separate notifications should be created for each category and also severity should be differentiated. This pull request fixes this.
This pull request also updates the mcelog plugin to only distpatch notifications for memory corrected and uncorrected errors when the value changes for each dimm and implements a persist option if you wish to continuously send notifications.