### PR TITLE
Kairosdb ttl support

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1547,7 +1547,7 @@
 #		SSLVersion "TLSv1"
 #		Format "Command"
 #		Attribute "key" "value"     # only available for KAIROSDB format
-#		TTL 0   # data ttl, only available for KAIRODB format
+#		TTL 0   # data ttl, only available for KAIROSDB format
 #		Metrics true
 #		Notifications false
 #		StoreRates false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1547,6 +1547,7 @@
 #		SSLVersion "TLSv1"
 #		Format "Command"
 #		Attribute "key" "value"     # only available for KAIROSDB format
+#       TTL 0   # data ttl, only available for KAIRODB format
 #		Metrics true
 #		Notifications false
 #		StoreRates false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1547,7 +1547,7 @@
 #		SSLVersion "TLSv1"
 #		Format "Command"
 #		Attribute "key" "value"     # only available for KAIROSDB format
-#       TTL 0   # data ttl, only available for KAIRODB format
+#		TTL 0   # data ttl, only available for KAIRODB format
 #		Metrics true
 #		Notifications false
 #		StoreRates false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8771,7 +8771,7 @@ Defaults to B<Command>.
 
 =item B<Attribute> I<String> I<String>
 
-Only available for KAIROSDB output format.
+Only available for the KAIROSDB output format.
 
 Consider the two given strings to be the key and value of an additional tag for
 each metric being sent out.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8778,6 +8778,14 @@ each metric being sent out.
 
 You can add multiple B<Attribute>.
 
+=item B<TTL> I<Int>
+
+Only available for KAIROSDB output format.
+
+Sets the Cassandra ttl for the data points.
+
+Please refer to L<http://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html?highlight=ttl>
+
 =item B<Metrics> B<true>|B<false>
 
 Controls whether I<metrics> are POSTed to this location. Defaults to B<true>.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8780,7 +8780,7 @@ You can add multiple B<Attribute>.
 
 =item B<TTL> I<Int>
 
-Only available for KAIROSDB output format.
+Only available for the KAIROSDB output format.
 
 Sets the Cassandra ttl for the data points.
 

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -183,7 +183,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
                                   const data_set_t *ds, const value_list_t *vl,
                                   int store_rates,
                                   char const *const *http_attrs,
-                                  size_t http_attrs_num) {
+                                  size_t http_attrs_num, int data_ttl) {
   char temp[512];
   size_t offset = 0;
   int status;
@@ -230,6 +230,9 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
     memset(temp, 0, sizeof(temp));
 
+    if (data_ttl != 0)
+      BUFFER_ADD(", \"ttl\": %i", data_ttl);
+
     BUFFER_ADD(", \"tags\":\{");
 
     BUFFER_ADD("\"host\": \"%s\"", vl->host);
@@ -260,12 +263,12 @@ static int format_kairosdb_value_list_nocheck(
     char *buffer, /* {{{ */
     size_t *ret_buffer_fill, size_t *ret_buffer_free, const data_set_t *ds,
     const value_list_t *vl, int store_rates, size_t temp_size,
-    char const *const *http_attrs, size_t http_attrs_num) {
+    char const *const *http_attrs, size_t http_attrs_num, int data_ttl) {
   char temp[temp_size];
   int status;
 
   status = value_list_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates,
-                                  http_attrs, http_attrs_num);
+                                  http_attrs, http_attrs_num, data_ttl);
   if (status != 0)
     return (status);
   temp_size = strlen(temp);
@@ -334,7 +337,7 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
                                size_t *ret_buffer_fill, size_t *ret_buffer_free,
                                const data_set_t *ds, const value_list_t *vl,
                                int store_rates, char const *const *http_attrs,
-                               size_t http_attrs_num) {
+                               size_t http_attrs_num, int data_ttl) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
     return (-EINVAL);
@@ -344,7 +347,7 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
 
   return (format_kairosdb_value_list_nocheck(
       buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
-      (*ret_buffer_free) - 2, http_attrs, http_attrs_num));
+      (*ret_buffer_free) - 2, http_attrs, http_attrs_num, data_ttl));
 } /* }}} int format_kairosdb_value_list */
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -41,7 +41,7 @@ int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free, const data_set_t *ds,
                                const value_list_t *vl, int store_rates,
                                char const *const *http_attrs,
-                               size_t http_attrs_num);
+                               size_t http_attrs_num, int data_ttl);
 int format_kairosdb_finalize(char *buffer, size_t *ret_buffer_fill,
                              size_t *ret_buffer_free);
 


### PR DESCRIPTION
Had a new option for the kairosdb ouput format.

TTL let you sets the Cassandra ttl for the data points.