### PR TITLE
write_prometheus plugin: Fix incorrect use of realloc().

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -546,9 +546,14 @@ metric_family_delete_metric(Io__Prometheus__Client__MetricFamily *fam,
             ((fam->n_metric - 1) - i) * sizeof(fam->metric[i]));
   fam->n_metric--;
 
+  if (fam->n_metric == 0) {
+    sfree(fam->metric);
+    return 0;
+  }
+
   Io__Prometheus__Client__Metric **tmp =
       realloc(fam->metric, fam->n_metric * sizeof(*fam->metric));
-  if ((tmp != NULL) || (fam->n_metric == 0))
+  if (tmp != NULL)
     fam->metric = tmp;
 
   return 0;


### PR DESCRIPTION
Calling `realloc(ptr, 0)` is undefined. Call `free()` explicitly.

Thanks to clang's scan-build for pointing this out.