### PR TITLE
Remove parentheses around return arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1399,8 +1399,8 @@ if test "x$fp_layout_type" = "xunknown"; then
                   && (c[2] == 0xc0) && (c[3] == 0xc7)
                   && (c[4] == 0x43) && (c[5] == 0x2b)
                   && (c[6] == 0x1f) && (c[7] == 0x5b))
-                return (0);
-              return (1);
+                return 0;
+              return 1;
             ]]
           )
         ],
@@ -1454,8 +1454,8 @@ if test "x$fp_layout_type" = "xunknown"; then
                   && (c[2] == 0xc0) && (c[3] == 0xc7)
                   && (c[4] == 0x43) && (c[5] == 0x2b)
                   && (c[6] == 0x1f) && (c[7] == 0x5b))
-                return (0);
-              return (1);
+                return 0;
+              return 1;
             ]]
           )
         ],
@@ -1503,8 +1503,8 @@ if test "x$fp_layout_type" = "xunknown"; then
                   && (c[2] == 0xc0) && (c[3] == 0xc7)
                   && (c[4] == 0x43) && (c[5] == 0x2b)
                   && (c[6] == 0x1f) && (c[7] == 0x5b))
-                return (0);
-              return (1);
+                return 0;
+              return 1;
             ]]
           )
         ],
@@ -3653,7 +3653,7 @@ if test "x$with_libmnl" = "xyes"; then
         ]],
         [[
           int retval = TCA_STATS2;
-          return (retval);
+          return retval;
         ]]
       )
     ],
@@ -3673,7 +3673,7 @@ if test "x$with_libmnl" = "xyes"; then
         ]],
         [[
           int retval = TCA_STATS;
-          return (retval);
+          return retval;
         ]]
       )
     ],

--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -93,16 +93,16 @@ static _Bool agg_is_regex(char const *str) /* {{{ */
   size_t len;
 
   if (str == NULL)
-    return (0);
+    return 0;
 
   len = strlen(str);
   if (len < 3)
-    return (0);
+    return 0;
 
   if ((str[0] == '/') && (str[len - 1] == '/'))
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* }}} _Bool agg_is_regex */
 
 static void agg_destroy(aggregation_t *agg) /* {{{ */
@@ -222,7 +222,7 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
 
 #undef COPY_FIELD
 
-  return (0);
+  return 0;
 } /* }}} int agg_instance_create_name */
 
 /* Create a new aggregation instance. */
@@ -236,7 +236,7 @@ static agg_instance_t *agg_instance_create(data_set_t const *ds, /* {{{ */
   inst = calloc(1, sizeof(*inst));
   if (inst == NULL) {
     ERROR("aggregation plugin: calloc() failed.");
-    return (NULL);
+    return NULL;
   }
   pthread_mutex_init(&inst->lock, /* attr = */ NULL);
 
@@ -256,7 +256,7 @@ static agg_instance_t *agg_instance_create(data_set_t const *ds, /* {{{ */
         agg_instance_destroy(inst);                                            \
         free(inst);                                                            \
         ERROR("aggregation plugin: calloc() failed.");                         \
-        return (NULL);                                                         \
+        return NULL;                                                           \
       }                                                                        \
     }                                                                          \
   } while (0)
@@ -275,7 +275,7 @@ static agg_instance_t *agg_instance_create(data_set_t const *ds, /* {{{ */
   agg_instance_list_head = inst;
   pthread_mutex_unlock(&agg_instance_list_lock);
 
-  return (inst);
+  return inst;
 } /* }}} agg_instance_t *agg_instance_create */
 
 /* Update the num, sum, min, max, ... fields of the aggregation instance, if
@@ -291,7 +291,7 @@ static int agg_instance_update(agg_instance_t *inst, /* {{{ */
           "data source. This is currently not supported by this plugin. "
           "Sorry.",
           ds->type);
-    return (EINVAL);
+    return EINVAL;
   }
 
   rate = uc_get_rate(ds, vl);
@@ -300,12 +300,12 @@ static int agg_instance_update(agg_instance_t *inst, /* {{{ */
     FORMAT_VL(ident, sizeof(ident), vl);
     ERROR("aggregation plugin: Unable to read the current rate of \"%s\".",
           ident);
-    return (ENOENT);
+    return ENOENT;
   }
 
   if (isnan(rate[0])) {
     sfree(rate);
-    return (0);
+    return 0;
   }
 
   pthread_mutex_lock(&inst->lock);
@@ -322,7 +322,7 @@ static int agg_instance_update(agg_instance_t *inst, /* {{{ */
   pthread_mutex_unlock(&inst->lock);
 
   sfree(rate);
-  return (0);
+  return 0;
 } /* }}} int agg_instance_update */
 
 static int agg_instance_read_func(agg_instance_t *inst, /* {{{ */
@@ -345,10 +345,10 @@ static int agg_instance_read_func(agg_instance_t *inst, /* {{{ */
      * COUNTER or a DERIVE, it will return EAGAIN. Catch this and handle
      * gracefully. */
     if (status == EAGAIN)
-      return (0);
+      return 0;
 
     WARNING("aggregation plugin: rate_to_value failed with status %i.", status);
-    return (-1);
+    return -1;
   }
 
   vl->values = &v;
@@ -359,7 +359,7 @@ static int agg_instance_read_func(agg_instance_t *inst, /* {{{ */
   vl->values = NULL;
   vl->values_len = 0;
 
-  return (0);
+  return 0;
 } /* }}} int agg_instance_read_func */
 
 static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
@@ -376,7 +376,7 @@ static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
   vl.meta = meta_data_create();
   if (vl.meta == NULL) {
     ERROR("aggregation plugin: meta_data_create failed.");
-    return (-1);
+    return -1;
   }
   meta_data_add_boolean(vl.meta, "aggregation:created", 1);
 
@@ -422,7 +422,7 @@ static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
   meta_data_destroy(vl.meta);
   vl.meta = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int agg_instance_read */
 
 /* lookup_class_callback_t for utils_vl_lookup */
@@ -430,7 +430,7 @@ static void *agg_lookup_class_callback(/* {{{ */
                                        data_set_t const *ds,
                                        value_list_t const *vl,
                                        void *user_class) {
-  return (agg_instance_create(ds, vl, (aggregation_t *)user_class));
+  return agg_instance_create(ds, vl, (aggregation_t *)user_class);
 } /* }}} void *agg_class_callback */
 
 /* lookup_obj_callback_t for utils_vl_lookup */
@@ -438,7 +438,7 @@ static int agg_lookup_obj_callback(data_set_t const *ds, /* {{{ */
                                    value_list_t const *vl,
                                    __attribute__((unused)) void *user_class,
                                    void *user_obj) {
-  return (agg_instance_update((agg_instance_t *)user_obj, ds, vl));
+  return agg_instance_update((agg_instance_t *)user_obj, ds, vl);
 } /* }}} int agg_lookup_obj_callback */
 
 /* lookup_free_class_callback_t for utils_vl_lookup */
@@ -501,7 +501,7 @@ static int agg_config_handle_group_by(oconfig_item_t const *ci, /* {{{ */
               value);
   } /* for (ci->values) */
 
-  return (0);
+  return 0;
 } /* }}} int agg_config_handle_group_by */
 
 static int agg_config_aggregation(oconfig_item_t *ci) /* {{{ */
@@ -513,7 +513,7 @@ static int agg_config_aggregation(oconfig_item_t *ci) /* {{{ */
   agg = calloc(1, sizeof(*agg));
   if (agg == NULL) {
     ERROR("aggregation plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(agg->ident.host, "/.*/", sizeof(agg->ident.host));
@@ -636,14 +636,14 @@ static int agg_config_aggregation(oconfig_item_t *ci) /* {{{ */
   if (!is_valid) /* {{{ */
   {
     sfree(agg);
-    return (-1);
+    return -1;
   } /* }}} */
 
   status = lookup_add(lookup, &agg->ident, agg->group_by, agg);
   if (status != 0) {
     ERROR("aggregation plugin: lookup_add failed with status %i.", status);
     sfree(agg);
-    return (-1);
+    return -1;
   }
 
   DEBUG("aggregation plugin: Successfully added aggregation: "
@@ -651,7 +651,7 @@ static int agg_config_aggregation(oconfig_item_t *ci) /* {{{ */
         "Type \"%s\", TypeInstance \"%s\")",
         agg->ident.host, agg->ident.plugin, agg->ident.plugin_instance,
         agg->ident.type, agg->ident.type_instance);
-  return (0);
+  return 0;
 } /* }}} int agg_config_aggregation */
 
 static int agg_config(oconfig_item_t *ci) /* {{{ */
@@ -665,7 +665,7 @@ static int agg_config(oconfig_item_t *ci) /* {{{ */
     if (lookup == NULL) {
       pthread_mutex_unlock(&agg_instance_list_lock);
       ERROR("aggregation plugin: lookup_create failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -682,7 +682,7 @@ static int agg_config(oconfig_item_t *ci) /* {{{ */
 
   pthread_mutex_unlock(&agg_instance_list_lock);
 
-  return (0);
+  return 0;
 } /* }}} int agg_config */
 
 static int agg_read(void) /* {{{ */
@@ -703,7 +703,7 @@ static int agg_read(void) /* {{{ */
    * Therefore we need to handle this case separately. */
   if (agg_instance_list_head == NULL) {
     pthread_mutex_unlock(&agg_instance_list_lock);
-    return (0);
+    return 0;
   }
 
   for (agg_instance_t *this = agg_instance_list_head; this != NULL;
@@ -721,7 +721,7 @@ static int agg_read(void) /* {{{ */
 
   pthread_mutex_unlock(&agg_instance_list_lock);
 
-  return ((success > 0) ? 0 : -1);
+  return (success > 0) ? 0 : -1;
 } /* }}} int agg_read */
 
 static int agg_write(data_set_t const *ds, value_list_t const *vl, /* {{{ */
@@ -734,7 +734,7 @@ static int agg_write(data_set_t const *ds, value_list_t const *vl, /* {{{ */
   (void)meta_data_get_boolean(vl->meta, "aggregation:created",
                               &created_by_aggregation);
   if (created_by_aggregation)
-    return (0);
+    return 0;
 
   if (lookup == NULL)
     status = ENOENT;
@@ -744,7 +744,7 @@ static int agg_write(data_set_t const *ds, value_list_t const *vl, /* {{{ */
       status = 0;
   }
 
-  return (status);
+  return status;
 } /* }}} int agg_write */
 
 void module_register(void) {

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -164,16 +164,16 @@ static char *camqp_bytes_cstring(amqp_bytes_t *in) /* {{{ */
   char *ret;
 
   if ((in == NULL) || (in->bytes == NULL))
-    return (NULL);
+    return NULL;
 
   ret = malloc(in->len + 1);
   if (ret == NULL)
-    return (NULL);
+    return NULL;
 
   memcpy(ret, in->bytes, in->len);
   ret[in->len] = 0;
 
-  return (ret);
+  return ret;
 } /* }}} char *camqp_bytes_cstring */
 
 static _Bool camqp_is_error(camqp_config_t *conf) /* {{{ */
@@ -182,9 +182,9 @@ static _Bool camqp_is_error(camqp_config_t *conf) /* {{{ */
 
   r = amqp_get_rpc_reply(conf->connection);
   if (r.reply_type == AMQP_RESPONSE_NORMAL)
-    return (0);
+    return 0;
 
-  return (1);
+  return 1;
 } /* }}} _Bool camqp_is_error */
 
 static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
@@ -204,10 +204,10 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
   case AMQP_RESPONSE_LIBRARY_EXCEPTION:
 #if HAVE_AMQP_RPC_REPLY_T_LIBRARY_ERRNO
     if (r.library_errno)
-      return (sstrerror(r.library_errno, buffer, buffer_size));
+      return sstrerror(r.library_errno, buffer, buffer_size);
 #else
     if (r.library_error)
-      return (sstrerror(r.library_error, buffer, buffer_size));
+      return sstrerror(r.library_error, buffer, buffer_size);
 #endif
     else
       sstrncpy(buffer, "End of stream", buffer_size);
@@ -236,7 +236,7 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
     ssnprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
   }
 
-  return (buffer);
+  return buffer;
 } /* }}} char *camqp_strerror */
 
 #if HAVE_AMQP_RPC_REPLY_T_LIBRARY_ERRNO
@@ -245,7 +245,7 @@ static int camqp_create_exchange(camqp_config_t *conf) /* {{{ */
   amqp_exchange_declare_ok_t *ed_ret;
 
   if (conf->exchange_type == NULL)
-    return (0);
+    return 0;
 
   ed_ret = amqp_exchange_declare(
       conf->connection,
@@ -261,14 +261,14 @@ static int camqp_create_exchange(camqp_config_t *conf) /* {{{ */
     ERROR("amqp plugin: amqp_exchange_declare failed: %s",
           camqp_strerror(conf, errbuf, sizeof(errbuf)));
     camqp_close_connection(conf);
-    return (-1);
+    return -1;
   }
 
   INFO("amqp plugin: Successfully created exchange \"%s\" "
        "with type \"%s\".",
        conf->exchange, conf->exchange_type);
 
-  return (0);
+  return 0;
 } /* }}} int camqp_create_exchange */
 #else
 static int camqp_create_exchange(camqp_config_t *conf) /* {{{ */
@@ -278,7 +278,7 @@ static int camqp_create_exchange(camqp_config_t *conf) /* {{{ */
   struct amqp_table_entry_t_ argument_table_entries[1];
 
   if (conf->exchange_type == NULL)
-    return (0);
+    return 0;
 
   /* Valid arguments: "auto_delete", "internal" */
   argument_table.num_entries = STATIC_ARRAY_SIZE(argument_table_entries);
@@ -304,14 +304,14 @@ static int camqp_create_exchange(camqp_config_t *conf) /* {{{ */
     ERROR("amqp plugin: amqp_exchange_declare failed: %s",
           camqp_strerror(conf, errbuf, sizeof(errbuf)));
     camqp_close_connection(conf);
-    return (-1);
+    return -1;
   }
 
   INFO("amqp plugin: Successfully created exchange \"%s\" "
        "with type \"%s\".",
        conf->exchange, conf->exchange_type);
 
-  return (0);
+  return 0;
 } /* }}} int camqp_create_exchange */
 #endif
 
@@ -333,7 +333,7 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
   if (qd_ret == NULL) {
     ERROR("amqp plugin: amqp_queue_declare failed.");
     camqp_close_connection(conf);
-    return (-1);
+    return -1;
   }
 
   if (conf->queue == NULL) {
@@ -341,7 +341,7 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
     if (conf->queue == NULL) {
       ERROR("amqp plugin: camqp_bytes_cstring failed.");
       camqp_close_connection(conf);
-      return (-1);
+      return -1;
     }
 
     INFO("amqp plugin: Created queue \"%s\".", conf->queue);
@@ -367,7 +367,7 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
       ERROR("amqp plugin: amqp_queue_bind failed: %s",
             camqp_strerror(conf, errbuf, sizeof(errbuf)));
       camqp_close_connection(conf);
-      return (-1);
+      return -1;
     }
 
     DEBUG("amqp plugin: Successfully bound queue \"%s\" to exchange \"%s\".",
@@ -388,10 +388,10 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
     ERROR("amqp plugin: amqp_basic_consume failed: %s",
           camqp_strerror(conf, errbuf, sizeof(errbuf)));
     camqp_close_connection(conf);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int camqp_setup_queue */
 
 static int camqp_connect(camqp_config_t *conf) /* {{{ */
@@ -407,14 +407,14 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
 #endif
 
   if (conf->connection != NULL)
-    return (0);
+    return 0;
 
   time_t now = time(NULL);
   if (now < (last_connect_time + conf->connection_retry_delay)) {
     DEBUG("amqp plugin: skipping connection retry, "
           "ConnectionRetryDelay: %d",
           conf->connection_retry_delay);
-    return (1);
+    return 1;
   } else {
     DEBUG("amqp plugin: retrying connection");
     last_connect_time = now;
@@ -423,7 +423,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
   conf->connection = amqp_new_connection();
   if (conf->connection == NULL) {
     ERROR("amqp plugin: amqp_new_connection failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
 #ifdef HAVE_AMQP_TCP_SOCKET
@@ -436,7 +436,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
     ERROR("amqp plugin: amqp_tcp_socket_new failed.");
     amqp_destroy_connection(conf->connection);
     conf->connection = NULL;
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   status = amqp_socket_open(socket, CONF(conf, host), conf->port);
@@ -447,7 +447,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
           sstrerror(status, errbuf, sizeof(errbuf)));
     amqp_destroy_connection(conf->connection);
     conf->connection = NULL;
-    return (status);
+    return status;
   }
 #else /* HAVE_AMQP_TCP_SOCKET */
 #define CLOSE_SOCKET() close(sockfd)
@@ -460,7 +460,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
           sstrerror(status, errbuf, sizeof(errbuf)));
     amqp_destroy_connection(conf->connection);
     conf->connection = NULL;
-    return (status);
+    return status;
   }
   amqp_set_sockfd(conf->connection, sockfd);
 #endif
@@ -477,7 +477,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
     amqp_destroy_connection(conf->connection);
     CLOSE_SOCKET();
     conf->connection = NULL;
-    return (1);
+    return 1;
   }
 
   amqp_channel_open(conf->connection, /* channel = */ 1);
@@ -489,7 +489,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
     amqp_destroy_connection(conf->connection);
     CLOSE_SOCKET();
     conf->connection = NULL;
-    return (1);
+    return 1;
   }
 
   INFO("amqp plugin: Successfully opened connection to vhost \"%s\" "
@@ -498,11 +498,11 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
 
   status = camqp_create_exchange(conf);
   if (status != 0)
-    return (status);
+    return status;
 
   if (!conf->publish)
-    return (camqp_setup_queue(conf));
-  return (0);
+    return camqp_setup_queue(conf);
+  return 0;
 } /* }}} int camqp_connect */
 
 static int camqp_shutdown(void) /* {{{ */
@@ -524,7 +524,7 @@ static int camqp_shutdown(void) /* {{{ */
 
   DEBUG("amqp plugin: All subscriber threads exited.");
 
-  return (0);
+  return 0;
 } /* }}} int camqp_shutdown */
 
 /*
@@ -550,17 +550,17 @@ static int camqp_read_body(camqp_config_t *conf, /* {{{ */
       ERROR("amqp plugin: amqp_simple_wait_frame failed: %s",
             sstrerror(status, errbuf, sizeof(errbuf)));
       camqp_close_connection(conf);
-      return (status);
+      return status;
     }
 
     if (frame.frame_type != AMQP_FRAME_BODY) {
       NOTICE("amqp plugin: Unexpected frame type: %#" PRIx8, frame.frame_type);
-      return (-1);
+      return -1;
     }
 
     if ((body_size - received) < frame.payload.body_fragment.len) {
       WARNING("amqp plugin: Body is larger than indicated by header.");
-      return (-1);
+      return -1;
     }
 
     memcpy(body_ptr, frame.payload.body_fragment.bytes,
@@ -573,19 +573,19 @@ static int camqp_read_body(camqp_config_t *conf, /* {{{ */
     status = cmd_handle_putval(stderr, body);
     if (status != 0)
       ERROR("amqp plugin: cmd_handle_putval failed with status %i.", status);
-    return (status);
+    return status;
   } else if (strcasecmp("application/json", content_type) == 0) {
     ERROR("amqp plugin: camqp_read_body: Parsing JSON data has not "
           "been implemented yet. FIXME!");
-    return (0);
+    return 0;
   } else {
     ERROR("amqp plugin: camqp_read_body: Unknown content type \"%s\".",
           content_type);
-    return (EINVAL);
+    return EINVAL;
   }
 
   /* not reached */
-  return (0);
+  return 0;
 } /* }}} int camqp_read_body */
 
 static int camqp_read_header(camqp_config_t *conf) /* {{{ */
@@ -602,26 +602,26 @@ static int camqp_read_header(camqp_config_t *conf) /* {{{ */
     ERROR("amqp plugin: amqp_simple_wait_frame failed: %s",
           sstrerror(status, errbuf, sizeof(errbuf)));
     camqp_close_connection(conf);
-    return (status);
+    return status;
   }
 
   if (frame.frame_type != AMQP_FRAME_HEADER) {
     NOTICE("amqp plugin: Unexpected frame type: %#" PRIx8, frame.frame_type);
-    return (-1);
+    return -1;
   }
 
   properties = frame.payload.properties.decoded;
   content_type = camqp_bytes_cstring(&properties->content_type);
   if (content_type == NULL) {
     ERROR("amqp plugin: Unable to determine content type.");
-    return (-1);
+    return -1;
   }
 
   status = camqp_read_body(conf, (size_t)frame.payload.properties.body_size,
                            content_type);
 
   sfree(content_type);
-  return (status);
+  return status;
 } /* }}} int camqp_read_header */
 
 static void *camqp_subscribe_thread(void *user_data) /* {{{ */
@@ -671,7 +671,7 @@ static void *camqp_subscribe_thread(void *user_data) /* {{{ */
 
   camqp_config_free(conf);
   pthread_exit(NULL);
-  return (NULL);
+  return NULL;
 } /* }}} void *camqp_subscribe_thread */
 
 static int camqp_subscribe_init(camqp_config_t *conf) /* {{{ */
@@ -684,7 +684,7 @@ static int camqp_subscribe_init(camqp_config_t *conf) /* {{{ */
   if (tmp == NULL) {
     ERROR("amqp plugin: realloc failed.");
     sfree(subscriber_threads);
-    return (ENOMEM);
+    return ENOMEM;
   }
   subscriber_threads = tmp;
   tmp = subscriber_threads + subscriber_threads_num;
@@ -696,12 +696,12 @@ static int camqp_subscribe_init(camqp_config_t *conf) /* {{{ */
     char errbuf[1024];
     ERROR("amqp plugin: pthread_create failed: %s",
           sstrerror(status, errbuf, sizeof(errbuf)));
-    return (status);
+    return status;
   }
 
   subscriber_threads_num++;
 
-  return (0);
+  return 0;
 } /* }}} int camqp_subscribe_init */
 
 /*
@@ -714,7 +714,7 @@ static int camqp_write_locked(camqp_config_t *conf, /* {{{ */
 
   status = camqp_connect(conf);
   if (status != 0)
-    return (status);
+    return status;
 
   amqp_basic_properties_t props = {._flags = AMQP_BASIC_CONTENT_TYPE_FLAG |
                                              AMQP_BASIC_DELIVERY_MODE_FLAG |
@@ -742,7 +742,7 @@ static int camqp_write_locked(camqp_config_t *conf, /* {{{ */
     camqp_close_connection(conf);
   }
 
-  return (status);
+  return status;
 } /* }}} int camqp_write_locked */
 
 static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
@@ -753,7 +753,7 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   int status;
 
   if ((ds == NULL) || (vl == NULL) || (conf == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (conf->routing_key != NULL) {
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
@@ -776,7 +776,7 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     status = cmd_create_putval(buffer, sizeof(buffer), ds, vl);
     if (status != 0) {
       ERROR("amqp plugin: cmd_create_putval failed with status %i.", status);
-      return (status);
+      return status;
     }
   } else if (conf->format == CAMQP_FORMAT_JSON) {
     size_t bfree = sizeof(buffer);
@@ -791,18 +791,18 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
                         conf->postfix, conf->escape_char, conf->graphite_flags);
     if (status != 0) {
       ERROR("amqp plugin: format_graphite failed with status %i.", status);
-      return (status);
+      return status;
     }
   } else {
     ERROR("amqp plugin: Invalid format (%i).", conf->format);
-    return (-1);
+    return -1;
   }
 
   pthread_mutex_lock(&conf->lock);
   status = camqp_write_locked(conf, buffer, routing_key);
   pthread_mutex_unlock(&conf->lock);
 
-  return (status);
+  return status;
 } /* }}} int camqp_write */
 
 /*
@@ -816,7 +816,7 @@ static int camqp_config_set_format(oconfig_item_t *ci, /* {{{ */
   string = NULL;
   status = cf_util_get_string(ci, &string);
   if (status != 0)
-    return (status);
+    return status;
 
   assert(string != NULL);
   if (strcasecmp("Command", string) == 0)
@@ -831,7 +831,7 @@ static int camqp_config_set_format(oconfig_item_t *ci, /* {{{ */
 
   free(string);
 
-  return (0);
+  return 0;
 } /* }}} int config_set_string */
 
 static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
@@ -842,7 +842,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
   conf = calloc(1, sizeof(*conf));
   if (conf == NULL) {
     ERROR("amqp plugin: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   /* Initialize "conf" {{{ */
@@ -879,7 +879,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
   status = cf_util_get_string(ci, &conf->name);
   if (status != 0) {
     sfree(conf);
-    return (status);
+    return status;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -970,7 +970,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
 
   if (status != 0) {
     camqp_config_free(conf);
-    return (status);
+    return status;
   }
 
   if (conf->exchange != NULL) {
@@ -988,17 +988,17 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
                              });
     if (status != 0) {
       camqp_config_free(conf);
-      return (status);
+      return status;
     }
   } else {
     status = camqp_subscribe_init(conf);
     if (status != 0) {
       camqp_config_free(conf);
-      return (status);
+      return status;
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int camqp_config_connection */
 
 static int camqp_config(oconfig_item_t *ci) /* {{{ */
@@ -1015,7 +1015,7 @@ static int camqp_config(oconfig_item_t *ci) /* {{{ */
               child->key);
   } /* for (ci->children_num) */
 
-  return (0);
+  return 0;
 } /* }}} int camqp_config */
 
 void module_register(void) {

--- a/src/apache.c
+++ b/src/apache.c
@@ -89,11 +89,11 @@ static size_t apache_curl_callback(void *buf, size_t size, size_t nmemb,
   if (st == NULL) {
     ERROR("apache plugin: apache_curl_callback: "
           "user_data pointer is NULL.");
-    return (0);
+    return 0;
   }
 
   if (len == 0)
-    return (len);
+    return len;
 
   if ((st->apache_buffer_fill + len) >= st->apache_buffer_size) {
     char *temp;
@@ -101,7 +101,7 @@ static size_t apache_curl_callback(void *buf, size_t size, size_t nmemb,
     temp = realloc(st->apache_buffer, st->apache_buffer_fill + len + 1);
     if (temp == NULL) {
       ERROR("apache plugin: realloc failed.");
-      return (0);
+      return 0;
     }
     st->apache_buffer = temp;
     st->apache_buffer_size = st->apache_buffer_fill + len + 1;
@@ -111,7 +111,7 @@ static size_t apache_curl_callback(void *buf, size_t size, size_t nmemb,
   st->apache_buffer_fill += len;
   st->apache_buffer[st->apache_buffer_fill] = 0;
 
-  return (len);
+  return len;
 } /* int apache_curl_callback */
 
 static size_t apache_header_callback(void *buf, size_t size, size_t nmemb,
@@ -123,15 +123,15 @@ static size_t apache_header_callback(void *buf, size_t size, size_t nmemb,
   if (st == NULL) {
     ERROR("apache plugin: apache_header_callback: "
           "user_data pointer is NULL.");
-    return (0);
+    return 0;
   }
 
   if (len == 0)
-    return (len);
+    return len;
 
   /* look for the Server header */
   if (strncasecmp(buf, "Server: ", strlen("Server: ")) != 0)
-    return (len);
+    return len;
 
   if (strstr(buf, "Apache") != NULL)
     st->server_type = APACHE;
@@ -146,7 +146,7 @@ static size_t apache_header_callback(void *buf, size_t size, size_t nmemb,
     NOTICE("apache plugin: Unknown server software: %s", hdr);
   }
 
-  return (len);
+  return len;
 } /* apache_header_callback */
 
 /* Configuration handling functiions
@@ -164,7 +164,7 @@ static int config_add(oconfig_item_t *ci) {
   st = calloc(1, sizeof(*st));
   if (st == NULL) {
     ERROR("apache plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   st->timeout = -1;
@@ -172,7 +172,7 @@ static int config_add(oconfig_item_t *ci) {
   status = cf_util_get_string(ci, &st->name);
   if (status != 0) {
     sfree(st);
-    return (status);
+    return status;
   }
   assert(st->name != NULL);
 
@@ -234,10 +234,10 @@ static int config_add(oconfig_item_t *ci) {
 
   if (status != 0) {
     apache_free(st);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int config_add */
 
 static int config(oconfig_item_t *ci) {
@@ -256,7 +256,7 @@ static int config(oconfig_item_t *ci) {
               child->key);
   } /* for (ci->children) */
 
-  return (status);
+  return status;
 } /* int config */
 
 /* initialize curl for each host */
@@ -272,7 +272,7 @@ static int init_host(apache_t *st) /* {{{ */
 
   if ((st->curl = curl_easy_init()) == NULL) {
     ERROR("apache plugin: init_host: `curl_easy_init' failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(st->curl, CURLOPT_NOSIGNAL, 1L);
@@ -321,7 +321,7 @@ static int init_host(apache_t *st) /* {{{ */
             "truncated.");
       curl_easy_cleanup(st->curl);
       st->curl = NULL;
-      return (-1);
+      return -1;
     }
 
     curl_easy_setopt(st->curl, CURLOPT_USERPWD, credentials);
@@ -347,7 +347,7 @@ static int init_host(apache_t *st) /* {{{ */
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int init_host */
 
 static void submit_value(const char *type, const char *type_instance,
@@ -505,14 +505,14 @@ static int apache_read_host(user_data_t *user_data) /* {{{ */
   if (st->curl == NULL) {
     status = init_host(st);
     if (status != 0)
-      return (-1);
+      return -1;
   }
   assert(st->curl != NULL);
 
   st->apache_buffer_fill = 0;
   if (curl_easy_perform(st->curl) != CURLE_OK) {
     ERROR("apache: curl_easy_perform failed: %s", st->apache_curl_error);
-    return (-1);
+    return -1;
   }
 
   /* fallback - server_type to apache if not set at this time */
@@ -558,7 +558,7 @@ static int apache_read_host(user_data_t *user_data) /* {{{ */
 
   st->apache_buffer_fill = 0;
 
-  return (0);
+  return 0;
 } /* }}} int apache_read_host */
 
 static int apache_init(void) /* {{{ */
@@ -566,7 +566,7 @@ static int apache_init(void) /* {{{ */
   /* Call this while collectd is still single-threaded to avoid
    * initialization issues in libgcrypt. */
   curl_global_init(CURL_GLOBAL_SSL);
-  return (0);
+  return 0;
 } /* }}} int apache_init */
 
 void module_register(void) {

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -85,22 +85,22 @@ static int net_shutdown(int *fd) {
   uint16_t packet_size = 0;
 
   if ((fd == NULL) || (*fd < 0))
-    return (EINVAL);
+    return EINVAL;
 
   (void)swrite(*fd, (void *)&packet_size, sizeof(packet_size));
   close(*fd);
   *fd = -1;
 
-  return (0);
+  return 0;
 } /* int net_shutdown */
 
 /* Close the network connection */
 static int apcups_shutdown(void) {
   if (global_sockfd < 0)
-    return (0);
+    return 0;
 
   net_shutdown(&global_sockfd);
-  return (0);
+  return 0;
 } /* int apcups_shutdown */
 
 /*
@@ -123,7 +123,7 @@ static int net_open(char const *node, char const *service) {
     INFO("apcups plugin: getaddrinfo failed: %s",
          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                 : gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   /* Create socket */
@@ -138,7 +138,7 @@ static int net_open(char const *node, char const *service) {
   if (sd < 0) {
     DEBUG("apcups plugin: Unable to open a socket");
     freeaddrinfo(ai_return);
-    return (-1);
+    return -1;
   }
 
   status = connect(sd, ai_list->ai_addr, ai_list->ai_addrlen);
@@ -151,12 +151,12 @@ static int net_open(char const *node, char const *service) {
     INFO("apcups plugin: connect failed: %s",
          sstrerror(errno, errbuf, sizeof(errbuf)));
     close(sd);
-    return (-1);
+    return -1;
   }
 
   DEBUG("apcups plugin: Done opening a socket %i", sd);
 
-  return (sd);
+  return sd;
 } /* int net_open */
 
 /*
@@ -175,7 +175,7 @@ static int net_recv(int *sockfd, char *buf, int buflen) {
   if (sread(*sockfd, (void *)&packet_size, sizeof(packet_size)) != 0) {
     close(*sockfd);
     *sockfd = -1;
-    return (-1);
+    return -1;
   }
 
   packet_size = ntohs(packet_size);
@@ -185,20 +185,20 @@ static int net_recv(int *sockfd, char *buf, int buflen) {
           packet_size, buflen);
     close(*sockfd);
     *sockfd = -1;
-    return (-2);
+    return -2;
   }
 
   if (packet_size == 0)
-    return (0);
+    return 0;
 
   /* now read the actual data */
   if (sread(*sockfd, (void *)buf, packet_size) != 0) {
     close(*sockfd);
     *sockfd = -1;
-    return (-1);
+    return -1;
   }
 
-  return ((int)packet_size);
+  return (int)packet_size;
 } /* static int net_recv (int *sockfd, char *buf, int buflen) */
 
 /*
@@ -220,17 +220,17 @@ static int net_send(int *sockfd, const char *buff, int len) {
   if (swrite(*sockfd, (void *)&packet_size, sizeof(packet_size)) != 0) {
     close(*sockfd);
     *sockfd = -1;
-    return (-1);
+    return -1;
   }
 
   /* send data packet */
   if (swrite(*sockfd, (void *)buff, len) != 0) {
     close(*sockfd);
     *sockfd = -1;
-    return (-2);
+    return -2;
   }
 
-  return (0);
+  return 0;
 }
 
 /* Get and print status from apcupsd NIS server */
@@ -256,7 +256,7 @@ static int apc_query_server(char const *node, char const *service,
       if (global_sockfd < 0) {
         ERROR("apcups plugin: Connecting to the "
               "apcupsd failed.");
-        return (-1);
+        return -1;
       }
     }
 
@@ -271,7 +271,7 @@ static int apc_query_server(char const *node, char const *service,
       }
 
       ERROR("apcups plugin: Writing to the socket failed.");
-      return (-1);
+      return -1;
     }
 
     break;
@@ -344,10 +344,10 @@ static int apc_query_server(char const *node, char const *service,
     char errbuf[1024];
     ERROR("apcups plugin: Reading from socket failed: %s",
           sstrerror(status, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static int apcups_config(oconfig_item_t *ci) {
@@ -380,7 +380,7 @@ static int apcups_config(oconfig_item_t *ci) {
     }
   }
 
-  return (0);
+  return 0;
 } /* int apcups_config */
 
 static void apc_submit_generic(const char *type, const char *type_inst,
@@ -428,12 +428,12 @@ static int apcups_read(void) {
     DEBUG("apcups plugin: apc_query_server (\"%s\", \"%s\") = %d",
           conf_node == NULL ? APCUPS_DEFAULT_NODE : conf_node, conf_service,
           status);
-    return (status);
+    return status;
   }
 
   apc_submit(&apcups_detail);
 
-  return (0);
+  return 0;
 } /* apcups_read */
 
 void module_register(void) {

--- a/src/apple_sensors.c
+++ b/src/apple_sensors.c
@@ -65,10 +65,10 @@ static int as_init(void) {
   if (status != kIOReturnSuccess) {
     ERROR("IOMasterPort failed: %s", mach_error_string(status));
     io_master_port = MACH_PORT_NULL;
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void as_submit(const char *type, const char *type_instance, double val) {
@@ -95,13 +95,13 @@ static int as_read(void) {
   int value_int;
   double value_double;
   if (!io_master_port || (io_master_port == MACH_PORT_NULL))
-    return (-1);
+    return -1;
 
   status = IOServiceGetMatchingServices(
       io_master_port, IOServiceNameMatching("IOHWSensor"), &iterator);
   if (status != kIOReturnSuccess) {
     ERROR("IOServiceGetMatchingServices failed: %s", mach_error_string(status));
-    return (-1);
+    return -1;
   }
 
   while ((io_obj = IOIteratorNext(iterator))) {
@@ -184,7 +184,7 @@ static int as_read(void) {
 
   IOObjectRelease(iterator);
 
-  return (0);
+  return 0;
 } /* int as_read */
 
 void module_register(void) {

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -43,12 +43,12 @@ static int aquaero_config(oconfig_item_t *ci) {
     }
   }
 
-  return (0);
+  return 0;
 }
 
 static int aquaero_shutdown(void) {
   libaquaero5_exit();
-  return (0);
+  return 0;
 } /* int aquaero_shutdown */
 
 static void aquaero_submit(const char *type, const char *type_instance,
@@ -98,7 +98,7 @@ static int aquaero_read(void) {
     ERROR("aquaero plugin: Failed to poll device \"%s\": %s (%s)",
           conf_device ? conf_device : "default", err_msg,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (libaquaero5_getsettings(conf_device, &aq_sett, &err_msg) < 0) {
@@ -107,7 +107,7 @@ static int aquaero_read(void) {
           "for device \"%s\": %s (%s)",
           conf_device ? conf_device : "default", err_msg,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   /* CPU Temperature sensor */
@@ -153,7 +153,7 @@ static int aquaero_read(void) {
   /* Liquid level */
   aquaero_submit_array("percent", "waterlevel", aq_data.level, AQ5_NUM_LEVEL);
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -125,7 +125,7 @@ static int ascent_submit_gauge(const char *plugin_instance, /* {{{ */
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
   plugin_dispatch_values(&vl);
-  return (0);
+  return 0;
 } /* }}} int ascent_submit_gauge */
 
 static size_t ascent_curl_callback(void *buf, size_t size,
@@ -134,7 +134,7 @@ static size_t ascent_curl_callback(void *buf, size_t size,
   size_t len = size * nmemb;
 
   if (len == 0)
-    return (len);
+    return len;
 
   if ((ascent_buffer_fill + len) >= ascent_buffer_size) {
     char *temp;
@@ -142,7 +142,7 @@ static size_t ascent_curl_callback(void *buf, size_t size,
     temp = realloc(ascent_buffer, ascent_buffer_fill + len + 1);
     if (temp == NULL) {
       ERROR("ascent plugin: realloc failed.");
-      return (0);
+      return 0;
     }
     ascent_buffer = temp;
     ascent_buffer_size = ascent_buffer_fill + len + 1;
@@ -152,7 +152,7 @@ static size_t ascent_curl_callback(void *buf, size_t size,
   ascent_buffer_fill += len;
   ascent_buffer[ascent_buffer_fill] = 0;
 
-  return (len);
+  return len;
 } /* }}} size_t ascent_curl_callback */
 
 static int ascent_submit_players(player_stats_t *ps) /* {{{ */
@@ -187,7 +187,7 @@ static int ascent_submit_players(player_stats_t *ps) /* {{{ */
     value = ((double)ps->latency_sum) / (1000.0 * ((double)ps->latency_num));
   ascent_submit_gauge(NULL, "latency", "average", value);
 
-  return (0);
+  return 0;
 } /* }}} int ascent_submit_players */
 
 static int ascent_account_player(player_stats_t *ps, /* {{{ */
@@ -226,7 +226,7 @@ static int ascent_account_player(player_stats_t *ps, /* {{{ */
     ps->latency_num++;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ascent_account_player */
 
 static int ascent_xml_submit_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
@@ -240,7 +240,7 @@ static int ascent_xml_submit_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
   if (str_ptr == NULL) {
     ERROR(
         "ascent plugin: ascent_xml_submit_gauge: xmlNodeListGetString failed.");
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp("N/A", str_ptr) == 0)
@@ -251,12 +251,12 @@ static int ascent_xml_submit_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
     if (str_ptr == end_ptr) {
       xmlFree(str_ptr);
       ERROR("ascent plugin: ascent_xml_submit_gauge: strtod failed.");
-      return (-1);
+      return -1;
     }
   }
   xmlFree(str_ptr);
 
-  return (ascent_submit_gauge(plugin_instance, type, type_instance, value));
+  return ascent_submit_gauge(plugin_instance, type, type_instance, value);
 } /* }}} int ascent_xml_submit_gauge */
 
 static int ascent_xml_read_int(xmlDoc *doc, xmlNode *node, /* {{{ */
@@ -267,7 +267,7 @@ static int ascent_xml_read_int(xmlDoc *doc, xmlNode *node, /* {{{ */
   str_ptr = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
   if (str_ptr == NULL) {
     ERROR("ascent plugin: ascent_xml_read_int: xmlNodeListGetString failed.");
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp("N/A", str_ptr) == 0)
@@ -278,13 +278,13 @@ static int ascent_xml_read_int(xmlDoc *doc, xmlNode *node, /* {{{ */
     if (str_ptr == end_ptr) {
       xmlFree(str_ptr);
       ERROR("ascent plugin: ascent_xml_read_int: strtol failed.");
-      return (-1);
+      return -1;
     }
   }
   xmlFree(str_ptr);
 
   *ret_value = value;
-  return (0);
+  return 0;
 } /* }}} int ascent_xml_read_int */
 
 static int ascent_xml_sessions_plr(xmlDoc *doc, xmlNode *node, /* {{{ */
@@ -317,7 +317,7 @@ static int ascent_xml_sessions_plr(xmlDoc *doc, xmlNode *node, /* {{{ */
     }
   } /* for (child) */
 
-  return (0);
+  return 0;
 } /* }}} int ascent_xml_sessions_plr */
 
 static int ascent_xml_sessions(xmlDoc *doc, xmlNode *node) /* {{{ */
@@ -343,7 +343,7 @@ static int ascent_xml_sessions(xmlDoc *doc, xmlNode *node) /* {{{ */
 
   ascent_submit_players(&ps);
 
-  return (0);
+  return 0;
 } /* }}} int ascent_xml_sessions */
 
 static int ascent_xml_status(xmlDoc *doc, xmlNode *node) /* {{{ */
@@ -380,7 +380,7 @@ static int ascent_xml_status(xmlDoc *doc, xmlNode *node) /* {{{ */
     }
   } /* for (child) */
 
-  return (0);
+  return 0;
 } /* }}} int ascent_xml_status */
 
 static int ascent_xml(const char *data) /* {{{ */
@@ -398,20 +398,20 @@ static int ascent_xml(const char *data) /* {{{ */
 #endif
   if (doc == NULL) {
     ERROR("ascent plugin: xmlParseMemory failed.");
-    return (-1);
+    return -1;
   }
 
   cur = xmlDocGetRootElement(doc);
   if (cur == NULL) {
     ERROR("ascent plugin: XML document is empty.");
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   }
 
   if (xmlStrcmp((const xmlChar *)"serverpage", cur->name) != 0) {
     ERROR("ascent plugin: XML root element is not \"serverpage\".");
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   }
 
   for (xmlNode *child = cur->xmlChildrenNode; child != NULL;
@@ -433,7 +433,7 @@ static int ascent_xml(const char *data) /* {{{ */
   } /* for (child) */
 
   xmlFreeDoc(doc);
-  return (0);
+  return 0;
 } /* }}} int ascent_xml */
 
 static int config_set(char **var, const char *value) /* {{{ */
@@ -444,29 +444,29 @@ static int config_set(char **var, const char *value) /* {{{ */
   }
 
   if ((*var = strdup(value)) == NULL)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* }}} int config_set */
 
 static int ascent_config(const char *key, const char *value) /* {{{ */
 {
   if (strcasecmp(key, "URL") == 0)
-    return (config_set(&url, value));
+    return config_set(&url, value);
   else if (strcasecmp(key, "User") == 0)
-    return (config_set(&user, value));
+    return config_set(&user, value);
   else if (strcasecmp(key, "Password") == 0)
-    return (config_set(&pass, value));
+    return config_set(&pass, value);
   else if (strcasecmp(key, "VerifyPeer") == 0)
-    return (config_set(&verify_peer, value));
+    return config_set(&verify_peer, value);
   else if (strcasecmp(key, "VerifyHost") == 0)
-    return (config_set(&verify_host, value));
+    return config_set(&verify_host, value);
   else if (strcasecmp(key, "CACert") == 0)
-    return (config_set(&cacert, value));
+    return config_set(&cacert, value);
   else if (strcasecmp(key, "Timeout") == 0)
-    return (config_set(&timeout, value));
+    return config_set(&timeout, value);
   else
-    return (-1);
+    return -1;
 } /* }}} int ascent_config */
 
 static int ascent_init(void) /* {{{ */
@@ -474,7 +474,7 @@ static int ascent_init(void) /* {{{ */
   if (url == NULL) {
     WARNING("ascent plugin: ascent_init: No URL configured, "
             "returning an error.");
-    return (-1);
+    return -1;
   }
 
   if (curl != NULL) {
@@ -483,7 +483,7 @@ static int ascent_init(void) /* {{{ */
 
   if ((curl = curl_easy_init()) == NULL) {
     ERROR("ascent plugin: ascent_init: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
@@ -504,7 +504,7 @@ static int ascent_init(void) /* {{{ */
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "
             "credentials have been truncated.");
-      return (-1);
+      return -1;
     }
 
     curl_easy_setopt(curl, CURLOPT_USERPWD, credentials);
@@ -536,7 +536,7 @@ static int ascent_init(void) /* {{{ */
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int ascent_init */
 
 static int ascent_read(void) /* {{{ */
@@ -545,25 +545,25 @@ static int ascent_read(void) /* {{{ */
 
   if (curl == NULL) {
     ERROR("ascent plugin: I don't have a CURL object.");
-    return (-1);
+    return -1;
   }
 
   if (url == NULL) {
     ERROR("ascent plugin: No URL has been configured.");
-    return (-1);
+    return -1;
   }
 
   ascent_buffer_fill = 0;
   if (curl_easy_perform(curl) != CURLE_OK) {
     ERROR("ascent plugin: curl_easy_perform failed: %s", ascent_curl_error);
-    return (-1);
+    return -1;
   }
 
   status = ascent_xml(ascent_buffer);
   if (status != 0)
-    return (-1);
+    return -1;
   else
-    return (0);
+    return 0;
 } /* }}} int ascent_read */
 
 void module_register(void) {

--- a/src/battery.c
+++ b/src/battery.c
@@ -147,13 +147,13 @@ static double dict_get_double(CFDictionaryRef dict,
                                       kCFStringEncodingASCII);
   if (key_obj == NULL) {
     DEBUG("CFStringCreateWithCString (%s) failed.\n", key_string);
-    return (NAN);
+    return NAN;
   }
 
   if ((val_obj = CFDictionaryGetValue(dict, key_obj)) == NULL) {
     DEBUG("CFDictionaryGetValue (%s) failed.", key_string);
     CFRelease(key_obj);
-    return (NAN);
+    return NAN;
   }
   CFRelease(key_obj);
 
@@ -166,10 +166,10 @@ static double dict_get_double(CFDictionaryRef dict,
     }
   } else {
     DEBUG("CFGetTypeID (val_obj) = %i", (int)CFGetTypeID(val_obj));
-    return (NAN);
+    return NAN;
   }
 
-  return (val_double);
+  return val_double;
 } /* }}} double dict_get_double */
 
 #if HAVE_IOKIT_PS_IOPOWERSOURCES_H
@@ -334,7 +334,7 @@ static int battery_read(void) /* {{{ */
   if (!isnan(voltage))
     battery_submit("0", "voltage", voltage);
 
-  return (0);
+  return 0;
 } /* }}} int battery_read */
 /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
@@ -371,9 +371,9 @@ static int sysfs_file_to_gauge(char const *dir, /* {{{ */
   status =
       sysfs_file_to_buffer(dir, power_supply, basename, buffer, sizeof(buffer));
   if (status != 0)
-    return (status);
+    return status;
 
-  return (strtogauge(buffer, ret_value));
+  return strtogauge(buffer, ret_value);
 } /* }}} sysfs_file_to_gauge */
 
 static int read_sysfs_capacity(char const *dir, /* {{{ */
@@ -387,21 +387,21 @@ static int read_sysfs_capacity(char const *dir, /* {{{ */
   status =
       sysfs_file_to_gauge(dir, power_supply, "energy_now", &capacity_charged);
   if (status != 0)
-    return (status);
+    return status;
 
   status =
       sysfs_file_to_gauge(dir, power_supply, "energy_full", &capacity_full);
   if (status != 0)
-    return (status);
+    return status;
 
   status = sysfs_file_to_gauge(dir, power_supply, "energy_full_design",
                                &capacity_design);
   if (status != 0)
-    return (status);
+    return status;
 
   submit_capacity(plugin_instance, capacity_charged * SYSFS_FACTOR,
                   capacity_full * SYSFS_FACTOR, capacity_design * SYSFS_FACTOR);
-  return (0);
+  return 0;
 } /* }}} int read_sysfs_capacity */
 
 static int read_sysfs_callback(char const *dir, /* {{{ */
@@ -418,9 +418,9 @@ static int read_sysfs_callback(char const *dir, /* {{{ */
   status =
       sysfs_file_to_buffer(dir, power_supply, "type", buffer, sizeof(buffer));
   if (status != 0)
-    return (0);
+    return 0;
   if (strcasecmp("Battery", buffer) != 0)
-    return (0);
+    return 0;
 
   (void)sysfs_file_to_buffer(dir, power_supply, "status", buffer,
                              sizeof(buffer));
@@ -451,7 +451,7 @@ static int read_sysfs_callback(char const *dir, /* {{{ */
   if (sysfs_file_to_gauge(dir, power_supply, "voltage_now", &v) == 0)
     battery_submit(plugin_instance, "voltage", v * SYSFS_FACTOR);
 
-  return (0);
+  return 0;
 } /* }}} int read_sysfs_callback */
 
 static int read_sysfs(void) /* {{{ */
@@ -460,12 +460,12 @@ static int read_sysfs(void) /* {{{ */
   int battery_counter = 0;
 
   if (access(SYSFS_PATH, R_OK) != 0)
-    return (ENOENT);
+    return ENOENT;
 
   status = walk_directory(SYSFS_PATH, read_sysfs_callback,
                           /* user_data = */ &battery_counter,
                           /* include hidden */ 0);
-  return (status);
+  return status;
 } /* }}} int read_sysfs */
 
 static int read_acpi_full_capacity(char const *dir, /* {{{ */
@@ -482,7 +482,7 @@ static int read_acpi_full_capacity(char const *dir, /* {{{ */
   ssnprintf(filename, sizeof(filename), "%s/%s/info", dir, power_supply);
   fh = fopen(filename, "r");
   if (fh == NULL)
-    return (errno);
+    return errno;
 
   /* last full capacity:      40090 mWh */
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -511,7 +511,7 @@ static int read_acpi_full_capacity(char const *dir, /* {{{ */
   }
 
   fclose(fh);
-  return (0);
+  return 0;
 } /* }}} int read_acpi_full_capacity */
 
 static int read_acpi_callback(char const *dir, /* {{{ */
@@ -536,9 +536,9 @@ static int read_acpi_callback(char const *dir, /* {{{ */
   fh = fopen(filename, "r");
   if (fh == NULL) {
     if ((errno == EAGAIN) || (errno == EINTR) || (errno == ENOENT))
-      return (0);
+      return 0;
     else
-      return (errno);
+      return errno;
   }
 
   /*
@@ -617,12 +617,12 @@ static int read_acpi(void) /* {{{ */
   int battery_counter = 0;
 
   if (access(PROC_ACPI_PATH, R_OK) != 0)
-    return (ENOENT);
+    return ENOENT;
 
   status = walk_directory(PROC_ACPI_PATH, read_acpi_callback,
                           /* user_data = */ &battery_counter,
                           /* include hidden */ 0);
-  return (status);
+  return status;
 } /* }}} int read_acpi */
 
 static int read_pmu(void) /* {{{ */
@@ -654,7 +654,7 @@ static int read_pmu(void) /* {{{ */
       else if ((errno == EAGAIN) || (errno == EINTR))
         continue;
       else
-        return (errno);
+        return errno;
     }
 
     while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -682,8 +682,8 @@ static int read_pmu(void) /* {{{ */
   }
 
   if (i == 0)
-    return (ENOENT);
-  return (0);
+    return ENOENT;
+  return 0;
 } /* }}} int read_pmu */
 
 static int battery_read(void) /* {{{ */
@@ -696,20 +696,20 @@ static int battery_read(void) /* {{{ */
   DEBUG("battery plugin: Trying sysfs ...");
   status = read_sysfs();
   if (status == 0)
-    return (0);
+    return 0;
 
   DEBUG("battery plugin: Trying acpi ...");
   status = read_acpi();
   if (status == 0)
-    return (0);
+    return 0;
 
   DEBUG("battery plugin: Trying pmu ...");
   status = read_pmu();
   if (status == 0)
-    return (0);
+    return 0;
 
   ERROR("battery plugin: All available input methods failed.");
-  return (-1);
+  return -1;
 } /* }}} int battery_read */
 #endif /* KERNEL_LINUX */
 
@@ -729,7 +729,7 @@ static int battery_config(oconfig_item_t *ci) {
               child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int battery_config */
 
 void module_register(void) {

--- a/src/battery_statefs.c
+++ b/src/battery_statefs.c
@@ -115,8 +115,8 @@ int battery_read_statefs(void) {
   if (success == 0) {
     ERROR("battery plugin: statefs backend: none of the statistics are "
           "available");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }

--- a/src/bind.c
+++ b/src/bind.c
@@ -271,7 +271,7 @@ static size_t bind_curl_callback(void *buf, size_t size, /* {{{ */
   size_t len = size * nmemb;
 
   if (len == 0)
-    return (len);
+    return len;
 
   if ((bind_buffer_fill + len) >= bind_buffer_size) {
     char *temp;
@@ -279,7 +279,7 @@ static size_t bind_curl_callback(void *buf, size_t size, /* {{{ */
     temp = realloc(bind_buffer, bind_buffer_fill + len + 1);
     if (temp == NULL) {
       ERROR("bind plugin: realloc failed.");
-      return (0);
+      return 0;
     }
     bind_buffer = temp;
     bind_buffer_size = bind_buffer_fill + len + 1;
@@ -289,7 +289,7 @@ static size_t bind_curl_callback(void *buf, size_t size, /* {{{ */
   bind_buffer_fill += len;
   bind_buffer[bind_buffer_fill] = 0;
 
-  return (len);
+  return len;
 } /* }}} size_t bind_curl_callback */
 
 /*
@@ -301,7 +301,7 @@ static int bind_xml_table_callback(const char *name, value_t value, /* {{{ */
   translation_table_ptr_t *table = (translation_table_ptr_t *)user_data;
 
   if (table == NULL)
-    return (-1);
+    return -1;
 
   for (size_t i = 0; i < table->table_length; i++) {
     if (strcmp(table->table[i].xml_name, name) != 0)
@@ -312,7 +312,7 @@ static int bind_xml_table_callback(const char *name, value_t value, /* {{{ */
     break;
   }
 
-  return (0);
+  return 0;
 } /* }}} int bind_xml_table_callback */
 
 /*
@@ -325,12 +325,12 @@ static int bind_xml_list_callback(const char *name, /* {{{ */
   list_info_ptr_t *list_info = (list_info_ptr_t *)user_data;
 
   if (list_info == NULL)
-    return (-1);
+    return -1;
 
   submit(current_time, list_info->plugin_instance, list_info->type,
          /* type instance = */ name, value);
 
-  return (0);
+  return 0;
 } /* }}} int bind_xml_list_callback */
 
 static int bind_xml_read_derive(xmlDoc *doc, xmlNode *node, /* {{{ */
@@ -342,7 +342,7 @@ static int bind_xml_read_derive(xmlDoc *doc, xmlNode *node, /* {{{ */
   str_ptr = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
   if (str_ptr == NULL) {
     ERROR("bind plugin: bind_xml_read_derive: xmlNodeListGetString failed.");
-    return (-1);
+    return -1;
   }
 
   status = parse_value(str_ptr, &value, DS_TYPE_DERIVE);
@@ -350,12 +350,12 @@ static int bind_xml_read_derive(xmlDoc *doc, xmlNode *node, /* {{{ */
     ERROR("bind plugin: Parsing string \"%s\" to derive value failed.",
           str_ptr);
     xmlFree(str_ptr);
-    return (-1);
+    return -1;
   }
 
   xmlFree(str_ptr);
   *ret_value = value.derive;
-  return (0);
+  return 0;
 } /* }}} int bind_xml_read_derive */
 
 static int bind_xml_read_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
@@ -366,7 +366,7 @@ static int bind_xml_read_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
   str_ptr = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
   if (str_ptr == NULL) {
     ERROR("bind plugin: bind_xml_read_gauge: xmlNodeListGetString failed.");
-    return (-1);
+    return -1;
   }
 
   errno = 0;
@@ -379,11 +379,11 @@ static int bind_xml_read_gauge(xmlDoc *doc, xmlNode *node, /* {{{ */
       ERROR("bind plugin: bind_xml_read_gauge: strtod failed with overflow.");
     else
       ERROR("bind plugin: bind_xml_read_gauge: strtod failed.");
-    return (-1);
+    return -1;
   }
 
   *ret_value = (gauge_t)value;
-  return (0);
+  return 0;
 } /* }}} int bind_xml_read_gauge */
 
 static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
@@ -399,12 +399,12 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
   if (xpathObj == NULL) {
     ERROR("bind plugin: Unable to evaluate XPath expression `%s'.",
           xpath_expression);
-    return (-1);
+    return -1;
   }
 
   if ((xpathObj->nodesetval == NULL) || (xpathObj->nodesetval->nodeNr < 1)) {
     xmlXPathFreeObject(xpathObj);
-    return (-1);
+    return -1;
   }
 
   if (xpathObj->nodesetval->nodeNr != 1) {
@@ -419,14 +419,14 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
     ERROR("bind plugin: bind_xml_read_timestamp: "
           "node->xmlChildrenNode == NULL");
     xmlXPathFreeObject(xpathObj);
-    return (-1);
+    return -1;
   }
 
   str_ptr = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
   if (str_ptr == NULL) {
     ERROR("bind plugin: bind_xml_read_timestamp: xmlNodeListGetString failed.");
     xmlXPathFreeObject(xpathObj);
-    return (-1);
+    return -1;
   }
 
   tmp = strptime(str_ptr, "%Y-%m-%dT%T", &tm);
@@ -434,7 +434,7 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
   if (tmp == NULL) {
     ERROR("bind plugin: bind_xml_read_timestamp: strptime failed.");
     xmlXPathFreeObject(xpathObj);
-    return (-1);
+    return -1;
   }
 
 #if HAVE_TIMEGM
@@ -443,7 +443,7 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
     char errbuf[1024];
     ERROR("bind plugin: timegm() failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   *ret_value = t;
 #else
@@ -452,7 +452,7 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
     char errbuf[1024];
     ERROR("bind plugin: mktime() failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   /* mktime assumes that tm is local time. Luckily, it also sets timezone to
    * the offset used for the conversion, and we undo the conversion to convert
@@ -461,7 +461,7 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
 #endif
 
   xmlXPathFreeObject(xpathObj);
-  return (0);
+  return 0;
 } /* }}} int bind_xml_read_timestamp */
 
 /*
@@ -485,7 +485,7 @@ static int bind_parse_generic_name_value(const char *xpath_expression, /* {{{ */
   if (xpathObj == NULL) {
     ERROR("bind plugin: Unable to evaluate XPath expression `%s'.",
           xpath_expression);
-    return (-1);
+    return -1;
   }
 
   num_entries = 0;
@@ -538,7 +538,7 @@ static int bind_parse_generic_name_value(const char *xpath_expression, /* {{{ */
 
   xmlXPathFreeObject(xpathObj);
 
-  return (0);
+  return 0;
 } /* }}} int bind_parse_generic_name_value */
 
 /*
@@ -564,7 +564,7 @@ static int bind_parse_generic_value_list(const char *xpath_expression, /* {{{ */
   if (xpathObj == NULL) {
     ERROR("bind plugin: Unable to evaluate XPath expression `%s'.",
           xpath_expression);
-    return (-1);
+    return -1;
   }
 
   num_entries = 0;
@@ -601,7 +601,7 @@ static int bind_parse_generic_value_list(const char *xpath_expression, /* {{{ */
 
   xmlXPathFreeObject(xpathObj);
 
-  return (0);
+  return 0;
 } /* }}} int bind_parse_generic_value_list */
 
 /*
@@ -626,7 +626,7 @@ static int bind_parse_generic_name_attr_value_list(
   if (xpathObj == NULL) {
     ERROR("bind plugin: Unable to evaluate XPath expression `%s'.",
           xpath_expression);
-    return (-1);
+    return -1;
   }
 
   num_entries = 0;
@@ -669,7 +669,7 @@ static int bind_parse_generic_name_attr_value_list(
 
   xmlXPathFreeObject(xpathObj);
 
-  return (0);
+  return 0;
 } /* }}} int bind_parse_generic_name_attr_value_list */
 
 static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
@@ -692,7 +692,7 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
     path_obj = xmlXPathEvalExpression(BAD_CAST "name", path_ctx);
     if (path_obj == NULL) {
       ERROR("bind plugin: xmlXPathEvalExpression failed.");
-      return (-1);
+      return -1;
     }
 
     for (int i = 0; path_obj->nodesetval && (i < path_obj->nodesetval->nodeNr);
@@ -707,7 +707,7 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
 
   if (zone_name == NULL) {
     ERROR("bind plugin: Could not determine zone name.");
-    return (-1);
+    return -1;
   }
 
   for (j = 0; j < view->zones_num; j++) {
@@ -719,7 +719,7 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
   zone_name = NULL;
 
   if (j >= view->zones_num)
-    return (0);
+    return 0;
 
   zone_name = view->zones[j];
 
@@ -755,7 +755,7 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
     }
   } /* }}} */
 
-  return (0);
+  return 0;
 } /* }}} int bind_xml_stats_handle_zone */
 
 static int bind_xml_stats_search_zones(int version, xmlDoc *doc, /* {{{ */
@@ -767,14 +767,14 @@ static int bind_xml_stats_search_zones(int version, xmlDoc *doc, /* {{{ */
   zone_path_context = xmlXPathNewContext(doc);
   if (zone_path_context == NULL) {
     ERROR("bind plugin: xmlXPathNewContext failed.");
-    return (-1);
+    return -1;
   }
 
   zone_nodes = xmlXPathEvalExpression(BAD_CAST "zones/zone", path_ctx);
   if (zone_nodes == NULL) {
     ERROR("bind plugin: Cannot find any <view> tags.");
     xmlXPathFreeContext(zone_path_context);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < zone_nodes->nodesetval->nodeNr; i++) {
@@ -789,7 +789,7 @@ static int bind_xml_stats_search_zones(int version, xmlDoc *doc, /* {{{ */
 
   xmlXPathFreeObject(zone_nodes);
   xmlXPathFreeContext(zone_path_context);
-  return (0);
+  return 0;
 } /* }}} int bind_xml_stats_search_zones */
 
 static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
@@ -804,7 +804,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
 
     if (view_name == NULL) {
       ERROR("bind plugin: Could not determine view name.");
-      return (-1);
+      return -1;
     }
 
     for (j = 0; j < views_num; j++) {
@@ -819,7 +819,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     path_obj = xmlXPathEvalExpression(BAD_CAST "name", path_ctx);
     if (path_obj == NULL) {
       ERROR("bind plugin: xmlXPathEvalExpression failed.");
-      return (-1);
+      return -1;
     }
 
     for (int i = 0; path_obj->nodesetval && (i < path_obj->nodesetval->nodeNr);
@@ -833,7 +833,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     if (view_name == NULL) {
       ERROR("bind plugin: Could not determine view name.");
       xmlXPathFreeObject(path_obj);
-      return (-1);
+      return -1;
     }
 
     for (j = 0; j < views_num; j++) {
@@ -849,7 +849,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
   }
 
   if (j >= views_num)
-    return (0);
+    return 0;
 
   view = views + j;
 
@@ -921,7 +921,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     bind_xml_stats_search_zones(version, doc, path_ctx, node, view,
                                 current_time);
 
-  return (0);
+  return 0;
 } /* }}} int bind_xml_stats_handle_view */
 
 static int bind_xml_stats_search_views(int version, xmlDoc *doc, /* {{{ */
@@ -934,14 +934,14 @@ static int bind_xml_stats_search_views(int version, xmlDoc *doc, /* {{{ */
   view_path_context = xmlXPathNewContext(doc);
   if (view_path_context == NULL) {
     ERROR("bind plugin: xmlXPathNewContext failed.");
-    return (-1);
+    return -1;
   }
 
   view_nodes = xmlXPathEvalExpression(BAD_CAST "views/view", xpathCtx);
   if (view_nodes == NULL) {
     ERROR("bind plugin: Cannot find any <view> tags.");
     xmlXPathFreeContext(view_path_context);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < view_nodes->nodesetval->nodeNr; i++) {
@@ -958,7 +958,7 @@ static int bind_xml_stats_search_views(int version, xmlDoc *doc, /* {{{ */
 
   xmlXPathFreeObject(view_nodes);
   xmlXPathFreeContext(view_path_context);
-  return (0);
+  return 0;
 } /* }}} int bind_xml_stats_search_views */
 
 static void bind_xml_stats_v3(xmlDoc *doc, /* {{{ */
@@ -1261,7 +1261,7 @@ static int bind_xml_stats(int version, xmlDoc *doc, /* {{{ */
                                    &current_time);
   if (status != 0) {
     ERROR("bind plugin: Reading `server/current-time' failed.");
-    return (-1);
+    return -1;
   }
   DEBUG("bind plugin: Current server time is %i.", (int)current_time);
 
@@ -1310,14 +1310,14 @@ static int bind_xml(const char *data) /* {{{ */
   doc = xmlParseMemory(data, strlen(data));
   if (doc == NULL) {
     ERROR("bind plugin: xmlParseMemory failed.");
-    return (-1);
+    return -1;
   }
 
   xpathCtx = xmlXPathNewContext(doc);
   if (xpathCtx == NULL) {
     ERROR("bind plugin: xmlXPathNewContext failed.");
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   }
 
   //
@@ -1369,7 +1369,7 @@ static int bind_xml(const char *data) /* {{{ */
     xmlXPathFreeContext(xpathCtx);
     xmlFreeDoc(doc);
 
-    return (ret);
+    return ret;
   }
 
   //
@@ -1381,13 +1381,13 @@ static int bind_xml(const char *data) /* {{{ */
     ERROR("bind plugin: Cannot find the <statistics> tag.");
     xmlXPathFreeContext(xpathCtx);
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   } else if (xpathObj->nodesetval == NULL) {
     ERROR("bind plugin: xmlXPathEvalExpression failed.");
     xmlXPathFreeObject(xpathObj);
     xmlXPathFreeContext(xpathCtx);
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < xpathObj->nodesetval->nodeNr; i++) {
@@ -1435,7 +1435,7 @@ static int bind_xml(const char *data) /* {{{ */
   xmlXPathFreeContext(xpathCtx);
   xmlFreeDoc(doc);
 
-  return (ret);
+  return ret;
 } /* }}} int bind_xml */
 
 static int bind_config_set_bool(const char *name, int *var, /* {{{ */
@@ -1444,7 +1444,7 @@ static int bind_config_set_bool(const char *name, int *var, /* {{{ */
     WARNING("bind plugin: The `%s' option needs "
             "exactly one boolean argument.",
             name);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.boolean)
@@ -1461,24 +1461,24 @@ static int bind_config_add_view_zone(cb_view_t *view, /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("bind plugin: The `Zone' option needs "
             "exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   tmp = realloc(view->zones, sizeof(char *) * (view->zones_num + 1));
   if (tmp == NULL) {
     ERROR("bind plugin: realloc failed.");
-    return (-1);
+    return -1;
   }
   view->zones = tmp;
 
   view->zones[view->zones_num] = strdup(ci->values[0].value.string);
   if (view->zones[view->zones_num] == NULL) {
     ERROR("bind plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
   view->zones_num++;
 
-  return (0);
+  return 0;
 } /* }}} int bind_config_add_view_zone */
 
 static int bind_config_add_view(oconfig_item_t *ci) /* {{{ */
@@ -1487,13 +1487,13 @@ static int bind_config_add_view(oconfig_item_t *ci) /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("bind plugin: `View' blocks need exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   tmp = realloc(views, sizeof(*views) * (views_num + 1));
   if (tmp == NULL) {
     ERROR("bind plugin: realloc failed.");
-    return (-1);
+    return -1;
   }
   views = tmp;
   tmp = views + views_num;
@@ -1509,7 +1509,7 @@ static int bind_config_add_view(oconfig_item_t *ci) /* {{{ */
   if (tmp->name == NULL) {
     ERROR("bind plugin: strdup failed.");
     sfree(views);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -1531,7 +1531,7 @@ static int bind_config_add_view(oconfig_item_t *ci) /* {{{ */
   } /* for (i = 0; i < ci->children_num; i++) */
 
   views_num++;
-  return (0);
+  return 0;
 } /* }}} int bind_config_add_view */
 
 static int bind_config(oconfig_item_t *ci) /* {{{ */
@@ -1544,7 +1544,7 @@ static int bind_config(oconfig_item_t *ci) /* {{{ */
           (child->values[0].type != OCONFIG_TYPE_STRING)) {
         WARNING("bind plugin: The `Url' option needs "
                 "exactly one string argument.");
-        return (-1);
+        return -1;
       }
 
       sfree(url);
@@ -1574,18 +1574,18 @@ static int bind_config(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int bind_config */
 
 static int bind_init(void) /* {{{ */
 {
   if (curl != NULL)
-    return (0);
+    return 0;
 
   curl = curl_easy_init();
   if (curl == NULL) {
     ERROR("bind plugin: bind_init: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
@@ -1601,7 +1601,7 @@ static int bind_init(void) /* {{{ */
                                                         plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int bind_init */
 
 static int bind_read(void) /* {{{ */
@@ -1610,20 +1610,20 @@ static int bind_read(void) /* {{{ */
 
   if (curl == NULL) {
     ERROR("bind plugin: I don't have a CURL object.");
-    return (-1);
+    return -1;
   }
 
   bind_buffer_fill = 0;
   if (curl_easy_perform(curl) != CURLE_OK) {
     ERROR("bind plugin: curl_easy_perform failed: %s", bind_curl_error);
-    return (-1);
+    return -1;
   }
 
   status = bind_xml(bind_buffer);
   if (status != 0)
-    return (-1);
+    return -1;
   else
-    return (0);
+    return 0;
 } /* }}} int bind_read */
 
 static int bind_shutdown(void) /* {{{ */
@@ -1633,7 +1633,7 @@ static int bind_shutdown(void) /* {{{ */
     curl = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int bind_shutdown */
 
 void module_register(void) {

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -634,7 +634,7 @@ static int cc_add_daemon_config(oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("ceph plugin: `Daemon' blocks need exactly one string "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   ret = cc_handle_str(ci, cd.name, DATA_MAX_NAME_LEN);

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -61,19 +61,19 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   FILE *fh;
 
   if (ignorelist_match(il_cgroup, cgroup_name))
-    return (0);
+    return 0;
 
   ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, cgroup_name);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {
     ERROR("cgroups plugin: stat (\"%s\") failed.", abs_path);
-    return (-1);
+    return -1;
   }
 
   /* We are only interested in directories, so skip everything else. */
   if (!S_ISDIR(statbuf.st_mode))
-    return (0);
+    return 0;
 
   ssnprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
             cgroup_name);
@@ -82,7 +82,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
     char errbuf[1024];
     ERROR("cgroups plugin: fopen (\"%s\") failed: %s", abs_path,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buf, sizeof(buf), fh) != NULL) {
@@ -124,7 +124,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   }
 
   fclose(fh);
-  return (0);
+  return 0;
 } /* int read_cpuacct_procs */
 
 /*
@@ -143,24 +143,24 @@ static int read_cpuacct_root(const char *dirname, const char *filename,
   status = lstat(abs_path, &statbuf);
   if (status != 0) {
     ERROR("cgroups plugin: stat (%s) failed.", abs_path);
-    return (-1);
+    return -1;
   }
 
   if (S_ISDIR(statbuf.st_mode)) {
     status = walk_directory(abs_path, read_cpuacct_procs,
                             /* user_data = */ NULL,
                             /* include_hidden = */ 0);
-    return (status);
+    return status;
   }
 
-  return (0);
+  return 0;
 }
 
 static int cgroups_init(void) {
   if (il_cgroup == NULL)
     il_cgroup = ignorelist_create(1);
 
-  return (0);
+  return 0;
 }
 
 static int cgroups_config(const char *key, const char *value) {
@@ -168,17 +168,17 @@ static int cgroups_config(const char *key, const char *value) {
 
   if (strcasecmp(key, "CGroup") == 0) {
     if (ignorelist_add(il_cgroup, value))
-      return (1);
-    return (0);
+      return 1;
+    return 0;
   } else if (strcasecmp(key, "IgnoreSelected") == 0) {
     if (IS_TRUE(value))
       ignorelist_set_invert(il_cgroup, 0);
     else
       ignorelist_set_invert(il_cgroup, 1);
-    return (0);
+    return 0;
   }
 
-  return (-1);
+  return -1;
 }
 
 static int cgroups_read(void) {
@@ -187,7 +187,7 @@ static int cgroups_read(void) {
 
   if (cu_mount_getlist(&mnt_list) == NULL) {
     ERROR("cgroups plugin: cu_mount_getlist failed.");
-    return (-1);
+    return -1;
   }
 
   for (cu_mount_t *mnt_ptr = mnt_list; mnt_ptr != NULL;
@@ -212,10 +212,10 @@ static int cgroups_read(void) {
   if (!cgroup_found) {
     WARNING("cgroups plugin: Unable to find cgroup "
             "mount-point with the \"cpuacct\" option.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int cgroup_read */
 
 void module_register(void) {

--- a/src/collectd-nagios.c
+++ b/src/collectd-nagios.c
@@ -118,7 +118,7 @@ cn_strdup(const char *str) /* {{{ */
   ret = (char *)malloc(strsize);
   if (ret != NULL)
     memcpy(ret, str, strsize);
-  return (ret);
+  return ret;
 } /* }}} char *cn_strdup */
 
 static int filter_ds(size_t *values_num, double **values,
@@ -127,19 +127,19 @@ static int filter_ds(size_t *values_num, double **values,
   char **new_names;
 
   if (match_ds_g == NULL)
-    return (RET_OKAY);
+    return RET_OKAY;
 
   new_values = (gauge_t *)calloc(match_ds_num_g, sizeof(*new_values));
   if (new_values == NULL) {
     fprintf(stderr, "calloc failed: %s\n", strerror(errno));
-    return (RET_UNKNOWN);
+    return RET_UNKNOWN;
   }
 
   new_names = (char **)calloc(match_ds_num_g, sizeof(*new_names));
   if (new_names == NULL) {
     fprintf(stderr, "calloc failed: %s\n", strerror(errno));
     free(new_values);
-    return (RET_UNKNOWN);
+    return RET_UNKNOWN;
   }
 
   for (size_t i = 0; i < match_ds_num_g; i++) {
@@ -153,7 +153,7 @@ static int filter_ds(size_t *values_num, double **values,
       for (j = 0; j < i; j++)
         free(new_names[j]);
       free(new_names);
-      return (RET_UNKNOWN);
+      return RET_UNKNOWN;
     }
 
     for (j = 0; j < *values_num; j++)
@@ -166,7 +166,7 @@ static int filter_ds(size_t *values_num, double **values,
       for (j = 0; j <= i; j++)
         free(new_names[j]);
       free(new_names);
-      return (RET_CRITICAL);
+      return RET_CRITICAL;
     }
 
     new_values[i] = (*values)[j];
@@ -180,7 +180,7 @@ static int filter_ds(size_t *values_num, double **values,
   *values = new_values;
   *values_names = new_names;
   *values_num = match_ds_num_g;
-  return (RET_OKAY);
+  return RET_OKAY;
 } /* int filter_ds */
 
 static void parse_range(char *string, range_t *range) {
@@ -227,7 +227,7 @@ static int match_range(range_t *range, double value) {
   if (!isnan(range->max) && (range->max < value))
     ret = 1;
 
-  return (((ret - range->invert) == 0) ? 0 : 1);
+  return ((ret - range->invert) == 0) ? 0 : 1;
 } /* int match_range */
 
 __attribute__((noreturn)) static void usage(const char *name) {
@@ -279,7 +279,7 @@ static int do_listval(lcc_connection_t *connection) {
     printf("UNKNOWN: %s\n", lcc_strerror(connection));
     if (ret_ident != NULL)
       free(ret_ident);
-    return (RET_UNKNOWN);
+    return RET_UNKNOWN;
   }
 
   status = lcc_sort_identifiers(connection, ret_ident, ret_ident_num);
@@ -287,7 +287,7 @@ static int do_listval(lcc_connection_t *connection) {
     printf("UNKNOWN: %s\n", lcc_strerror(connection));
     if (ret_ident != NULL)
       free(ret_ident);
-    return (RET_UNKNOWN);
+    return RET_UNKNOWN;
   }
 
   for (size_t i = 0; i < ret_ident_num; ++i) {
@@ -322,7 +322,7 @@ static int do_listval(lcc_connection_t *connection) {
 
   free(ret_ident);
   free(hostname);
-  return (RET_OKAY);
+  return RET_OKAY;
 } /* int do_listval */
 
 static int do_check_con_none(size_t values_num, double *values,
@@ -349,7 +349,7 @@ static int do_check_con_none(size_t values_num, double *values,
 
   if ((num_critical == 0) && (num_warning == 0) && (num_okay == 0)) {
     printf("WARNING: No defined values found\n");
-    return (RET_WARNING);
+    return RET_WARNING;
   } else if ((num_critical == 0) && (num_warning == 0)) {
     status_str = "OKAY";
     status_code = RET_OKAY;
@@ -370,7 +370,7 @@ static int do_check_con_none(size_t values_num, double *values,
   }
   printf("\n");
 
-  return (status_code);
+  return status_code;
 } /* int do_check_con_none */
 
 static int do_check_con_average(size_t values_num, double *values,
@@ -389,7 +389,7 @@ static int do_check_con_average(size_t values_num, double *values,
         continue;
 
       printf("CRITICAL: Data source \"%s\" is NaN\n", values_names[i]);
-      return (RET_CRITICAL);
+      return RET_CRITICAL;
     }
 
     total += values[i];
@@ -398,7 +398,7 @@ static int do_check_con_average(size_t values_num, double *values,
 
   if (total_num == 0) {
     printf("WARNING: No defined values found\n");
-    return (RET_WARNING);
+    return RET_WARNING;
   }
 
   average = total / total_num;
@@ -419,7 +419,7 @@ static int do_check_con_average(size_t values_num, double *values,
     printf(" %s=%f;;;;", values_names[i], values[i]);
   printf("\n");
 
-  return (status_code);
+  return status_code;
 } /* int do_check_con_average */
 
 static int do_check_con_sum(size_t values_num, double *values,
@@ -437,7 +437,7 @@ static int do_check_con_sum(size_t values_num, double *values,
         continue;
 
       printf("CRITICAL: Data source \"%s\" is NaN\n", values_names[i]);
-      return (RET_CRITICAL);
+      return RET_CRITICAL;
     }
 
     total += values[i];
@@ -446,7 +446,7 @@ static int do_check_con_sum(size_t values_num, double *values,
 
   if (total_num == 0) {
     printf("WARNING: No defined values found\n");
-    return (RET_WARNING);
+    return RET_WARNING;
   }
 
   if (match_range(&range_critical_g, total) != 0) {
@@ -465,7 +465,7 @@ static int do_check_con_sum(size_t values_num, double *values,
     printf(" %s=%f;;;;", values_names[i], values[i]);
   printf("\n");
 
-  return (status_code);
+  return status_code;
 } /* int do_check_con_sum */
 
 static int do_check_con_percentage(size_t values_num, double *values,
@@ -478,7 +478,7 @@ static int do_check_con_percentage(size_t values_num, double *values,
 
   if ((values_num < 1) || (isnan(values[0]))) {
     printf("WARNING: The first value is not defined\n");
-    return (RET_WARNING);
+    return RET_WARNING;
   }
 
   for (size_t i = 0; i < values_num; i++) {
@@ -487,7 +487,7 @@ static int do_check_con_percentage(size_t values_num, double *values,
         continue;
 
       printf("CRITICAL: Data source \"%s\" is NaN\n", values_names[i]);
-      return (RET_CRITICAL);
+      return RET_CRITICAL;
     }
 
     sum += values[i];
@@ -495,7 +495,7 @@ static int do_check_con_percentage(size_t values_num, double *values,
 
   if (sum == 0.0) {
     printf("WARNING: Values sum up to zero\n");
-    return (RET_WARNING);
+    return RET_WARNING;
   }
 
   percentage = 100.0 * values[0] / sum;
@@ -514,7 +514,7 @@ static int do_check_con_percentage(size_t values_num, double *values,
   printf("%s: %lf percent |", status_str, percentage);
   for (size_t i = 0; i < values_num; i++)
     printf(" %s=%lf;;;;", values_names[i], values[i]);
-  return (status_code);
+  return status_code;
 } /* int do_check_con_percentage */
 
 static int do_check(lcc_connection_t *connection) {
@@ -533,7 +533,7 @@ static int do_check(lcc_connection_t *connection) {
     printf("ERROR: Creating an identifier failed: %s.\n",
            lcc_strerror(connection));
     LCC_DESTROY(connection);
-    return (RET_CRITICAL);
+    return RET_CRITICAL;
   }
 
   status = lcc_getval(connection, &ident, &values_num, &values, &values_names);
@@ -541,14 +541,14 @@ static int do_check(lcc_connection_t *connection) {
     printf("ERROR: Retrieving values from the daemon failed: %s.\n",
            lcc_strerror(connection));
     LCC_DESTROY(connection);
-    return (RET_CRITICAL);
+    return RET_CRITICAL;
   }
 
   LCC_DESTROY(connection);
 
   status = filter_ds(&values_num, &values, &values_names);
   if (status != RET_OKAY)
-    return (status);
+    return status;
 
   status = RET_UNKNOWN;
   if (consolitation_g == CON_NONE)
@@ -566,7 +566,7 @@ static int do_check(lcc_connection_t *connection) {
       free(values_names[i]);
   free(values_names);
 
-  return (status);
+  return status;
 } /* int do_check */
 
 int main(int argc, char **argv) {
@@ -625,13 +625,13 @@ int main(int argc, char **argv) {
       tmp = realloc(match_ds_g, (match_ds_num_g + 1) * sizeof(char *));
       if (tmp == NULL) {
         fprintf(stderr, "realloc failed: %s\n", strerror(errno));
-        return (RET_UNKNOWN);
+        return RET_UNKNOWN;
       }
       match_ds_g = tmp;
       match_ds_g[match_ds_num_g] = cn_strdup(optarg);
       if (match_ds_g[match_ds_num_g] == NULL) {
         fprintf(stderr, "cn_strdup failed: %s\n", strerror(errno));
-        return (RET_UNKNOWN);
+        return RET_UNKNOWN;
       }
       match_ds_num_g++;
       break;
@@ -657,11 +657,11 @@ int main(int argc, char **argv) {
   status = lcc_connect(address, &connection);
   if (status != 0) {
     printf("ERROR: Connecting to daemon at %s failed.\n", socket_file_g);
-    return (RET_CRITICAL);
+    return RET_CRITICAL;
   }
 
   if (0 == strcasecmp(value_string_g, "LIST"))
-    return (do_listval(connection));
+    return do_listval(connection);
 
-  return (do_check(connection));
+  return do_check(connection);
 } /* int main */

--- a/src/collectd-tg.c
+++ b/src/collectd-tg.c
@@ -107,7 +107,7 @@ static double dtime(void) /* {{{ */
   if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
     perror("clock_gettime");
 
-  return ((double)ts.tv_sec) + (((double)ts.tv_nsec) / 1e9);
+  return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
 } /* }}} double dtime */
 #else
 /* Work around for Mac OS X which doesn't have clock_gettime(2). *sigh* */
@@ -118,7 +118,7 @@ static double dtime(void) /* {{{ */
   if (gettimeofday(&tv, /* timezone = */ NULL) != 0)
     perror("gettimeofday");
 
-  return ((double)tv.tv_sec) + (((double)tv.tv_usec) / 1e6);
+  return (double)tv.tv_sec + ((double)tv.tv_usec) / 1e6;
 } /* }}} double dtime */
 #endif
 
@@ -128,11 +128,11 @@ static int compare_time(const void *v0, const void *v1) /* {{{ */
   const lcc_value_list_t *vl1 = v1;
 
   if (vl0->time < vl1->time)
-    return (-1);
+    return -1;
   else if (vl0->time > vl1->time)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* }}} int compare_time */
 
 static int get_boundet_random(int min, int max) /* {{{ */
@@ -140,14 +140,13 @@ static int get_boundet_random(int min, int max) /* {{{ */
   int range;
 
   if (min >= max)
-    return (-1);
+    return -1;
   if (min == (max - 1))
-    return (min);
+    return min;
 
   range = max - min;
 
-  return (min + ((int)(((double)range) * ((double)random()) /
-                       (((double)RAND_MAX) + 1.0))));
+  return min + ((int)(((double)range) * ((double)random()) / (((double)RAND_MAX) + 1.0)));
 } /* }}} int get_boundet_random */
 
 static lcc_value_list_t *create_value_list(void) /* {{{ */
@@ -158,14 +157,14 @@ static lcc_value_list_t *create_value_list(void) /* {{{ */
   vl = calloc(1, sizeof(*vl));
   if (vl == NULL) {
     fprintf(stderr, "calloc failed.\n");
-    return (NULL);
+    return NULL;
   }
 
   vl->values = calloc(/* nmemb = */ 1, sizeof(*vl->values));
   if (vl->values == NULL) {
     fprintf(stderr, "calloc failed.\n");
     free(vl);
-    return (NULL);
+    return NULL;
   }
 
   vl->values_types = calloc(/* nmemb = */ 1, sizeof(*vl->values_types));
@@ -173,7 +172,7 @@ static lcc_value_list_t *create_value_list(void) /* {{{ */
     fprintf(stderr, "calloc failed.\n");
     free(vl->values);
     free(vl);
-    return (NULL);
+    return NULL;
   }
 
   vl->values_len = 1;
@@ -199,7 +198,7 @@ static lcc_value_list_t *create_value_list(void) /* {{{ */
   snprintf(vl->identifier.type_instance, sizeof(vl->identifier.type_instance),
            "ti%li", random());
 
-  return (vl);
+  return vl;
 } /* }}} int create_value_list */
 
 static void destroy_value_list(lcc_value_list_t *vl) /* {{{ */
@@ -228,7 +227,7 @@ static int send_value(lcc_value_list_t *vl) /* {{{ */
 
   vl->time += vl->interval;
 
-  return (0);
+  return 0;
 } /* }}} int send_value */
 
 static int get_integer_opt(const char *str, int *ret_value) /* {{{ */
@@ -252,7 +251,7 @@ static int get_integer_opt(const char *str, int *ret_value) /* {{{ */
   }
 
   *ret_value = tmp;
-  return (0);
+  return 0;
 } /* }}} int get_integer_opt */
 
 static int get_double_opt(const char *str, double *ret_value) /* {{{ */
@@ -276,7 +275,7 @@ static int get_double_opt(const char *str, double *ret_value) /* {{{ */
   }
 
   *ret_value = tmp;
-  return (0);
+  return 0;
 } /* }}} int get_double_opt */
 
 static int read_options(int argc, char **argv) /* {{{ */
@@ -317,7 +316,7 @@ static int read_options(int argc, char **argv) /* {{{ */
     } /* switch (opt) */
   }   /* while (getopt) */
 
-  return (0);
+  return 0;
 } /* }}} int read_options */
 
 int main(int argc, char **argv) /* {{{ */

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -138,12 +138,12 @@ static int array_grow(void **array, size_t *array_len, size_t elem_size) {
   tmp = realloc(*array, (*array_len + 1) * elem_size);
   if (tmp == NULL) {
     fprintf(stderr, "ERROR: Failed to allocate memory.\n");
-    return (-1);
+    return -1;
   }
 
   *array = tmp;
   ++(*array_len);
-  return (0);
+  return 0;
 } /* array_grow */
 
 static int parse_identifier(lcc_connection_t *c, const char *value,
@@ -162,7 +162,7 @@ static int parse_identifier(lcc_connection_t *c, const char *value,
     if (gethostname(hostname, sizeof(hostname)) != 0) {
       fprintf(stderr, "ERROR: Failed to get local hostname: %s",
               strerror(errno));
-      return (-1);
+      return -1;
     }
     hostname[sizeof(hostname) - 1] = '\0';
 
@@ -177,9 +177,9 @@ static int parse_identifier(lcc_connection_t *c, const char *value,
   if (status != 0) {
     fprintf(stderr, "ERROR: Failed to parse identifier ``%s'': %s.\n",
             ident_str, lcc_strerror(c));
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* parse_identifier */
 
 static int getval(lcc_connection_t *c, int argc, char **argv) {
@@ -195,12 +195,12 @@ static int getval(lcc_connection_t *c, int argc, char **argv) {
 
   if (argc != 2) {
     fprintf(stderr, "ERROR: getval: Missing identifier.\n");
-    return (-1);
+    return -1;
   }
 
   status = parse_identifier(c, argv[1], &ident);
   if (status != 0)
-    return (status);
+    return status;
 
 #define BAIL_OUT(s)                                                            \
   do {                                                                         \
@@ -212,7 +212,7 @@ static int getval(lcc_connection_t *c, int argc, char **argv) {
       free(ret_values_names);                                                  \
     }                                                                          \
     ret_values_num = 0;                                                        \
-    return (s);                                                                \
+    return s;                                                                  \
   } while (0)
 
   status =
@@ -249,7 +249,7 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
     if (plugins != NULL)                                                       \
       free(plugins);                                                           \
     plugins_num = 0;                                                           \
-    return (s);                                                                \
+    return s;                                                                  \
   } while (0)
 
   for (int i = 1; i < argc; ++i) {
@@ -347,7 +347,7 @@ static int listval(lcc_connection_t *c, int argc, char **argv) {
 
   if (argc != 1) {
     fprintf(stderr, "ERROR: listval: Does not accept any arguments.\n");
-    return (-1);
+    return -1;
   }
 
 #define BAIL_OUT(s)                                                            \
@@ -355,7 +355,7 @@ static int listval(lcc_connection_t *c, int argc, char **argv) {
     if (ret_ident != NULL)                                                     \
       free(ret_ident);                                                         \
     ret_ident_num = 0;                                                         \
-    return (s);                                                                \
+    return s;                                                                  \
   } while (0)
 
   status = lcc_listval(c, &ret_ident, &ret_ident_num);
@@ -396,7 +396,7 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
   if (argc < 3) {
     fprintf(stderr, "ERROR: putval: Missing identifier "
                     "and/or value list.\n");
-    return (-1);
+    return -1;
   }
 
   vl.values = values;
@@ -404,7 +404,7 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
 
   status = parse_identifier(c, argv[1], &vl.identifier);
   if (status != 0)
-    return (status);
+    return status;
 
   for (int i = 2; i < argc; ++i) {
     char *tmp;
@@ -426,7 +426,7 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
         if (endptr == value) {
           fprintf(stderr, "ERROR: Failed to parse interval as number: %s.\n",
                   value);
-          return (-1);
+          return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
           fprintf(stderr, "WARNING: Ignoring trailing garbage after "
                           "interval: %s.\n",
@@ -434,7 +434,7 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
         }
       } else {
         fprintf(stderr, "ERROR: putval: Unknown option `%s'.\n", key);
-        return (-1);
+        return -1;
       }
     } else { /* value list */
       char *value;
@@ -443,7 +443,7 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
 
       if (tmp == NULL) {
         fprintf(stderr, "ERROR: putval: Invalid value list: %s.\n", argv[i]);
-        return (-1);
+        return -1;
       }
 
       *tmp = '\0';
@@ -459,10 +459,10 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
         if (endptr == argv[i]) {
           fprintf(stderr, "ERROR: Failed to parse time as number: %s.\n",
                   argv[i]);
-          return (-1);
+          return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
           fprintf(stderr, "ERROR: Garbage after time: %s.\n", endptr);
-          return (-1);
+          return -1;
         }
       }
 
@@ -499,10 +499,10 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
         if (endptr == value) {
           fprintf(stderr, "ERROR: Failed to parse value as number: %s.\n",
                   argv[i]);
-          return (-1);
+          return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
           fprintf(stderr, "ERROR: Garbage after value: %s.\n", endptr);
-          return (-1);
+          return -1;
         }
 
         value = tmp;
@@ -514,16 +514,16 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
       status = lcc_putval(c, &vl);
       if (status != 0) {
         fprintf(stderr, "ERROR: %s\n", lcc_strerror(c));
-        return (-1);
+        return -1;
       }
     }
   }
 
   if (values_len == 0) {
     fprintf(stderr, "ERROR: putval: Missing value list(s).\n");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* putval */
 
 int main(int argc, char **argv) {
@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
   if (status != 0) {
     fprintf(stderr, "ERROR: Failed to connect to daemon at %s: %s.\n", address,
             strerror(errno));
-    return (1);
+    return 1;
   }
 
   if (strcasecmp(argv[optind], "getval") == 0)
@@ -576,12 +576,12 @@ int main(int argc, char **argv) {
     status = putval(c, argc - optind, argv + optind);
   else {
     fprintf(stderr, "%s: invalid command: %s\n", argv[0], argv[optind]);
-    return (1);
+    return 1;
   }
 
   LCC_DESTROY(c);
 
   if (status != 0)
-    return (status);
-  return (0);
+    return status;
+  return 0;
 } /* main */

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -70,13 +70,13 @@ static int conntrack_read(void) {
   char const *path = old_files ? CONNTRACK_FILE_OLD : CONNTRACK_FILE;
   if (parse_value_file(path, &conntrack, DS_TYPE_GAUGE) != 0) {
     ERROR("conntrack plugin: Reading \"%s\" failed.", path);
-    return (-1);
+    return -1;
   }
 
   path = old_files ? CONNTRACK_MAX_FILE_OLD : CONNTRACK_MAX_FILE;
   if (parse_value_file(path, &conntrack_max, DS_TYPE_GAUGE) != 0) {
     ERROR("conntrack plugin: Reading \"%s\" failed.", path);
-    return (-1);
+    return -1;
   }
 
   conntrack_pct.gauge = (conntrack.gauge / conntrack_max.gauge) * 100;
@@ -85,7 +85,7 @@ static int conntrack_read(void) {
   conntrack_submit("conntrack", "max", conntrack_max);
   conntrack_submit("percent", "used", conntrack_pct);
 
-  return (0);
+  return 0;
 } /* static int conntrack_read */
 
 void module_register(void) {

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -69,7 +69,7 @@ static int cs_read(void) {
   if (status != 0) {
     ERROR("contextswitch plugin: sysctlbyname "
           "(vm.stats.sys.v_swtch) failed");
-    return (-1);
+    return -1;
   }
 
   cs_submit(value);
@@ -87,7 +87,7 @@ static int cs_read(void) {
   if (fh == NULL) {
     ERROR("contextswitch plugin: unable to open /proc/stat: %s",
           sstrerror(errno, buffer, sizeof(buffer)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -129,7 +129,7 @@ static int cs_read(void) {
     char errbuf[1024];
     ERROR("contextswitch plugin: perfstat_cpu_total: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   cs_submit(perfcputotal.pswitch);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -209,9 +209,9 @@ static int cpu_config(char const *key, char const *value) /* {{{ */
   else if (strcasecmp(key, "ReportNumCpu") == 0)
     report_num_cpu = IS_TRUE(value) ? 1 : 0;
   else
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 } /* }}} int cpu_config */
 
 static int init(void) {
@@ -229,12 +229,12 @@ static int init(void) {
           "load information. "
           "<https://collectd.org/bugs/22>");
     cpu_list_len = 0;
-    return (-1);
+    return -1;
   }
   if (status != KERN_SUCCESS) {
     ERROR("cpu plugin: host_processors() failed with status %d.", (int)status);
     cpu_list_len = 0;
-    return (-1);
+    return -1;
   }
 
   INFO("cpu plugin: Found %i processor%s.", (int)cpu_list_len,
@@ -247,7 +247,7 @@ static int init(void) {
   numcpu = 0;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   /* Solaris doesn't count linear.. *sigh* */
   for (numcpu = 0, ksp_chain = kc->kc_chain;
@@ -269,7 +269,7 @@ static int init(void) {
   if (status == -1) {
     char errbuf[1024];
     WARNING("cpu plugin: sysctl: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 /* #endif CAN_USE_SYSCTL */
 
@@ -282,7 +282,7 @@ static int init(void) {
     char errbuf[1024];
     WARNING("cpu plugin: sysctlbyname(hw.ncpu): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
 #ifdef HAVE_SYSCTL_KERN_CP_TIMES
@@ -292,7 +292,7 @@ static int init(void) {
     char errbuf[1024];
     WARNING("cpu plugin: sysctlbyname(kern.smp.maxcpus): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 #else
   if (numcpu != 1)
@@ -310,7 +310,7 @@ static int init(void) {
 /* nothing to initialize */
 #endif /* HAVE_PERFSTAT */
 
-  return (0);
+  return 0;
 } /* int init */
 
 static void submit_value(int cpu_num, int cpu_state, const char *type,
@@ -362,7 +362,7 @@ static int cpu_states_alloc(size_t cpu_num) /* {{{ */
   tmp = realloc(cpu_states, sz * sizeof(*cpu_states));
   if (tmp == NULL) {
     ERROR("cpu plugin: realloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
   cpu_states = tmp;
   tmp = cpu_states + cpu_states_num;
@@ -377,9 +377,9 @@ static cpu_state_t *get_cpu_state(size_t cpu_num, size_t state) /* {{{ */
   size_t index = ((cpu_num * COLLECTD_CPU_STATE_MAX) + state);
 
   if (index >= cpu_states_num)
-    return (NULL);
+    return NULL;
 
-  return (&cpu_states[index]);
+  return &cpu_states[index];
 } /* }}} cpu_state_t *get_cpu_state */
 
 #if defined(HAVE_PERFSTAT) /* {{{ */
@@ -390,13 +390,13 @@ static int total_rate(gauge_t *sum_by_state, size_t state, derive_t d,
   int status =
       value_to_rate(&rate, (value_t){.derive = d}, DS_TYPE_DERIVE, now, conv);
   if (status != 0)
-    return (status);
+    return status;
 
   sum_by_state[state] = rate;
 
   if (state != COLLECTD_CPU_STATE_IDLE)
     RATE_ADD(sum_by_state[COLLECTD_CPU_STATE_ACTIVE], sum_by_state[state]);
-  return (0);
+  return 0;
 }
 #endif /* }}} HAVE_PERFSTAT */
 
@@ -567,11 +567,11 @@ static int cpu_stage(size_t cpu_num, size_t state, derive_t d,
   value_t val = {.derive = d};
 
   if (state >= COLLECTD_CPU_STATE_ACTIVE)
-    return (EINVAL);
+    return EINVAL;
 
   status = cpu_states_alloc(cpu_num);
   if (status != 0)
-    return (status);
+    return status;
 
   if (global_cpu_num <= cpu_num)
     global_cpu_num = cpu_num + 1;
@@ -580,11 +580,11 @@ static int cpu_stage(size_t cpu_num, size_t state, derive_t d,
 
   status = value_to_rate(&rate, val, DS_TYPE_DERIVE, now, &s->conv);
   if (status != 0)
-    return (status);
+    return status;
 
   s->rate = rate;
   s->has_value = 1;
-  return (0);
+  return 0;
 } /* }}} int cpu_stage */
 
 static int cpu_read(void) {
@@ -639,7 +639,7 @@ static int cpu_read(void) {
     char errbuf[1024];
     ERROR("cpu plugin: fopen (/proc/stat) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buf, 1024, fh) != NULL) {
@@ -678,7 +678,7 @@ static int cpu_read(void) {
   static cpu_stat_t cs;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (int cpu = 0; cpu < numcpu; cpu++) {
     if (kstat_read(kc, ksp[cpu], &cs) == -1)
@@ -703,7 +703,7 @@ static int cpu_read(void) {
   if (numcpu < 1) {
     ERROR("cpu plugin: Could not determine number of "
           "installed CPUs using sysctl(3).");
-    return (-1);
+    return -1;
   }
 
   memset(cpuinfo, 0, sizeof(cpuinfo));
@@ -721,7 +721,7 @@ static int cpu_read(void) {
         char errbuf[1024];
         ERROR("cpu plugin: sysctl failed: %s.",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
     }
   } else
@@ -738,7 +738,7 @@ static int cpu_read(void) {
       char errbuf[1024];
       ERROR("cpu plugin: sysctl failed: %s.",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
 
     for (int i = 0; i < CPUSTATES; i++) {
@@ -768,7 +768,7 @@ static int cpu_read(void) {
     char errbuf[1024];
     ERROR("cpu plugin: sysctlbyname failed: %s.",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < numcpu; i++) {
@@ -791,7 +791,7 @@ static int cpu_read(void) {
     char errbuf[1024];
     ERROR("cpu plugin: sysctlbyname failed: %s.",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   cpu_stage(0, COLLECTD_CPU_STATE_USER, (derive_t)cpuinfo[CP_USER], now);
@@ -807,7 +807,7 @@ static int cpu_read(void) {
 
   if (cs == NULL) {
     ERROR("cpu plugin: sg_get_cpu_stats failed.");
-    return (-1);
+    return -1;
   }
 
   cpu_state(0, COLLECTD_CPU_STATE_IDLE, (derive_t)cs->idle);
@@ -827,7 +827,7 @@ static int cpu_read(void) {
     char errbuf[1024];
     WARNING("cpu plugin: perfstat_cpu: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (pnumcpu != numcpu || perfcpu == NULL) {
@@ -841,7 +841,7 @@ static int cpu_read(void) {
     char errbuf[1024];
     WARNING("cpu plugin: perfstat_cpu: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < cpus; i++) {
@@ -854,7 +854,7 @@ static int cpu_read(void) {
 
   cpu_commit();
   cpu_reset();
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -52,7 +52,7 @@ static int cpufreq_init(void) {
   if (num_cpu == 0)
     plugin_unregister_read("cpufreq");
 
-  return (0);
+  return 0;
 } /* int cpufreq_init */
 
 static void cpufreq_submit(int cpu_num, value_t value) {
@@ -85,7 +85,7 @@ static int cpufreq_read(void) {
     cpufreq_submit(i, v);
   }
 
-  return (0);
+  return 0;
 } /* int cpufreq_read */
 
 void module_register(void) {

--- a/src/cpusleep.c
+++ b/src/cpusleep.c
@@ -51,12 +51,12 @@ static int cpusleep_read(void) {
   struct timespec b, m;
   if (clock_gettime(CLOCK_BOOTTIME, &b) < 0) {
     ERROR("cpusleep plugin: clock_boottime failed");
-    return (-1);
+    return -1;
   }
 
   if (clock_gettime(CLOCK_MONOTONIC, &m) < 0) {
     ERROR("cpusleep plugin: clock_monotonic failed");
-    return (-1);
+    return -1;
   }
 
   // to avoid false positives in counter overflow due to reboot,
@@ -67,7 +67,7 @@ static int cpusleep_read(void) {
 
   cpusleep_submit(sleep);
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/csv.c
+++ b/src/csv.c
@@ -49,7 +49,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
   status = ssnprintf(buffer, buffer_len, "%.3f", CDTIME_T_TO_DOUBLE(vl->time));
   if ((status < 1) || (status >= buffer_len))
-    return (-1);
+    return -1;
   offset = status;
 
   for (size_t i = 0; i < ds->ds_num; i++) {
@@ -58,7 +58,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
         (ds->ds[i].type != DS_TYPE_DERIVE) &&
         (ds->ds[i].type != DS_TYPE_ABSOLUTE)) {
       sfree(rates);
-      return (-1);
+      return -1;
     }
 
     if (ds->ds[i].type == DS_TYPE_GAUGE) {
@@ -70,7 +70,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
       if (rates == NULL) {
         WARNING("csv plugin: "
                 "uc_get_rate failed.");
-        return (-1);
+        return -1;
       }
       status =
           ssnprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
@@ -87,14 +87,14 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
     if ((status < 1) || (status >= (buffer_len - offset))) {
       sfree(rates);
-      return (-1);
+      return -1;
     }
 
     offset += status;
   } /* for ds->ds_num */
 
   sfree(rates);
-  return (0);
+  return 0;
 } /* int value_list_to_string */
 
 static int value_list_to_filename(char *buffer, size_t buffer_size,
@@ -110,7 +110,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
     size_t len = strlen(datadir) + 1;
 
     if (len >= ptr_size)
-      return (ENOBUFS);
+      return ENOBUFS;
 
     memcpy(ptr, datadir, len);
     ptr[len - 1] = '/';
@@ -120,12 +120,12 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
 
   status = FORMAT_VL(ptr, ptr_size, vl);
   if (status != 0)
-    return (status);
+    return status;
 
   /* Skip all the time formatting stuff when printing to STDOUT or
    * STDERR. */
   if (use_stdio)
-    return (0);
+    return 0;
 
   ptr_size -= strlen(ptr);
   ptr += strlen(ptr);
@@ -133,7 +133,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
   /* "-2013-07-12" => 11 bytes */
   if (ptr_size < 12) {
     ERROR("csv plugin: Buffer too small.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   /* TODO: Find a way to minimize the calls to `localtime_r',
@@ -141,31 +141,31 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
   now = time(NULL);
   if (localtime_r(&now, &struct_tm) == NULL) {
     ERROR("csv plugin: localtime_r failed");
-    return (-1);
+    return -1;
   }
 
   status = strftime(ptr, ptr_size, "-%Y-%m-%d", &struct_tm);
   if (status == 0) /* yep, it returns zero on error. */
   {
     ERROR("csv plugin: strftime failed");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int value_list_to_filename */
 
 static int csv_create_file(const char *filename, const data_set_t *ds) {
   FILE *csv;
 
   if (check_create_dir(filename))
-    return (-1);
+    return -1;
 
   csv = fopen(filename, "w");
   if (csv == NULL) {
     char errbuf[1024];
     ERROR("csv plugin: fopen (%s) failed: %s", filename,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   fprintf(csv, "epoch");
@@ -186,10 +186,10 @@ static int csv_config(const char *key, const char *value) {
     }
     if (strcasecmp("stdout", value) == 0) {
       use_stdio = 1;
-      return (0);
+      return 0;
     } else if (strcasecmp("stderr", value) == 0) {
       use_stdio = 2;
-      return (0);
+      return 0;
     }
     datadir = strdup(value);
     if (datadir != NULL) {
@@ -209,9 +209,9 @@ static int csv_config(const char *key, const char *value) {
     else
       store_rates = 0;
   } else {
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* int csv_config */
 
 static int csv_write(const data_set_t *ds, const value_list_t *vl,
@@ -231,12 +231,12 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
 
   status = value_list_to_filename(filename, sizeof(filename), vl);
   if (status != 0)
-    return (-1);
+    return -1;
 
   DEBUG("csv plugin: csv_write: filename = %s;", filename);
 
   if (value_list_to_string(values, sizeof(values), ds, vl) != 0)
-    return (-1);
+    return -1;
 
   if (use_stdio) {
     escape_string(filename, sizeof(filename));
@@ -251,22 +251,22 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
 
     fprintf(use_stdio == 1 ? stdout : stderr, "PUTVAL %s interval=%.3f %s\n",
             filename, CDTIME_T_TO_DOUBLE(vl->interval), values);
-    return (0);
+    return 0;
   }
 
   if (stat(filename, &statbuf) == -1) {
     if (errno == ENOENT) {
       if (csv_create_file(filename, ds))
-        return (-1);
+        return -1;
     } else {
       char errbuf[1024];
       ERROR("stat(%s) failed: %s", filename,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   } else if (!S_ISREG(statbuf.st_mode)) {
     ERROR("stat(%s): Not a regular file!", filename);
-    return (-1);
+    return -1;
   }
 
   csv = fopen(filename, "a");
@@ -274,7 +274,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
     char errbuf[1024];
     ERROR("csv plugin: fopen (%s) failed: %s", filename,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   csv_fd = fileno(csv);
 
@@ -288,7 +288,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
     ERROR("csv plugin: flock (%s) failed: %s", filename,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     fclose(csv);
-    return (-1);
+    return -1;
   }
 
   fprintf(csv, "%s\n", values);
@@ -297,7 +297,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
    * because the `FILE *' may need to flush a cache first */
   fclose(csv);
 
-  return (0);
+  return 0;
 } /* int csv_write */
 
 void module_register(void) {

--- a/src/curl.c
+++ b/src/curl.c
@@ -97,11 +97,11 @@ static size_t cc_curl_callback(void *buf, /* {{{ */
 
   len = size * nmemb;
   if (len == 0)
-    return (len);
+    return len;
 
   wp = user_data;
   if (wp == NULL)
-    return (0);
+    return 0;
 
   if ((wp->buffer_fill + len) >= wp->buffer_size) {
     char *temp;
@@ -111,7 +111,7 @@ static size_t cc_curl_callback(void *buf, /* {{{ */
     temp = realloc(wp->buffer, temp_size);
     if (temp == NULL) {
       ERROR("curl plugin: realloc failed.");
-      return (0);
+      return 0;
     }
     wp->buffer = temp;
     wp->buffer_size = temp_size;
@@ -121,7 +121,7 @@ static size_t cc_curl_callback(void *buf, /* {{{ */
   wp->buffer_fill += len;
   wp->buffer[wp->buffer_fill] = 0;
 
-  return (len);
+  return len;
 } /* }}} size_t cc_curl_callback */
 
 static void cc_web_match_free(web_match_t *wm) /* {{{ */
@@ -170,16 +170,16 @@ static int cc_config_append_string(const char *name,
   struct curl_slist *temp = NULL;
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl plugin: `%s' needs exactly one string argument.", name);
-    return (-1);
+    return -1;
   }
 
   temp = curl_slist_append(*dest, ci->values[0].value.string);
   if (temp == NULL)
-    return (-1);
+    return -1;
 
   *dest = temp;
 
-  return (0);
+  return 0;
 } /* }}} int cc_config_append_string */
 
 static int cc_config_add_match_dstype(int *dstype_ret, /* {{{ */
@@ -188,7 +188,7 @@ static int cc_config_add_match_dstype(int *dstype_ret, /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl plugin: `DSType' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   if (strncasecmp("Gauge", ci->values[0].value.string, strlen("Gauge")) == 0) {
@@ -243,11 +243,11 @@ static int cc_config_add_match_dstype(int *dstype_ret, /* {{{ */
   if (dstype == 0) {
     WARNING("curl plugin: `%s' is not a valid argument to `DSType'.",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   *dstype_ret = dstype;
-  return (0);
+  return 0;
 } /* }}} int cc_config_add_match_dstype */
 
 static int cc_config_add_match(web_page_t *page, /* {{{ */
@@ -262,7 +262,7 @@ static int cc_config_add_match(web_page_t *page, /* {{{ */
   match = calloc(1, sizeof(*match));
   if (match == NULL) {
     ERROR("curl plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -309,7 +309,7 @@ static int cc_config_add_match(web_page_t *page, /* {{{ */
 
   if (status != 0) {
     cc_web_match_free(match);
-    return (status);
+    return status;
   }
 
   match->match =
@@ -317,7 +317,7 @@ static int cc_config_add_match(web_page_t *page, /* {{{ */
   if (match->match == NULL) {
     ERROR("curl plugin: match_create_simple failed.");
     cc_web_match_free(match);
-    return (-1);
+    return -1;
   } else {
     web_match_t *prev;
 
@@ -331,7 +331,7 @@ static int cc_config_add_match(web_page_t *page, /* {{{ */
       prev->next = match;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cc_config_add_match */
 
 static int cc_page_init_curl(web_page_t *wp) /* {{{ */
@@ -339,7 +339,7 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
   wp->curl = curl_easy_init();
   if (wp->curl == NULL) {
     ERROR("curl plugin: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(wp->curl, CURLOPT_NOSIGNAL, 1L);
@@ -366,7 +366,7 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
     wp->credentials = malloc(credentials_size);
     if (wp->credentials == NULL) {
       ERROR("curl plugin: malloc failed.");
-      return (-1);
+      return -1;
     }
 
     ssnprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
@@ -395,7 +395,7 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int cc_page_init_curl */
 
 static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
@@ -405,13 +405,13 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl plugin: `Page' blocks need exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   page = calloc(1, sizeof(*page));
   if (page == NULL) {
     ERROR("curl plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   page->url = NULL;
   page->user = NULL;
@@ -428,7 +428,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
   if (page->instance == NULL) {
     ERROR("curl plugin: strdup failed.");
     sfree(page);
-    return (-1);
+    return -1;
   }
 
   /* Process all children */
@@ -501,7 +501,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     cc_web_page_free(page);
-    return (status);
+    return status;
   }
 
   /* Add the new page to the linked list */
@@ -516,7 +516,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
     prev->next = page;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cc_config_add_page */
 
 static int cc_config(oconfig_item_t *ci) /* {{{ */
@@ -545,20 +545,20 @@ static int cc_config(oconfig_item_t *ci) /* {{{ */
 
   if ((success == 0) && (errors > 0)) {
     ERROR("curl plugin: All statements failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cc_config */
 
 static int cc_init(void) /* {{{ */
 {
   if (pages_g == NULL) {
     INFO("curl plugin: No pages have been defined.");
-    return (-1);
+    return -1;
   }
   curl_global_init(CURL_GLOBAL_SSL);
-  return (0);
+  return 0;
 } /* }}} int cc_init */
 
 static void cc_submit(const web_page_t *wp, const web_match_t *wm, /* {{{ */
@@ -615,7 +615,7 @@ static int cc_read_page(web_page_t *wp) /* {{{ */
   if (status != CURLE_OK) {
     ERROR("curl plugin: curl_easy_perform failed with status %i: %s", status,
           wp->curl_errbuf);
-    return (-1);
+    return -1;
   }
 
   if (wp->response_time)
@@ -654,7 +654,7 @@ static int cc_read_page(web_page_t *wp) /* {{{ */
     match_value_reset(mv);
   } /* for (wm = wp->matches; wm != NULL; wm = wm->next) */
 
-  return (0);
+  return 0;
 } /* }}} int cc_read_page */
 
 static int cc_read(void) /* {{{ */
@@ -662,7 +662,7 @@ static int cc_read(void) /* {{{ */
   for (web_page_t *wp = pages_g; wp != NULL; wp = wp->next)
     cc_read_page(wp);
 
-  return (0);
+  return 0;
 } /* }}} int cc_read */
 
 static int cc_shutdown(void) /* {{{ */
@@ -670,7 +670,7 @@ static int cc_shutdown(void) /* {{{ */
   cc_web_page_free(pages_g);
   pages_g = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int cc_shutdown */
 
 void module_register(void) {

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -118,18 +118,18 @@ static size_t cj_curl_callback(void *buf, /* {{{ */
   len = size * nmemb;
 
   if (len == 0)
-    return (len);
+    return len;
 
   db = user_data;
   if (db == NULL)
-    return (0);
+    return 0;
 
   status = yajl_parse(db->yajl, (unsigned char *)buf, len);
   if (status == yajl_status_ok)
-    return (len);
+    return len;
 #if !HAVE_YAJL_V2
   else if (status == yajl_status_insufficient_data)
-    return (len);
+    return len;
 #endif
 
   unsigned char *msg =
@@ -137,7 +137,7 @@ static size_t cj_curl_callback(void *buf, /* {{{ */
                      /* jsonText = */ (unsigned char *)buf, (unsigned int)len);
   ERROR("curl_json plugin: yajl_parse failed: %s", msg);
   yajl_free_error(db->yajl, msg);
-  return (0); /* abort write callback */
+  return 0; /* abort write callback */
 } /* }}} size_t cj_curl_callback */
 
 static int cj_get_type(cj_key_t *key) {
@@ -196,12 +196,12 @@ static void cj_cb_inc_array_index(void *ctx, _Bool update_key) {
 
 static int cj_cb_boolean(void *ctx, int boolVal) {
   cj_cb_inc_array_index(ctx, /* update_key = */ 0);
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 }
 
 static int cj_cb_null(void *ctx) {
   cj_cb_inc_array_index(ctx, /* update_key = */ 0);
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 }
 
 static int cj_cb_number(void *ctx, const char *number, yajl_len_t number_len) {
@@ -223,13 +223,13 @@ static int cj_cb_number(void *ctx, const char *number, yajl_len_t number_len) {
       NOTICE("curl_json plugin: Found \"%s\", but the configuration expects"
              " a map.",
              buffer);
-      return (CJ_CB_CONTINUE);
+      return CJ_CB_CONTINUE;
     }
 
     cj_cb_inc_array_index(ctx, /* update_key = */ 1);
     key = db->state[db->depth].key;
     if ((key == NULL) || !CJ_IS_KEY(key)) {
-      return (CJ_CB_CONTINUE);
+      return CJ_CB_CONTINUE;
     }
   } else {
     cj_cb_inc_array_index(ctx, /* update_key = */ 1);
@@ -239,11 +239,11 @@ static int cj_cb_number(void *ctx, const char *number, yajl_len_t number_len) {
   status = parse_value(buffer, &vt, type);
   if (status != 0) {
     NOTICE("curl_json plugin: Unable to parse number: \"%s\"", buffer);
-    return (CJ_CB_CONTINUE);
+    return CJ_CB_CONTINUE;
   }
 
   cj_submit(db, key, &vt);
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 } /* int cj_cb_number */
 
 /* Queries the key-tree of the parent context for "in_name" and, if found,
@@ -284,12 +284,12 @@ static int cj_cb_map_key(void *ctx, unsigned char const *in_name,
       db->state[db->depth].key = NULL;
   }
 
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 }
 
 static int cj_cb_string(void *ctx, const unsigned char *val, yajl_len_t len) {
   /* Handle the string as if it was a number. */
-  return (cj_cb_number(ctx, (const char *)val, len));
+  return cj_cb_number(ctx, (const char *)val, len);
 } /* int cj_cb_string */
 
 static int cj_cb_start(void *ctx) {
@@ -297,16 +297,16 @@ static int cj_cb_start(void *ctx) {
   if (++db->depth >= YAJL_MAX_DEPTH) {
     ERROR("curl_json plugin: %s depth exceeds max, aborting.",
           db->url ? db->url : db->sock);
-    return (CJ_CB_ABORT);
+    return CJ_CB_ABORT;
   }
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 }
 
 static int cj_cb_end(void *ctx) {
   cj_t *db = (cj_t *)ctx;
   db->state[db->depth].tree = NULL;
   --db->depth;
-  return (CJ_CB_CONTINUE);
+  return CJ_CB_CONTINUE;
 }
 
 static int cj_cb_start_map(void *ctx) {
@@ -412,7 +412,7 @@ static void cj_free(void *arg) /* {{{ */
 /* Configuration handling functions {{{ */
 
 static c_avl_tree_t *cj_avl_create(void) {
-  return c_avl_create((int (*)(const void *, const void *))strcmp);
+  return c_avl_create((int(*)(const void *, const void *))strcmp);
 }
 
 static int cj_config_append_string(const char *name,
@@ -421,16 +421,16 @@ static int cj_config_append_string(const char *name,
   struct curl_slist *temp = NULL;
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_json plugin: `%s' needs exactly one string argument.", name);
-    return (-1);
+    return -1;
   }
 
   temp = curl_slist_append(*dest, ci->values[0].value.string);
   if (temp == NULL)
-    return (-1);
+    return -1;
 
   *dest = temp;
 
-  return (0);
+  return 0;
 } /* }}} int cj_config_append_string */
 
 static int cj_config_add_key(cj_t *db, /* {{{ */
@@ -441,13 +441,13 @@ static int cj_config_add_key(cj_t *db, /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_json plugin: The `Key' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   key = calloc(1, sizeof(*key));
   if (key == NULL) {
     ERROR("curl_json plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   key->magic = CJ_KEY_MAGIC;
 
@@ -455,14 +455,14 @@ static int cj_config_add_key(cj_t *db, /* {{{ */
     status = cf_util_get_string(ci, &key->path);
     if (status != 0) {
       sfree(key);
-      return (status);
+      return status;
     }
   } else {
     ERROR("curl_json plugin: cj_config: "
           "Invalid key: %s",
           ci->key);
     cj_key_free(key);
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -484,13 +484,13 @@ static int cj_config_add_key(cj_t *db, /* {{{ */
 
   if (status != 0) {
     cj_key_free(key);
-    return (-1);
+    return -1;
   }
 
   if (key->type == NULL) {
     WARNING("curl_json plugin: `Type' missing in `Key' block.");
     cj_key_free(key);
-    return (-1);
+    return -1;
   }
 
   /* store path in a tree that will match the json map structure, example:
@@ -535,11 +535,11 @@ static int cj_config_add_key(cj_t *db, /* {{{ */
   if (strlen(name) == 0) {
     ERROR("curl_json plugin: invalid key: %s", key->path);
     cj_key_free(key);
-    return (-1);
+    return -1;
   }
 
   c_avl_insert(tree, strdup(name), key);
-  return (status);
+  return status;
 } /* }}} int cj_config_add_key */
 
 static int cj_init_curl(cj_t *db) /* {{{ */
@@ -547,7 +547,7 @@ static int cj_init_curl(cj_t *db) /* {{{ */
   db->curl = curl_easy_init();
   if (db->curl == NULL) {
     ERROR("curl_json plugin: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(db->curl, CURLOPT_NOSIGNAL, 1L);
@@ -574,7 +574,7 @@ static int cj_init_curl(cj_t *db) /* {{{ */
     db->credentials = malloc(credentials_size);
     if (db->credentials == NULL) {
       ERROR("curl_json plugin: malloc failed.");
-      return (-1);
+      return -1;
     }
 
     ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
@@ -606,7 +606,7 @@ static int cj_init_curl(cj_t *db) /* {{{ */
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int cj_init_curl */
 
 static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
@@ -617,13 +617,13 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_json plugin: The `URL' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   db = calloc(1, sizeof(*db));
   if (db == NULL) {
     ERROR("curl_json plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   db->timeout = -1;
@@ -637,11 +637,11 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
           "Invalid key: %s",
           ci->key);
     cj_free(db);
-    return (-1);
+    return -1;
   }
   if (status != 0) {
     sfree(db);
-    return (status);
+    return status;
   }
 
   /* Fill the `cj_t' structure.. */
@@ -717,10 +717,10 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
     sfree(cb_name);
   } else {
     cj_free(db);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 /* }}} int cj_config_add_database */
 
@@ -751,10 +751,10 @@ static int cj_config(oconfig_item_t *ci) /* {{{ */
 
   if ((success == 0) && (errors > 0)) {
     ERROR("curl_json plugin: All statements failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cj_config */
 
 /* }}} End of configuration handling functions */
@@ -802,13 +802,13 @@ static int cj_sock_perform(cj_t *db) /* {{{ */
 
   int fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0)
-    return (-1);
+    return -1;
   if (connect(fd, (struct sockaddr *)&sa_unix, sizeof(sa_unix)) < 0) {
     ERROR("curl_json plugin: connect(%s) failed: %s",
           (db->sock != NULL) ? db->sock : "<null>",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(fd);
-    return (-1);
+    return -1;
   }
 
   ssize_t red;
@@ -820,13 +820,13 @@ static int cj_sock_perform(cj_t *db) /* {{{ */
             (db->sock != NULL) ? db->sock : "<null>",
             sstrerror(errno, errbuf, sizeof(errbuf)));
       close(fd);
-      return (-1);
+      return -1;
     }
     if (!cj_curl_callback(buffer, red, 1, db))
       break;
   } while (red > 0);
   close(fd);
-  return (0);
+  return 0;
 } /* }}} int cj_sock_perform */
 
 static int cj_curl_perform(cj_t *db) /* {{{ */
@@ -840,7 +840,7 @@ static int cj_curl_perform(cj_t *db) /* {{{ */
   if (status != CURLE_OK) {
     ERROR("curl_json plugin: curl_easy_perform failed with status %i: %s (%s)",
           status, db->curl_errbuf, url);
-    return (-1);
+    return -1;
   }
   if (db->stats != NULL)
     curl_stats_dispatch(db->stats, db->curl, cj_host(db), "curl_json",
@@ -854,9 +854,9 @@ static int cj_curl_perform(cj_t *db) /* {{{ */
     ERROR("curl_json plugin: curl_easy_perform failed with "
           "response code %ld (%s)",
           rc, url);
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* }}} int cj_curl_perform */
 
 static int cj_perform(cj_t *db) /* {{{ */
@@ -874,7 +874,7 @@ static int cj_perform(cj_t *db) /* {{{ */
   if (db->yajl == NULL) {
     ERROR("curl_json plugin: yajl_alloc failed.");
     db->yajl = yprev;
-    return (-1);
+    return -1;
   }
 
   if (db->url)
@@ -884,7 +884,7 @@ static int cj_perform(cj_t *db) /* {{{ */
   if (status < 0) {
     yajl_free(db->yajl);
     db->yajl = yprev;
-    return (-1);
+    return -1;
   }
 
 #if HAVE_YAJL_V2
@@ -901,12 +901,12 @@ static int cj_perform(cj_t *db) /* {{{ */
     yajl_free_error(db->yajl, errmsg);
     yajl_free(db->yajl);
     db->yajl = yprev;
-    return (-1);
+    return -1;
   }
 
   yajl_free(db->yajl);
   db->yajl = yprev;
-  return (0);
+  return 0;
 } /* }}} int cj_perform */
 
 static int cj_read(user_data_t *ud) /* {{{ */
@@ -915,7 +915,7 @@ static int cj_read(user_data_t *ud) /* {{{ */
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("curl_json plugin: cj_read: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   db = (cj_t *)ud->data;
@@ -933,7 +933,7 @@ static int cj_init(void) /* {{{ */
   /* Call this while collectd is still single-threaded to avoid
    * initialization issues in libgcrypt. */
   curl_global_init(CURL_GLOBAL_SSL);
-  return (0);
+  return 0;
 } /* }}} int cj_init */
 
 void module_register(void) {

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -111,11 +111,11 @@ static size_t cx_curl_callback(void *buf, /* {{{ */
   if (db == NULL) {
     ERROR("curl_xml plugin: cx_curl_callback: "
           "user_data pointer is NULL.");
-    return (0);
+    return 0;
   }
 
   if (len == 0)
-    return (len);
+    return len;
 
   if ((db->buffer_fill + len) >= db->buffer_size) {
     char *temp;
@@ -123,7 +123,7 @@ static size_t cx_curl_callback(void *buf, /* {{{ */
     temp = realloc(db->buffer, db->buffer_fill + len + 1);
     if (temp == NULL) {
       ERROR("curl_xml plugin: realloc failed.");
-      return (0);
+      return 0;
     }
     db->buffer = temp;
     db->buffer_size = db->buffer_fill + len + 1;
@@ -133,7 +133,7 @@ static size_t cx_curl_callback(void *buf, /* {{{ */
   db->buffer_fill += len;
   db->buffer[db->buffer_fill] = 0;
 
-  return (len);
+  return len;
 } /* }}} size_t cx_curl_callback */
 
 static void cx_xpath_free(cx_xpath_t *xpath) /* {{{ */
@@ -221,33 +221,33 @@ static int cx_config_append_string(const char *name,
   struct curl_slist *temp = NULL;
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_xml plugin: `%s' needs exactly one string argument.", name);
-    return (-1);
+    return -1;
   }
 
   temp = curl_slist_append(*dest, ci->values[0].value.string);
   if (temp == NULL)
-    return (-1);
+    return -1;
 
   *dest = temp;
 
-  return (0);
+  return 0;
 } /* }}} int cx_config_append_string */
 
 static int cx_check_type(const data_set_t *ds, cx_xpath_t *xpath) /* {{{ */
 {
   if (!ds) {
     WARNING("curl_xml plugin: DataSet `%s' not defined.", xpath->type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num != xpath->values_len) {
     WARNING("curl_xml plugin: DataSet `%s' requires %zu values, but config "
             "talks about %zu",
             xpath->type, ds->ds_num, xpath->values_len);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} cx_check_type */
 
 static xmlXPathObjectPtr
@@ -271,7 +271,7 @@ static int cx_if_not_text_node(xmlNodePtr node) /* {{{ */
 {
   if (node->type == XML_TEXT_NODE || node->type == XML_ATTRIBUTE_NODE ||
       node->type == XML_ELEMENT_NODE)
-    return (0);
+    return 0;
 
   WARNING("curl_xml plugin: "
           "Node \"%s\" doesn't seem to be a text node. Skipping...",
@@ -290,7 +290,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
   values_node_obj =
       cx_evaluate_xpath(xpath_ctx, BAD_CAST xpath->values[index].path);
   if (values_node_obj == NULL)
-    return (-1); /* Error already logged. */
+    return -1; /* Error already logged. */
 
   values_node = values_node_obj->nodesetval;
   tmp_size = (values_node) ? values_node->nodeNr : 0;
@@ -301,7 +301,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
             "Skipping...",
             xpath->values[index].path);
     xmlXPathFreeObject(values_node_obj);
-    return (-1);
+    return -1;
   }
 
   if (tmp_size > 1) {
@@ -310,7 +310,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
             "only one node. Skipping...",
             xpath->values[index].path);
     xmlXPathFreeObject(values_node_obj);
-    return (-1);
+    return -1;
   }
 
   /* ignoring the element if other than textnode/attribute*/
@@ -320,7 +320,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
             "only text/attribute node which is not the case. Skipping...",
             xpath->values[index].path);
     xmlXPathFreeObject(values_node_obj);
-    return (-1);
+    return -1;
   }
 
   node_value = (char *)xmlNodeGetContent(values_node->nodeTab[0]);
@@ -351,7 +351,7 @@ static int cx_handle_single_value_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
 
   /* We have reached here which means that
    * we have got something to work */
-  return (0);
+  return 0;
 } /* }}} int cx_handle_single_value_xpath */
 
 static int cx_handle_all_value_xpaths(xmlXPathContextPtr xpath_ctx, /* {{{ */
@@ -368,13 +368,13 @@ static int cx_handle_all_value_xpaths(xmlXPathContextPtr xpath_ctx, /* {{{ */
   for (size_t i = 0; i < xpath->values_len; i++) {
     status = cx_handle_single_value_xpath(xpath_ctx, xpath, ds, vl, i);
     if (status != 0)
-      return (-1); /* An error has been printed. */
+      return -1; /* An error has been printed. */
   }                /* for (i = 0; i < xpath->values_len; i++) */
 
   plugin_dispatch_values(vl);
   vl->values = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int cx_handle_all_value_xpaths */
 
 static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
@@ -393,7 +393,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
             "Base-XPath %s is a table (more than one result was returned), "
             "but no instance-XPath has been defined.",
             xpath->path);
-    return (-1);
+    return -1;
   }
 
   /* instance has to be an xpath expression */
@@ -402,7 +402,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
 
     instance_node_obj = cx_evaluate_xpath(xpath_ctx, BAD_CAST xpath->instance);
     if (instance_node_obj == NULL)
-      return (-1); /* error is logged already */
+      return -1; /* error is logged already */
 
     instance_node = instance_node_obj->nodesetval;
     tmp_size = (instance_node) ? instance_node->nodeNr : 0;
@@ -414,7 +414,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
           "any of the nodes. Skipping the node.",
           xpath->instance);
       xmlXPathFreeObject(instance_node_obj);
-      return (-1);
+      return -1;
     }
 
     if (tmp_size > 1) {
@@ -423,7 +423,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
               "to return only one text node. Skipping the node.",
               xpath->instance);
       xmlXPathFreeObject(instance_node_obj);
-      return (-1);
+      return -1;
     }
 
     /* ignoring the element if other than textnode/attribute */
@@ -434,7 +434,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
               "which is not the case. Skipping the node.",
               xpath->instance);
       xmlXPathFreeObject(instance_node_obj);
-      return (-1);
+      return -1;
     }
   } /* if (xpath->instance != NULL) */
 
@@ -461,7 +461,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
    * somewhere inside this structure. */
   xmlXPathFreeObject(instance_node_obj);
 
-  return (0);
+  return 0;
 } /* }}} int cx_handle_instance_xpath */
 
 static int cx_handle_base_xpath(char const *plugin_instance, /* {{{ */
@@ -528,7 +528,7 @@ static int cx_handle_base_xpath(char const *plugin_instance, /* {{{ */
   /* free up the allocated memory */
   xmlXPathFreeObject(base_node_obj);
 
-  return (0);
+  return 0;
 } /* }}} cx_handle_base_xpath */
 
 static int cx_handle_parsed_xml(xmlDocPtr doc, /* {{{ */
@@ -565,14 +565,14 @@ static int cx_parse_stats_xml(xmlChar *xml, cx_t *db) /* {{{ */
   doc = xmlParseDoc(xml);
   if (doc == NULL) {
     ERROR("curl_xml plugin: Failed to parse the xml document  - %s", xml);
-    return (-1);
+    return -1;
   }
 
   xpath_ctx = xmlXPathNewContext(doc);
   if (xpath_ctx == NULL) {
     ERROR("curl_xml plugin: Failed to create the xml context");
     xmlFreeDoc(doc);
-    return (-1);
+    return -1;
   }
 
   for (size_t i = 0; i < db->namespaces_num; i++) {
@@ -585,7 +585,7 @@ static int cx_parse_stats_xml(xmlChar *xml, cx_t *db) /* {{{ */
             ns->prefix, ns->url);
       xmlXPathFreeContext(xpath_ctx);
       xmlFreeDoc(doc);
-      return (status);
+      return status;
     }
   }
 
@@ -609,7 +609,7 @@ static int cx_curl_perform(cx_t *db, CURL *curl) /* {{{ */
   if (status != CURLE_OK) {
     ERROR("curl_xml plugin: curl_easy_perform failed with status %i: %s (%s)",
           status, db->curl_errbuf, url);
-    return (-1);
+    return -1;
   }
   if (db->stats != NULL)
     curl_stats_dispatch(db->stats, db->curl, cx_host(db), "curl_xml",
@@ -623,7 +623,7 @@ static int cx_curl_perform(cx_t *db, CURL *curl) /* {{{ */
     ERROR(
         "curl_xml plugin: curl_easy_perform failed with response code %ld (%s)",
         rc, url);
-    return (-1);
+    return -1;
   }
 
   ptr = db->buffer;
@@ -640,7 +640,7 @@ static int cx_read(user_data_t *ud) /* {{{ */
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("curl_xml plugin: cx_read: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   db = (cx_t *)ud->data;
@@ -654,13 +654,13 @@ static int cx_config_add_values(const char *name, cx_xpath_t *xpath, /* {{{ */
                                 oconfig_item_t *ci) {
   if (ci->values_num < 1) {
     WARNING("curl_xml plugin: `ValuesFrom' needs at least one argument.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; i++)
     if (ci->values[i].type != OCONFIG_TYPE_STRING) {
       WARNING("curl_xml plugin: `ValuesFrom' needs only string argument.");
-      return (-1);
+      return -1;
     }
 
   sfree(xpath->values);
@@ -668,7 +668,7 @@ static int cx_config_add_values(const char *name, cx_xpath_t *xpath, /* {{{ */
   xpath->values_len = 0;
   xpath->values = malloc(sizeof(cx_values_t) * ci->values_num);
   if (xpath->values == NULL)
-    return (-1);
+    return -1;
   xpath->values_len = (size_t)ci->values_num;
 
   /* populate cx_values_t structure */
@@ -678,7 +678,7 @@ static int cx_config_add_values(const char *name, cx_xpath_t *xpath, /* {{{ */
              sizeof(xpath->values[i].path));
   }
 
-  return (0);
+  return 0;
 } /* }}} cx_config_add_values */
 
 static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
@@ -691,13 +691,13 @@ static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
   xpath = calloc(1, sizeof(*xpath));
   if (xpath == NULL) {
     ERROR("curl_xml plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   status = cf_util_get_string(ci, &xpath->path);
   if (status != 0) {
     cx_xpath_free(xpath);
-    return (status);
+    return status;
   }
 
   /* error out if xpath->path is an empty string */
@@ -705,7 +705,7 @@ static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
     ERROR("curl_xml plugin: invalid xpath. "
           "xpath value can't be an empty string");
     cx_xpath_free(xpath);
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -745,7 +745,7 @@ static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
     if (db->list == NULL) {
       ERROR("curl_xml plugin: list creation failed.");
       cx_xpath_free(xpath);
-      return (-1);
+      return -1;
     }
   }
 
@@ -753,7 +753,7 @@ static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
   if (name == NULL) {
     ERROR("curl_xml plugin: strdup failed.");
     cx_xpath_free(xpath);
-    return (-1);
+    return -1;
   }
 
   le = llentry_create(name, xpath);
@@ -761,11 +761,11 @@ static int cx_config_add_xpath(cx_t *db, oconfig_item_t *ci) /* {{{ */
     ERROR("curl_xml plugin: llentry_create failed.");
     cx_xpath_free(xpath);
     sfree(name);
-    return (-1);
+    return -1;
   }
 
   llist_append(db->list, le);
-  return (0);
+  return 0;
 } /* }}} int cx_config_add_xpath */
 
 static int cx_config_add_namespace(cx_t *db, /* {{{ */
@@ -776,14 +776,14 @@ static int cx_config_add_namespace(cx_t *db, /* {{{ */
       (ci->values[1].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_xml plugin: The `Namespace' option "
             "needs exactly two string arguments.");
-    return (EINVAL);
+    return EINVAL;
   }
 
   ns = realloc(db->namespaces,
                sizeof(*db->namespaces) * (db->namespaces_num + 1));
   if (ns == NULL) {
     ERROR("curl_xml plugin: realloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
   db->namespaces = ns;
   ns = db->namespaces + db->namespaces_num;
@@ -796,11 +796,11 @@ static int cx_config_add_namespace(cx_t *db, /* {{{ */
     sfree(ns->prefix);
     sfree(ns->url);
     ERROR("curl_xml plugin: strdup failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   db->namespaces_num++;
-  return (0);
+  return 0;
 } /* }}} int cx_config_add_namespace */
 
 /* Initialize db->curl */
@@ -809,7 +809,7 @@ static int cx_init_curl(cx_t *db) /* {{{ */
   db->curl = curl_easy_init();
   if (db->curl == NULL) {
     ERROR("curl_xml plugin: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(db->curl, CURLOPT_NOSIGNAL, 1L);
@@ -836,7 +836,7 @@ static int cx_init_curl(cx_t *db) /* {{{ */
     db->credentials = malloc(credentials_size);
     if (db->credentials == NULL) {
       ERROR("curl_xml plugin: malloc failed.");
-      return (-1);
+      return -1;
     }
 
     ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
@@ -865,7 +865,7 @@ static int cx_init_curl(cx_t *db) /* {{{ */
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int cx_init_curl */
 
 static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
@@ -876,13 +876,13 @@ static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("curl_xml plugin: The `URL' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   db = calloc(1, sizeof(*db));
   if (db == NULL) {
     ERROR("curl_xml plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   db->timeout = -1;
@@ -891,14 +891,14 @@ static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
     status = cf_util_get_string(ci, &db->url);
     if (status != 0) {
       sfree(db);
-      return (status);
+      return status;
     }
   } else {
     ERROR("curl_xml plugin: cx_config: "
           "Invalid key: %s",
           ci->key);
     cx_free(db);
-    return (-1);
+    return -1;
   }
 
   /* Fill the `cx_t' structure.. */
@@ -974,10 +974,10 @@ static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
     sfree(cb_name);
   } else {
     cx_free(db);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cx_config_add_url */
 
 /* }}} End of configuration handling functions */
@@ -1008,10 +1008,10 @@ static int cx_config(oconfig_item_t *ci) /* {{{ */
 
   if ((success == 0) && (errors > 0)) {
     ERROR("curl_xml plugin: All statements failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cx_config */
 
 static int cx_init(void) /* {{{ */
@@ -1019,7 +1019,7 @@ static int cx_init(void) /* {{{ */
   /* Call this while collectd is still single-threaded to avoid
    * initialization issues in libgcrypt. */
   curl_global_init(CURL_GLOBAL_SSL);
-  return (0);
+  return 0;
 } /* }}} int cx_init */
 
 void module_register(void) {

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -94,18 +94,18 @@ static int init_hostname(void) {
   str = global_option_get("Hostname");
   if ((str != NULL) && (str[0] != 0)) {
     sstrncpy(hostname_g, str, sizeof(hostname_g));
-    return (0);
+    return 0;
   }
 
   if (gethostname(hostname_g, sizeof(hostname_g)) != 0) {
     fprintf(stderr, "`gethostname' failed and no "
                     "hostname was configured.\n");
-    return (-1);
+    return -1;
   }
 
   str = global_option_get("FQDNLookup");
   if (IS_FALSE(str))
-    return (0);
+    return 0;
 
   struct addrinfo ai_hints = {.ai_flags = AI_CANONNAME};
 
@@ -117,7 +117,7 @@ static int init_hostname(void) {
           "name. Please fix the network "
           "configuration.",
           hostname_g);
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -130,7 +130,7 @@ static int init_hostname(void) {
   }
 
   freeaddrinfo(ai_list);
-  return (0);
+  return 0;
 } /* int init_hostname */
 
 static int init_global_variables(void) {
@@ -147,15 +147,15 @@ static int init_global_variables(void) {
   if (timeout_g <= 1) {
     fprintf(stderr, "Cannot set the timeout to a correct value.\n"
                     "Please check your settings.\n");
-    return (-1);
+    return -1;
   }
   DEBUG("timeout_g = %i;", timeout_g);
 
   if (init_hostname() != 0)
-    return (-1);
+    return -1;
   DEBUG("hostname_g = %s;", hostname_g);
 
-  return (0);
+  return 0;
 } /* int init_global_variables */
 
 static int change_basedir(const char *orig_dir) {
@@ -167,7 +167,7 @@ static int change_basedir(const char *orig_dir) {
   if (dir == NULL) {
     char errbuf[1024];
     ERROR("strdup failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   dirlen = strlen(dir);
@@ -176,19 +176,19 @@ static int change_basedir(const char *orig_dir) {
 
   if (dirlen == 0) {
     free(dir);
-    return (-1);
+    return -1;
   }
 
   status = chdir(dir);
   if (status == 0) {
     free(dir);
-    return (0);
+    return 0;
   } else if (errno != ENOENT) {
     char errbuf[1024];
     ERROR("change_basedir: chdir (%s): %s", dir,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     free(dir);
-    return (-1);
+    return -1;
   }
 
   status = mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO);
@@ -197,7 +197,7 @@ static int change_basedir(const char *orig_dir) {
     ERROR("change_basedir: mkdir (%s): %s", dir,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     free(dir);
-    return (-1);
+    return -1;
   }
 
   status = chdir(dir);
@@ -206,11 +206,11 @@ static int change_basedir(const char *orig_dir) {
     ERROR("change_basedir: chdir (%s): %s", dir,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     free(dir);
-    return (-1);
+    return -1;
   }
 
   free(dir);
-  return (0);
+  return 0;
 } /* static int change_basedir (char *dir) */
 
 #if HAVE_LIBKSTAT
@@ -285,12 +285,12 @@ static int do_init(void) {
 #endif
           )) {
     ERROR("sg_init: %s", sg_str_error(sg_get_error()));
-    return (-1);
+    return -1;
   }
 
   if (sg_drop_privileges()) {
     ERROR("sg_drop_privileges: %s", sg_str_error(sg_get_error()));
-    return (-1);
+    return -1;
   }
 #endif
 
@@ -329,12 +329,12 @@ static int do_loop(void) {
       if (errno != EINTR) {
         char errbuf[1024];
         ERROR("nanosleep failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
     }
   } /* while (loop == 0) */
 
-  return (0);
+  return 0;
 } /* int do_loop */
 
 static int do_shutdown(void) {
@@ -349,13 +349,13 @@ static int pidfile_create(void) {
   if ((fh = fopen(file, "w")) == NULL) {
     char errbuf[1024];
     ERROR("fopen (%s): %s", file, sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   fprintf(fh, "%i\n", (int)getpid());
   fclose(fh);
 
-  return (0);
+  return 0;
 } /* static int pidfile_create (const char *file) */
 
 static int pidfile_remove(void) {
@@ -363,7 +363,7 @@ static int pidfile_remove(void) {
   if (file == NULL)
     return 0;
 
-  return (unlink(file));
+  return unlink(file);
 } /* static int pidfile_remove (const char *file) */
 #endif /* COLLECT_DAEMON */
 
@@ -522,7 +522,7 @@ int main(int argc, char **argv) {
   if (cf_read(configfile)) {
     fprintf(stderr, "Error: Reading the config file failed!\n"
                     "Read the logs for details.\n");
-    return (1);
+    return 1;
   }
 
   /*
@@ -532,10 +532,10 @@ int main(int argc, char **argv) {
   if ((basedir = global_option_get("BaseDir")) == NULL) {
     fprintf(stderr,
             "Don't have a basedir to use. This should not happen. Ever.");
-    return (1);
+    return 1;
   } else if (change_basedir(basedir)) {
     fprintf(stderr, "Error: Unable to change to directory `%s'.\n", basedir);
-    return (1);
+    return 1;
   }
 
   /*
@@ -548,7 +548,7 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
 
   if (test_config)
-    return (0);
+    return 0;
 
 #if COLLECT_DAEMON
   /*
@@ -573,11 +573,11 @@ int main(int argc, char **argv) {
       /* error */
       char errbuf[1024];
       fprintf(stderr, "fork: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (1);
+      return 1;
     } else if (pid != 0) {
       /* parent */
       /* printf ("Running (PID %i)\n", pid); */
-      return (0);
+      return 0;
     }
 
     /* Detach from session */
@@ -596,21 +596,21 @@ int main(int argc, char **argv) {
     if (status != 0) {
       ERROR("Error: Could not connect `STDIN' to `/dev/null' (status %d)",
             status);
-      return (1);
+      return 1;
     }
 
     status = dup(0);
     if (status != 1) {
       ERROR("Error: Could not connect `STDOUT' to `/dev/null' (status %d)",
             status);
-      return (1);
+      return 1;
     }
 
     status = dup(0);
     if (status != 2) {
       ERROR("Error: Could not connect `STDERR' to `/dev/null', (status %d)",
             status);
-      return (1);
+      return 1;
     }
   }    /* if (daemonize) */
 #endif /* COLLECT_DAEMON */
@@ -628,7 +628,7 @@ int main(int argc, char **argv) {
     char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal INT: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   struct sigaction sig_term_action = {.sa_handler = sig_term_handler};
@@ -637,7 +637,7 @@ int main(int argc, char **argv) {
     char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal TERM: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   struct sigaction sig_usr1_action = {.sa_handler = sig_usr1_handler};
@@ -646,7 +646,7 @@ int main(int argc, char **argv) {
     char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal USR1: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   /*
@@ -680,5 +680,5 @@ int main(int argc, char **argv) {
     pidfile_remove();
 #endif /* COLLECT_DAEMON */
 
-  return (exit_status);
+  return exit_status;
 } /* int main */

--- a/src/daemon/collectd.h
+++ b/src/daemon/collectd.h
@@ -240,9 +240,7 @@
 
 /* Only enable __attribute__() for compilers known to support it. */
 #if !defined(__clang__) && !defined(__GNUC__)
-#if !defined(__attribute__)
 #define __attribute__(x) /**/
-#endif
 #endif
 
 #if defined(COLLECT_DEBUG) && COLLECT_DEBUG && defined(__GNUC__) && __GNUC__

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -81,7 +81,7 @@ char *sstrncpy(char *dest, const char *src, size_t n) {
   strncpy(dest, src, n);
   dest[n - 1] = '\0';
 
-  return (dest);
+  return dest;
 } /* char *sstrncpy */
 
 int ssnprintf(char *dest, size_t n, const char *format, ...) {
@@ -93,7 +93,7 @@ int ssnprintf(char *dest, size_t n, const char *format, ...) {
   dest[n - 1] = '\0';
   va_end(ap);
 
-  return (ret);
+  return ret;
 } /* int ssnprintf */
 
 char *ssnprintf_alloc(char const *format, ...) /* {{{ */
@@ -111,17 +111,17 @@ char *ssnprintf_alloc(char const *format, ...) /* {{{ */
   status = vsnprintf(static_buffer, sizeof(static_buffer), format, ap);
   va_end(ap);
   if (status < 0)
-    return (NULL);
+    return NULL;
 
   /* "status" does not include the null byte. */
   alloc_buffer_size = (size_t)(status + 1);
   if (alloc_buffer_size <= sizeof(static_buffer))
-    return (strdup(static_buffer));
+    return strdup(static_buffer);
 
   /* Allocate a buffer large enough to hold the string. */
   alloc_buffer = calloc(1, alloc_buffer_size);
   if (alloc_buffer == NULL)
-    return (NULL);
+    return NULL;
 
   /* Print again into this new buffer. */
   va_start(ap, format);
@@ -129,10 +129,10 @@ char *ssnprintf_alloc(char const *format, ...) /* {{{ */
   va_end(ap);
   if (status < 0) {
     sfree(alloc_buffer);
-    return (NULL);
+    return NULL;
   }
 
-  return (alloc_buffer);
+  return alloc_buffer;
 } /* }}} char *ssnprintf_alloc */
 
 char *sstrdup(const char *s) {
@@ -140,7 +140,7 @@ char *sstrdup(const char *s) {
   size_t sz;
 
   if (s == NULL)
-    return (NULL);
+    return NULL;
 
   /* Do not use `strdup' here, because it's not specified in POSIX. It's
    * ``only'' an XSI extension. */
@@ -152,7 +152,7 @@ char *sstrdup(const char *s) {
   }
   memcpy(r, s, sz);
 
-  return (r);
+  return r;
 } /* char *sstrdup */
 
 /* Even though Posix requires "strerror_r" to return an "int",
@@ -197,7 +197,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
   }
 #endif /* STRERROR_R_CHAR_P */
 
-  return (buf);
+  return buf;
 } /* char *sstrerror */
 
 void *smalloc(size_t size) {
@@ -208,7 +208,7 @@ void *smalloc(size_t size) {
     exit(3);
   }
 
-  return (r);
+  return r;
 } /* void *smalloc */
 
 #if 0
@@ -239,14 +239,14 @@ ssize_t sread(int fd, void *buf, size_t count) {
       continue;
 
     if (status < 0)
-      return (status);
+      return status;
 
     if (status == 0) {
       DEBUG("Received EOF from fd %i. "
             "Closing fd and returning error.",
             fd);
       close(fd);
-      return (-1);
+      return -1;
     }
 
     assert((0 > status) || (nleft >= (size_t)status));
@@ -255,7 +255,7 @@ ssize_t sread(int fd, void *buf, size_t count) {
     ptr = ptr + ((size_t)status);
   }
 
-  return (0);
+  return 0;
 }
 
 ssize_t swrite(int fd, const void *buf, size_t count) {
@@ -298,7 +298,7 @@ ssize_t swrite(int fd, const void *buf, size_t count) {
     ptr = ptr + ((size_t)status);
   }
 
-  return (0);
+  return 0;
 }
 
 int strsplit(char *string, char **fields, size_t size) {
@@ -317,7 +317,7 @@ int strsplit(char *string, char **fields, size_t size) {
       break;
   }
 
-  return ((int)i);
+  return (int)i;
 }
 
 int strjoin(char *buffer, size_t buffer_size, char **fields, size_t fields_num,
@@ -330,7 +330,7 @@ int strjoin(char *buffer, size_t buffer_size, char **fields, size_t fields_num,
 
   if (((fields_num != 0) && (fields == NULL)) ||
       ((buffer_size != 0) && (buffer == NULL)))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (buffer != NULL)
     buffer[0] = 0;
@@ -383,14 +383,14 @@ int escape_string(char *buffer, size_t buffer_size) {
   /* Check if we need to escape at all first */
   temp = strpbrk(buffer, " \t\"\\");
   if (temp == NULL)
-    return (0);
+    return 0;
 
   if (buffer_size < 3)
-    return (EINVAL);
+    return EINVAL;
 
   temp = calloc(1, buffer_size);
   if (temp == NULL)
-    return (ENOMEM);
+    return ENOMEM;
 
   temp[0] = '"';
   j = 1;
@@ -418,7 +418,7 @@ int escape_string(char *buffer, size_t buffer_size) {
 
   sstrncpy(buffer, temp, buffer_size);
   sfree(temp);
-  return (0);
+  return 0;
 } /* int escape_string */
 
 int strunescape(char *buf, size_t buf_len) {
@@ -430,7 +430,7 @@ int strunescape(char *buf, size_t buf_len) {
       ERROR("string unescape: backslash found at end of string.");
       /* Ensure null-byte at the end of the buffer. */
       buf[i] = 0;
-      return (-1);
+      return -1;
     }
 
     switch (buf[i + 1]) {
@@ -453,7 +453,7 @@ int strunescape(char *buf, size_t buf_len) {
     memmove(buf + i + 1, buf + i + 2, buf_len - i - 2);
     buf[buf_len - 1] = 0;
   }
-  return (0);
+  return 0;
 } /* int strunescape */
 
 size_t strstripnewline(char *buffer) {
@@ -466,7 +466,7 @@ size_t strstripnewline(char *buffer) {
     buffer[buffer_len] = 0;
   }
 
-  return (buffer_len);
+  return buffer_len;
 } /* size_t strstripnewline */
 
 int escape_slashes(char *buffer, size_t buffer_size) {
@@ -477,10 +477,10 @@ int escape_slashes(char *buffer, size_t buffer_size) {
   if (buffer_len <= 1) {
     if (strcmp("/", buffer) == 0) {
       if (buffer_size < 5)
-        return (-1);
+        return -1;
       sstrncpy(buffer, "root", buffer_size);
     }
-    return (0);
+    return 0;
   }
 
   /* Move one to the left */
@@ -494,7 +494,7 @@ int escape_slashes(char *buffer, size_t buffer_size) {
       buffer[i] = '_';
   }
 
-  return (0);
+  return 0;
 } /* int escape_slashes */
 
 void replace_special(char *buffer, size_t buffer_size) {
@@ -520,7 +520,7 @@ int timeval_cmp(struct timeval tv0, struct timeval tv1, struct timeval *delta) {
       delta->tv_sec = 0;
       delta->tv_usec = 0;
     }
-    return (0);
+    return 0;
   }
 
   if ((tv0.tv_sec < tv1.tv_sec) ||
@@ -548,7 +548,7 @@ int timeval_cmp(struct timeval tv0, struct timeval tv1, struct timeval *delta) {
   assert((delta == NULL) ||
          ((0 <= delta->tv_usec) && (delta->tv_usec < 1000000)));
 
-  return (status);
+  return status;
 } /* int timeval_cmp */
 
 int check_create_dir(const char *file_orig) {
@@ -569,12 +569,12 @@ int check_create_dir(const char *file_orig) {
    * Sanity checks first
    */
   if (file_orig == NULL)
-    return (-1);
+    return -1;
 
   if ((len = strlen(file_orig)) < 1)
-    return (-1);
+    return -1;
   else if (len >= sizeof(file_copy))
-    return (-1);
+    return -1;
 
   /*
    * If `file_orig' ends in a slash the last component is a directory,
@@ -618,7 +618,7 @@ int check_create_dir(const char *file_orig) {
       ERROR("Cowardly refusing to create a directory that "
             "begins with a `.' (dot): `%s'",
             file_orig);
-      return (-2);
+      return -2;
     }
 
     /*
@@ -628,7 +628,7 @@ int check_create_dir(const char *file_orig) {
     if (strjoin(dir + path_is_absolute, (size_t)(dir_len - path_is_absolute),
                 fields, (size_t)(i + 1), "/") < 0) {
       ERROR("strjoin failed: `%s', component #%i", file_orig, i);
-      return (-1);
+      return -1;
     }
 
     while (42) {
@@ -646,24 +646,24 @@ int check_create_dir(const char *file_orig) {
           char errbuf[1024];
           ERROR("check_create_dir: mkdir (%s): %s", dir,
                 sstrerror(errno, errbuf, sizeof(errbuf)));
-          return (-1);
+          return -1;
         } else {
           char errbuf[1024];
           ERROR("check_create_dir: stat (%s): %s", dir,
                 sstrerror(errno, errbuf, sizeof(errbuf)));
-          return (-1);
+          return -1;
         }
       } else if (!S_ISDIR(statbuf.st_mode)) {
         ERROR("check_create_dir: `%s' exists but is not "
               "a directory!",
               dir);
-        return (-1);
+        return -1;
       }
       break;
     }
   }
 
-  return (0);
+  return 0;
 } /* check_create_dir */
 
 #ifdef HAVE_LIBKSTAT
@@ -673,20 +673,20 @@ int get_kstat(kstat_t **ksp_ptr, char *module, int instance, char *name) {
   *ksp_ptr = NULL;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   ssnprintf(ident, sizeof(ident), "%s,%i,%s", module, instance, name);
 
   *ksp_ptr = kstat_lookup(kc, module, instance, name);
   if (*ksp_ptr == NULL) {
     ERROR("get_kstat: Cound not find kstat %s", ident);
-    return (-1);
+    return -1;
   }
 
   if ((*ksp_ptr)->ks_type != KSTAT_TYPE_NAMED) {
     ERROR("get_kstat: kstat %s has wrong type", ident);
     *ksp_ptr = NULL;
-    return (-1);
+    return -1;
   }
 
 #ifdef assert
@@ -696,15 +696,15 @@ int get_kstat(kstat_t **ksp_ptr, char *module, int instance, char *name) {
 
   if (kstat_read(kc, *ksp_ptr, NULL) == -1) {
     ERROR("get_kstat: kstat %s could not be read", ident);
-    return (-1);
+    return -1;
   }
 
   if ((*ksp_ptr)->ks_type != KSTAT_TYPE_NAMED) {
     ERROR("get_kstat: kstat %s has wrong type", ident);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 long long get_kstat_value(kstat_t *ksp, char *name) {
@@ -713,16 +713,16 @@ long long get_kstat_value(kstat_t *ksp, char *name) {
 
   if (ksp == NULL) {
     ERROR("get_kstat_value (\"%s\"): ksp is NULL.", name);
-    return (-1LL);
+    return -1LL;
   } else if (ksp->ks_type != KSTAT_TYPE_NAMED) {
     ERROR("get_kstat_value (\"%s\"): ksp->ks_type (%#x) "
           "is not KSTAT_TYPE_NAMED (%#x).",
           name, (unsigned int)ksp->ks_type, (unsigned int)KSTAT_TYPE_NAMED);
-    return (-1LL);
+    return -1LL;
   }
 
   if ((kn = (kstat_named_t *)kstat_data_lookup(ksp, name)) == NULL)
-    return (-1LL);
+    return -1LL;
 
   if (kn->data_type == KSTAT_DATA_INT32)
     retval = (long long)kn->value.i32;
@@ -737,14 +737,14 @@ long long get_kstat_value(kstat_t *ksp, char *name) {
   else
     WARNING("get_kstat_value: Not a numeric value: %s", name);
 
-  return (retval);
+  return retval;
 }
 #endif /* HAVE_LIBKSTAT */
 
 #ifndef HAVE_HTONLL
 unsigned long long ntohll(unsigned long long n) {
 #if BYTE_ORDER == BIG_ENDIAN
-  return (n);
+  return n;
 #else
   return (((unsigned long long)ntohl(n)) << 32) + ntohl(n >> 32);
 #endif
@@ -752,7 +752,7 @@ unsigned long long ntohll(unsigned long long n) {
 
 unsigned long long htonll(unsigned long long n) {
 #if BYTE_ORDER == BIG_ENDIAN
-  return (n);
+  return n;
 #else
   return (((unsigned long long)htonl(n)) << 32) + htonl(n >> 32);
 #endif
@@ -793,13 +793,13 @@ double ntohd(double d) {
   if ((ret.byte[0] == 0x00) && (ret.byte[1] == 0x00) && (ret.byte[2] == 0x00) &&
       (ret.byte[3] == 0x00) && (ret.byte[4] == 0x00) && (ret.byte[5] == 0x00) &&
       (ret.byte[6] == 0xf8) && (ret.byte[7] == 0x7f)) {
-    return (NAN);
+    return NAN;
   } else {
     uint64_t tmp;
 
     tmp = ret.integer;
     ret.integer = FP_CONVERT(tmp);
-    return (ret.floating);
+    return ret.floating;
   }
 } /* double ntohd */
 
@@ -815,14 +815,14 @@ double htond(double d) {
     ret.byte[4] = ret.byte[5] = 0x00;
     ret.byte[6] = 0xf8;
     ret.byte[7] = 0x7f;
-    return (ret.floating);
+    return ret.floating;
   } else {
     uint64_t tmp;
 
     ret.floating = d;
     tmp = FP_CONVERT(ret.integer);
     ret.integer = tmp;
-    return (ret.floating);
+    return ret.floating;
   }
 } /* double htond */
 #endif /* FP_LAYOUT_NEED_ENDIANFLIP || FP_LAYOUT_NEED_INTSWAP */
@@ -840,7 +840,7 @@ int format_name(char *ret, int ret_len, const char *hostname,
   do {                                                                         \
     size_t l = strlen(str);                                                    \
     if (l >= buffer_size)                                                      \
-      return (ENOBUFS);                                                        \
+      return ENOBUFS;                                                          \
     memcpy(buffer, (str), l);                                                  \
     buffer += l;                                                               \
     buffer_size -= l;                                                          \
@@ -866,7 +866,7 @@ int format_name(char *ret, int ret_len, const char *hostname,
   buffer[0] = 0;
 
 #undef APPEND
-  return (0);
+  return 0;
 } /* int format_name */
 
 int format_values(char *ret, size_t ret_len, /* {{{ */
@@ -885,10 +885,10 @@ int format_values(char *ret, size_t ret_len, /* {{{ */
     status = ssnprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else if (((size_t)status) >= (ret_len - offset)) {                       \
       sfree(rates);                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else                                                                     \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -903,7 +903,7 @@ int format_values(char *ret, size_t ret_len, /* {{{ */
         rates = uc_get_rate(ds, vl);
       if (rates == NULL) {
         WARNING("format_values: uc_get_rate failed.");
-        return (-1);
+        return -1;
       }
       BUFFER_ADD(":" GAUGE_FORMAT, rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
@@ -915,14 +915,14 @@ int format_values(char *ret, size_t ret_len, /* {{{ */
     else {
       ERROR("format_values: Unknown data source type: %i", ds->ds[i].type);
       sfree(rates);
-      return (-1);
+      return -1;
     }
   } /* for ds->ds_num */
 
 #undef BUFFER_ADD
 
   sfree(rates);
-  return (0);
+  return 0;
 } /* }}} int format_values */
 
 int parse_identifier(char *str, char **ret_host, char **ret_plugin,
@@ -936,18 +936,18 @@ int parse_identifier(char *str, char **ret_host, char **ret_plugin,
 
   hostname = str;
   if (hostname == NULL)
-    return (-1);
+    return -1;
 
   plugin = strchr(hostname, '/');
   if (plugin == NULL)
-    return (-1);
+    return -1;
   *plugin = '\0';
   plugin++;
 
   type = strchr(plugin, '/');
   if (type == NULL) {
     if (default_host == NULL)
-      return (-1);
+      return -1;
     /* else: no host specified; use default */
     type = plugin;
     plugin = hostname;
@@ -974,7 +974,7 @@ int parse_identifier(char *str, char **ret_host, char **ret_plugin,
   *ret_plugin_instance = plugin_instance;
   *ret_type = type;
   *ret_type_instance = type_instance;
-  return (0);
+  return 0;
 } /* int parse_identifier */
 
 int parse_identifier_vl(const char *str, value_list_t *vl) /* {{{ */
@@ -988,7 +988,7 @@ int parse_identifier_vl(const char *str, value_list_t *vl) /* {{{ */
   int status;
 
   if ((str == NULL) || (vl == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   sstrncpy(str_copy, str, sizeof(str_copy));
 
@@ -996,7 +996,7 @@ int parse_identifier_vl(const char *str, value_list_t *vl) /* {{{ */
                             &type_instance,
                             /* default_host = */ NULL);
   if (status != 0)
-    return (status);
+    return status;
 
   sstrncpy(vl->host, host, sizeof(vl->host));
   sstrncpy(vl->plugin, plugin, sizeof(vl->plugin));
@@ -1007,7 +1007,7 @@ int parse_identifier_vl(const char *str, value_list_t *vl) /* {{{ */
   sstrncpy(vl->type_instance, (type_instance != NULL) ? type_instance : "",
            sizeof(vl->type_instance));
 
-  return (0);
+  return 0;
 } /* }}} int parse_identifier_vl */
 
 int parse_value(const char *value_orig, value_t *ret_value, int ds_type) {
@@ -1016,11 +1016,11 @@ int parse_value(const char *value_orig, value_t *ret_value, int ds_type) {
   size_t value_len;
 
   if (value_orig == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   value = strdup(value_orig);
   if (value == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   value_len = strlen(value);
 
   while ((value_len > 0) && isspace((int)value[value_len - 1])) {
@@ -1100,7 +1100,7 @@ int parse_values(char *buffer, value_list_t *vl, const data_set_t *ds) {
             || (endptr == ptr)  /* Invalid string */
             || (endptr == NULL) /* This should not happen */
             || (*endptr != 0))  /* Trailing chars */
-          return (-1);
+          return -1;
 
         vl->time = DOUBLE_TO_CDTIME_T(tmp);
       }
@@ -1117,8 +1117,8 @@ int parse_values(char *buffer, value_list_t *vl, const data_set_t *ds) {
   } /* while (strtok_r) */
 
   if ((ptr != NULL) || (i == 0))
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* int parse_values */
 
 int parse_value_file(char const *path, value_t *ret_value, int ds_type) {
@@ -1127,11 +1127,11 @@ int parse_value_file(char const *path, value_t *ret_value, int ds_type) {
 
   fh = fopen(path, "r");
   if (fh == NULL)
-    return (-1);
+    return -1;
 
   if (fgets(buffer, sizeof(buffer), fh) == NULL) {
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   fclose(fh);
@@ -1185,7 +1185,7 @@ int getpwnam_r(const char *name, struct passwd *pwbuf, char *buf, size_t buflen,
 
   pthread_mutex_unlock(&getpwnam_r_lock);
 
-  return (status);
+  return status;
 } /* int getpwnam_r */
 #endif /* !HAVE_GETPWNAM_R */
 
@@ -1210,7 +1210,7 @@ int notification_init(notification_t *n, int severity, const char *message,
   if (type_instance != NULL)
     sstrncpy(n->type_instance, type_instance, sizeof(n->type_instance));
 
-  return (0);
+  return 0;
 } /* int notification_init */
 
 int walk_directory(const char *dir, dirwalk_callback_f callback,
@@ -1252,8 +1252,8 @@ int walk_directory(const char *dir, dirwalk_callback_f callback,
   closedir(dh);
 
   if ((success == 0) && (failure > 0))
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 }
 
 ssize_t read_file_contents(const char *filename, char *buf, size_t bufsize) {
@@ -1262,7 +1262,7 @@ ssize_t read_file_contents(const char *filename, char *buf, size_t bufsize) {
 
   fh = fopen(filename, "r");
   if (fh == NULL)
-    return (-1);
+    return -1;
 
   ret = (ssize_t)fread(buf, 1, bufsize, fh);
   if ((ret == 0) && (ferror(fh) != 0)) {
@@ -1271,7 +1271,7 @@ ssize_t read_file_contents(const char *filename, char *buf, size_t bufsize) {
   }
 
   fclose(fh);
-  return (ret);
+  return ret;
 }
 
 counter_t counter_diff(counter_t old_value, counter_t new_value) {
@@ -1286,7 +1286,7 @@ counter_t counter_diff(counter_t old_value, counter_t new_value) {
     diff = new_value - old_value;
   }
 
-  return (diff);
+  return diff;
 } /* counter_t counter_diff */
 
 int rate_to_value(value_t *ret_value, gauge_t rate, /* {{{ */
@@ -1299,7 +1299,7 @@ int rate_to_value(value_t *ret_value, gauge_t rate, /* {{{ */
     state->last_time = t;
 
     *ret_value = state->last_value;
-    return (0);
+    return 0;
   }
 
   /* Counter and absolute can't handle negative rates. Reset "last time"
@@ -1308,13 +1308,13 @@ int rate_to_value(value_t *ret_value, gauge_t rate, /* {{{ */
   if ((rate < 0.0) &&
       ((ds_type == DS_TYPE_COUNTER) || (ds_type == DS_TYPE_ABSOLUTE))) {
     memset(state, 0, sizeof(*state));
-    return (EINVAL);
+    return EINVAL;
   }
 
   /* Another invalid state: The time is not increasing. */
   if (t <= state->last_time) {
     memset(state, 0, sizeof(*state));
-    return (EINVAL);
+    return EINVAL;
   }
 
   delta_t = t - state->last_time;
@@ -1337,7 +1337,7 @@ int rate_to_value(value_t *ret_value, gauge_t rate, /* {{{ */
     }
 
     state->last_time = t;
-    return (EAGAIN);
+    return EAGAIN;
   } /* }}} */
 
   if (ds_type == DS_TYPE_DERIVE) {
@@ -1361,7 +1361,7 @@ int rate_to_value(value_t *ret_value, gauge_t rate, /* {{{ */
 
   state->last_time = t;
   *ret_value = state->last_value;
-  return (0);
+  return 0;
 } /* }}} value_t rate_to_value */
 
 int value_to_rate(gauge_t *ret_rate, /* {{{ */
@@ -1372,7 +1372,7 @@ int value_to_rate(gauge_t *ret_rate, /* {{{ */
   /* Another invalid state: The time is not increasing. */
   if (t <= state->last_time) {
     memset(state, 0, sizeof(*state));
-    return (EINVAL);
+    return EINVAL;
   }
 
   interval = CDTIME_T_TO_DOUBLE(t - state->last_time);
@@ -1381,7 +1381,7 @@ int value_to_rate(gauge_t *ret_rate, /* {{{ */
   if (state->last_time == 0) {
     state->last_value = value;
     state->last_time = t;
-    return (EAGAIN);
+    return EAGAIN;
   }
 
   switch (ds_type) {
@@ -1410,7 +1410,7 @@ int value_to_rate(gauge_t *ret_rate, /* {{{ */
 
   state->last_value = value;
   state->last_time = t;
-  return (0);
+  return 0;
 } /* }}} value_t rate_to_value */
 
 int service_name_to_port_number(const char *service_name) {
@@ -1419,7 +1419,7 @@ int service_name_to_port_number(const char *service_name) {
   int service_number;
 
   if (service_name == NULL)
-    return (-1);
+    return -1;
 
   struct addrinfo ai_hints = {.ai_family = AF_UNSPEC};
 
@@ -1427,7 +1427,7 @@ int service_name_to_port_number(const char *service_name) {
   if (status != 0) {
     ERROR("service_name_to_port_number: getaddrinfo failed: %s",
           gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   service_number = -1;
@@ -1452,8 +1452,8 @@ int service_name_to_port_number(const char *service_name) {
   freeaddrinfo(ai_list);
 
   if ((service_number > 0) && (service_number <= 65535))
-    return (service_number);
-  return (-1);
+    return service_number;
+  return -1;
 } /* int service_name_to_port_number */
 
 void set_sock_opts(int sockfd) /* {{{ */
@@ -1499,16 +1499,16 @@ int strtoderive(const char *string, derive_t *ret_value) /* {{{ */
   char *endptr;
 
   if ((string == NULL) || (ret_value == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   errno = 0;
   endptr = NULL;
   tmp = (derive_t)strtoll(string, &endptr, /* base = */ 0);
   if ((endptr == string) || (errno != 0))
-    return (-1);
+    return -1;
 
   *ret_value = tmp;
-  return (0);
+  return 0;
 } /* }}} int strtoderive */
 
 int strtogauge(const char *string, gauge_t *ret_value) /* {{{ */
@@ -1517,18 +1517,18 @@ int strtogauge(const char *string, gauge_t *ret_value) /* {{{ */
   char *endptr = NULL;
 
   if ((string == NULL) || (ret_value == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   errno = 0;
   endptr = NULL;
   tmp = (gauge_t)strtod(string, &endptr);
   if (errno != 0)
-    return (errno);
+    return errno;
   else if ((endptr == NULL) || (*endptr != 0))
-    return (EINVAL);
+    return EINVAL;
 
   *ret_value = tmp;
-  return (0);
+  return 0;
 } /* }}} int strtogauge */
 
 int strarray_add(char ***ret_array, size_t *ret_array_len,
@@ -1538,20 +1538,20 @@ int strarray_add(char ***ret_array, size_t *ret_array_len,
   size_t array_len = *ret_array_len;
 
   if (str == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   array = realloc(*ret_array, (array_len + 1) * sizeof(*array));
   if (array == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   *ret_array = array;
 
   array[array_len] = strdup(str);
   if (array[array_len] == NULL)
-    return (ENOMEM);
+    return ENOMEM;
 
   array_len++;
   *ret_array_len = array_len;
-  return (0);
+  return 0;
 } /* }}} int strarray_add */
 
 void strarray_free(char **array, size_t array_len) /* {{{ */
@@ -1569,27 +1569,27 @@ int check_capability(int arg) /* {{{ */
   cap_flag_value_t cap_flag_value;
 
   if (!CAP_IS_SUPPORTED(cap_value))
-    return (-1);
+    return -1;
 
   if (!(cap = cap_get_proc())) {
     ERROR("check_capability: cap_get_proc failed.");
-    return (-1);
+    return -1;
   }
 
   if (cap_get_flag(cap, cap_value, CAP_EFFECTIVE, &cap_flag_value) < 0) {
     ERROR("check_capability: cap_get_flag failed.");
     cap_free(cap);
-    return (-1);
+    return -1;
   }
   cap_free(cap);
 
-  return (cap_flag_value != CAP_SET);
+  return cap_flag_value != CAP_SET;
 } /* }}} int check_capability */
 #else
 int check_capability(__attribute__((unused)) int arg) /* {{{ */
 {
   WARNING("check_capability: unsupported capability implementation. "
           "Some plugin(s) may require elevated privileges to work properly.");
-  return (0);
+  return 0;
 } /* }}} int check_capability */
 #endif /* HAVE_CAPABILITY */

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -55,7 +55,7 @@ DEF_TEST(sstrncpy) {
   EXPECT_EQ_STR("collect", ptr);
   OK(buffer[3] == buffer[12]);
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(ssnprintf) {
@@ -76,7 +76,7 @@ DEF_TEST(ssnprintf) {
   EXPECT_EQ_STR("collect", ptr);
   OK(buffer[3] == buffer[12]);
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(sstrdup) {
@@ -91,7 +91,7 @@ DEF_TEST(sstrdup) {
   ptr = sstrdup(NULL);
   OK(ptr == NULL);
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(strsplit) {
@@ -141,7 +141,7 @@ DEF_TEST(strsplit) {
   status = strsplit(buffer, fields, 8);
   OK(status == 0);
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(strjoin) {
@@ -190,7 +190,7 @@ DEF_TEST(strjoin) {
   /* use (NULL, 0) to determine required buffer size. */
   EXPECT_EQ_INT(3, strjoin(NULL, 0, (char *[]){"a", "b"}, 2, "-"));
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(escape_slashes) {
@@ -264,7 +264,7 @@ DEF_TEST(strunescape) {
   status = strunescape(buffer, sizeof(buffer));
   OK(status != 0);
   EXPECT_EQ_STR("\tbackslash end", buffer);
-  return (0);
+  return 0;
 
   /* Backslash at buffer end */
   strncpy(buffer, "\\t3\\56", sizeof(buffer));
@@ -278,7 +278,7 @@ DEF_TEST(strunescape) {
   OK(buffer[5] == '6');
   OK(buffer[6] == '7');
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(parse_values) {
@@ -323,7 +323,7 @@ DEF_TEST(parse_values) {
     EXPECT_EQ_DOUBLE(cases[i].value, vl.values[0].gauge);
   }
 
-  return (0);
+  return 0;
 }
 
 DEF_TEST(value_to_rate) {

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -128,13 +128,13 @@ static cf_callback_t *cf_search(const char *type) {
   cf_callback_t *cf_cb;
 
   if (type == NULL)
-    return (NULL);
+    return NULL;
 
   for (cf_cb = first_callback; cf_cb != NULL; cf_cb = cf_cb->next)
     if (strcasecmp(cf_cb->type, type) == 0)
       break;
 
-  return (cf_cb);
+  return cf_cb;
 }
 
 static int cf_dispatch(const char *type, const char *orig_key,
@@ -147,7 +147,7 @@ static int cf_dispatch(const char *type, const char *orig_key,
   int i = 0;
 
   if (orig_key == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   DEBUG("type = %s, key = %s, value = %s", ESCAPE_NULL(type), orig_key,
         ESCAPE_NULL(orig_value));
@@ -157,14 +157,14 @@ static int cf_dispatch(const char *type, const char *orig_key,
             "the plugin isn't loaded or didn't register "
             "a configuration callback.",
             type);
-    return (-1);
+    return -1;
   }
 
   if ((key = strdup(orig_key)) == NULL)
-    return (1);
+    return 1;
   if ((value = strdup(orig_value)) == NULL) {
     free(key);
-    return (2);
+    return 2;
   }
 
   ret = -1;
@@ -186,26 +186,26 @@ static int cf_dispatch(const char *type, const char *orig_key,
   free(key);
   free(value);
 
-  return (ret);
+  return ret;
 } /* int cf_dispatch */
 
 static int dispatch_global_option(const oconfig_item_t *ci) {
   if (ci->values_num != 1)
-    return (-1);
+    return -1;
   if (ci->values[0].type == OCONFIG_TYPE_STRING)
-    return (global_option_set(ci->key, ci->values[0].value.string, 0));
+    return global_option_set(ci->key, ci->values[0].value.string, 0);
   else if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     char tmp[128];
     ssnprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
-    return (global_option_set(ci->key, tmp, 0));
+    return global_option_set(ci->key, tmp, 0);
   } else if (ci->values[0].type == OCONFIG_TYPE_BOOLEAN) {
     if (ci->values[0].value.boolean)
-      return (global_option_set(ci->key, "true", 0));
+      return global_option_set(ci->key, "true", 0);
     else
-      return (global_option_set(ci->key, "false", 0));
+      return global_option_set(ci->key, "false", 0);
   }
 
-  return (-1);
+  return -1;
 } /* int dispatch_global_option */
 
 static int dispatch_value_typesdb(oconfig_item_t *ci) {
@@ -215,7 +215,7 @@ static int dispatch_value_typesdb(oconfig_item_t *ci) {
 
   if (ci->values_num < 1) {
     ERROR("configfile: `TypesDB' needs at least one argument.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; ++i) {
@@ -228,19 +228,19 @@ static int dispatch_value_typesdb(oconfig_item_t *ci) {
 
     read_types_list(ci->values[i].value.string);
   }
-  return (0);
+  return 0;
 } /* int dispatch_value_typesdb */
 
 static int dispatch_value_plugindir(oconfig_item_t *ci) {
   assert(strcasecmp(ci->key, "PluginDir") == 0);
 
   if (ci->values_num != 1)
-    return (-1);
+    return -1;
   if (ci->values[0].type != OCONFIG_TYPE_STRING)
-    return (-1);
+    return -1;
 
   plugin_set_dir(ci->values[0].value.string);
-  return (0);
+  return 0;
 }
 
 static int dispatch_loadplugin(oconfig_item_t *ci) {
@@ -253,9 +253,9 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
   assert(strcasecmp(ci->key, "LoadPlugin") == 0);
 
   if (ci->values_num != 1)
-    return (-1);
+    return -1;
   if (ci->values[0].type != OCONFIG_TYPE_STRING)
-    return (-1);
+    return -1;
 
   name = ci->values[0].value.string;
   if (strcmp("libvirt", name) == 0)
@@ -289,7 +289,7 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
   /* reset to the "global" context */
   plugin_set_ctx(old_ctx);
 
-  return (ret_val);
+  return ret_val;
 } /* int dispatch_value_loadplugin */
 
 static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
@@ -314,14 +314,14 @@ static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
                          ci->values[i].value.boolean ? "true" : "false");
 
     if ((status < 0) || (status >= buffer_free))
-      return (-1);
+      return -1;
     buffer_free -= status;
     buffer_ptr += status;
   }
   /* skip the initial space */
   buffer_ptr = buffer + 1;
 
-  return (cf_dispatch(plugin, ci->key, buffer_ptr));
+  return cf_dispatch(plugin, ci->key, buffer_ptr);
 } /* int dispatch_value_plugin */
 
 static int dispatch_value(oconfig_item_t *ci) {
@@ -339,18 +339,18 @@ static int dispatch_value(oconfig_item_t *ci) {
       break;
     }
 
-  return (ret);
+  return ret;
 } /* int dispatch_value */
 
 static int dispatch_block_plugin(oconfig_item_t *ci) {
   const char *name;
 
   if (strcasecmp(ci->key, "Plugin") != 0)
-    return (-1);
+    return -1;
   if (ci->values_num < 1)
-    return (-1);
+    return -1;
   if (ci->values[0].type != OCONFIG_TYPE_STRING)
-    return (-1);
+    return -1;
 
   name = ci->values[0].value.string;
   if (strcmp("libvirt", name) == 0) {
@@ -380,7 +380,7 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
       ERROR("Automatically loading plugin \"%s\" failed "
             "with status %i.",
             name, status);
-      return (status);
+      return status;
     }
   }
 
@@ -394,7 +394,7 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
       old_ctx = plugin_set_ctx(cb->ctx);
       ret_val = (cb->callback(ci));
       plugin_set_ctx(old_ctx);
-      return (ret_val);
+      return ret_val;
     }
   }
 
@@ -413,18 +413,18 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
     }
   }
 
-  return (0);
+  return 0;
 }
 
 static int dispatch_block(oconfig_item_t *ci) {
   if (strcasecmp(ci->key, "LoadPlugin") == 0)
-    return (dispatch_loadplugin(ci));
+    return dispatch_loadplugin(ci);
   else if (strcasecmp(ci->key, "Plugin") == 0)
-    return (dispatch_block_plugin(ci));
+    return dispatch_block_plugin(ci);
   else if (strcasecmp(ci->key, "Chain") == 0)
-    return (fc_configure(ci));
+    return fc_configure(ci);
 
-  return (0);
+  return 0;
 }
 
 static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
@@ -458,7 +458,7 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
    * all children. */
   if (dst->children_num + src->children_num - 1 == 0) {
     dst->children_num = 0;
-    return (0);
+    return 0;
   }
 
   temp =
@@ -466,7 +466,7 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
                                  (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
-    return (-1);
+    return -1;
   }
   dst->children = temp;
 
@@ -493,20 +493,20 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
   /* Update the number of children. */
   dst->children_num += (src->children_num - 1);
 
-  return (0);
+  return 0;
 } /* int cf_ci_replace_child */
 
 static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   oconfig_item_t *temp;
 
   if ((src == NULL) || (src->children_num == 0))
-    return (0);
+    return 0;
 
   temp = realloc(dst->children, sizeof(oconfig_item_t) *
                                     (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
-    return (-1);
+    return -1;
   }
   dst->children = temp;
 
@@ -514,7 +514,7 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
          sizeof(oconfig_item_t) * src->children_num);
   dst->children_num += src->children_num;
 
-  return (0);
+  return 0;
 } /* int cf_ci_append_children */
 
 #define CF_MAX_DEPTH 8
@@ -553,13 +553,13 @@ static int cf_include_all(oconfig_item_t *root, int depth) {
     sfree(pattern);
 
     if (new == NULL)
-      return (-1);
+      return -1;
 
     /* Now replace the i'th child in `root' with `new'. */
     if (cf_ci_replace_child(root, new, i) < 0) {
       sfree(new->values);
       sfree(new);
-      return (-1);
+      return -1;
     }
 
     /* ... and go back to the new i'th child. */
@@ -569,7 +569,7 @@ static int cf_include_all(oconfig_item_t *root, int depth) {
     sfree(new);
   } /* for (i = 0; i < root->children_num; i++) */
 
-  return (0);
+  return 0;
 } /* int cf_include_all */
 
 static oconfig_item_t *cf_read_file(const char *file, const char *pattern,
@@ -589,7 +589,7 @@ static oconfig_item_t *cf_read_file(const char *file, const char *pattern,
             "does not match pattern `%s'.",
             filename, pattern);
       free(tmp);
-      return (NULL);
+      return NULL;
     }
 
     free(tmp);
@@ -604,16 +604,16 @@ static oconfig_item_t *cf_read_file(const char *file, const char *pattern,
   root = oconfig_parse_file(file);
   if (root == NULL) {
     ERROR("configfile: Cannot read file `%s'.", file);
-    return (NULL);
+    return NULL;
   }
 
   status = cf_include_all(root, depth);
   if (status != 0) {
     oconfig_free(root);
-    return (NULL);
+    return NULL;
   }
 
-  return (root);
+  return root;
 } /* oconfig_item_t *cf_read_file */
 
 static int cf_compare_string(const void *p1, const void *p2) {
@@ -636,14 +636,14 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
     char errbuf[1024];
     ERROR("configfile: opendir failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (NULL);
+    return NULL;
   }
 
   root = calloc(1, sizeof(*root));
   if (root == NULL) {
     ERROR("configfile: calloc failed.");
     closedir(dh);
-    return (NULL);
+    return NULL;
   }
 
   while ((de = readdir(dh)) != NULL) {
@@ -663,7 +663,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
         free(filenames[i]);
       free(filenames);
       free(root);
-      return (NULL);
+      return NULL;
     }
 
     ++filenames_num;
@@ -675,7 +675,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
         free(filenames[i]);
       free(filenames);
       free(root);
-      return (NULL);
+      return NULL;
     }
     filenames = tmp;
 
@@ -684,7 +684,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
 
   if (filenames == NULL) {
     closedir(dh);
-    return (root);
+    return root;
   }
 
   qsort((void *)filenames, filenames_num, sizeof(*filenames),
@@ -710,7 +710,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
 
   closedir(dh);
   free(filenames);
-  return (root);
+  return root;
 } /* oconfig_item_t *cf_read_dir */
 
 /*
@@ -736,19 +736,19 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
     ERROR("configfile: Not including `%s' because the maximum "
           "nesting depth has been reached.",
           path);
-    return (NULL);
+    return NULL;
   }
 
   status = wordexp(path, &we, WRDE_NOCMD);
   if (status != 0) {
     ERROR("configfile: wordexp (%s) failed.", path);
-    return (NULL);
+    return NULL;
   }
 
   root = calloc(1, sizeof(*root));
   if (root == NULL) {
     ERROR("configfile: calloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* wordexp() might return a sorted list already. That's not
@@ -783,7 +783,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
     if (temp == NULL) {
       oconfig_free(root);
-      return (NULL);
+      return NULL;
     }
 
     cf_ci_append_children(root, temp);
@@ -793,7 +793,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
   wordfree(&we);
 
-  return (root);
+  return root;
 } /* oconfig_item_t *cf_read_generic */
 /* #endif HAVE_WORDEXP_H */
 
@@ -807,7 +807,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
     ERROR("configfile: Not including `%s' because the maximum "
           "nesting depth has been reached.",
           path);
-    return (NULL);
+    return NULL;
   }
 
   status = stat(path, &statbuf);
@@ -815,16 +815,16 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
     char errbuf[1024];
     ERROR("configfile: stat (%s) failed: %s", path,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (NULL);
+    return NULL;
   }
 
   if (S_ISREG(statbuf.st_mode))
-    return (cf_read_file(path, pattern, depth));
+    return cf_read_file(path, pattern, depth);
   else if (S_ISDIR(statbuf.st_mode))
-    return (cf_read_dir(path, pattern, depth));
+    return cf_read_dir(path, pattern, depth);
 
   ERROR("configfile: %s is neither a file nor a directory.", path);
-  return (NULL);
+  return NULL;
 } /* oconfig_item_t *cf_read_generic */
 #endif /* !HAVE_WORDEXP_H */
 
@@ -841,14 +841,14 @@ int global_option_set(const char *option, const char *value, _Bool from_cli) {
 
   if (i >= cf_global_options_num) {
     ERROR("configfile: Cannot set unknown global option `%s'.", option);
-    return (-1);
+    return -1;
   }
 
   if (cf_global_options[i].from_cli && (!from_cli)) {
     DEBUG("configfile: Ignoring %s `%s' option because "
           "it was overriden by a command-line option.",
           option, value);
-    return (0);
+    return 0;
   }
 
   sfree(cf_global_options[i].value);
@@ -860,7 +860,7 @@ int global_option_set(const char *option, const char *value, _Bool from_cli) {
 
   cf_global_options[i].from_cli = from_cli;
 
-  return (0);
+  return 0;
 }
 
 const char *global_option_get(const char *option) {
@@ -871,11 +871,10 @@ const char *global_option_get(const char *option) {
 
   if (i >= cf_global_options_num) {
     ERROR("configfile: Cannot get unknown global option `%s'.", option);
-    return (NULL);
+    return NULL;
   }
 
-  return ((cf_global_options[i].value != NULL) ? cf_global_options[i].value
-                                               : cf_global_options[i].def);
+  return (cf_global_options[i].value != NULL) ? cf_global_options[i].value : cf_global_options[i].def;
 } /* char *global_option_get */
 
 long global_option_get_long(const char *option, long default_value) {
@@ -884,14 +883,14 @@ long global_option_get_long(const char *option, long default_value) {
 
   str = global_option_get(option);
   if (NULL == str)
-    return (default_value);
+    return default_value;
 
   errno = 0;
   value = strtol(str, /* endptr = */ NULL, /* base = */ 0);
   if (errno != 0)
-    return (default_value);
+    return default_value;
 
-  return (value);
+  return value;
 } /* char *global_option_get_long */
 
 cdtime_t global_option_get_time(const char *name, cdtime_t def) /* {{{ */
@@ -902,21 +901,21 @@ cdtime_t global_option_get_time(const char *name, cdtime_t def) /* {{{ */
 
   optstr = global_option_get(name);
   if (optstr == NULL)
-    return (def);
+    return def;
 
   errno = 0;
   v = strtod(optstr, &endptr);
   if ((endptr == NULL) || (*endptr != 0) || (errno != 0))
-    return (def);
+    return def;
   else if (v <= 0.0)
-    return (def);
+    return def;
 
-  return (DOUBLE_TO_CDTIME_T(v));
+  return DOUBLE_TO_CDTIME_T(v);
 } /* }}} cdtime_t global_option_get_time */
 
 cdtime_t cf_get_default_interval(void) {
-  return (global_option_get_time(
-      "Interval", DOUBLE_TO_CDTIME_T(COLLECTD_DEFAULT_INTERVAL)));
+  return global_option_get_time("Interval",
+                                DOUBLE_TO_CDTIME_T(COLLECTD_DEFAULT_INTERVAL));
 }
 
 void cf_unregister(const char *type) {
@@ -974,12 +973,12 @@ int cf_register_complex(const char *type, int (*callback)(oconfig_item_t *)) {
 
   new = malloc(sizeof(*new));
   if (new == NULL)
-    return (-1);
+    return -1;
 
   new->type = strdup(type);
   if (new->type == NULL) {
     sfree(new);
-    return (-1);
+    return -1;
   }
 
   new->callback = callback;
@@ -996,7 +995,7 @@ int cf_register_complex(const char *type, int (*callback)(oconfig_item_t *)) {
     last->next = new;
   }
 
-  return (0);
+  return 0;
 } /* int cf_register_complex */
 
 int cf_read(const char *filename) {
@@ -1006,11 +1005,11 @@ int cf_read(const char *filename) {
   conf = cf_read_generic(filename, /* pattern = */ NULL, /* depth = */ 0);
   if (conf == NULL) {
     ERROR("Unable to read config file %s.", filename);
-    return (-1);
+    return -1;
   } else if (conf->children_num == 0) {
     ERROR("Configuration file %s is empty.", filename);
     oconfig_free(conf);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < conf->children_num; i++) {
@@ -1045,18 +1044,18 @@ int cf_util_get_string(const oconfig_item_t *ci, char **ret_string) /* {{{ */
     ERROR("cf_util_get_string: The %s option requires "
           "exactly one string argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   string = strdup(ci->values[0].value.string);
   if (string == NULL)
-    return (-1);
+    return -1;
 
   if (*ret_string != NULL)
     sfree(*ret_string);
   *ret_string = string;
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_string */
 
 /* Assures the config option is a string and copies it to the provided buffer.
@@ -1064,67 +1063,67 @@ int cf_util_get_string(const oconfig_item_t *ci, char **ret_string) /* {{{ */
 int cf_util_get_string_buffer(const oconfig_item_t *ci, char *buffer, /* {{{ */
                               size_t buffer_size) {
   if ((ci == NULL) || (buffer == NULL) || (buffer_size < 1))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     ERROR("cf_util_get_string_buffer: The %s option requires "
           "exactly one string argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   strncpy(buffer, ci->values[0].value.string, buffer_size);
   buffer[buffer_size - 1] = 0;
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_string_buffer */
 
 /* Assures the config option is a number and returns it as an int. */
 int cf_util_get_int(const oconfig_item_t *ci, int *ret_value) /* {{{ */
 {
   if ((ci == NULL) || (ret_value == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)) {
     ERROR("cf_util_get_int: The %s option requires "
           "exactly one numeric argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret_value = (int)ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_int */
 
 int cf_util_get_double(const oconfig_item_t *ci, double *ret_value) /* {{{ */
 {
   if ((ci == NULL) || (ret_value == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)) {
     ERROR("cf_util_get_double: The %s option requires "
           "exactly one numeric argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret_value = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_double */
 
 int cf_util_get_boolean(const oconfig_item_t *ci, _Bool *ret_bool) /* {{{ */
 {
   if ((ci == NULL) || (ret_bool == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || ((ci->values[0].type != OCONFIG_TYPE_BOOLEAN) &&
                                 (ci->values[0].type != OCONFIG_TYPE_STRING))) {
     ERROR("cf_util_get_boolean: The %s option requires "
           "exactly one boolean argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   switch (ci->values[0].type) {
@@ -1145,12 +1144,12 @@ int cf_util_get_boolean(const oconfig_item_t *ci, _Bool *ret_bool) /* {{{ */
       ERROR("cf_util_get_boolean: Cannot parse string value `%s' of the `%s' "
             "option as a boolean value.",
             ci->values[0].value.string, ci->key);
-      return (-1);
+      return -1;
     }
     break;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_boolean */
 
 int cf_util_get_flag(const oconfig_item_t *ci, /* {{{ */
@@ -1159,12 +1158,12 @@ int cf_util_get_flag(const oconfig_item_t *ci, /* {{{ */
   _Bool b;
 
   if (ret_value == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   b = 0;
   status = cf_util_get_boolean(ci, &b);
   if (status != 0)
-    return (status);
+    return status;
 
   if (b) {
     *ret_value |= flag;
@@ -1172,7 +1171,7 @@ int cf_util_get_flag(const oconfig_item_t *ci, /* {{{ */
     *ret_value &= ~flag;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_flag */
 
 /* Assures that the config option is a string or a number if the correct range
@@ -1189,11 +1188,11 @@ int cf_util_get_port_number(const oconfig_item_t *ci) /* {{{ */
     ERROR("cf_util_get_port_number: The \"%s\" option requires "
           "exactly one string argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].type == OCONFIG_TYPE_STRING)
-    return (service_name_to_port_number(ci->values[0].value.string));
+    return service_name_to_port_number(ci->values[0].value.string);
 
   assert(ci->values[0].type == OCONFIG_TYPE_NUMBER);
   tmp = (int)(ci->values[0].value.number + 0.5);
@@ -1203,10 +1202,10 @@ int cf_util_get_port_number(const oconfig_item_t *ci) /* {{{ */
           "you specified, %i, is not in the valid "
           "range of 1-65535.",
           ci->key, tmp);
-    return (-1);
+    return -1;
   }
 
-  return (tmp);
+  return tmp;
 } /* }}} int cf_util_get_port_number */
 
 int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
@@ -1219,11 +1218,11 @@ int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
     ERROR("cf_util_get_service: The %s option requires exactly "
           "one argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].type == OCONFIG_TYPE_STRING)
-    return (cf_util_get_string(ci, ret_string));
+    return cf_util_get_string(ci, ret_string);
   if (ci->values[0].type != OCONFIG_TYPE_NUMBER) {
     ERROR("cf_util_get_service: The %s option requires "
           "exactly one string or numeric argument.",
@@ -1233,48 +1232,48 @@ int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
   port = 0;
   status = cf_util_get_int(ci, &port);
   if (status != 0)
-    return (status);
+    return status;
   else if ((port < 1) || (port > 65535)) {
     ERROR("cf_util_get_service: The port number given "
           "for the %s option is out of "
           "range (%i).",
           ci->key, port);
-    return (-1);
+    return -1;
   }
 
   service = malloc(6);
   if (service == NULL) {
     ERROR("cf_util_get_service: Out of memory.");
-    return (-1);
+    return -1;
   }
   ssnprintf(service, 6, "%i", port);
 
   sfree(*ret_string);
   *ret_string = service;
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_service */
 
 int cf_util_get_cdtime(const oconfig_item_t *ci, cdtime_t *ret_value) /* {{{ */
 {
   if ((ci == NULL) || (ret_value == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)) {
     ERROR("cf_util_get_cdtime: The %s option requires "
           "exactly one numeric argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.number < 0.0) {
     ERROR("cf_util_get_cdtime: The numeric argument of the %s "
           "option must not be negative.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret_value = DOUBLE_TO_CDTIME_T(ci->values[0].value.number);
 
-  return (0);
+  return 0;
 } /* }}} int cf_util_get_cdtime */

--- a/src/daemon/filter_chain.c
+++ b/src/daemon/filter_chain.c
@@ -166,16 +166,16 @@ static char *fc_strdup(const char *orig) /* {{{ */
   char *dest;
 
   if (orig == NULL)
-    return (NULL);
+    return NULL;
 
   sz = strlen(orig) + 1;
   dest = malloc(sz);
   if (dest == NULL)
-    return (NULL);
+    return NULL;
 
   memcpy(dest, orig, sz);
 
-  return (dest);
+  return dest;
 } /* }}} char *fc_strdup */
 
 /*
@@ -208,7 +208,7 @@ static int fc_config_add_match(fc_match_t **matches_head, /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("Filter subsystem: `Match' blocks require "
             "exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   ptr = match_list_head;
@@ -222,13 +222,13 @@ static int fc_config_add_match(fc_match_t **matches_head, /* {{{ */
     WARNING("Filter subsystem: Cannot find a \"%s\" match. "
             "Did you load the appropriate plugin?",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   m = calloc(1, sizeof(*m));
   if (m == NULL) {
     ERROR("fc_config_add_match: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(m->name, ptr->name, sizeof(m->name));
@@ -241,7 +241,7 @@ static int fc_config_add_match(fc_match_t **matches_head, /* {{{ */
     if (status != 0) {
       WARNING("Filter subsystem: Failed to create a %s match.", m->name);
       fc_free_matches(m);
-      return (-1);
+      return -1;
     }
   }
 
@@ -255,7 +255,7 @@ static int fc_config_add_match(fc_match_t **matches_head, /* {{{ */
     *matches_head = m;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_config_add_match */
 
 static int fc_config_add_target(fc_target_t **targets_head, /* {{{ */
@@ -267,7 +267,7 @@ static int fc_config_add_target(fc_target_t **targets_head, /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("Filter subsystem: `Target' blocks require "
             "exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   ptr = target_list_head;
@@ -281,13 +281,13 @@ static int fc_config_add_target(fc_target_t **targets_head, /* {{{ */
     WARNING("Filter subsystem: Cannot find a \"%s\" target. "
             "Did you load the appropriate plugin?",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   t = calloc(1, sizeof(*t));
   if (t == NULL) {
     ERROR("fc_config_add_target: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(t->name, ptr->name, sizeof(t->name));
@@ -300,7 +300,7 @@ static int fc_config_add_target(fc_target_t **targets_head, /* {{{ */
     if (status != 0) {
       WARNING("Filter subsystem: Failed to create a %s target.", t->name);
       fc_free_targets(t);
-      return (-1);
+      return -1;
     }
   } else {
     t->user_data = NULL;
@@ -316,7 +316,7 @@ static int fc_config_add_target(fc_target_t **targets_head, /* {{{ */
     *targets_head = t;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_config_add_target */
 
 static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
@@ -327,18 +327,18 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
 
   if (ci->values_num > 1) {
     WARNING("Filter subsystem: `Rule' blocks have at most one argument.");
-    return (-1);
+    return -1;
   } else if ((ci->values_num == 1) &&
              (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("Filter subsystem: `Rule' blocks expect one string argument "
             "or no argument at all.");
-    return (-1);
+    return -1;
   }
 
   rule = calloc(1, sizeof(*rule));
   if (rule == NULL) {
     ERROR("fc_config_add_rule: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   if (ci->values_num == 1) {
@@ -378,7 +378,7 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
 
   if (status != 0) {
     fc_free_rules(rule);
-    return (-1);
+    return -1;
   }
 
   if (chain->rules != NULL) {
@@ -393,7 +393,7 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
     chain->rules = rule;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_config_add_rule */
 
 static int fc_config_add_chain(const oconfig_item_t *ci) /* {{{ */
@@ -405,7 +405,7 @@ static int fc_config_add_chain(const oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("Filter subsystem: <Chain> blocks require exactly one "
             "string argument.");
-    return (-1);
+    return -1;
   }
 
   if (chain_list_head != NULL) {
@@ -417,7 +417,7 @@ static int fc_config_add_chain(const oconfig_item_t *ci) /* {{{ */
     chain = calloc(1, sizeof(*chain));
     if (chain == NULL) {
       ERROR("fc_config_add_chain: calloc failed.");
-      return (-1);
+      return -1;
     }
     sstrncpy(chain->name, ci->values[0].value.string, sizeof(chain->name));
   }
@@ -442,12 +442,12 @@ static int fc_config_add_chain(const oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     fc_free_chains(chain);
-    return (-1);
+    return -1;
   }
 
   if (chain_list_head != NULL) {
     if (!new_chain)
-      return (0);
+      return 0;
 
     fc_chain_t *ptr;
 
@@ -460,7 +460,7 @@ static int fc_config_add_chain(const oconfig_item_t *ci) /* {{{ */
     chain_list_head = chain;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_config_add_chain */
 
 /*
@@ -475,7 +475,7 @@ static int fc_bit_jump_create(const oconfig_item_t *ci, /* {{{ */
   if (ci->children_num != 1) {
     ERROR("Filter subsystem: The built-in target `jump' needs exactly "
           "one `Chain' argument!");
-    return (-1);
+    return -1;
   }
 
   ci_chain = ci->children;
@@ -483,23 +483,23 @@ static int fc_bit_jump_create(const oconfig_item_t *ci, /* {{{ */
     ERROR("Filter subsystem: The built-in target `jump' does not "
           "support the configuration option `%s'.",
           ci_chain->key);
-    return (-1);
+    return -1;
   }
 
   if ((ci_chain->values_num != 1) ||
       (ci_chain->values[0].type != OCONFIG_TYPE_STRING)) {
     ERROR("Filter subsystem: Built-in target `jump': The `Chain' option "
           "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   *user_data = fc_strdup(ci_chain->values[0].value.string);
   if (*user_data == NULL) {
     ERROR("fc_bit_jump_create: fc_strdup failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_bit_jump_create */
 
 static int fc_bit_jump_destroy(void **user_data) /* {{{ */
@@ -509,7 +509,7 @@ static int fc_bit_jump_destroy(void **user_data) /* {{{ */
     *user_data = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_bit_jump_destroy */
 
 static int fc_bit_jump_invoke(const data_set_t *ds, /* {{{ */
@@ -531,16 +531,16 @@ static int fc_bit_jump_invoke(const data_set_t *ds, /* {{{ */
     ERROR("Filter subsystem: Built-in target `jump': There is no chain "
           "named `%s'.",
           chain_name);
-    return (-1);
+    return -1;
   }
 
   status = fc_process_chain(ds, vl, chain);
   if (status < 0)
-    return (status);
+    return status;
   else if (status == FC_TARGET_STOP)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
   else
-    return (FC_TARGET_CONTINUE);
+    return FC_TARGET_CONTINUE;
 } /* }}} int fc_bit_jump_invoke */
 
 static int
@@ -548,7 +548,7 @@ fc_bit_stop_invoke(const data_set_t __attribute__((unused)) * ds, /* {{{ */
                    value_list_t __attribute__((unused)) * vl,
                    notification_meta_t __attribute__((unused)) * *meta,
                    void __attribute__((unused)) * *user_data) {
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int fc_bit_stop_invoke */
 
 static int
@@ -556,7 +556,7 @@ fc_bit_return_invoke(const data_set_t __attribute__((unused)) * ds, /* {{{ */
                      value_list_t __attribute__((unused)) * vl,
                      notification_meta_t __attribute__((unused)) * *meta,
                      void __attribute__((unused)) * *user_data) {
-  return (FC_TARGET_RETURN);
+  return FC_TARGET_RETURN;
 } /* }}} int fc_bit_return_invoke */
 
 static int fc_bit_write_create(const oconfig_item_t *ci, /* {{{ */
@@ -606,7 +606,7 @@ static int fc_bit_write_create(const oconfig_item_t *ci, /* {{{ */
 
   *user_data = plugin_list;
 
-  return (0);
+  return 0;
 } /* }}} int fc_bit_write_create */
 
 static int fc_bit_write_destroy(void **user_data) /* {{{ */
@@ -614,7 +614,7 @@ static int fc_bit_write_destroy(void **user_data) /* {{{ */
   fc_writer_t *plugin_list;
 
   if ((user_data == NULL) || (*user_data == NULL))
-    return (0);
+    return 0;
 
   plugin_list = *user_data;
 
@@ -622,7 +622,7 @@ static int fc_bit_write_destroy(void **user_data) /* {{{ */
     free(plugin_list[i].plugin);
   free(plugin_list);
 
-  return (0);
+  return 0;
 } /* }}} int fc_bit_write_destroy */
 
 static int fc_bit_write_invoke(const data_set_t *ds, /* {{{ */
@@ -688,7 +688,7 @@ static int fc_bit_write_invoke(const data_set_t *ds, /* {{{ */
     } /* for (i = 0; plugin_list[i] != NULL; i++) */
   }
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int fc_bit_write_invoke */
 
 static int fc_init_once(void) /* {{{ */
@@ -697,7 +697,7 @@ static int fc_init_once(void) /* {{{ */
   target_proc_t tproc = {0};
 
   if (done != 0)
-    return (0);
+    return 0;
 
   tproc.create = fc_bit_jump_create;
   tproc.destroy = fc_bit_jump_destroy;
@@ -723,7 +723,7 @@ static int fc_init_once(void) /* {{{ */
   fc_register_target("write", tproc);
 
   done++;
-  return (0);
+  return 0;
 } /* }}} int fc_init_once */
 
 /*
@@ -738,7 +738,7 @@ int fc_register_match(const char *name, match_proc_t proc) /* {{{ */
 
   m = calloc(1, sizeof(*m));
   if (m == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   sstrncpy(m->name, name, sizeof(m->name));
   memcpy(&m->proc, &proc, sizeof(m->proc));
@@ -755,7 +755,7 @@ int fc_register_match(const char *name, match_proc_t proc) /* {{{ */
     ptr->next = m;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_register_match */
 
 /* Add a target to list of available targets. */
@@ -767,7 +767,7 @@ int fc_register_target(const char *name, target_proc_t proc) /* {{{ */
 
   t = calloc(1, sizeof(*t));
   if (t == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   sstrncpy(t->name, name, sizeof(t->name));
   memcpy(&t->proc, &proc, sizeof(t->proc));
@@ -784,19 +784,19 @@ int fc_register_target(const char *name, target_proc_t proc) /* {{{ */
     ptr->next = t;
   }
 
-  return (0);
+  return 0;
 } /* }}} int fc_register_target */
 
 fc_chain_t *fc_chain_get_by_name(const char *chain_name) /* {{{ */
 {
   if (chain_name == NULL)
-    return (NULL);
+    return NULL;
 
   for (fc_chain_t *chain = chain_list_head; chain != NULL; chain = chain->next)
     if (strcasecmp(chain_name, chain->name) == 0)
-      return (chain);
+      return chain;
 
-  return (NULL);
+  return NULL;
 } /* }}} int fc_chain_get_by_name */
 
 int fc_process_chain(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -805,7 +805,7 @@ int fc_process_chain(const data_set_t *ds, value_list_t *vl, /* {{{ */
   int status = FC_TARGET_CONTINUE;
 
   if (chain == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("fc_process_chain (chain = %s);", chain->name);
 
@@ -875,7 +875,7 @@ int fc_process_chain(const data_set_t *ds, value_list_t *vl, /* {{{ */
   } /* for (rule) */
 
   if ((status == FC_TARGET_STOP) || (status == FC_TARGET_RETURN))
-    return (status);
+    return status;
 
   DEBUG("fc_process_chain (%s): Executing the default targets.", chain->name);
 
@@ -908,15 +908,15 @@ int fc_process_chain(const data_set_t *ds, value_list_t *vl, /* {{{ */
           chain->name, target->name,
           (status == FC_TARGET_STOP) ? "stop" : "return");
     if (status == FC_TARGET_STOP)
-      return (FC_TARGET_STOP);
+      return FC_TARGET_STOP;
     else
-      return (FC_TARGET_CONTINUE);
+      return FC_TARGET_CONTINUE;
   }
 
   DEBUG("fc_process_chain (%s): Signaling `continue' at end of chain.",
         chain->name);
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int fc_process_chain */
 
 /* Iterate over all rules in the chain and execute all targets for which all
@@ -924,8 +924,7 @@ int fc_process_chain(const data_set_t *ds, value_list_t *vl, /* {{{ */
 int fc_default_action(const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   /* FIXME: Pass the meta-data to match targets here (when implemented). */
-  return (fc_bit_write_invoke(ds, vl,
-                              /* meta = */ NULL, /* user_data = */ NULL));
+  return fc_bit_write_invoke(ds, vl, NULL, NULL);
 } /* }}} int fc_default_action */
 
 int fc_configure(const oconfig_item_t *ci) /* {{{ */
@@ -933,12 +932,12 @@ int fc_configure(const oconfig_item_t *ci) /* {{{ */
   fc_init_once();
 
   if (ci == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if (strcasecmp("Chain", ci->key) == 0)
-    return (fc_config_add_chain(ci));
+    return fc_config_add_chain(ci);
 
   WARNING("Filter subsystem: Unknown top level config option `%s'.", ci->key);
 
-  return (-1);
+  return -1;
 } /* }}} int fc_configure */

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -67,16 +67,16 @@ static char *md_strdup(const char *orig) /* {{{ */
   char *dest;
 
   if (orig == NULL)
-    return (NULL);
+    return NULL;
 
   sz = strlen(orig) + 1;
   dest = malloc(sz);
   if (dest == NULL)
-    return (NULL);
+    return NULL;
 
   memcpy(dest, orig, sz);
 
-  return (dest);
+  return dest;
 } /* }}} char *md_strdup */
 
 static meta_entry_t *md_entry_alloc(const char *key) /* {{{ */
@@ -86,20 +86,20 @@ static meta_entry_t *md_entry_alloc(const char *key) /* {{{ */
   e = calloc(1, sizeof(*e));
   if (e == NULL) {
     ERROR("md_entry_alloc: calloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   e->key = md_strdup(key);
   if (e->key == NULL) {
     free(e);
     ERROR("md_entry_alloc: md_strdup failed.");
-    return (NULL);
+    return NULL;
   }
 
   e->type = 0;
   e->next = NULL;
 
-  return (e);
+  return e;
 } /* }}} meta_entry_t *md_entry_alloc */
 
 /* XXX: The lock on md must be held while calling this function! */
@@ -115,14 +115,14 @@ static meta_entry_t *md_entry_clone_contents(const meta_entry_t *orig) /* {{{ */
 
   copy = md_entry_alloc(orig->key);
   if (copy == NULL)
-    return (NULL);
+    return NULL;
   copy->type = orig->type;
   if (copy->type == MD_TYPE_STRING)
     copy->value.mv_string = strdup(orig->value.mv_string);
   else
     copy->value = orig->value;
 
-  return (copy);
+  return copy;
 } /* }}} meta_entry_t *md_entry_clone_contents */
 
 static meta_entry_t *md_entry_clone(const meta_entry_t *orig) /* {{{ */
@@ -130,12 +130,12 @@ static meta_entry_t *md_entry_clone(const meta_entry_t *orig) /* {{{ */
   meta_entry_t *copy;
 
   if (orig == NULL)
-    return (NULL);
+    return NULL;
 
   copy = md_entry_clone_contents(orig);
 
   copy->next = md_entry_clone(orig->next);
-  return (copy);
+  return copy;
 } /* }}} meta_entry_t *md_entry_clone */
 
 static void md_entry_free(meta_entry_t *e) /* {{{ */
@@ -160,7 +160,7 @@ static int md_entry_insert(meta_data_t *md, meta_entry_t *e) /* {{{ */
   meta_entry_t *prev;
 
   if ((md == NULL) || (e == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
@@ -201,7 +201,7 @@ static int md_entry_insert(meta_data_t *md, meta_entry_t *e) /* {{{ */
     md_entry_free(this);
   }
 
-  return (0);
+  return 0;
 } /* }}} int md_entry_insert */
 
 /* XXX: The lock on md must be held while calling this function! */
@@ -254,7 +254,7 @@ static int md_entry_insert_clone(meta_data_t *md, meta_entry_t *orig) /* {{{ */
     md_entry_free(this);
   }
 
-  return (0);
+  return 0;
 } /* }}} int md_entry_insert_clone */
 
 /* XXX: The lock on md must be held while calling this function! */
@@ -263,13 +263,13 @@ static meta_entry_t *md_entry_lookup(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL))
-    return (NULL);
+    return NULL;
 
   for (e = md->head; e != NULL; e = e->next)
     if (strcasecmp(key, e->key) == 0)
       break;
 
-  return (e);
+  return e;
 } /* }}} meta_entry_t *md_entry_lookup */
 
 /*
@@ -293,12 +293,12 @@ meta_data_t *meta_data_create(void) /* {{{ */
   md = calloc(1, sizeof(*md));
   if (md == NULL) {
     ERROR("meta_data_create: calloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   pthread_mutex_init(&md->lock, /* attr = */ NULL);
 
-  return (md);
+  return md;
 } /* }}} meta_data_t *meta_data_create */
 
 meta_data_t *meta_data_clone(meta_data_t *orig) /* {{{ */
@@ -306,27 +306,27 @@ meta_data_t *meta_data_clone(meta_data_t *orig) /* {{{ */
   meta_data_t *copy;
 
   if (orig == NULL)
-    return (NULL);
+    return NULL;
 
   copy = meta_data_create();
   if (copy == NULL)
-    return (NULL);
+    return NULL;
 
   pthread_mutex_lock(&orig->lock);
   copy->head = md_entry_clone(orig->head);
   pthread_mutex_unlock(&orig->lock);
 
-  return (copy);
+  return copy;
 } /* }}} meta_data_t *meta_data_clone */
 
 int meta_data_clone_merge(meta_data_t **dest, meta_data_t *orig) /* {{{ */
 {
   if (orig == NULL)
-    return (0);
+    return 0;
 
   if (*dest == NULL) {
     *dest = meta_data_clone(orig);
-    return (0);
+    return 0;
   }
 
   pthread_mutex_lock(&orig->lock);
@@ -335,7 +335,7 @@ int meta_data_clone_merge(meta_data_t **dest, meta_data_t *orig) /* {{{ */
   }
   pthread_mutex_unlock(&orig->lock);
 
-  return (0);
+  return 0;
 } /* }}} int meta_data_clone_merge */
 
 void meta_data_destroy(meta_data_t *md) /* {{{ */
@@ -351,19 +351,19 @@ void meta_data_destroy(meta_data_t *md) /* {{{ */
 int meta_data_exists(meta_data_t *md, const char *key) /* {{{ */
 {
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   for (meta_entry_t *e = md->head; e != NULL; e = e->next) {
     if (strcasecmp(key, e->key) == 0) {
       pthread_mutex_unlock(&md->lock);
-      return (1);
+      return 1;
     }
   }
 
   pthread_mutex_unlock(&md->lock);
-  return (0);
+  return 0;
 } /* }}} int meta_data_exists */
 
 int meta_data_type(meta_data_t *md, const char *key) /* {{{ */
@@ -398,7 +398,7 @@ int meta_data_toc(meta_data_t *md, char ***toc) /* {{{ */
 
   if (count == 0) {
     pthread_mutex_unlock(&md->lock);
-    return (count);
+    return count;
   }
 
   *toc = calloc(count, sizeof(**toc));
@@ -415,7 +415,7 @@ int meta_data_delete(meta_data_t *md, const char *key) /* {{{ */
   meta_entry_t *prev;
 
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
@@ -431,7 +431,7 @@ int meta_data_delete(meta_data_t *md, const char *key) /* {{{ */
 
   if (this == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (prev == NULL)
@@ -444,7 +444,7 @@ int meta_data_delete(meta_data_t *md, const char *key) /* {{{ */
   this->next = NULL;
   md_entry_free(this);
 
-  return (0);
+  return 0;
 } /* }}} int meta_data_delete */
 
 /*
@@ -455,21 +455,21 @@ int meta_data_add_string(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   e = md_entry_alloc(key);
   if (e == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   e->value.mv_string = md_strdup(value);
   if (e->value.mv_string == NULL) {
     ERROR("meta_data_add_string: md_strdup failed.");
     md_entry_free(e);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
   e->type = MD_TYPE_STRING;
 
-  return (md_entry_insert(md, e));
+  return md_entry_insert(md, e);
 } /* }}} int meta_data_add_string */
 
 int meta_data_add_signed_int(meta_data_t *md, /* {{{ */
@@ -477,16 +477,16 @@ int meta_data_add_signed_int(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   e = md_entry_alloc(key);
   if (e == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   e->value.mv_signed_int = value;
   e->type = MD_TYPE_SIGNED_INT;
 
-  return (md_entry_insert(md, e));
+  return md_entry_insert(md, e);
 } /* }}} int meta_data_add_signed_int */
 
 int meta_data_add_unsigned_int(meta_data_t *md, /* {{{ */
@@ -494,16 +494,16 @@ int meta_data_add_unsigned_int(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   e = md_entry_alloc(key);
   if (e == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   e->value.mv_unsigned_int = value;
   e->type = MD_TYPE_UNSIGNED_INT;
 
-  return (md_entry_insert(md, e));
+  return md_entry_insert(md, e);
 } /* }}} int meta_data_add_unsigned_int */
 
 int meta_data_add_double(meta_data_t *md, /* {{{ */
@@ -511,16 +511,16 @@ int meta_data_add_double(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   e = md_entry_alloc(key);
   if (e == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   e->value.mv_double = value;
   e->type = MD_TYPE_DOUBLE;
 
-  return (md_entry_insert(md, e));
+  return md_entry_insert(md, e);
 } /* }}} int meta_data_add_double */
 
 int meta_data_add_boolean(meta_data_t *md, /* {{{ */
@@ -528,16 +528,16 @@ int meta_data_add_boolean(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   e = md_entry_alloc(key);
   if (e == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   e->value.mv_boolean = value;
   e->type = MD_TYPE_BOOLEAN;
 
-  return (md_entry_insert(md, e));
+  return md_entry_insert(md, e);
 } /* }}} int meta_data_add_boolean */
 
 /*
@@ -549,34 +549,34 @@ int meta_data_get_string(meta_data_t *md, /* {{{ */
   char *temp;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (e->type != MD_TYPE_STRING) {
     ERROR("meta_data_get_string: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   temp = md_strdup(e->value.mv_string);
   if (temp == NULL) {
     pthread_mutex_unlock(&md->lock);
     ERROR("meta_data_get_string: md_strdup failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   pthread_mutex_unlock(&md->lock);
 
   *value = temp;
 
-  return (0);
+  return 0;
 } /* }}} int meta_data_get_string */
 
 int meta_data_get_signed_int(meta_data_t *md, /* {{{ */
@@ -584,26 +584,26 @@ int meta_data_get_signed_int(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (e->type != MD_TYPE_SIGNED_INT) {
     ERROR("meta_data_get_signed_int: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   *value = e->value.mv_signed_int;
 
   pthread_mutex_unlock(&md->lock);
-  return (0);
+  return 0;
 } /* }}} int meta_data_get_signed_int */
 
 int meta_data_get_unsigned_int(meta_data_t *md, /* {{{ */
@@ -611,26 +611,26 @@ int meta_data_get_unsigned_int(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (e->type != MD_TYPE_UNSIGNED_INT) {
     ERROR("meta_data_get_unsigned_int: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   *value = e->value.mv_unsigned_int;
 
   pthread_mutex_unlock(&md->lock);
-  return (0);
+  return 0;
 } /* }}} int meta_data_get_unsigned_int */
 
 int meta_data_get_double(meta_data_t *md, /* {{{ */
@@ -638,26 +638,26 @@ int meta_data_get_double(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (e->type != MD_TYPE_DOUBLE) {
     ERROR("meta_data_get_double: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   *value = e->value.mv_double;
 
   pthread_mutex_unlock(&md->lock);
-  return (0);
+  return 0;
 } /* }}} int meta_data_get_double */
 
 int meta_data_get_boolean(meta_data_t *md, /* {{{ */
@@ -665,26 +665,26 @@ int meta_data_get_boolean(meta_data_t *md, /* {{{ */
   meta_entry_t *e;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   if (e->type != MD_TYPE_BOOLEAN) {
     ERROR("meta_data_get_boolean: Type mismatch for key `%s'", e->key);
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   *value = e->value.mv_boolean;
 
   pthread_mutex_unlock(&md->lock);
-  return (0);
+  return 0;
 } /* }}} int meta_data_get_boolean */
 
 int meta_data_as_string(meta_data_t *md, /* {{{ */
@@ -696,14 +696,14 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
   int type;
 
   if ((md == NULL) || (key == NULL) || (value == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&md->lock);
 
   e = md_entry_lookup(md, key);
   if (e == NULL) {
     pthread_mutex_unlock(&md->lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   type = e->type;
@@ -730,7 +730,7 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
   default:
     pthread_mutex_unlock(&md->lock);
     ERROR("meta_data_as_string: unknown type %d for key `%s'", type, key);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   pthread_mutex_unlock(&md->lock);
@@ -739,10 +739,10 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
   if (temp == NULL) {
     pthread_mutex_unlock(&md->lock);
     ERROR("meta_data_as_string: md_strdup failed for key `%s'.", key);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   *value = temp;
 
-  return (0);
+  return 0;
 } /* }}} int meta_data_as_string */

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -148,9 +148,9 @@ static int plugin_dispatch_values_internal(value_list_t *vl);
 
 static const char *plugin_get_dir(void) {
   if (plugindir == NULL)
-    return (PLUGINDIR);
+    return PLUGINDIR;
   else
-    return (plugindir);
+    return plugindir;
 }
 
 static int plugin_update_internal_statistics(void) { /* {{{ */
@@ -258,7 +258,7 @@ static int register_callback(llist_t **list, /* {{{ */
       ERROR("plugin: register_callback: "
             "llist_create failed.");
       destroy_callback(cf);
-      return (-1);
+      return -1;
     }
   }
 
@@ -266,7 +266,7 @@ static int register_callback(llist_t **list, /* {{{ */
   if (key == NULL) {
     ERROR("plugin: register_callback: strdup failed.");
     destroy_callback(cf);
-    return (-1);
+    return -1;
   }
 
   le = llist_search(*list, name);
@@ -277,7 +277,7 @@ static int register_callback(llist_t **list, /* {{{ */
             "llentry_create failed.");
       sfree(key);
       destroy_callback(cf);
-      return (-1);
+      return -1;
     }
 
     llist_append(*list, le);
@@ -296,7 +296,7 @@ static int register_callback(llist_t **list, /* {{{ */
     sfree(key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int register_callback */
 
 static void log_list_callbacks(llist_t **list, /* {{{ */
@@ -346,7 +346,7 @@ static int create_register_callback(llist_t **list, /* {{{ */
   cf = calloc(1, sizeof(*cf));
   if (cf == NULL) {
     ERROR("plugin: create_register_callback: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   cf->cf_callback = callback;
@@ -359,7 +359,7 @@ static int create_register_callback(llist_t **list, /* {{{ */
 
   cf->cf_ctx = plugin_get_ctx();
 
-  return (register_callback(list, name, cf));
+  return register_callback(list, name, cf);
 } /* }}} int create_register_callback */
 
 static int plugin_unregister(llist_t *list, const char *name) /* {{{ */
@@ -367,11 +367,11 @@ static int plugin_unregister(llist_t *list, const char *name) /* {{{ */
   llentry_t *e;
 
   if (list == NULL)
-    return (-1);
+    return -1;
 
   e = llist_search(list, name);
   if (e == NULL)
-    return (-1);
+    return -1;
 
   llist_remove(list, e);
 
@@ -380,7 +380,7 @@ static int plugin_unregister(llist_t *list, const char *name) /* {{{ */
 
   llentry_destroy(e);
 
-  return (0);
+  return 0;
 } /* }}} int plugin_unregister */
 
 /*
@@ -414,7 +414,7 @@ static int plugin_load_file(const char *file, _Bool global) {
     if (list_log != NULL)
       fprintf(stderr, "ERROR: %s\n", errbuf);
 
-    return (1);
+    return 1;
   }
 
   reg_handle = (void (*)(void))dlsym(dlh, "module_register");
@@ -422,12 +422,12 @@ static int plugin_load_file(const char *file, _Bool global) {
     WARNING("Couldn't find symbol \"module_register\" in \"%s\": %s\n", file,
             dlerror());
     dlclose(dlh);
-    return (-1);
+    return -1;
   }
 
   (*reg_handle)();
 
-  return (0);
+  return 0;
 }
 
 static void *plugin_read_thread(void __attribute__((unused)) * args) {
@@ -582,7 +582,7 @@ static void *plugin_read_thread(void __attribute__((unused)) * args) {
   } /* while (read_loop) */
 
   pthread_exit(NULL);
-  return ((void *)0);
+  return (void *)0;
 } /* void *plugin_read_thread */
 
 #ifdef PTHREAD_MAX_NAMELEN_NP
@@ -685,11 +685,11 @@ plugin_value_list_clone(value_list_t const *vl_orig) /* {{{ */
   value_list_t *vl;
 
   if (vl_orig == NULL)
-    return (NULL);
+    return NULL;
 
   vl = malloc(sizeof(*vl));
   if (vl == NULL)
-    return (NULL);
+    return NULL;
   memcpy(vl, vl_orig, sizeof(*vl));
 
   if (vl->host[0] == 0)
@@ -698,7 +698,7 @@ plugin_value_list_clone(value_list_t const *vl_orig) /* {{{ */
   vl->values = calloc(vl_orig->values_len, sizeof(*vl->values));
   if (vl->values == NULL) {
     plugin_value_list_free(vl);
-    return (NULL);
+    return NULL;
   }
   memcpy(vl->values, vl_orig->values,
          vl_orig->values_len * sizeof(*vl->values));
@@ -706,7 +706,7 @@ plugin_value_list_clone(value_list_t const *vl_orig) /* {{{ */
   vl->meta = meta_data_clone(vl->meta);
   if ((vl_orig->meta != NULL) && (vl->meta == NULL)) {
     plugin_value_list_free(vl);
-    return (NULL);
+    return NULL;
   }
 
   if (vl->time == 0)
@@ -733,7 +733,7 @@ plugin_value_list_clone(value_list_t const *vl_orig) /* {{{ */
     }
   }
 
-  return (vl);
+  return vl;
 } /* }}} value_list_t *plugin_value_list_clone */
 
 static int plugin_write_enqueue(value_list_t const *vl) /* {{{ */
@@ -742,13 +742,13 @@ static int plugin_write_enqueue(value_list_t const *vl) /* {{{ */
 
   q = malloc(sizeof(*q));
   if (q == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   q->next = NULL;
 
   q->vl = plugin_value_list_clone(vl);
   if (q->vl == NULL) {
     sfree(q);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   /* Store context of caller (read plugin); otherwise, it would not be
@@ -771,7 +771,7 @@ static int plugin_write_enqueue(value_list_t const *vl) /* {{{ */
   pthread_cond_signal(&write_cond);
   pthread_mutex_unlock(&write_lock);
 
-  return (0);
+  return 0;
 } /* }}} int plugin_write_enqueue */
 
 static value_list_t *plugin_write_dequeue(void) /* {{{ */
@@ -786,7 +786,7 @@ static value_list_t *plugin_write_dequeue(void) /* {{{ */
 
   if (write_queue_head == NULL) {
     pthread_mutex_unlock(&write_lock);
-    return (NULL);
+    return NULL;
   }
 
   q = write_queue_head;
@@ -803,7 +803,7 @@ static value_list_t *plugin_write_dequeue(void) /* {{{ */
 
   vl = q->vl;
   sfree(q);
-  return (vl);
+  return vl;
 } /* }}} value_list_t *plugin_write_dequeue */
 
 static void *plugin_write_thread(void __attribute__((unused)) * args) /* {{{ */
@@ -819,7 +819,7 @@ static void *plugin_write_thread(void __attribute__((unused)) * args) /* {{{ */
   }
 
   pthread_exit(NULL);
-  return ((void *)0);
+  return (void *)0;
 } /* }}} void *plugin_write_thread */
 
 static void start_write_threads(size_t num) /* {{{ */
@@ -925,7 +925,7 @@ static _Bool plugin_is_loaded(char const *name) {
   assert(plugins_loaded != NULL);
 
   status = c_avl_get(plugins_loaded, name, /* ret_value = */ NULL);
-  return (status == 0);
+  return status == 0;
 }
 
 static int plugin_mark_loaded(char const *name) {
@@ -934,11 +934,11 @@ static int plugin_mark_loaded(char const *name) {
 
   name_copy = strdup(name);
   if (name_copy == NULL)
-    return (ENOMEM);
+    return ENOMEM;
 
   status = c_avl_insert(plugins_loaded,
                         /* key = */ name_copy, /* value = */ NULL);
-  return (status);
+  return status;
 }
 
 static void plugin_free_loaded(void) {
@@ -969,12 +969,12 @@ int plugin_load(char const *plugin_name, _Bool global) {
   int status;
 
   if (plugin_name == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* Check if plugin is already loaded and don't do anything in this
    * case. */
   if (plugin_is_loaded(plugin_name))
-    return (0);
+    return 0;
 
   dir = plugin_get_dir();
   ret = 1;
@@ -999,14 +999,14 @@ int plugin_load(char const *plugin_name, _Bool global) {
   status = ssnprintf(typename, sizeof(typename), "%s.so", plugin_name);
   if ((status < 0) || ((size_t)status >= sizeof(typename))) {
     WARNING("plugin_load: Filename too long: \"%s.so\"", plugin_name);
-    return (-1);
+    return -1;
   }
 
   if ((dh = opendir(dir)) == NULL) {
     char errbuf[1024];
     ERROR("plugin_load: opendir (%s) failed: %s", dir,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while ((de = readdir(dh)) != NULL) {
@@ -1049,7 +1049,7 @@ int plugin_load(char const *plugin_name, _Bool global) {
   if (filename[0] == 0)
     ERROR("plugin_load: Could not find plugin \"%s\" in %s", plugin_name, dir);
 
-  return (ret);
+  return ret;
 }
 
 /*
@@ -1059,17 +1059,16 @@ int plugin_register_config(const char *name,
                            int (*callback)(const char *key, const char *val),
                            const char **keys, int keys_num) {
   cf_register(name, callback, keys, keys_num);
-  return (0);
+  return 0;
 } /* int plugin_register_config */
 
 int plugin_register_complex_config(const char *type,
                                    int (*callback)(oconfig_item_t *)) {
-  return (cf_register_complex(type, callback));
+  return cf_register_complex(type, callback);
 } /* int plugin_register_complex_config */
 
 int plugin_register_init(const char *name, int (*callback)(void)) {
-  return (create_register_callback(&list_init, name, (void *)callback,
-                                   /* user_data = */ NULL));
+  return create_register_callback(&list_init, name, (void *)callback, NULL);
 } /* plugin_register_init */
 
 static int plugin_compare_read_func(const void *arg0, const void *arg1) {
@@ -1080,11 +1079,11 @@ static int plugin_compare_read_func(const void *arg0, const void *arg1) {
   rf1 = arg1;
 
   if (rf0->rf_next_read < rf1->rf_next_read)
-    return (-1);
+    return -1;
   else if (rf0->rf_next_read > rf1->rf_next_read)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* int plugin_compare_read_func */
 
 /* Add a read function to both, the heap and a linked list. The linked list if
@@ -1104,7 +1103,7 @@ static int plugin_insert_read(read_func_t *rf) {
     if (read_list == NULL) {
       pthread_mutex_unlock(&read_lock);
       ERROR("plugin_insert_read: read_list failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -1113,7 +1112,7 @@ static int plugin_insert_read(read_func_t *rf) {
     if (read_heap == NULL) {
       pthread_mutex_unlock(&read_lock);
       ERROR("plugin_insert_read: c_heap_create failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -1124,14 +1123,14 @@ static int plugin_insert_read(read_func_t *rf) {
             "Check for duplicate \"LoadPlugin\" lines "
             "in your configuration!",
             rf->rf_name);
-    return (EINVAL);
+    return EINVAL;
   }
 
   le = llentry_create(rf->rf_name, rf);
   if (le == NULL) {
     pthread_mutex_unlock(&read_lock);
     ERROR("plugin_insert_read: llentry_create failed.");
-    return (-1);
+    return -1;
   }
 
   status = c_heap_insert(read_heap, rf);
@@ -1139,7 +1138,7 @@ static int plugin_insert_read(read_func_t *rf) {
     pthread_mutex_unlock(&read_lock);
     ERROR("plugin_insert_read: c_heap_insert failed.");
     llentry_destroy(le);
-    return (-1);
+    return -1;
   }
 
   /* This does not fail. */
@@ -1148,7 +1147,7 @@ static int plugin_insert_read(read_func_t *rf) {
   /* Wake up all the read threads. */
   pthread_cond_broadcast(&read_cond);
   pthread_mutex_unlock(&read_lock);
-  return (0);
+  return 0;
 } /* int plugin_insert_read */
 
 int plugin_register_read(const char *name, int (*callback)(void)) {
@@ -1158,7 +1157,7 @@ int plugin_register_read(const char *name, int (*callback)(void)) {
   rf = calloc(1, sizeof(*rf));
   if (rf == NULL) {
     ERROR("plugin_register_read: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   rf->rf_callback = (void *)callback;
@@ -1176,7 +1175,7 @@ int plugin_register_read(const char *name, int (*callback)(void)) {
     sfree(rf);
   }
 
-  return (status);
+  return status;
 } /* int plugin_register_read */
 
 int plugin_register_complex_read(const char *group, const char *name,
@@ -1188,7 +1187,7 @@ int plugin_register_complex_read(const char *group, const char *name,
   rf = calloc(1, sizeof(*rf));
   if (rf == NULL) {
     ERROR("plugin_register_complex_read: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   rf->rf_callback = (void *)callback;
@@ -1216,18 +1215,18 @@ int plugin_register_complex_read(const char *group, const char *name,
     sfree(rf);
   }
 
-  return (status);
+  return status;
 } /* int plugin_register_complex_read */
 
 int plugin_register_write(const char *name, plugin_write_cb callback,
                           user_data_t const *ud) {
-  return (create_register_callback(&list_write, name, (void *)callback, ud));
+  return create_register_callback(&list_write, name, (void *)callback, ud);
 } /* int plugin_register_write */
 
 static int plugin_flush_timeout_callback(user_data_t *ud) {
   flush_callback_t *cb = ud->data;
 
-  return plugin_flush(cb->name, cb->timeout, /* identifier = */ NULL);
+  return plugin_flush(cb->name, cb->timeout, NULL);
 } /* static int plugin_flush_callback */
 
 static void plugin_flush_timeout_callback_free(void *data) {
@@ -1252,7 +1251,7 @@ static char *plugin_flush_callback_name(const char *name) {
   flush_name = malloc(name_size + prefix_size + 1);
   if (flush_name == NULL) {
     ERROR("plugin_flush_callback_name: malloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   sstrncpy(flush_name, flush_prefix, prefix_size + 1);
@@ -1276,13 +1275,13 @@ int plugin_register_flush(const char *name, plugin_flush_cb callback,
 
     flush_name = plugin_flush_callback_name(name);
     if (flush_name == NULL)
-      return (-1);
+      return -1;
 
     cb = malloc(sizeof(*cb));
     if (cb == NULL) {
       ERROR("plugin_register_flush: malloc failed.");
       sfree(flush_name);
-      return (-1);
+      return -1;
     }
 
     cb->name = strdup(name);
@@ -1290,7 +1289,7 @@ int plugin_register_flush(const char *name, plugin_flush_cb callback,
       ERROR("plugin_register_flush: strdup failed.");
       sfree(cb);
       sfree(flush_name);
-      return (-1);
+      return -1;
     }
     cb->timeout = ctx.flush_timeout;
 
@@ -1316,12 +1315,12 @@ int plugin_register_flush(const char *name, plugin_flush_cb callback,
 
 int plugin_register_missing(const char *name, plugin_missing_cb callback,
                             user_data_t const *ud) {
-  return (create_register_callback(&list_missing, name, (void *)callback, ud));
+  return create_register_callback(&list_missing, name, (void *)callback, ud);
 } /* int plugin_register_missing */
 
 int plugin_register_shutdown(const char *name, int (*callback)(void)) {
-  return (create_register_callback(&list_shutdown, name, (void *)callback,
-                                   /* user_data = */ NULL));
+  return create_register_callback(&list_shutdown, name, (void *)callback,
+                                  NULL);
 } /* int plugin_register_shutdown */
 
 static void plugin_free_data_sets(void) {
@@ -1352,50 +1351,50 @@ int plugin_register_data_set(const data_set_t *ds) {
   } else if (data_sets == NULL) {
     data_sets = c_avl_create((int (*)(const void *, const void *))strcmp);
     if (data_sets == NULL)
-      return (-1);
+      return -1;
   }
 
   ds_copy = malloc(sizeof(*ds_copy));
   if (ds_copy == NULL)
-    return (-1);
+    return -1;
   memcpy(ds_copy, ds, sizeof(data_set_t));
 
   ds_copy->ds = malloc(sizeof(*ds_copy->ds) * ds->ds_num);
   if (ds_copy->ds == NULL) {
     sfree(ds_copy);
-    return (-1);
+    return -1;
   }
 
   for (size_t i = 0; i < ds->ds_num; i++)
     memcpy(ds_copy->ds + i, ds->ds + i, sizeof(data_source_t));
 
-  return (c_avl_insert(data_sets, (void *)ds_copy->type, (void *)ds_copy));
+  return c_avl_insert(data_sets, (void *)ds_copy->type, (void *)ds_copy);
 } /* int plugin_register_data_set */
 
 int plugin_register_log(const char *name, plugin_log_cb callback,
                         user_data_t const *ud) {
-  return (create_register_callback(&list_log, name, (void *)callback, ud));
+  return create_register_callback(&list_log, name, (void *)callback, ud);
 } /* int plugin_register_log */
 
 int plugin_register_notification(const char *name,
                                  plugin_notification_cb callback,
                                  user_data_t const *ud) {
-  return (
-      create_register_callback(&list_notification, name, (void *)callback, ud));
+  return create_register_callback(&list_notification, name, (void *)callback,
+                                  ud);
 } /* int plugin_register_log */
 
 int plugin_unregister_config(const char *name) {
   cf_unregister(name);
-  return (0);
+  return 0;
 } /* int plugin_unregister_config */
 
 int plugin_unregister_complex_config(const char *name) {
   cf_unregister_complex(name);
-  return (0);
+  return 0;
 } /* int plugin_unregister_complex_config */
 
 int plugin_unregister_init(const char *name) {
-  return (plugin_unregister(list_init, name));
+  return plugin_unregister(list_init, name);
 }
 
 int plugin_unregister_read(const char *name) /* {{{ */
@@ -1404,20 +1403,20 @@ int plugin_unregister_read(const char *name) /* {{{ */
   read_func_t *rf;
 
   if (name == NULL)
-    return (-ENOENT);
+    return -ENOENT;
 
   pthread_mutex_lock(&read_lock);
 
   if (read_list == NULL) {
     pthread_mutex_unlock(&read_lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   le = llist_search(read_list, name);
   if (le == NULL) {
     pthread_mutex_unlock(&read_lock);
     WARNING("plugin_unregister_read: No such read function: %s", name);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   llist_remove(read_list, le);
@@ -1432,7 +1431,7 @@ int plugin_unregister_read(const char *name) /* {{{ */
 
   DEBUG("plugin_unregister_read: Marked `%s' for removal.", name);
 
-  return (0);
+  return 0;
 } /* }}} int plugin_unregister_read */
 
 void plugin_log_available_writers(void) {
@@ -1455,13 +1454,13 @@ int plugin_unregister_read_group(const char *group) /* {{{ */
   int found = 0;
 
   if (group == NULL)
-    return (-ENOENT);
+    return -ENOENT;
 
   pthread_mutex_lock(&read_lock);
 
   if (read_list == NULL) {
     pthread_mutex_unlock(&read_lock);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   while (42) {
@@ -1491,14 +1490,14 @@ int plugin_unregister_read_group(const char *group) /* {{{ */
     WARNING("plugin_unregister_read_group: No such "
             "group of read function: %s",
             group);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
-  return (0);
+  return 0;
 } /* }}} int plugin_unregister_read_group */
 
 int plugin_unregister_write(const char *name) {
-  return (plugin_unregister(list_write, name));
+  return plugin_unregister(list_write, name);
 }
 
 int plugin_unregister_flush(const char *name) {
@@ -1518,34 +1517,34 @@ int plugin_unregister_flush(const char *name) {
 }
 
 int plugin_unregister_missing(const char *name) {
-  return (plugin_unregister(list_missing, name));
+  return plugin_unregister(list_missing, name);
 }
 
 int plugin_unregister_shutdown(const char *name) {
-  return (plugin_unregister(list_shutdown, name));
+  return plugin_unregister(list_shutdown, name);
 }
 
 int plugin_unregister_data_set(const char *name) {
   data_set_t *ds;
 
   if (data_sets == NULL)
-    return (-1);
+    return -1;
 
   if (c_avl_remove(data_sets, name, NULL, (void *)&ds) != 0)
-    return (-1);
+    return -1;
 
   sfree(ds->ds);
   sfree(ds);
 
-  return (0);
+  return 0;
 } /* int plugin_unregister_data_set */
 
 int plugin_unregister_log(const char *name) {
-  return (plugin_unregister(list_log, name));
+  return plugin_unregister(list_log, name);
 }
 
 int plugin_unregister_notification(const char *name) {
-  return (plugin_unregister(list_notification, name));
+  return plugin_unregister(list_notification, name);
 }
 
 int plugin_init_all(void) {
@@ -1660,7 +1659,7 @@ int plugin_read_all_once(void) {
 
   if (read_heap == NULL) {
     NOTICE("No read-functions are registered.");
-    return (0);
+    return 0;
   }
 
   while (42) {
@@ -1696,7 +1695,7 @@ int plugin_read_all_once(void) {
     destroy_callback((void *)rf);
   }
 
-  return (return_status);
+  return return_status;
 } /* int plugin_read_all_once */
 
 int plugin_write(const char *plugin, /* {{{ */
@@ -1705,16 +1704,16 @@ int plugin_write(const char *plugin, /* {{{ */
   int status;
 
   if (vl == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (list_write == NULL)
-    return (ENOENT);
+    return ENOENT;
 
   if (ds == NULL) {
     ds = plugin_get_ds(vl->type);
     if (ds == NULL) {
       ERROR("plugin_write: Unable to lookup type `%s'.", vl->type);
-      return (ENOENT);
+      return ENOENT;
     }
   }
 
@@ -1759,7 +1758,7 @@ int plugin_write(const char *plugin, /* {{{ */
     }
 
     if (le == NULL)
-      return (ENOENT);
+      return ENOENT;
 
     cf = le->value;
 
@@ -1771,14 +1770,14 @@ int plugin_write(const char *plugin, /* {{{ */
     status = (*callback)(ds, vl, &cf->cf_udata);
   }
 
-  return (status);
+  return status;
 } /* }}} int plugin_write */
 
 int plugin_flush(const char *plugin, cdtime_t timeout, const char *identifier) {
   llentry_t *le;
 
   if (list_flush == NULL)
-    return (0);
+    return 0;
 
   le = llist_head(list_flush);
   while (le != NULL) {
@@ -1801,7 +1800,7 @@ int plugin_flush(const char *plugin, cdtime_t timeout, const char *identifier) {
 
     le = le->next;
   }
-  return (0);
+  return 0;
 } /* int plugin_flush */
 
 int plugin_shutdown_all(void) {
@@ -1867,7 +1866,7 @@ int plugin_shutdown_all(void) {
 
   plugin_free_loaded();
   plugin_free_data_sets();
-  return (ret);
+  return ret;
 } /* void plugin_shutdown_all */
 
 int plugin_dispatch_missing(const value_list_t *vl) /* {{{ */
@@ -1875,7 +1874,7 @@ int plugin_dispatch_missing(const value_list_t *vl) /* {{{ */
   llentry_t *le;
 
   if (list_missing == NULL)
-    return (0);
+    return 0;
 
   le = llist_head(list_missing);
   while (le != NULL) {
@@ -1895,15 +1894,15 @@ int plugin_dispatch_missing(const value_list_t *vl) /* {{{ */
         ERROR("plugin_dispatch_missing: Callback function \"%s\" "
               "failed with status %i.",
               le->key, status);
-        return (status);
+        return status;
       } else {
-        return (0);
+        return 0;
       }
     }
 
     le = le->next;
   }
-  return (0);
+  return 0;
 } /* int }}} plugin_dispatch_missing */
 
 static int plugin_dispatch_values_internal(value_list_t *vl) {
@@ -1925,7 +1924,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
     ERROR("plugin_dispatch_values: Invalid value list "
           "from plugin %s.",
           vl->plugin);
-    return (-1);
+    return -1;
   }
 
   /* Free meta data only if the calling function didn't specify any. In
@@ -1944,7 +1943,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
     ERROR("plugin_dispatch_values: No data sets registered. "
           "Could the types database be read? Check "
           "your `TypesDB' setting!");
-    return (-1);
+    return -1;
   }
 
   if (c_avl_get(data_sets, vl->type, (void *)&ds) != 0) {
@@ -1954,7 +1953,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
     INFO("plugin_dispatch_values: Dataset not found: %s "
          "(from \"%s\"), check your types.db!",
          vl->type, ident);
-    return (-1);
+    return -1;
   }
 
   DEBUG("plugin_dispatch_values: time = %.3f; interval = %.3f; "
@@ -1980,7 +1979,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
           "(ds->ds_num = %zu) != "
           "(vl->values_len = %zu)",
           ds->type, ds->ds_num, vl->values_len);
-    return (-1);
+    return -1;
   }
 #endif
 
@@ -1998,7 +1997,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
               "status %i (%#x).",
               status, status);
     } else if (status == FC_TARGET_STOP)
-      return (0);
+      return 0;
   }
 
   /* Update the value cache */
@@ -2020,7 +2019,7 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
     vl->meta = NULL;
   }
 
-  return (0);
+  return 0;
 } /* int plugin_dispatch_values_internal */
 
 static double get_drop_probability(void) /* {{{ */
@@ -2034,14 +2033,14 @@ static double get_drop_probability(void) /* {{{ */
   pthread_mutex_unlock(&write_lock);
 
   if (wql < write_limit_low)
-    return (0.0);
+    return 0.0;
   if (wql >= write_limit_high)
-    return (1.0);
+    return 1.0;
 
   pos = 1 + wql - write_limit_low;
   size = 1 + write_limit_high - write_limit_low;
 
-  return (((double)pos) / ((double)size));
+  return (double)pos / (double)size;
 } /* }}} double get_drop_probability */
 
 static _Bool check_drop_value(void) /* {{{ */
@@ -2054,11 +2053,11 @@ static _Bool check_drop_value(void) /* {{{ */
   int status;
 
   if (write_limit_high == 0)
-    return (0);
+    return 0;
 
   p = get_drop_probability();
   if (p == 0.0)
-    return (0);
+    return 0;
 
   status = pthread_mutex_trylock(&last_message_lock);
   if (status == 0) {
@@ -2075,13 +2074,13 @@ static _Bool check_drop_value(void) /* {{{ */
   }
 
   if (p == 1.0)
-    return (1);
+    return 1;
 
   q = cdrand_d();
   if (q > p)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* }}} _Bool check_drop_value */
 
 int plugin_dispatch_values(value_list_t const *vl) {
@@ -2094,7 +2093,7 @@ int plugin_dispatch_values(value_list_t const *vl) {
       stats_values_dropped++;
       pthread_mutex_unlock(&statistics_lock);
     }
-    return (0);
+    return 0;
   }
 
   status = plugin_write_enqueue(vl);
@@ -2103,10 +2102,10 @@ int plugin_dispatch_values(value_list_t const *vl) {
     ERROR("plugin_dispatch_values: plugin_write_enqueue failed "
           "with status %i (%s).",
           status, sstrerror(status, errbuf, sizeof(errbuf)));
-    return (status);
+    return status;
   }
 
-  return (0);
+  return 0;
 }
 
 __attribute__((sentinel)) int
@@ -2181,7 +2180,7 @@ plugin_dispatch_multivalue(value_list_t const *template, /* {{{ */
   va_end(ap);
 
   plugin_value_list_free(vl);
-  return (failed);
+  return failed;
 } /* }}} int plugin_dispatch_multivalue */
 
 int plugin_dispatch_notification(const notification_t *notif) {
@@ -2195,7 +2194,7 @@ int plugin_dispatch_notification(const notification_t *notif) {
 
   /* Nobody cares for notifications */
   if (list_notification == NULL)
-    return (-1);
+    return -1;
 
   le = llist_head(list_notification);
   while (le != NULL) {
@@ -2218,7 +2217,7 @@ int plugin_dispatch_notification(const notification_t *notif) {
     le = le->next;
   }
 
-  return (0);
+  return 0;
 } /* int plugin_dispatch_notification */
 
 void plugin_log(int level, const char *format, ...) {
@@ -2276,7 +2275,7 @@ int parse_log_severity(const char *severity) {
     log_level = LOG_DEBUG;
 #endif /* COLLECT_DEBUG */
 
-  return (log_level);
+  return log_level;
 } /* int parse_log_severity */
 
 int parse_notif_severity(const char *severity) {
@@ -2290,7 +2289,7 @@ int parse_notif_severity(const char *severity) {
            (strcmp(severity, "WARN") == 0))
     notif_severity = NOTIF_WARNING;
 
-  return (notif_severity);
+  return notif_severity;
 } /* int parse_notif_severity */
 
 const data_set_t *plugin_get_ds(const char *name) {
@@ -2298,15 +2297,15 @@ const data_set_t *plugin_get_ds(const char *name) {
 
   if (data_sets == NULL) {
     ERROR("plugin_get_ds: No data sets are defined yet.");
-    return (NULL);
+    return NULL;
   }
 
   if (c_avl_get(data_sets, name, (void *)&ds) != 0) {
     DEBUG("No such dataset registered: %s", name);
-    return (NULL);
+    return NULL;
   }
 
-  return (ds);
+  return ds;
 } /* data_set_t *plugin_get_ds */
 
 static int plugin_notification_meta_add(notification_t *n, const char *name,
@@ -2317,13 +2316,13 @@ static int plugin_notification_meta_add(notification_t *n, const char *name,
 
   if ((n == NULL) || (name == NULL) || (value == NULL)) {
     ERROR("plugin_notification_meta_add: A pointer is NULL!");
-    return (-1);
+    return -1;
   }
 
   meta = calloc(1, sizeof(*meta));
   if (meta == NULL) {
     ERROR("plugin_notification_meta_add: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(meta->name, name, sizeof(meta->name));
@@ -2335,7 +2334,7 @@ static int plugin_notification_meta_add(notification_t *n, const char *name,
     if (meta->nm_value.nm_string == NULL) {
       ERROR("plugin_notification_meta_add: strdup failed.");
       sfree(meta);
-      return (-1);
+      return -1;
     }
     break;
   }
@@ -2358,7 +2357,7 @@ static int plugin_notification_meta_add(notification_t *n, const char *name,
   default: {
     ERROR("plugin_notification_meta_add: Unknown type: %i", type);
     sfree(meta);
-    return (-1);
+    return -1;
   }
   } /* switch (type) */
 
@@ -2372,33 +2371,33 @@ static int plugin_notification_meta_add(notification_t *n, const char *name,
   else
     tail->next = meta;
 
-  return (0);
+  return 0;
 } /* int plugin_notification_meta_add */
 
 int plugin_notification_meta_add_string(notification_t *n, const char *name,
                                         const char *value) {
-  return (plugin_notification_meta_add(n, name, NM_TYPE_STRING, value));
+  return plugin_notification_meta_add(n, name, NM_TYPE_STRING, value);
 }
 
 int plugin_notification_meta_add_signed_int(notification_t *n, const char *name,
                                             int64_t value) {
-  return (plugin_notification_meta_add(n, name, NM_TYPE_SIGNED_INT, &value));
+  return plugin_notification_meta_add(n, name, NM_TYPE_SIGNED_INT, &value);
 }
 
 int plugin_notification_meta_add_unsigned_int(notification_t *n,
                                               const char *name,
                                               uint64_t value) {
-  return (plugin_notification_meta_add(n, name, NM_TYPE_UNSIGNED_INT, &value));
+  return plugin_notification_meta_add(n, name, NM_TYPE_UNSIGNED_INT, &value);
 }
 
 int plugin_notification_meta_add_double(notification_t *n, const char *name,
                                         double value) {
-  return (plugin_notification_meta_add(n, name, NM_TYPE_DOUBLE, &value));
+  return plugin_notification_meta_add(n, name, NM_TYPE_DOUBLE, &value);
 }
 
 int plugin_notification_meta_add_boolean(notification_t *n, const char *name,
                                          _Bool value) {
-  return (plugin_notification_meta_add(n, name, NM_TYPE_BOOLEAN, &value));
+  return plugin_notification_meta_add(n, name, NM_TYPE_BOOLEAN, &value);
 }
 
 int plugin_notification_meta_copy(notification_t *dst,
@@ -2426,7 +2425,7 @@ int plugin_notification_meta_copy(notification_t *dst,
                                            meta->nm_value.nm_boolean);
   }
 
-  return (0);
+  return 0;
 } /* int plugin_notification_meta_copy */
 
 int plugin_notification_meta_free(notification_meta_t *n) {
@@ -2435,7 +2434,7 @@ int plugin_notification_meta_free(notification_meta_t *n) {
 
   if (n == NULL) {
     ERROR("plugin_notification_meta_free: n == NULL!");
-    return (-1);
+    return -1;
   }
 
   this = n;
@@ -2455,7 +2454,7 @@ int plugin_notification_meta_free(notification_meta_t *n) {
     this = next;
   }
 
-  return (0);
+  return 0;
 } /* int plugin_notification_meta_free */
 
 static void plugin_ctx_destructor(void *ctx) {
@@ -2479,7 +2478,7 @@ static plugin_ctx_t *plugin_ctx_create(void) {
   assert(plugin_ctx_key_initialized);
   pthread_setspecific(plugin_ctx_key, ctx);
   DEBUG("Created new plugin context.");
-  return (ctx);
+  return ctx;
 } /* int plugin_ctx_create */
 
 void plugin_init_ctx(void) {
@@ -2500,7 +2499,7 @@ plugin_ctx_t plugin_get_ctx(void) {
       return ctx_init;
   }
 
-  return (*ctx);
+  return *ctx;
 } /* plugin_ctx_t plugin_get_ctx */
 
 plugin_ctx_t plugin_set_ctx(plugin_ctx_t ctx) {
@@ -2520,7 +2519,7 @@ plugin_ctx_t plugin_set_ctx(plugin_ctx_t ctx) {
   old = *c;
   *c = ctx;
 
-  return (old);
+  return old;
 } /* void plugin_set_ctx */
 
 cdtime_t plugin_get_interval(void) {

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -40,7 +40,7 @@ static int parse_ds(data_source_t *dsrc, char *buf, size_t buf_len) {
 
   if (buf_len < 11) {
     ERROR("parse_ds: (buf_len = %zu) < 11", buf_len);
-    return (-1);
+    return -1;
   }
 
   if (buf[buf_len - 1] == ',') {
@@ -61,7 +61,7 @@ static int parse_ds(data_source_t *dsrc, char *buf, size_t buf_len) {
 
   if (fields_num != 4) {
     ERROR("parse_ds: (fields_num = %i) != 4", fields_num);
-    return (-1);
+    return -1;
   }
 
   sstrncpy(dsrc->name, fields[0], sizeof(dsrc->name));
@@ -77,7 +77,7 @@ static int parse_ds(data_source_t *dsrc, char *buf, size_t buf_len) {
   else {
     ERROR("(fields[1] = %s) != (GAUGE || COUNTER || DERIVE || ABSOLUTE)",
           fields[1]);
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp(fields[2], "U") == 0)
@@ -90,7 +90,7 @@ static int parse_ds(data_source_t *dsrc, char *buf, size_t buf_len) {
   else
     dsrc->max = atof(fields[3]);
 
-  return (0);
+  return 0;
 } /* int parse_ds */
 
 static void parse_line(char *buf) {
@@ -170,7 +170,7 @@ int read_types_list(const char *file) {
   FILE *fh;
 
   if (file == NULL)
-    return (-1);
+    return -1;
 
   fh = fopen(file, "r");
   if (fh == NULL) {
@@ -179,7 +179,7 @@ int read_types_list(const char *file) {
             sstrerror(errno, errbuf, sizeof(errbuf)));
     ERROR("Failed to open types database `%s': %s", file,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   parse_file(fh);
@@ -189,5 +189,5 @@ int read_types_list(const char *file) {
 
   DEBUG("Done parsing `%s'", file);
 
-  return (0);
+  return 0;
 } /* int read_types_list */

--- a/src/daemon/utils_avltree.c
+++ b/src/daemon/utils_avltree.c
@@ -94,12 +94,12 @@ static int calc_height(c_avl_node_t *n) {
   int height_right;
 
   if (n == NULL)
-    return (0);
+    return 0;
 
   height_left = (n->left == NULL) ? 0 : n->left->height;
   height_right = (n->right == NULL) ? 0 : n->right->height;
 
-  return (((height_left > height_right) ? height_left : height_right) + 1);
+  return ((height_left > height_right) ? height_left : height_right) + 1;
 } /* int calc_height */
 
 static c_avl_node_t *search(c_avl_tree_t *t, const void *key) {
@@ -110,14 +110,14 @@ static c_avl_node_t *search(c_avl_tree_t *t, const void *key) {
   while (n != NULL) {
     cmp = t->compare(key, n->key);
     if (cmp == 0)
-      return (n);
+      return n;
     else if (cmp < 0)
       n = n->left;
     else
       n = n->right;
   }
 
-  return (NULL);
+  return NULL;
 }
 
 /*         (x)             (y)
@@ -159,7 +159,7 @@ static c_avl_node_t *rotate_right(c_avl_tree_t *t, c_avl_node_t *x) {
   x->height = calc_height(x);
   y->height = calc_height(y);
 
-  return (y);
+  return y;
 } /* void rotate_right */
 
 /*
@@ -202,17 +202,17 @@ static c_avl_node_t *rotate_left(c_avl_tree_t *t, c_avl_node_t *x) {
   x->height = calc_height(x);
   y->height = calc_height(y);
 
-  return (y);
+  return y;
 } /* void rotate_left */
 
 static c_avl_node_t *rotate_left_right(c_avl_tree_t *t, c_avl_node_t *x) {
   rotate_left(t, x->left);
-  return (rotate_right(t, x));
+  return rotate_right(t, x);
 } /* void rotate_left_right */
 
 static c_avl_node_t *rotate_right_left(c_avl_tree_t *t, c_avl_node_t *x) {
   rotate_right(t, x->right);
-  return (rotate_left(t, x));
+  return rotate_left(t, x);
 } /* void rotate_right_left */
 
 static void rebalance(c_avl_tree_t *t, c_avl_node_t *n) {
@@ -256,7 +256,7 @@ static c_avl_node_t *c_avl_node_next(c_avl_node_t *n) {
   c_avl_node_t *r; /* return node */
 
   if (n == NULL) {
-    return (NULL);
+    return NULL;
   }
 
   /* If we can't descent any further, we have to backtrack to the first
@@ -274,10 +274,10 @@ static c_avl_node_t *c_avl_node_next(c_avl_node_t *n) {
      * r->left != n => r->right = n => r->parent == NULL */
     if ((r == NULL) || (r->left != n)) {
       assert((r == NULL) || (r->parent == NULL));
-      return (NULL);
+      return NULL;
     } else {
       assert(r->left == n);
-      return (r);
+      return r;
     }
   } else {
     r = n->right;
@@ -285,14 +285,14 @@ static c_avl_node_t *c_avl_node_next(c_avl_node_t *n) {
       r = r->left;
   }
 
-  return (r);
+  return r;
 } /* c_avl_node_t *c_avl_node_next */
 
 static c_avl_node_t *c_avl_node_prev(c_avl_node_t *n) {
   c_avl_node_t *r; /* return node */
 
   if (n == NULL) {
-    return (NULL);
+    return NULL;
   }
 
   /* If we can't descent any further, we have to backtrack to the first
@@ -310,10 +310,10 @@ static c_avl_node_t *c_avl_node_prev(c_avl_node_t *n) {
      * r->right != n => r->left = n => r->parent == NULL */
     if ((r == NULL) || (r->right != n)) {
       assert((r == NULL) || (r->parent == NULL));
-      return (NULL);
+      return NULL;
     } else {
       assert(r->right == n);
-      return (r);
+      return r;
     }
   } else {
     r = n->left;
@@ -321,7 +321,7 @@ static c_avl_node_t *c_avl_node_prev(c_avl_node_t *n) {
       r = r->right;
   }
 
-  return (r);
+  return r;
 } /* c_avl_node_t *c_avl_node_prev */
 
 static int _remove(c_avl_tree_t *t, c_avl_node_t *n) {
@@ -409,7 +409,7 @@ static int _remove(c_avl_tree_t *t, c_avl_node_t *n) {
     assert(0);
   }
 
-  return (0);
+  return 0;
 } /* void *_remove */
 
 /*
@@ -419,16 +419,16 @@ c_avl_tree_t *c_avl_create(int (*compare)(const void *, const void *)) {
   c_avl_tree_t *t;
 
   if (compare == NULL)
-    return (NULL);
+    return NULL;
 
   if ((t = malloc(sizeof(*t))) == NULL)
-    return (NULL);
+    return NULL;
 
   t->root = NULL;
   t->compare = compare;
   t->size = 0;
 
-  return (t);
+  return t;
 }
 
 void c_avl_destroy(c_avl_tree_t *t) {
@@ -444,7 +444,7 @@ int c_avl_insert(c_avl_tree_t *t, void *key, void *value) {
   int cmp;
 
   if ((new = malloc(sizeof(*new))) == NULL)
-    return (-1);
+    return -1;
 
   new->key = key;
   new->value = value;
@@ -456,7 +456,7 @@ int c_avl_insert(c_avl_tree_t *t, void *key, void *value) {
     new->parent = NULL;
     t->root = new;
     t->size = 1;
-    return (0);
+    return 0;
   }
 
   nptr = t->root;
@@ -464,7 +464,7 @@ int c_avl_insert(c_avl_tree_t *t, void *key, void *value) {
     cmp = t->compare(nptr->key, new->key);
     if (cmp == 0) {
       free_node(new);
-      return (1);
+      return 1;
     } else if (cmp < 0) {
       /* nptr < new */
       if (nptr->right == NULL) {
@@ -491,7 +491,7 @@ int c_avl_insert(c_avl_tree_t *t, void *key, void *value) {
 
   verify_tree(t->root);
   ++t->size;
-  return (0);
+  return 0;
 } /* int c_avl_insert */
 
 int c_avl_remove(c_avl_tree_t *t, const void *key, void **rkey, void **rvalue) {
@@ -502,7 +502,7 @@ int c_avl_remove(c_avl_tree_t *t, const void *key, void **rkey, void **rvalue) {
 
   n = search(t, key);
   if (n == NULL)
-    return (-1);
+    return -1;
 
   if (rkey != NULL)
     *rkey = n->key;
@@ -512,7 +512,7 @@ int c_avl_remove(c_avl_tree_t *t, const void *key, void **rkey, void **rvalue) {
   status = _remove(t, n);
   verify_tree(t->root);
   --t->size;
-  return (status);
+  return status;
 } /* void *c_avl_remove */
 
 int c_avl_get(c_avl_tree_t *t, const void *key, void **value) {
@@ -522,12 +522,12 @@ int c_avl_get(c_avl_tree_t *t, const void *key, void **value) {
 
   n = search(t, key);
   if (n == NULL)
-    return (-1);
+    return -1;
 
   if (value != NULL)
     *value = n->value;
 
-  return (0);
+  return 0;
 }
 
 int c_avl_pick(c_avl_tree_t *t, void **key, void **value) {
@@ -535,9 +535,9 @@ int c_avl_pick(c_avl_tree_t *t, void **key, void **value) {
   c_avl_node_t *p;
 
   if ((key == NULL) || (value == NULL))
-    return (-1);
+    return -1;
   if (t->root == NULL)
-    return (-1);
+    return -1;
 
   n = t->root;
   while ((n->left != NULL) || (n->right != NULL)) {
@@ -570,28 +570,28 @@ int c_avl_pick(c_avl_tree_t *t, void **key, void **value) {
   --t->size;
   rebalance(t, p);
 
-  return (0);
+  return 0;
 } /* int c_avl_pick */
 
 c_avl_iterator_t *c_avl_get_iterator(c_avl_tree_t *t) {
   c_avl_iterator_t *iter;
 
   if (t == NULL)
-    return (NULL);
+    return NULL;
 
   iter = calloc(1, sizeof(*iter));
   if (iter == NULL)
-    return (NULL);
+    return NULL;
   iter->tree = t;
 
-  return (iter);
+  return iter;
 } /* c_avl_iterator_t *c_avl_get_iterator */
 
 int c_avl_iterator_next(c_avl_iterator_t *iter, void **key, void **value) {
   c_avl_node_t *n;
 
   if ((iter == NULL) || (key == NULL) || (value == NULL))
-    return (-1);
+    return -1;
 
   if (iter->node == NULL) {
     for (n = iter->tree->root; n != NULL; n = n->left)
@@ -603,20 +603,20 @@ int c_avl_iterator_next(c_avl_iterator_t *iter, void **key, void **value) {
   }
 
   if (n == NULL)
-    return (-1);
+    return -1;
 
   iter->node = n;
   *key = n->key;
   *value = n->value;
 
-  return (0);
+  return 0;
 } /* int c_avl_iterator_next */
 
 int c_avl_iterator_prev(c_avl_iterator_t *iter, void **key, void **value) {
   c_avl_node_t *n;
 
   if ((iter == NULL) || (key == NULL) || (value == NULL))
-    return (-1);
+    return -1;
 
   if (iter->node == NULL) {
     for (n = iter->tree->root; n != NULL; n = n->left)
@@ -628,19 +628,19 @@ int c_avl_iterator_prev(c_avl_iterator_t *iter, void **key, void **value) {
   }
 
   if (n == NULL)
-    return (-1);
+    return -1;
 
   iter->node = n;
   *key = n->key;
   *value = n->value;
 
-  return (0);
+  return 0;
 } /* int c_avl_iterator_prev */
 
 void c_avl_iterator_destroy(c_avl_iterator_t *iter) { free(iter); }
 
 int c_avl_size(c_avl_tree_t *t) {
   if (t == NULL)
-    return (0);
-  return (t->size);
+    return 0;
+  return t->size;
 }

--- a/src/daemon/utils_avltree_test.c
+++ b/src/daemon/utils_avltree_test.c
@@ -41,7 +41,7 @@ static int compare_callback(void const *v0, void const *v1) {
   assert(v1 != NULL);
 
   compare_total_count++;
-  return (strcmp(v0, v1));
+  return strcmp(v0, v1);
 }
 
 DEF_TEST(success) {
@@ -127,7 +127,7 @@ DEF_TEST(success) {
 
   c_avl_destroy(t);
 
-  return (0);
+  return 0;
 }
 
 int main(void) {

--- a/src/daemon/utils_cache_mock.c
+++ b/src/daemon/utils_cache_mock.c
@@ -30,14 +30,14 @@
 gauge_t *uc_get_rate(__attribute__((unused)) data_set_t const *ds,
                      __attribute__((unused)) value_list_t const *vl) {
   errno = ENOTSUP;
-  return (NULL);
+  return NULL;
 }
 
 int uc_get_rate_by_name(const char *name, gauge_t **ret_values,
                         size_t *ret_values_num) {
-  return (ENOTSUP);
+  return ENOTSUP;
 }
 
 int uc_get_names(char ***ret_names, cdtime_t **ret_times, size_t *ret_number) {
-  return (ENOTSUP);
+  return ENOTSUP;
 }

--- a/src/daemon/utils_heap.c
+++ b/src/daemon/utils_heap.c
@@ -99,11 +99,11 @@ c_heap_t *c_heap_create(int (*compare)(const void *, const void *)) {
   c_heap_t *h;
 
   if (compare == NULL)
-    return (NULL);
+    return NULL;
 
   h = calloc(1, sizeof(*h));
   if (h == NULL)
-    return (NULL);
+    return NULL;
 
   pthread_mutex_init(&h->lock, /* attr = */ NULL);
   h->compare = compare;
@@ -112,7 +112,7 @@ c_heap_t *c_heap_create(int (*compare)(const void *, const void *)) {
   h->list_len = 0;
   h->list_size = 0;
 
-  return (h);
+  return h;
 } /* c_heap_t *c_heap_create */
 
 void c_heap_destroy(c_heap_t *h) {
@@ -133,7 +133,7 @@ int c_heap_insert(c_heap_t *h, void *ptr) {
   size_t index;
 
   if ((h == NULL) || (ptr == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   pthread_mutex_lock(&h->lock);
 
@@ -144,7 +144,7 @@ int c_heap_insert(c_heap_t *h, void *ptr) {
     tmp = realloc(h->list, (h->list_size + 16) * sizeof(*h->list));
     if (tmp == NULL) {
       pthread_mutex_unlock(&h->lock);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     h->list = tmp;
@@ -160,20 +160,20 @@ int c_heap_insert(c_heap_t *h, void *ptr) {
   reheap(h, /* parent of this node = */ (index - 1) / 2, DIR_UP);
 
   pthread_mutex_unlock(&h->lock);
-  return (0);
+  return 0;
 } /* int c_heap_insert */
 
 void *c_heap_get_root(c_heap_t *h) {
   void *ret = NULL;
 
   if (h == NULL)
-    return (NULL);
+    return NULL;
 
   pthread_mutex_lock(&h->lock);
 
   if (h->list_len == 0) {
     pthread_mutex_unlock(&h->lock);
-    return (NULL);
+    return NULL;
   } else if (h->list_len == 1) {
     ret = h->list[0];
     h->list[0] = NULL;
@@ -201,5 +201,5 @@ void *c_heap_get_root(c_heap_t *h) {
 
   pthread_mutex_unlock(&h->lock);
 
-  return (ret);
+  return ret;
 } /* void *c_heap_get_root */

--- a/src/daemon/utils_heap_test.c
+++ b/src/daemon/utils_heap_test.c
@@ -68,7 +68,7 @@ DEF_TEST(simple) {
   }
 
   c_heap_destroy(h);
-  return (0);
+  return 0;
 }
 
 int main(void) {

--- a/src/daemon/utils_llist.c
+++ b/src/daemon/utils_llist.c
@@ -46,9 +46,9 @@ llist_t *llist_create(void) {
 
   ret = calloc(1, sizeof(*ret));
   if (ret == NULL)
-    return (NULL);
+    return NULL;
 
-  return (ret);
+  return ret;
 }
 
 void llist_destroy(llist_t *l) {
@@ -76,7 +76,7 @@ llentry_t *llentry_create(char *key, void *value) {
     e->next = NULL;
   }
 
-  return (e);
+  return e;
 }
 
 void llentry_destroy(llentry_t *e) { free(e); }
@@ -124,16 +124,16 @@ void llist_remove(llist_t *l, llentry_t *e) {
   --(l->size);
 }
 
-int llist_size(llist_t *l) { return (l ? l->size : 0); }
+int llist_size(llist_t *l) { return l ? l->size : 0; }
 
 static int llist_strcmp(llentry_t *e, void *ud) {
   if ((e == NULL) || (ud == NULL))
-    return (-1);
-  return (strcmp(e->key, (const char *)ud));
+    return -1;
+  return strcmp(e->key, (const char *)ud);
 }
 
 llentry_t *llist_search(llist_t *l, const char *key) {
-  return (llist_search_custom(l, llist_strcmp, (void *)key));
+  return llist_search_custom(l, llist_strcmp, (void *)key);
 }
 
 llentry_t *llist_search_custom(llist_t *l, int (*compare)(llentry_t *, void *),
@@ -141,7 +141,7 @@ llentry_t *llist_search_custom(llist_t *l, int (*compare)(llentry_t *, void *),
   llentry_t *e;
 
   if (l == NULL)
-    return (NULL);
+    return NULL;
 
   e = l->head;
   while (e != NULL) {
@@ -153,17 +153,17 @@ llentry_t *llist_search_custom(llist_t *l, int (*compare)(llentry_t *, void *),
     e = next;
   }
 
-  return (e);
+  return e;
 }
 
 llentry_t *llist_head(llist_t *l) {
   if (l == NULL)
-    return (NULL);
-  return (l->head);
+    return NULL;
+  return l->head;
 }
 
 llentry_t *llist_tail(llist_t *l) {
   if (l == NULL)
-    return (NULL);
-  return (l->tail);
+    return NULL;
+  return l->tail;
 }

--- a/src/daemon/utils_random.c
+++ b/src/daemon/utils_random.c
@@ -58,7 +58,7 @@ double cdrand_d(void) {
   r = erand48(seed);
   pthread_mutex_unlock(&lock);
 
-  return (r);
+  return r;
 }
 
 uint32_t cdrand_u(void) {
@@ -81,5 +81,5 @@ long cdrand_range(long min, long max) {
   r = (long)(0.5 + (cdrand_d() * range));
   r += min;
 
-  return (r);
+  return r;
 }

--- a/src/daemon/utils_subst.c
+++ b/src/daemon/utils_subst.c
@@ -119,7 +119,7 @@ char *subst_string(char *buf, size_t buflen, const char *string,
 
   if ((buf == NULL) || (string == NULL) || (needle == NULL) ||
       (replacement == NULL))
-    return (NULL);
+    return NULL;
 
   needle_len = strlen(needle);
   sstrncpy(buf, string, buflen);
@@ -157,5 +157,5 @@ char *subst_string(char *buf, size_t buflen, const char *string,
             i, string, needle, replacement);
   }
 
-  return (buf);
+  return buf;
 } /* char *subst_string */

--- a/src/daemon/utils_threshold.c
+++ b/src/daemon/utils_threshold.c
@@ -58,9 +58,9 @@ threshold_t *threshold_get(const char *hostname, const char *plugin,
   name[sizeof(name) - 1] = '\0';
 
   if (c_avl_get(threshold_tree, name, (void *)&th) == 0)
-    return (th);
+    return th;
   else
-    return (NULL);
+    return NULL;
 } /* }}} threshold_t *threshold_get */
 
 /*
@@ -76,39 +76,39 @@ threshold_t *threshold_search(const value_list_t *vl) { /* {{{ */
 
   if ((th = threshold_get(vl->host, vl->plugin, vl->plugin_instance, vl->type,
                           vl->type_instance)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get(vl->host, vl->plugin, vl->plugin_instance,
                                vl->type, NULL)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get(vl->host, vl->plugin, NULL, vl->type,
                                vl->type_instance)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get(vl->host, vl->plugin, NULL, vl->type, NULL)) !=
            NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get(vl->host, "", NULL, vl->type,
                                vl->type_instance)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get(vl->host, "", NULL, vl->type, NULL)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", vl->plugin, vl->plugin_instance, vl->type,
                                vl->type_instance)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", vl->plugin, vl->plugin_instance, vl->type,
                                NULL)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", vl->plugin, NULL, vl->type,
                                vl->type_instance)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", vl->plugin, NULL, vl->type, NULL)) != NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", "", NULL, vl->type, vl->type_instance)) !=
            NULL)
-    return (th);
+    return th;
   else if ((th = threshold_get("", "", NULL, vl->type, NULL)) != NULL)
-    return (th);
+    return th;
 
-  return (NULL);
+  return NULL;
 } /* }}} threshold_t *threshold_search */
 
 int ut_search_threshold(const value_list_t *vl, /* {{{ */
@@ -116,14 +116,14 @@ int ut_search_threshold(const value_list_t *vl, /* {{{ */
   threshold_t *t;
 
   if (vl == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* Is this lock really necessary? */
   pthread_mutex_lock(&threshold_lock);
   t = threshold_search(vl);
   if (t == NULL) {
     pthread_mutex_unlock(&threshold_lock);
-    return (ENOENT);
+    return ENOENT;
   }
 
   memcpy(ret_threshold, t, sizeof(*ret_threshold));
@@ -131,5 +131,5 @@ int ut_search_threshold(const value_list_t *vl, /* {{{ */
 
   ret_threshold->next = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int ut_search_threshold */

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -101,7 +101,7 @@ static const char *cdbi_strerror(dbi_conn conn, /* {{{ */
 
   if (conn == NULL) {
     sstrncpy(buffer, "connection is NULL", buffer_size);
-    return (buffer);
+    return buffer;
   }
 
   msg = NULL;
@@ -112,7 +112,7 @@ static const char *cdbi_strerror(dbi_conn conn, /* {{{ */
     ssnprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
               status);
 
-  return (buffer);
+  return buffer;
 } /* }}} const char *cdbi_conn_error */
 
 static int cdbi_result_get_field(dbi_result res, /* {{{ */
@@ -124,7 +124,7 @@ static int cdbi_result_get_field(dbi_result res, /* {{{ */
   if (src_type == DBI_TYPE_ERROR) {
     ERROR("dbi plugin: cdbi_result_get: "
           "dbi_result_get_field_type_idx failed.");
-    return (-1);
+    return -1;
   }
 
   if (src_type == DBI_TYPE_INTEGER) {
@@ -144,7 +144,7 @@ static int cdbi_result_get_field(dbi_result res, /* {{{ */
     if (value == NULL)
       sstrncpy(buffer, "", buffer_size);
     else if (strcmp("ERROR", value) == 0)
-      return (-1);
+      return -1;
     else
       sstrncpy(buffer, value, buffer_size);
   }
@@ -160,10 +160,10 @@ static int cdbi_result_get_field(dbi_result res, /* {{{ */
     ERROR("dbi plugin: Column `%s': Don't know how to handle "
           "source type %hu.",
           field_name, src_type);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_result_get_field */
 
 static void cdbi_database_free(cdbi_database_t *db) /* {{{ */
@@ -221,14 +221,14 @@ static int cdbi_config_add_database_driver_option(cdbi_database_t *db, /* {{{ */
        (ci->values[1].type != OCONFIG_TYPE_NUMBER))) {
     WARNING("dbi plugin: The `DriverOption' config option "
             "needs exactly two arguments.");
-    return (-1);
+    return -1;
   }
 
   option = realloc(db->driver_options,
                    sizeof(*option) * (db->driver_options_num + 1));
   if (option == NULL) {
     ERROR("dbi plugin: realloc failed");
-    return (-1);
+    return -1;
   }
 
   db->driver_options = option;
@@ -238,7 +238,7 @@ static int cdbi_config_add_database_driver_option(cdbi_database_t *db, /* {{{ */
   option->key = strdup(ci->values[0].value.string);
   if (option->key == NULL) {
     ERROR("dbi plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   if (ci->values[1].type == OCONFIG_TYPE_STRING) {
@@ -246,7 +246,7 @@ static int cdbi_config_add_database_driver_option(cdbi_database_t *db, /* {{{ */
     if (option->value.string == NULL) {
       ERROR("dbi plugin: strdup failed.");
       sfree(option->key);
-      return (-1);
+      return -1;
     }
   } else {
     assert(ci->values[1].type == OCONFIG_TYPE_NUMBER);
@@ -255,7 +255,7 @@ static int cdbi_config_add_database_driver_option(cdbi_database_t *db, /* {{{ */
   }
 
   db->driver_options_num++;
-  return (0);
+  return 0;
 } /* }}} int cdbi_config_add_database_driver_option */
 
 static int cdbi_config_add_database(oconfig_item_t *ci) /* {{{ */
@@ -266,19 +266,19 @@ static int cdbi_config_add_database(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("dbi plugin: The `Database' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   db = calloc(1, sizeof(*db));
   if (db == NULL) {
     ERROR("dbi plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   status = cf_util_get_string(ci, &db->name);
   if (status != 0) {
     sfree(db);
-    return (status);
+    return status;
   }
 
   /* Fill the `cdbi_database_t' structure.. */
@@ -371,10 +371,10 @@ static int cdbi_config_add_database(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     cdbi_database_free(db);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_config_add_database */
 
 static int cdbi_config(oconfig_item_t *ci) /* {{{ */
@@ -391,7 +391,7 @@ static int cdbi_config(oconfig_item_t *ci) /* {{{ */
     }
   } /* for (ci->children) */
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_config */
 
 /* }}} End of configuration handling functions */
@@ -402,34 +402,34 @@ static int cdbi_init(void) /* {{{ */
   int status;
 
   if (did_init != 0)
-    return (0);
+    return 0;
 
   if (queries_num == 0) {
     ERROR("dbi plugin: No <Query> blocks have been found. Without them, "
           "this plugin can't do anything useful, so we will return an error.");
-    return (-1);
+    return -1;
   }
 
   if (databases_num == 0) {
     ERROR("dbi plugin: No <Database> blocks have been found. Without them, "
           "this plugin can't do anything useful, so we will return an error.");
-    return (-1);
+    return -1;
   }
 
   status = dbi_initialize_r(/* driverdir = */ NULL, &dbi_instance);
   if (status < 0) {
     ERROR("dbi plugin: cdbi_init: dbi_initialize_r failed with status %i.",
           status);
-    return (-1);
+    return -1;
   } else if (status == 0) {
     ERROR("dbi plugin: `dbi_initialize_r' could not load any drivers. Please "
           "install at least one `DBD' or check your installation.");
-    return (-1);
+    return -1;
   }
   DEBUG("dbi plugin: cdbi_init: dbi_initialize_r reports %i driver%s.", status,
         (status == 1) ? "" : "s");
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_init */
 
 static int cdbi_read_database_query(cdbi_database_t *db, /* {{{ */
@@ -619,7 +619,7 @@ static int cdbi_connect_database(cdbi_database_t *db) /* {{{ */
   if (db->connection != NULL) {
     status = dbi_conn_ping(db->connection);
     if (status != 0) /* connection is alive */
-      return (0);
+      return 0;
 
     dbi_conn_close(db->connection);
     db->connection = NULL;
@@ -635,14 +635,14 @@ static int cdbi_connect_database(cdbi_database_t *db) /* {{{ */
          driver = dbi_driver_list_r(driver, dbi_instance)) {
       INFO("dbi plugin: * %s", dbi_driver_get_name(driver));
     }
-    return (-1);
+    return -1;
   }
 
   connection = dbi_conn_open(driver);
   if (connection == NULL) {
     ERROR("dbi plugin: cdbi_connect_database: dbi_conn_open (%s) failed.",
           db->driver);
-    return (-1);
+    return -1;
   }
 
   /* Set all the driver options. Because this is a very very very generic
@@ -686,7 +686,7 @@ static int cdbi_connect_database(cdbi_database_t *db) /* {{{ */
       }
 
       dbi_conn_close(connection);
-      return (-1);
+      return -1;
     }
   } /* for (i = 0; i < db->driver_options_num; i++) */
 
@@ -697,7 +697,7 @@ static int cdbi_connect_database(cdbi_database_t *db) /* {{{ */
           "dbi_conn_connect failed: %s",
           db->name, cdbi_strerror(connection, errbuf, sizeof(errbuf)));
     dbi_conn_close(connection);
-    return (-1);
+    return -1;
   }
 
   if (db->select_db != NULL) {
@@ -710,12 +710,12 @@ static int cdbi_connect_database(cdbi_database_t *db) /* {{{ */
           db->name, db->select_db,
           cdbi_strerror(connection, errbuf, sizeof(errbuf)));
       dbi_conn_close(connection);
-      return (-1);
+      return -1;
     }
   }
 
   db->connection = connection;
-  return (0);
+  return 0;
 } /* }}} int cdbi_connect_database */
 
 static int cdbi_read_database(user_data_t *ud) /* {{{ */
@@ -728,7 +728,7 @@ static int cdbi_read_database(user_data_t *ud) /* {{{ */
 
   status = cdbi_connect_database(db);
   if (status != 0)
-    return (status);
+    return status;
   assert(db->connection != NULL);
 
   db_version = dbi_conn_get_engine_version(db->connection);
@@ -749,10 +749,10 @@ static int cdbi_read_database(user_data_t *ud) /* {{{ */
 
   if (success == 0) {
     ERROR("dbi plugin: All queries failed for database `%s'.", db->name);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_read_database */
 
 static int cdbi_shutdown(void) /* {{{ */
@@ -771,7 +771,7 @@ static int cdbi_shutdown(void) /* {{{ */
   queries = NULL;
   queries_num = 0;
 
-  return (0);
+  return 0;
 } /* }}} int cdbi_shutdown */
 
 void module_register(void) /* {{{ */

--- a/src/df.c
+++ b/src/df.c
@@ -68,7 +68,7 @@ static int df_init(void) {
   if (il_fstype == NULL)
     il_fstype = ignorelist_create(1);
 
-  return (0);
+  return 0;
 }
 
 static int df_config(const char *key, const char *value) {
@@ -76,16 +76,16 @@ static int df_config(const char *key, const char *value) {
 
   if (strcasecmp(key, "Device") == 0) {
     if (ignorelist_add(il_device, value))
-      return (1);
-    return (0);
+      return 1;
+    return 0;
   } else if (strcasecmp(key, "MountPoint") == 0) {
     if (ignorelist_add(il_mountpoint, value))
-      return (1);
-    return (0);
+      return 1;
+    return 0;
   } else if (strcasecmp(key, "FSType") == 0) {
     if (ignorelist_add(il_fstype, value))
-      return (1);
-    return (0);
+      return 1;
+    return 0;
   } else if (strcasecmp(key, "IgnoreSelected") == 0) {
     if (IS_TRUE(value)) {
       ignorelist_set_invert(il_device, 0);
@@ -96,36 +96,36 @@ static int df_config(const char *key, const char *value) {
       ignorelist_set_invert(il_mountpoint, 1);
       ignorelist_set_invert(il_fstype, 1);
     }
-    return (0);
+    return 0;
   } else if (strcasecmp(key, "ReportByDevice") == 0) {
     if (IS_TRUE(value))
       by_device = 1;
 
-    return (0);
+    return 0;
   } else if (strcasecmp(key, "ReportInodes") == 0) {
     if (IS_TRUE(value))
       report_inodes = 1;
     else
       report_inodes = 0;
 
-    return (0);
+    return 0;
   } else if (strcasecmp(key, "ValuesAbsolute") == 0) {
     if (IS_TRUE(value))
       values_absolute = 1;
     else
       values_absolute = 0;
 
-    return (0);
+    return 0;
   } else if (strcasecmp(key, "ValuesPercentage") == 0) {
     if (IS_TRUE(value))
       values_percentage = 1;
     else
       values_percentage = 0;
 
-    return (0);
+    return 0;
   }
 
-  return (-1);
+  return -1;
 }
 
 __attribute__((nonnull(2))) static void df_submit_one(char *plugin_instance,
@@ -158,7 +158,7 @@ static int df_read(void) {
   mnt_list = NULL;
   if (cu_mount_getlist(&mnt_list) == NULL) {
     ERROR("df plugin: cu_mount_getlist failed.");
-    return (-1);
+    return -1;
   }
 
   for (cu_mount_t *mnt_ptr = mnt_list; mnt_ptr != NULL;
@@ -285,7 +285,7 @@ static int df_read(void) {
         df_submit_one(disk_name, "percent_bytes", "used",
                       (gauge_t)((float_t)(blk_used) / statbuf.f_blocks * 100));
       } else
-        return (-1);
+        return -1;
     }
 
     /* inode handling */
@@ -316,7 +316,7 @@ static int df_read(void) {
               disk_name, "percent_inodes", "used",
               (gauge_t)((float_t)(inode_used) / statbuf.f_files * 100));
         } else
-          return (-1);
+          return -1;
       }
       if (values_absolute) {
         df_submit_one(disk_name, "df_inodes", "free", (gauge_t)inode_free);
@@ -329,7 +329,7 @@ static int df_read(void) {
 
   cu_mount_freelist(mnt_list);
 
-  return (0);
+  return 0;
 } /* int df_read */
 
 void module_register(void) {

--- a/src/disk.c
+++ b/src/disk.c
@@ -156,7 +156,7 @@ static int disk_config(const char *key, const char *value) {
   if (ignorelist == NULL)
     ignorelist = ignorelist_create(/* invert = */ 1);
   if (ignorelist == NULL)
-    return (1);
+    return 1;
 
   if (strcasecmp("Disk", key) == 0) {
     ignorelist_add(ignorelist, value);
@@ -179,16 +179,16 @@ static int disk_config(const char *key, const char *value) {
       conf_udev_name_attr = NULL;
     }
     if ((conf_udev_name_attr = strdup(value)) == NULL)
-      return (1);
+      return 1;
 #else
     WARNING("disk plugin: The \"UdevNameAttr\" option is only supported "
             "if collectd is built with libudev support");
 #endif
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int disk_config */
 
 static int disk_init(void) {
@@ -204,7 +204,7 @@ static int disk_init(void) {
   if (status != kIOReturnSuccess) {
     ERROR("IOMasterPort failed: %s", mach_error_string(status));
     io_master_port = MACH_PORT_NULL;
-    return (-1);
+    return -1;
   }
 /* #endif HAVE_IOKIT_IOKITLIB_H */
 
@@ -214,7 +214,7 @@ static int disk_init(void) {
     handle_udev = udev_new();
     if (handle_udev == NULL) {
       ERROR("disk plugin: udev_new() failed!");
-      return (-1);
+      return -1;
     }
   }
 #endif /* HAVE_UDEV_H */
@@ -226,12 +226,12 @@ static int disk_init(void) {
   rv = geom_gettree(&geom_tree);
   if (rv != 0) {
     ERROR("geom_gettree() failed, returned %d", rv);
-    return (-1);
+    return -1;
   }
   rv = geom_stats_open();
   if (rv != 0) {
     ERROR("geom_stats_open() failed, returned %d", rv);
-    return (-1);
+    return -1;
   }
 /* #endif KERNEL_FREEBSD */
 
@@ -241,7 +241,7 @@ static int disk_init(void) {
   numdisk = 0;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (numdisk = 0, ksp_chain = kc->kc_chain;
        (numdisk < MAX_NUMDISK) && (ksp_chain != NULL);
@@ -255,7 +255,7 @@ static int disk_init(void) {
   }
 #endif /* HAVE_LIBKSTAT */
 
-  return (0);
+  return 0;
 } /* int disk_init */
 
 static int disk_shutdown(void) {
@@ -265,7 +265,7 @@ static int disk_shutdown(void) {
     udev_unref(handle_udev);
 #endif /* HAVE_UDEV_H */
 #endif /* KERNEL_LINUX */
-  return (0);
+  return 0;
 } /* int disk_shutdown */
 
 static void disk_submit(const char *plugin_instance, const char *type,
@@ -321,7 +321,7 @@ static counter_t disk_calc_time_incr(counter_t delta_time,
   double avg_time = ((double)delta_time) / ((double)delta_ops);
   double avg_time_incr = interval * avg_time;
 
-  return ((counter_t)(avg_time_incr + .5));
+  return (counter_t)(avg_time_incr + .5);
 }
 #endif
 
@@ -363,7 +363,7 @@ static signed long long dict_get_value(CFDictionaryRef dict, const char *key) {
                                       kCFStringEncodingASCII);
   if (key_obj == NULL) {
     DEBUG("CFStringCreateWithCString (%s) failed.", key);
-    return (-1LL);
+    return -1LL;
   }
 
   /* get => we don't need to release (== free) the object */
@@ -373,15 +373,15 @@ static signed long long dict_get_value(CFDictionaryRef dict, const char *key) {
 
   if (val_obj == NULL) {
     DEBUG("CFDictionaryGetValue (%s) failed.", key);
-    return (-1LL);
+    return -1LL;
   }
 
   if (!CFNumberGetValue(val_obj, kCFNumberSInt64Type, &val_int)) {
     DEBUG("CFNumberGetValue (%s) failed.", key);
-    return (-1LL);
+    return -1LL;
   }
 
-  return (val_int);
+  return val_int;
 }
 #endif /* HAVE_IOKIT_IOKITLIB_H */
 
@@ -405,10 +405,10 @@ static int disk_read(void) {
 
   /* Get the list of all disk objects. */
   if (IOServiceGetMatchingServices(
-          io_master_port, IOServiceMatching(kIOBlockStorageDriverClass),
-          &disk_list) != kIOReturnSuccess) {
+                                   io_master_port, IOServiceMatching(kIOBlockStorageDriverClass),
+                                   &disk_list) != kIOReturnSuccess) {
     ERROR("disk plugin: IOServiceGetMatchingServices failed.");
-    return (-1);
+    return -1;
   }
 
   while ((disk = IOIteratorNext(disk_list)) != 0) {
@@ -551,7 +551,7 @@ static int disk_read(void) {
     snap = geom_stats_snapshot_get();
     if (snap == NULL) {
       ERROR("disk plugin: geom_stats_snapshot_get() failed.");
-      return (-1);
+      return -1;
     }
 
     /* Check if we have dirty read from this snapshot */
@@ -568,7 +568,7 @@ static int disk_read(void) {
         if (geom_gettree(&geom_tree) != 0) {
           ERROR("disk plugin: geom_gettree() failed");
           geom_stats_snapshot_free(snap);
-          return (-1);
+          return -1;
         }
         geom_id = geom_lookupid(&geom_tree, snap_iter->id);
       }
@@ -682,7 +682,7 @@ static int disk_read(void) {
     fh = fopen("/proc/partitions", "r");
     if (fh == NULL) {
       ERROR("disk plugin: fopen (/proc/{diskstats,partitions}) failed.");
-      return (-1);
+      return -1;
     }
 
     /* Kernel is 2.4.* */
@@ -910,7 +910,7 @@ static int disk_read(void) {
   static kstat_io_t kio;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (int i = 0; i < numdisk; i++) {
     if (kstat_read(kc, ksp[i], &kio) == -1)
@@ -946,7 +946,7 @@ static int disk_read(void) {
   char name[DATA_MAX_NAME_LEN];
 
   if ((ds = sg_get_disk_io_stats(&disks)) == NULL)
-    return (0);
+    return 0;
 
   for (int counter = 0; counter < disks; counter++) {
     strncpy(name, ds->disk_name, sizeof(name));
@@ -977,7 +977,7 @@ static int disk_read(void) {
     char errbuf[1024];
     WARNING("disk plugin: perfstat_disk: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (numdisk != pnumdisk || stat_disk == NULL) {
@@ -993,7 +993,7 @@ static int disk_read(void) {
     char errbuf[1024];
     WARNING("disk plugin: perfstat_disk : %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < rnumdisk; i++) {
@@ -1020,7 +1020,7 @@ static int disk_read(void) {
   }
 #endif /* defined(HAVE_PERFSTAT) */
 
-  return (0);
+  return 0;
 } /* int disk_read */
 
 void module_register(void) {

--- a/src/dns.c
+++ b/src/dns.c
@@ -84,7 +84,7 @@ static counter_list_t *counter_list_search(counter_list_t **list,
     if (entry->key == key)
       break;
 
-  return (entry);
+  return entry;
 }
 
 static counter_list_t *counter_list_create(counter_list_t **list,
@@ -94,7 +94,7 @@ static counter_list_t *counter_list_create(counter_list_t **list,
 
   entry = calloc(1, sizeof(*entry));
   if (entry == NULL)
-    return (NULL);
+    return NULL;
 
   entry->key = key;
   entry->value = value;
@@ -111,7 +111,7 @@ static counter_list_t *counter_list_create(counter_list_t **list,
     last->next = entry;
   }
 
-  return (entry);
+  return entry;
 }
 
 static void counter_list_add(counter_list_t **list, unsigned int key,
@@ -132,7 +132,7 @@ static int dns_config(const char *key, const char *value) {
     if (pcap_device != NULL)
       free(pcap_device);
     if ((pcap_device = strdup(value)) == NULL)
-      return (1);
+      return 1;
   } else if (strcasecmp(key, "IgnoreSource") == 0) {
     if (value != NULL)
       ignore_list_add_name(value);
@@ -142,10 +142,10 @@ static int dns_config(const char *key, const char *value) {
     else
       select_numeric_qtype = 1;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void dns_child_callback(const rfc1035_header_t *dns) {
@@ -208,19 +208,19 @@ static int dns_run_pcap_loop(void) {
     ERROR("dns plugin: Opening interface `%s' "
           "failed: %s",
           (pcap_device != NULL) ? pcap_device : "any", pcap_error);
-    return (PCAP_ERROR);
+    return PCAP_ERROR;
   }
 
   status = pcap_compile(pcap_obj, &fp, "udp port 53", 1, 0);
   if (status < 0) {
     ERROR("dns plugin: pcap_compile failed: %s", pcap_statustostr(status));
-    return (status);
+    return status;
   }
 
   status = pcap_setfilter(pcap_obj, &fp);
   if (status < 0) {
     ERROR("dns plugin: pcap_setfilter failed: %s", pcap_statustostr(status));
-    return (status);
+    return status;
   }
 
   DEBUG("dns plugin: PCAP object created.");
@@ -237,7 +237,7 @@ static int dns_run_pcap_loop(void) {
     status = PCAP_ERROR_IFACE_NOT_UP;
 
   pcap_close(pcap_obj);
-  return (status);
+  return status;
 } /* int dns_run_pcap_loop */
 
 static int dns_sleep_one_interval(void) /* {{{ */
@@ -247,10 +247,10 @@ static int dns_sleep_one_interval(void) /* {{{ */
     if ((errno == EINTR) || (errno == EAGAIN))
       continue;
 
-    return (errno);
+    return errno;
   }
 
-  return (0);
+  return 0;
 } /* }}} int dns_sleep_one_interval */
 
 static void *dns_child_loop(__attribute__((unused)) void *dummy) /* {{{ */
@@ -269,7 +269,7 @@ static void *dns_child_loop(__attribute__((unused)) void *dummy) /* {{{ */
     ERROR("dns plugin: PCAP returned error %s.", pcap_statustostr(status));
 
   listen_thread_init = 0;
-  return (NULL);
+  return NULL;
 } /* }}} void *dns_child_loop */
 
 static int dns_init(void) {
@@ -282,7 +282,7 @@ static int dns_init(void) {
   pthread_mutex_unlock(&traffic_mutex);
 
   if (listen_thread_init != 0)
-    return (-1);
+    return -1;
 
   status = plugin_thread_create(&listen_thread, NULL, dns_child_loop, (void *)0,
                                 "dns listen");
@@ -290,7 +290,7 @@ static int dns_init(void) {
     char errbuf[1024];
     ERROR("dns plugin: pthread_create failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   listen_thread_init = 1;
@@ -308,7 +308,7 @@ static int dns_init(void) {
   }
 #endif
 
-  return (0);
+  return 0;
 } /* int dns_init */
 
 static void submit_derive(const char *type, const char *type_instance,
@@ -392,7 +392,7 @@ static int dns_read(void) {
     submit_derive("dns_rcode", rcode_str(keys[i]), values[i]);
   }
 
-  return (0);
+  return 0;
 } /* int dns_read */
 
 void module_register(void) {

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -253,7 +253,7 @@ static int dpdk_helper_stats_count_get(dpdk_helper_ctx_t *phc) {
 }
 
 static int dpdk_stats_get_size(dpdk_helper_ctx_t *phc) {
-  return (dpdk_helper_data_size_get(phc) - sizeof(dpdk_stats_ctx_t));
+  return dpdk_helper_data_size_get(phc) - sizeof(dpdk_stats_ctx_t);
 }
 
 int dpdk_helper_command_handler(dpdk_helper_ctx_t *phc, enum DPDK_CMD cmd) {

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -57,7 +57,7 @@ static const char *drbd_names[] = {
 };
 static size_t drbd_names_num = STATIC_ARRAY_SIZE(drbd_names);
 
-static int drbd_init(void) { return (0); }
+static int drbd_init(void) { return 0; }
 
 static int drbd_submit_fields(long int resource, char **fields,
                               size_t fields_num) {
@@ -67,14 +67,14 @@ static int drbd_submit_fields(long int resource, char **fields,
 
   if (resource < 0) {
     WARNING("drbd plugin: Unable to parse resource");
-    return (EINVAL);
+    return EINVAL;
   }
 
   if (fields_num != drbd_names_num) {
     WARNING("drbd plugin: Wrong number of fields for "
             "r%ld statistics. Expected %zu, got %zu.",
             resource, drbd_names_num, fields_num);
-    return (EINVAL);
+    return EINVAL;
   }
 
   ssnprintf(plugin_instance, sizeof(plugin_instance), "r%ld", resource);
@@ -86,7 +86,7 @@ static int drbd_submit_fields(long int resource, char **fields,
       continue;
     data = strchr(fields[i], ':');
     if (data == NULL)
-      return (EINVAL);
+      return EINVAL;
     (void)parse_value(++data, &values[i], DS_TYPE_DERIVE);
   }
 
@@ -103,7 +103,7 @@ static int drbd_submit_fields(long int resource, char **fields,
     plugin_dispatch_values(&vl);
   }
 
-  return (0);
+  return 0;
 } /* drbd_submit_fields */
 
 static int drbd_read(void) {
@@ -117,7 +117,7 @@ static int drbd_read(void) {
   fh = fopen(drbd_stats, "r");
   if (fh == NULL) {
     WARNING("drbd plugin: Unable to open %s", drbd_stats);
-    return (EINVAL);
+    return EINVAL;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -142,7 +142,7 @@ static int drbd_read(void) {
   } /* while (fgets) */
 
   fclose(fh);
-  return (0);
+  return 0;
 } /* void drbd_read */
 
 void module_register(void) {

--- a/src/email.c
+++ b/src/email.c
@@ -357,7 +357,7 @@ static void *collect(void *arg) {
   } /* while (1) */
 
   pthread_exit((void *)0);
-  return ((void *)0);
+  return (void *)0;
 } /* static void *collect (void *) */
 
 static void *open_connection(void __attribute__((unused)) * arg) {
@@ -527,7 +527,7 @@ static void *open_connection(void __attribute__((unused)) * arg) {
   }
 
   pthread_exit((void *)0);
-  return ((void *)0);
+  return (void *)0;
 } /* static void *open_connection (void *) */
 
 static int email_init(void) {
@@ -537,10 +537,10 @@ static int email_init(void) {
     disabled = 1;
     log_err("plugin_thread_create() failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int email_init */
 
 static void type_list_free(type_list_t *t) {
@@ -609,7 +609,7 @@ static int email_shutdown(void) {
 
   sfree(sock_file);
   sfree(sock_group);
-  return (0);
+  return 0;
 } /* static void email_shutdown (void) */
 
 static void email_submit(const char *type, const char *type_instance,
@@ -663,7 +663,7 @@ static int email_read(void) {
   int score_count_old;
 
   if (disabled)
-    return (-1);
+    return -1;
 
   /* email count */
   pthread_mutex_lock(&count_mutex);
@@ -710,7 +710,7 @@ static int email_read(void) {
   for (type_t *ptr = list_check_copy.head; NULL != ptr; ptr = ptr->next)
     email_submit("spam_check", ptr->name, ptr->value);
 
-  return (0);
+  return 0;
 } /* int email_read */
 
 void module_register(void) {

--- a/src/entropy.c
+++ b/src/entropy.c
@@ -50,11 +50,11 @@ static int entropy_read(void) {
   value_t v;
   if (parse_value_file(ENTROPY_FILE, &v, DS_TYPE_GAUGE) != 0) {
     ERROR("entropy plugin: Reading \"" ENTROPY_FILE "\" failed.");
-    return (-1);
+    return -1;
   }
 
   entropy_submit(v);
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/ethstat.c
+++ b/src/ethstat.c
@@ -62,19 +62,19 @@ static int ethstat_add_interface(const oconfig_item_t *ci) /* {{{ */
 
   tmp = realloc(interfaces, sizeof(*interfaces) * (interfaces_num + 1));
   if (tmp == NULL)
-    return (-1);
+    return -1;
   interfaces = tmp;
   interfaces[interfaces_num] = NULL;
 
   status = cf_util_get_string(ci, interfaces + interfaces_num);
   if (status != 0)
-    return (status);
+    return status;
 
   interfaces_num++;
   INFO("ethstat plugin: Registered interface %s",
        interfaces[interfaces_num - 1]);
 
-  return (0);
+  return 0;
 } /* }}} int ethstat_add_interface */
 
 static int ethstat_add_map(const oconfig_item_t *ci) /* {{{ */
@@ -90,20 +90,20 @@ static int ethstat_add_map(const oconfig_item_t *ci) /* {{{ */
     ERROR("ethstat plugin: The %s option requires "
           "two or three string arguments.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   key = strdup(ci->values[0].value.string);
   if (key == NULL) {
     ERROR("ethstat plugin: strdup(3) failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   map = calloc(1, sizeof(*map));
   if (map == NULL) {
     sfree(key);
     ERROR("ethstat plugin: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   sstrncpy(map->type, ci->values[1].value.string, sizeof(map->type));
@@ -117,7 +117,7 @@ static int ethstat_add_map(const oconfig_item_t *ci) /* {{{ */
       sfree(map);
       sfree(key);
       ERROR("ethstat plugin: c_avl_create() failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -132,10 +132,10 @@ static int ethstat_add_map(const oconfig_item_t *ci) /* {{{ */
 
     sfree(map);
     sfree(key);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ethstat_add_map */
 
 static int ethstat_config(oconfig_item_t *ci) /* {{{ */
@@ -154,7 +154,7 @@ static int ethstat_config(oconfig_item_t *ci) /* {{{ */
               child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} */
 
 static void ethstat_submit_value(const char *device, const char *type_instance,
@@ -223,14 +223,14 @@ static int ethstat_read_interface(char *device) {
     ERROR("ethstat plugin: Failed to get driver information "
           "from %s: %s",
           device, sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   n_stats = (size_t)drvinfo.n_stats;
   if (n_stats < 1) {
     close(fd);
     ERROR("ethstat plugin: No stats available for %s", device);
-    return (-1);
+    return -1;
   }
 
   strings_size = sizeof(struct ethtool_gstrings) + (n_stats * ETH_GSTRING_LEN);
@@ -243,7 +243,7 @@ static int ethstat_read_interface(char *device) {
     sfree(strings);
     sfree(stats);
     ERROR("ethstat plugin: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   strings->cmd = ETHTOOL_GSTRINGS;
@@ -258,7 +258,7 @@ static int ethstat_read_interface(char *device) {
     free(stats);
     ERROR("ethstat plugin: Cannot get strings from %s: %s", device,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   stats->cmd = ETHTOOL_GSTATS;
@@ -272,7 +272,7 @@ static int ethstat_read_interface(char *device) {
     free(stats);
     ERROR("ethstat plugin: Reading statistics from %s failed: %s", device,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (size_t i = 0; i < n_stats; i++) {
@@ -292,7 +292,7 @@ static int ethstat_read_interface(char *device) {
   sfree(strings);
   sfree(stats);
 
-  return (0);
+  return 0;
 } /* }}} ethstat_read_interface */
 
 static int ethstat_read(void) {
@@ -307,7 +307,7 @@ static int ethstat_shutdown(void) {
   void *value = NULL;
 
   if (value_map == NULL)
-    return (0);
+    return 0;
 
   while (c_avl_pick(value_map, &key, &value) == 0) {
     sfree(key);
@@ -317,7 +317,7 @@ static int ethstat_shutdown(void) {
   c_avl_destroy(value_map);
   value_map = NULL;
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/exec.c
+++ b/src/exec.c
@@ -108,26 +108,26 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
 
   if (ci->children_num != 0) {
     WARNING("exec plugin: The config option `%s' may not be a block.", ci->key);
-    return (-1);
+    return -1;
   }
   if (ci->values_num < 2) {
     WARNING("exec plugin: The config option `%s' needs at least two "
             "arguments.",
             ci->key);
-    return (-1);
+    return -1;
   }
   if ((ci->values[0].type != OCONFIG_TYPE_STRING) ||
       (ci->values[1].type != OCONFIG_TYPE_STRING)) {
     WARNING("exec plugin: The first two arguments to the `%s' option must "
             "be string arguments.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   pl = calloc(1, sizeof(*pl));
   if (pl == NULL) {
     ERROR("exec plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp("NotificationExec", ci->key) == 0)
@@ -139,7 +139,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
   if (pl->user == NULL) {
     ERROR("exec plugin: strdup failed.");
     sfree(pl);
-    return (-1);
+    return -1;
   }
 
   pl->group = strchr(pl->user, ':');
@@ -153,7 +153,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
     ERROR("exec plugin: strdup failed.");
     sfree(pl->user);
     sfree(pl);
-    return (-1);
+    return -1;
   }
 
   pl->argv = calloc(ci->values_num, sizeof(*pl->argv));
@@ -162,7 +162,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
     sfree(pl->exec);
     sfree(pl->user);
     sfree(pl);
-    return (-1);
+    return -1;
   }
 
   {
@@ -179,7 +179,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
     sfree(pl->exec);
     sfree(pl->user);
     sfree(pl);
-    return (-1);
+    return -1;
   }
 
   for (i = 1; i < (ci->values_num - 1); i++) {
@@ -213,7 +213,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
     sfree(pl->exec);
     sfree(pl->user);
     sfree(pl);
-    return (-1);
+    return -1;
   }
 
   for (i = 0; pl->argv[i] != NULL; i++) {
@@ -223,7 +223,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
   pl->next = pl_head;
   pl_head = pl;
 
-  return (0);
+  return 0;
 } /* int exec_config_exec }}} */
 
 static int exec_config(oconfig_item_t *ci) /* {{{ */
@@ -238,7 +238,7 @@ static int exec_config(oconfig_item_t *ci) /* {{{ */
     }
   } /* for (i) */
 
-  return (0);
+  return 0;
 } /* int exec_config }}} */
 
 static void set_environment(void) /* {{{ */
@@ -332,7 +332,7 @@ static int create_pipe(int fd_pipe[2]) /* {{{ */
   if (status != 0) {
     ERROR("exec plugin: pipe failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   return 0;
@@ -372,7 +372,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   char nambuf[2048];
 
   if (pl->pid != 0)
-    return (-1);
+    return -1;
 
   if ((create_pipe(fd_pipe_in) == -1) || (create_pipe(fd_pipe_out) == -1) ||
       (create_pipe(fd_pipe_err) == -1))
@@ -487,26 +487,26 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   else
     close(fd_pipe_err[0]);
 
-  return (pid);
+  return pid;
 
 failed:
   close_pipe(fd_pipe_in);
   close_pipe(fd_pipe_out);
   close_pipe(fd_pipe_err);
 
-  return (-1);
+  return -1;
 } /* int fork_child }}} */
 
 static int parse_line(char *buffer) /* {{{ */
 {
   if (strncasecmp("PUTVAL", buffer, strlen("PUTVAL")) == 0)
-    return (cmd_handle_putval(stdout, buffer));
+    return cmd_handle_putval(stdout, buffer);
   else if (strncasecmp("PUTNOTIF", buffer, strlen("PUTNOTIF")) == 0)
-    return (handle_putnotif(stdout, buffer));
+    return handle_putnotif(stdout, buffer);
   else {
     ERROR("exec plugin: Unable to parse command, ignoring line: \"%s\"",
           buffer);
-    return (-1);
+    return -1;
   }
 } /* int parse_line }}} */
 
@@ -655,7 +655,7 @@ static void *exec_read_one(void *arg) /* {{{ */
     close(fd_err);
 
   pthread_exit((void *)0);
-  return (NULL);
+  return NULL;
 } /* void *exec_read_one }}} */
 
 static void *exec_notification_one(void *arg) /* {{{ */
@@ -737,7 +737,7 @@ static void *exec_notification_one(void *arg) /* {{{ */
   n->meta = NULL;
   sfree(arg);
   pthread_exit((void *)0);
-  return (NULL);
+  return NULL;
 } /* void *exec_notification_one }}} */
 
 static int exec_init(void) /* {{{ */
@@ -763,7 +763,7 @@ static int exec_init(void) /* {{{ */
   }
 #endif
 
-  return (0);
+  return 0;
 } /* int exec_init }}} */
 
 static int exec_read(void) /* {{{ */
@@ -791,7 +791,7 @@ static int exec_read(void) /* {{{ */
     pthread_attr_destroy(&attr);
   } /* for (pl) */
 
-  return (0);
+  return 0;
 } /* int exec_read }}} */
 
 static int exec_notification(const notification_t *n, /* {{{ */
@@ -831,7 +831,7 @@ static int exec_notification(const notification_t *n, /* {{{ */
     pthread_attr_destroy(&attr);
   } /* for (pl) */
 
-  return (0);
+  return 0;
 } /* }}} int exec_notification */
 
 static int exec_shutdown(void) /* {{{ */
@@ -855,7 +855,7 @@ static int exec_shutdown(void) /* {{{ */
   } /* while (pl) */
   pl_head = NULL;
 
-  return (0);
+  return 0;
 } /* int exec_shutdown }}} */
 
 void module_register(void) {

--- a/src/fhcount.c
+++ b/src/fhcount.c
@@ -49,7 +49,7 @@ static int fhcount_config(const char *key, const char *value) {
     ret = 0;
   }
 
-  return (ret);
+  return ret;
 }
 
 static void fhcount_submit(const char *type, const char *type_instance,
@@ -82,12 +82,12 @@ static int fhcount_read(void) {
   fp = fopen("/proc/sys/fs/file-nr", "r");
   if (fp == NULL) {
     ERROR("fhcount: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
   if (fgets(buffer, buffer_len, fp) == NULL) {
     ERROR("fhcount: fgets: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
     fclose(fp);
-    return (EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
   fclose(fp);
 
@@ -96,7 +96,7 @@ static int fhcount_read(void) {
 
   if (numfields != 3) {
     ERROR("fhcount: Line doesn't contain 3 fields");
-    return (EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   // Define the values
@@ -117,7 +117,7 @@ static int fhcount_read(void) {
     fhcount_submit("percent", "unused", (gauge_t)prc_unused);
   }
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -105,16 +105,16 @@ static int fc_config_set_instance(fc_directory_conf_t *dir, const char *str) {
     /* do nothing */;
 
   if (*ptr == 0)
-    return (-1);
+    return -1;
 
   copy = strdup(ptr);
   if (copy == NULL)
-    return (-1);
+    return -1;
 
   sfree(dir->instance);
   dir->instance = copy;
 
-  return (0);
+  return 0;
 } /* int fc_config_set_instance */
 
 static int fc_config_add_dir_instance(fc_directory_conf_t *dir,
@@ -122,10 +122,10 @@ static int fc_config_add_dir_instance(fc_directory_conf_t *dir,
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("filecount plugin: The `Instance' config option needs exactly "
             "one string argument.");
-    return (-1);
+    return -1;
   }
 
-  return (fc_config_set_instance(dir, ci->values[0].value.string));
+  return fc_config_set_instance(dir, ci->values[0].value.string);
 } /* int fc_config_add_dir_instance */
 
 static int fc_config_add_dir_name(fc_directory_conf_t *dir,
@@ -135,19 +135,19 @@ static int fc_config_add_dir_name(fc_directory_conf_t *dir,
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("filecount plugin: The `Name' config option needs exactly one "
             "string argument.");
-    return (-1);
+    return -1;
   }
 
   temp = strdup(ci->values[0].value.string);
   if (temp == NULL) {
     ERROR("filecount plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   sfree(dir->name);
   dir->name = temp;
 
-  return (0);
+  return 0;
 } /* int fc_config_add_dir_name */
 
 static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
@@ -159,12 +159,12 @@ static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
                                 (ci->values[0].type != OCONFIG_TYPE_NUMBER))) {
     WARNING("filecount plugin: The `MTime' config option needs exactly one "
             "string or numeric argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     dir->mtime = (int64_t)ci->values[0].value.number;
-    return (0);
+    return 0;
   }
 
   errno = 0;
@@ -174,7 +174,7 @@ static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
       (endptr == ci->values[0].value.string)) {
     WARNING("filecount plugin: Converting `%s' to a number failed.",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   switch (*endptr) {
@@ -210,12 +210,12 @@ static int fc_config_add_dir_mtime(fc_directory_conf_t *dir,
 
   default:
     WARNING("filecount plugin: Invalid suffix for `MTime': `%c'", *endptr);
-    return (-1);
+    return -1;
   } /* switch (*endptr) */
 
   dir->mtime = (int64_t)temp;
 
-  return (0);
+  return 0;
 } /* int fc_config_add_dir_mtime */
 
 static int fc_config_add_dir_size(fc_directory_conf_t *dir,
@@ -227,12 +227,12 @@ static int fc_config_add_dir_size(fc_directory_conf_t *dir,
                                 (ci->values[0].type != OCONFIG_TYPE_NUMBER))) {
     WARNING("filecount plugin: The `Size' config option needs exactly one "
             "string or numeric argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     dir->size = (int64_t)ci->values[0].value.number;
-    return (0);
+    return 0;
   }
 
   errno = 0;
@@ -242,7 +242,7 @@ static int fc_config_add_dir_size(fc_directory_conf_t *dir,
       (endptr == ci->values[0].value.string)) {
     WARNING("filecount plugin: Converting `%s' to a number failed.",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   switch (*endptr) {
@@ -278,12 +278,12 @@ static int fc_config_add_dir_size(fc_directory_conf_t *dir,
 
   default:
     WARNING("filecount plugin: Invalid suffix for `Size': `%c'", *endptr);
-    return (-1);
+    return -1;
   } /* switch (*endptr) */
 
   dir->size = (int64_t)temp;
 
-  return (0);
+  return 0;
 } /* int fc_config_add_dir_size */
 
 static int fc_config_add_dir_option(fc_directory_conf_t *dir,
@@ -291,7 +291,7 @@ static int fc_config_add_dir_option(fc_directory_conf_t *dir,
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_BOOLEAN)) {
     WARNING("filecount plugin: The `Recursive' config options needs exactly "
             "one boolean argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.boolean)
@@ -299,7 +299,7 @@ static int fc_config_add_dir_option(fc_directory_conf_t *dir,
   else
     dir->options &= ~bit;
 
-  return (0);
+  return 0;
 } /* int fc_config_add_dir_option */
 
 static int fc_config_add_dir(oconfig_item_t *ci) {
@@ -309,21 +309,21 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("filecount plugin: `Directory' needs exactly one string "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   /* Initialize `dir' */
   dir = calloc(1, sizeof(*dir));
   if (dir == NULL) {
     ERROR("filecount plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   dir->path = strdup(ci->values[0].value.string);
   if (dir->path == NULL) {
     ERROR("filecount plugin: strdup failed.");
     sfree(dir);
-    return (-1);
+    return -1;
   }
 
   fc_config_set_instance(dir, dir->path);
@@ -380,10 +380,10 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
     sfree(dir->instance);
     sfree(dir->path);
     sfree(dir);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int fc_config_add_dir */
 
 static int fc_config(oconfig_item_t *ci) {
@@ -397,16 +397,16 @@ static int fc_config(oconfig_item_t *ci) {
     }
   } /* for (ci->children) */
 
-  return (0);
+  return 0;
 } /* int fc_config */
 
 static int fc_init(void) {
   if (directories_num < 1) {
     WARNING("filecount plugin: No directories have been configured.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int fc_init */
 
 static int fc_read_dir_callback(const char *dirname, const char *filename,
@@ -417,29 +417,29 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
   int status;
 
   if (dir == NULL)
-    return (-1);
+    return -1;
 
   ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {
     ERROR("filecount plugin: stat (%s) failed.", abs_path);
-    return (-1);
+    return -1;
   }
 
   if (S_ISDIR(statbuf.st_mode) && (dir->options & FC_RECURSIVE)) {
     status = walk_directory(
         abs_path, fc_read_dir_callback, dir,
         /* include hidden = */ (dir->options & FC_HIDDEN) ? 1 : 0);
-    return (status);
+    return status;
   } else if (!S_ISREG(statbuf.st_mode)) {
-    return (0);
+    return 0;
   }
 
   if (dir->name != NULL) {
     status = fnmatch(dir->name, filename, /* flags = */ 0);
     if (status != 0)
-      return (0);
+      return 0;
   }
 
   if (dir->mtime != 0) {
@@ -455,7 +455,7 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
 
     if (((dir->mtime < 0) && (statbuf.st_mtime < mtime)) ||
         ((dir->mtime > 0) && (statbuf.st_mtime > mtime)))
-      return (0);
+      return 0;
   }
 
   if (dir->size != 0) {
@@ -468,13 +468,13 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
 
     if (((dir->size < 0) && (statbuf.st_size > size)) ||
         ((dir->size > 0) && (statbuf.st_size < size)))
-      return (0);
+      return 0;
   }
 
   dir->files_num++;
   dir->files_size += (uint64_t)statbuf.st_size;
 
-  return (0);
+  return 0;
 } /* int fc_read_dir_callback */
 
 static int fc_read_dir(fc_directory_conf_t *dir) {
@@ -491,19 +491,19 @@ static int fc_read_dir(fc_directory_conf_t *dir) {
                      /* include hidden */ (dir->options & FC_HIDDEN) ? 1 : 0);
   if (status != 0) {
     WARNING("filecount plugin: walk_directory (%s) failed.", dir->path);
-    return (-1);
+    return -1;
   }
 
   fc_submit_dir(dir);
 
-  return (0);
+  return 0;
 } /* int fc_read_dir */
 
 static int fc_read(void) {
   for (size_t i = 0; i < directories_num; i++)
     fc_read_dir(directories[i]);
 
-  return (0);
+  return 0;
 } /* int fc_read */
 
 void module_register(void) {

--- a/src/fscache.c
+++ b/src/fscache.c
@@ -209,9 +209,9 @@ static int fscache_read(void) {
 
   } else {
     printf("cant open file\n");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -152,7 +152,7 @@ static metric_map_t *metric_lookup(const char *key) /* {{{ */
   }
 
   if (i >= map_len)
-    return (NULL);
+    return NULL;
 
   /* Look up the DS type and ds_index. */
   if (map[i].ds_type < 0) /* {{{ */
@@ -162,14 +162,14 @@ static metric_map_t *metric_lookup(const char *key) /* {{{ */
     ds = plugin_get_ds(map[i].type);
     if (ds == NULL) {
       WARNING("gmond plugin: Type not defined: %s", map[i].type);
-      return (NULL);
+      return NULL;
     }
 
     if ((map[i].ds_name == NULL) && (ds->ds_num != 1)) {
       WARNING("gmond plugin: No data source name defined for metric %s, "
               "but type %s has more than one data source.",
               map[i].ganglia_name, map[i].type);
-      return (NULL);
+      return NULL;
     }
 
     if (map[i].ds_name == NULL) {
@@ -185,7 +185,7 @@ static metric_map_t *metric_lookup(const char *key) /* {{{ */
         WARNING("gmond plugin: There is no data source "
                 "named `%s' in type `%s'.",
                 map[i].ds_name, ds->type);
-        return (NULL);
+        return NULL;
       }
       map[i].ds_index = j;
     }
@@ -193,7 +193,7 @@ static metric_map_t *metric_lookup(const char *key) /* {{{ */
     map[i].ds_type = ds->ds[map[i].ds_index].type;
   } /* }}} if ((map[i].ds_type < 0) || (map[i].ds_index < 0)) */
 
-  return (map + i);
+  return map + i;
 } /* }}} metric_map_t *metric_lookup */
 
 static int create_sockets(socket_entry_t **ret_sockets, /* {{{ */
@@ -208,7 +208,7 @@ static int create_sockets(socket_entry_t **ret_sockets, /* {{{ */
   int status;
 
   if (*ret_sockets != NULL)
-    return (EINVAL);
+    return EINVAL;
 
   struct addrinfo ai_hints = {.ai_family = AF_UNSPEC,
                               .ai_flags = AI_ADDRCONFIG | AI_PASSIVE,
@@ -223,7 +223,7 @@ static int create_sockets(socket_entry_t **ret_sockets, /* {{{ */
           (service == NULL) ? "(null)" : service,
           (ai_return == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                     : gai_strerror(ai_return));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -348,12 +348,12 @@ static int create_sockets(socket_entry_t **ret_sockets, /* {{{ */
 
   if (sockets_num == 0) {
     sfree(sockets);
-    return (-1);
+    return -1;
   }
 
   *ret_sockets = sockets;
   *ret_sockets_num = sockets_num;
-  return (0);
+  return 0;
 } /* }}} int create_sockets */
 
 static int request_meta_data(const char *host, const char *name) /* {{{ */
@@ -371,7 +371,7 @@ static int request_meta_data(const char *host, const char *name) /* {{{ */
       (msg.Ganglia_metadata_msg_u.grequest.metric_id.name == NULL)) {
     sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.host);
     sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.name);
-    return (-1);
+    return -1;
   }
 
   xdrmem_create(&xdr, buffer, sizeof(buffer), XDR_ENCODE);
@@ -379,7 +379,7 @@ static int request_meta_data(const char *host, const char *name) /* {{{ */
   if (!xdr_Ganglia_metadata_msg(&xdr, &msg)) {
     sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.host);
     sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.name);
-    return (-1);
+    return -1;
   }
 
   buffer_size = xdr_getpos(&xdr);
@@ -403,7 +403,7 @@ static int request_meta_data(const char *host, const char *name) /* {{{ */
 
   sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.host);
   sfree(msg.Ganglia_metadata_msg_u.grequest.metric_id.name);
-  return (0);
+  return 0;
 } /* }}} int request_meta_data */
 
 static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
@@ -415,7 +415,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   int status;
 
   if (staging_tree == NULL)
-    return (NULL);
+    return NULL;
 
   ssnprintf(key, sizeof(key), "%s/%s/%s", host, type,
             (type_instance != NULL) ? type_instance : "");
@@ -423,12 +423,12 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   se = NULL;
   status = c_avl_get(staging_tree, key, (void *)&se);
   if (status == 0)
-    return (se);
+    return se;
 
   /* insert new entry */
   se = calloc(1, sizeof(*se));
   if (se == NULL)
-    return (NULL);
+    return NULL;
 
   sstrncpy(se->key, key, sizeof(se->key));
   se->flags = 0;
@@ -436,7 +436,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   se->vl.values = (value_t *)calloc(values_len, sizeof(*se->vl.values));
   if (se->vl.values == NULL) {
     sfree(se);
-    return (NULL);
+    return NULL;
   }
   se->vl.values_len = values_len;
 
@@ -453,10 +453,10 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
     ERROR("gmond plugin: c_avl_insert failed.");
     sfree(se->vl.values);
     sfree(se);
-    return (NULL);
+    return NULL;
   }
 
-  return (se);
+  return se;
 } /* }}} staging_entry_t *staging_entry_get */
 
 static int staging_entry_update(const char *host, const char *name, /* {{{ */
@@ -468,13 +468,13 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
   ds = plugin_get_ds(type);
   if (ds == NULL) {
     ERROR("gmond plugin: Looking up type %s failed.", type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num <= ds_index) {
     ERROR("gmond plugin: Invalid index %zu: %s has only %zu data source(s).",
           ds_index, ds->type, ds->ds_num);
-    return (-1);
+    return -1;
   }
 
   pthread_mutex_lock(&staging_lock);
@@ -483,11 +483,11 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
   if (se == NULL) {
     pthread_mutex_unlock(&staging_lock);
     ERROR("gmond plugin: staging_entry_get failed.");
-    return (-1);
+    return -1;
   }
   if (se->vl.values_len != ds->ds_num) {
     pthread_mutex_unlock(&staging_lock);
-    return (-1);
+    return -1;
   }
 
   if (ds_type == DS_TYPE_COUNTER)
@@ -506,7 +506,7 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
   /* Check if all data sources have been set. If not, return here. */
   if (se->flags != ((0x01 << se->vl.values_len) - 1)) {
     pthread_mutex_unlock(&staging_lock);
-    return (0);
+    return 0;
   }
 
   /* Check if the interval of this metric is known. If not, request meta data
@@ -517,7 +517,7 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
     pthread_mutex_unlock(&staging_lock);
 
     request_meta_data(host, name);
-    return (0);
+    return 0;
   }
 
   plugin_dispatch_values(&se->vl);
@@ -525,7 +525,7 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
   se->flags = 0;
   pthread_mutex_unlock(&staging_lock);
 
-  return (0);
+  return 0;
 } /* }}} int staging_entry_update */
 
 static int mc_handle_value_msg(Ganglia_value_msg *msg) /* {{{ */
@@ -606,7 +606,7 @@ static int mc_handle_value_msg(Ganglia_value_msg *msg) /* {{{ */
   }
   default:
     DEBUG("gmond plugin: Value type not handled: %i", msg->id);
-    return (-1);
+    return -1;
   } /* }}} switch (msg->id) */
 
   assert(host != NULL);
@@ -625,12 +625,12 @@ static int mc_handle_value_msg(Ganglia_value_msg *msg) /* {{{ */
     else
       assert(23 == 42);
 
-    return (staging_entry_update(host, name, map->type, map->type_instance,
-                                 map->ds_index, map->ds_type, val_copy));
+    return staging_entry_update(host, name, map->type, map->type_instance,
+                                map->ds_index, map->ds_type, val_copy);
   }
 
   DEBUG("gmond plugin: Cannot find a translation for %s.", name);
-  return (-1);
+  return -1;
 } /* }}} int mc_handle_value_msg */
 
 static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
@@ -645,19 +645,19 @@ static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
     msg_meta = msg->Ganglia_metadata_msg_u.gfull;
 
     if (msg_meta.metric.tmax == 0)
-      return (-1);
+      return -1;
 
     map = metric_lookup(msg_meta.metric_id.name);
     if (map == NULL) {
       DEBUG("gmond plugin: Not handling meta data %s.",
             msg_meta.metric_id.name);
-      return (0);
+      return 0;
     }
 
     ds = plugin_get_ds(map->type);
     if (ds == NULL) {
       WARNING("gmond plugin: Could not find data set %s.", map->type);
-      return (-1);
+      return -1;
     }
 
     DEBUG("gmond plugin: Received meta data for %s/%s.",
@@ -672,16 +672,16 @@ static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
 
     if (se == NULL) {
       ERROR("gmond plugin: staging_entry_get failed.");
-      return (-1);
+      return -1;
     }
 
     break;
   }
 
-  default: { return (-1); }
+  default: { return -1; }
   }
 
-  return (0);
+  return 0;
 } /* }}} int mc_handle_metadata_msg */
 
 static int mc_handle_metric(void *buffer, size_t buffer_size) /* {{{ */
@@ -719,10 +719,10 @@ static int mc_handle_metric(void *buffer, size_t buffer_size) /* {{{ */
 
   default:
     DEBUG("gmond plugin: Unknown format: %i", format);
-    return (-1);
+    return -1;
   } /* switch (format) */
 
-  return (0);
+  return 0;
 } /* }}} int mc_handle_metric */
 
 static int mc_handle_socket(struct pollfd *p) /* {{{ */
@@ -732,7 +732,7 @@ static int mc_handle_socket(struct pollfd *p) /* {{{ */
 
   if ((p->revents & (POLLIN | POLLPRI)) == 0) {
     p->revents = 0;
-    return (-1);
+    return -1;
   }
 
   buffer_size = recv(p->fd, buffer, sizeof(buffer), /* flags = */ 0);
@@ -741,11 +741,11 @@ static int mc_handle_socket(struct pollfd *p) /* {{{ */
     ERROR("gmond plugin: recv failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     p->revents = 0;
-    return (-1);
+    return -1;
   }
 
   mc_handle_metric(buffer, (size_t)buffer_size);
-  return (0);
+  return 0;
 } /* }}} int mc_handle_socket */
 
 static void *mc_receive_thread(void *arg) /* {{{ */
@@ -761,7 +761,7 @@ static void *mc_receive_thread(void *arg) /* {{{ */
       /* listen = */ 1);
   if (status != 0) {
     ERROR("gmond plugin: create_sockets failed.");
-    return ((void *)-1);
+    return (void *)-1;
   }
 
   mc_receive_sockets = (struct pollfd *)calloc(mc_receive_sockets_num,
@@ -773,7 +773,7 @@ static void *mc_receive_thread(void *arg) /* {{{ */
     free(mc_receive_socket_entries);
     mc_receive_socket_entries = NULL;
     mc_receive_sockets_num = 0;
-    return ((void *)-1);
+    return (void *)-1;
   }
 
   for (size_t i = 0; i < mc_receive_sockets_num; i++) {
@@ -800,7 +800,7 @@ static void *mc_receive_thread(void *arg) /* {{{ */
   } /* while (mc_receive_thread_loop != 0) */
 
   free(mc_receive_socket_entries);
-  return ((void *)0);
+  return (void *)0;
 } /* }}} void *mc_receive_thread */
 
 static int mc_receive_thread_start(void) /* {{{ */
@@ -808,7 +808,7 @@ static int mc_receive_thread_start(void) /* {{{ */
   int status;
 
   if (mc_receive_thread_running != 0)
-    return (-1);
+    return -1;
 
   mc_receive_thread_loop = 1;
 
@@ -818,17 +818,17 @@ static int mc_receive_thread_start(void) /* {{{ */
   if (status != 0) {
     ERROR("gmond plugin: Starting receive thread failed.");
     mc_receive_thread_loop = 0;
-    return (-1);
+    return -1;
   }
 
   mc_receive_thread_running = 1;
-  return (0);
+  return 0;
 } /* }}} int start_receive_thread */
 
 static int mc_receive_thread_stop(void) /* {{{ */
 {
   if (mc_receive_thread_running == 0)
-    return (-1);
+    return -1;
 
   mc_receive_thread_loop = 0;
 
@@ -839,7 +839,7 @@ static int mc_receive_thread_stop(void) /* {{{ */
 
   mc_receive_thread_running = 0;
 
-  return (0);
+  return 0;
 } /* }}} int mc_receive_thread_stop */
 
 /*
@@ -862,18 +862,18 @@ static int gmond_config_set_string(oconfig_item_t *ci, char **str) /* {{{ */
     WARNING("gmond plugin: The `%s' option needs "
             "exactly one string argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   tmp = strdup(ci->values[0].value.string);
   if (tmp == NULL) {
     ERROR("gmond plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   sfree(*str);
   *str = tmp;
-  return (0);
+  return 0;
 } /* }}} int gmond_config_set_string */
 
 static int gmond_config_add_metric(oconfig_item_t *ci) /* {{{ */
@@ -883,13 +883,13 @@ static int gmond_config_add_metric(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("gmond plugin: `Metric' blocks need "
             "exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   map = realloc(metric_map, (metric_map_len + 1) * sizeof(*metric_map));
   if (map == NULL) {
     ERROR("gmond plugin: realloc failed.");
-    return (-1);
+    return -1;
   }
   metric_map = map;
   map = metric_map + metric_map_len;
@@ -904,7 +904,7 @@ static int gmond_config_add_metric(oconfig_item_t *ci) /* {{{ */
   map->ganglia_name = strdup(ci->values[0].value.string);
   if (map->ganglia_name == NULL) {
     ERROR("gmond plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -925,11 +925,11 @@ static int gmond_config_add_metric(oconfig_item_t *ci) /* {{{ */
     ERROR("gmond plugin: No type is set for metric %s.", map->ganglia_name);
     sfree(map->ganglia_name);
     sfree(map->type_instance);
-    return (-1);
+    return -1;
   }
 
   metric_map_len++;
-  return (0);
+  return 0;
 } /* }}} int gmond_config_add_metric */
 
 static int gmond_config_set_address(oconfig_item_t *ci, /* {{{ */
@@ -941,14 +941,14 @@ static int gmond_config_set_address(oconfig_item_t *ci, /* {{{ */
     WARNING("gmond plugin: The `%s' config option needs "
             "one or two string arguments.",
             ci->key);
-    return (-1);
+    return -1;
   }
   if ((ci->values[0].type != OCONFIG_TYPE_STRING) ||
       ((ci->values_num == 2) && (ci->values[1].type != OCONFIG_TYPE_STRING))) {
     WARNING("gmond plugin: The `%s' config option needs "
             "one or two string arguments.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   addr = strdup(ci->values[0].value.string);
@@ -961,7 +961,7 @@ static int gmond_config_set_address(oconfig_item_t *ci, /* {{{ */
     ERROR("gmond plugin: strdup failed.");
     sfree(addr);
     sfree(port);
-    return (-1);
+    return -1;
   }
 
   sfree(*ret_addr);
@@ -970,7 +970,7 @@ static int gmond_config_set_address(oconfig_item_t *ci, /* {{{ */
   *ret_addr = addr;
   *ret_port = port;
 
-  return (0);
+  return 0;
 } /* }}} int gmond_config_set_address */
 
 static int gmond_config(oconfig_item_t *ci) /* {{{ */
@@ -987,7 +987,7 @@ static int gmond_config(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int gmond_config */
 
 static int gmond_init(void) /* {{{ */
@@ -1001,12 +1001,12 @@ static int gmond_init(void) /* {{{ */
   staging_tree = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (staging_tree == NULL) {
     ERROR("gmond plugin: c_avl_create failed.");
-    return (-1);
+    return -1;
   }
 
   mc_receive_thread_start();
 
-  return (0);
+  return 0;
 } /* }}} int gmond_init */
 
 static int gmond_shutdown(void) /* {{{ */
@@ -1022,7 +1022,7 @@ static int gmond_shutdown(void) /* {{{ */
   mc_send_sockets_num = 0;
   pthread_mutex_unlock(&mc_send_sockets_lock);
 
-  return (0);
+  return 0;
 } /* }}} int gmond_shutdown */
 
 void module_register(void) {

--- a/src/gps.c
+++ b/src/gps.c
@@ -226,7 +226,7 @@ static int cgps_read(void) {
   cgps_submit("satellites", data_copy.sats_used, "used");
   cgps_submit("satellites", data_copy.sats_visible, "visible");
 
-  return (0);
+  return 0;
 }
 
 /**
@@ -262,7 +262,7 @@ static int cgps_config(oconfig_item_t *ci) {
     cgps_config_data.timeout = CGPS_DEFAULT_TIMEOUT;
   }
 
-  return (0);
+  return 0;
 }
 
 /**
@@ -286,10 +286,10 @@ static int cgps_init(void) {
       plugin_thread_create(&cgps_thread_id, NULL, cgps_thread, NULL, "gps");
   if (status != 0) {
     ERROR("gps plugin: pthread_create() failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 /**
@@ -315,7 +315,7 @@ static int cgps_shutdown(void) {
   sfree(cgps_config_data.port);
   sfree(cgps_config_data.host);
 
-  return (0);
+  return 0;
 }
 
 /**

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -112,7 +112,7 @@ static char *hddtemp_query_daemon(void) {
     ERROR("hddtemp plugin: getaddrinfo (%s, %s): %s", host, port,
           (ai_return == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                     : gai_strerror(ai_return));
-    return (NULL);
+    return NULL;
   }
 
   fd = -1;
@@ -146,7 +146,7 @@ static char *hddtemp_query_daemon(void) {
 
   if (fd < 0) {
     ERROR("hddtemp plugin: Could not connect to daemon.");
-    return (NULL);
+    return NULL;
   }
 
   /* receive data from the hddtemp daemon */
@@ -169,7 +169,7 @@ static char *hddtemp_query_daemon(void) {
         close(fd);
         free(buffer);
         ERROR("hddtemp plugin: Allocation failed.");
-        return (NULL);
+        return NULL;
       }
       buffer = new_buffer;
     }
@@ -186,7 +186,7 @@ static char *hddtemp_query_daemon(void) {
             sstrerror(errno, errbuf, sizeof(errbuf)));
       close(fd);
       free(buffer);
-      return (NULL);
+      return NULL;
     }
     buffer_fill += status;
   }
@@ -197,13 +197,13 @@ static char *hddtemp_query_daemon(void) {
             buffer);
     close(fd);
     free(buffer);
-    return (NULL);
+    return NULL;
   }
 
   assert(buffer_fill < buffer_size);
   buffer[buffer_fill] = '\0';
   close(fd);
-  return (buffer);
+  return buffer;
 }
 
 static int hddtemp_config(const char *key, const char *value) {
@@ -218,10 +218,10 @@ static int hddtemp_config(const char *key, const char *value) {
     else
       sstrncpy(hddtemp_port, value, sizeof(hddtemp_port));
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void hddtemp_submit(char *type_instance, double value) {
@@ -248,7 +248,7 @@ static int hddtemp_read(void) {
   /* get data from daemon */
   buf = hddtemp_query_daemon();
   if (buf == NULL)
-    return (-1);
+    return -1;
 
   /* NB: strtok_r will eat up "||" and leading "|"'s */
   ptr = buf;
@@ -276,7 +276,7 @@ static int hddtemp_read(void) {
   }
 
   free(buf);
-  return (0);
+  return 0;
 } /* int hddtemp_read */
 
 /* module_register

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -76,7 +76,7 @@ static int hp_config(oconfig_item_t *ci) {
             child->key);
   }
 
-  return (0);
+  return 0;
 }
 
 static void submit_hp(const struct entry_info *info) {

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -80,10 +80,10 @@ static int strtouint64(const char *s, uint64_t *n) {
 
   if (!(*s != '\0' && *endptr == '\0')) {
     DEBUG(RDT_PLUGIN ": Error converting '%s' to unsigned number.", s);
-    return (-EINVAL);
+    return -EINVAL;
   }
 
-  return (0);
+  return 0;
 }
 
 /*
@@ -136,12 +136,12 @@ static size_t strlisttonums(char *s, uint64_t *nums, size_t max) {
       *p = '\0';
       ret = strtouint64(token, &start);
       if (ret < 0)
-        return (0);
+        return 0;
       ret = strtouint64(p + 1, &end);
       if (ret < 0)
-        return (0);
+        return 0;
       if (start > end) {
-        return (0);
+        return 0;
       }
       for (n = start; n <= end; n++) {
         if (!(isdup(nums, index, n))) {
@@ -156,7 +156,7 @@ static size_t strlisttonums(char *s, uint64_t *nums, size_t max) {
 
       ret = strtouint64(token, &val);
       if (ret < 0)
-        return (0);
+        return 0;
 
       if (!(isdup(nums, index, val))) {
         nums[index] = val;
@@ -223,14 +223,14 @@ static int cgroup_set(rdt_core_group_t *cg, char *desc, uint64_t *cores,
   cg->cores = calloc(num_cores, sizeof(unsigned));
   if (cg->cores == NULL) {
     ERROR(RDT_PLUGIN ": Error allocating core group table");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
   cg->num_cores = num_cores;
   cg->desc = strdup(desc);
   if (cg->desc == NULL) {
     ERROR(RDT_PLUGIN ": Error allocating core group description");
     sfree(cg->cores);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   for (size_t i = 0; i < num_cores; i++)
@@ -281,7 +281,7 @@ static int oconfig_to_cgroups(oconfig_item_t *item, rdt_core_group_t *groups,
     if (n == 0) {
       ERROR(RDT_PLUGIN ": Error parsing core group (%s)",
             item->values[j].value.string);
-      return (-EINVAL);
+      return -EINVAL;
     }
 
     /* set core group info */
@@ -401,14 +401,14 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
 
   if (item == NULL) {
     DEBUG(RDT_PLUGIN ": cgroups_config: Invalid argument.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   DEBUG(RDT_PLUGIN ": Core groups [%d]:", item->values_num);
   for (int j = 0; j < item->values_num; j++) {
     if (item->values[j].type != OCONFIG_TYPE_STRING) {
       ERROR(RDT_PLUGIN ": given core group value is not a string [idx=%d]", j);
-      return (-EINVAL);
+      return -EINVAL;
     }
     DEBUG(RDT_PLUGIN ":  [%d]: %s", j, item->values[j].value.string);
   }
@@ -417,7 +417,7 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
   if (n < 0) {
     rdt_free_cgroups();
     ERROR(RDT_PLUGIN ": Error parsing core groups configuration.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   /* validate configured core id values */
@@ -429,7 +429,7 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
                 g_rdt->cgroups[group_idx].desc,
                 (int)g_rdt->cgroups[group_idx].cores[core_idx]);
         rdt_free_cgroups();
-        return (-EINVAL);
+        return -EINVAL;
       }
     }
   }
@@ -464,7 +464,7 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
       if (found != 0) {
         rdt_free_cgroups();
         ERROR(RDT_PLUGIN ": Cannot monitor same cores in different groups.");
-        return (-EINVAL);
+        return -EINVAL;
       }
     }
 
@@ -473,11 +473,11 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
     if (g_rdt->pgroups[i] == NULL) {
       rdt_free_cgroups();
       ERROR(RDT_PLUGIN ": Failed to allocate memory for monitoring data.");
-      return (-ENOMEM);
+      return -ENOMEM;
     }
   }
 
-  return (0);
+  return 0;
 }
 
 static void rdt_pqos_log(void *context, const size_t size, const char *msg) {
@@ -489,13 +489,13 @@ static int rdt_preinit(void) {
 
   if (g_rdt != NULL) {
     /* already initialized if config callback was called before init callback */
-    return (0);
+    return 0;
   }
 
   g_rdt = calloc(1, sizeof(*g_rdt));
   if (g_rdt == NULL) {
     ERROR(RDT_PLUGIN ": Failed to allocate memory for rdt context.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   struct pqos_config pqos = {.fd_log = -1,
@@ -531,7 +531,7 @@ static int rdt_preinit(void) {
   /* Reset pqos monitoring groups registers */
   pqos_mon_reset();
 
-  return (0);
+  return 0;
 
 rdt_preinit_error2:
   pqos_fini();
@@ -540,7 +540,7 @@ rdt_preinit_error1:
 
   sfree(g_rdt);
 
-  return (-1);
+  return -1;
 }
 
 static int rdt_config(oconfig_item_t *ci) {
@@ -581,7 +581,7 @@ static int rdt_config(oconfig_item_t *ci) {
   }
 
 exit:
-  return (0);
+  return 0;
 }
 
 static void rdt_submit_derive(char *cgroup, char *type, char *type_instance,
@@ -621,13 +621,13 @@ static int rdt_read(__attribute__((unused)) user_data_t *ud) {
 
   if (g_rdt == NULL) {
     ERROR(RDT_PLUGIN ": rdt_read: plugin not initialized.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   ret = pqos_mon_poll(&g_rdt->pgroups[0], (unsigned)g_rdt->num_groups);
   if (ret != PQOS_RETVAL_OK) {
     ERROR(RDT_PLUGIN ": Failed to poll monitoring data.");
-    return (-1);
+    return -1;
   }
 
 #if COLLECT_DEBUG
@@ -657,14 +657,14 @@ static int rdt_read(__attribute__((unused)) user_data_t *ud) {
     }
   }
 
-  return (0);
+  return 0;
 }
 
 static int rdt_init(void) {
   int ret;
 
   if(g_state == CONFIGURATION_ERROR)
-    return (-1);
+    return -1;
 
   ret = rdt_preinit();
   if (ret != 0)
@@ -682,7 +682,7 @@ static int rdt_init(void) {
             cg->desc, ret);
   }
 
-  return (0);
+  return 0;
 }
 
 static int rdt_shutdown(void) {
@@ -691,7 +691,7 @@ static int rdt_shutdown(void) {
   DEBUG(RDT_PLUGIN ": rdt_shutdown.");
 
   if (g_rdt == NULL)
-    return (0);
+    return 0;
 
   /* Stop monitoring */
   for (int i = 0; i < g_rdt->num_groups; i++) {
@@ -705,7 +705,7 @@ static int rdt_shutdown(void) {
   rdt_free_cgroups();
   sfree(g_rdt);
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/interface.c
+++ b/src/interface.c
@@ -120,10 +120,10 @@ static int interface_config(const char *key, const char *value) {
             "Solaris.");
 #endif /* HAVE_LIBKSTAT */
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 #if HAVE_LIBKSTAT
@@ -133,7 +133,7 @@ static int interface_init(void) {
   numif = 0;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (numif = 0, ksp_chain = kc->kc_chain;
        (numif < MAX_NUMIF) && (ksp_chain != NULL);
@@ -149,7 +149,7 @@ static int interface_init(void) {
     ksp[numif++] = ksp_chain;
   }
 
-  return (0);
+  return 0;
 } /* int interface_init */
 #endif /* HAVE_LIBKSTAT */
 
@@ -202,7 +202,7 @@ static int interface_read(void) {
   struct IFA_DATA *if_data;
 
   if (getifaddrs(&if_list) != 0)
-    return (-1);
+    return -1;
 
   for (struct ifaddrs *if_ptr = if_list; if_ptr != NULL;
        if_ptr = if_ptr->ifa_next) {
@@ -239,7 +239,7 @@ static int interface_read(void) {
     char errbuf[1024];
     WARNING("interface plugin: fopen: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, 1024, fh) != NULL) {
@@ -289,7 +289,7 @@ static int interface_read(void) {
   char iname[DATA_MAX_NAME_LEN];
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (int i = 0; i < numif; i++) {
     if (kstat_read(kc, ksp[i], NULL) == -1)
@@ -355,7 +355,7 @@ static int interface_read(void) {
     char errbuf[1024];
     WARNING("interface plugin: perfstat_netinterface: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (pnif != nif || ifstat == NULL) {
@@ -370,7 +370,7 @@ static int interface_read(void) {
     char errbuf[1024];
     WARNING("interface plugin: perfstat_netinterface (interfaces=%d): %s", nif,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ifs; i++) {
@@ -385,7 +385,7 @@ static int interface_read(void) {
   }
 #endif /* HAVE_PERFSTAT */
 
-  return (0);
+  return 0;
 } /* int interface_read */
 
 void module_register(void) {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -123,13 +123,13 @@ static int ipc_read_sem(void) /* {{{ */
     ERROR("ipc plugin: semctl(2) failed: %s. "
           "Maybe the kernel is not configured for semaphores?",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   ipc_submit_g("sem", "count", "arrays", seminfo.semusz);
   ipc_submit_g("sem", "count", "total", seminfo.semaem);
 
-  return (0);
+  return 0;
 } /* }}} int ipc_read_sem */
 
 static int ipc_read_shm(void) /* {{{ */
@@ -143,14 +143,14 @@ static int ipc_read_shm(void) /* {{{ */
     ERROR("ipc plugin: shmctl(2) failed: %s. "
           "Maybe the kernel is not configured for shared memory?",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   ipc_submit_g("shm", "segments", NULL, shm_info.used_ids);
   ipc_submit_g("shm", "bytes", "total", shm_info.shm_tot * pagesize_g);
   ipc_submit_g("shm", "bytes", "rss", shm_info.shm_rss * pagesize_g);
   ipc_submit_g("shm", "bytes", "swapped", shm_info.shm_swp * pagesize_g);
-  return (0);
+  return 0;
 }
 /* }}} int ipc_read_shm */
 
@@ -160,20 +160,20 @@ static int ipc_read_msg(void) /* {{{ */
 
   if (msgctl(0, MSG_INFO, (struct msqid_ds *)(void *)&msginfo) < 0) {
     ERROR("Kernel is not configured for message queues");
-    return (-1);
+    return -1;
   }
   ipc_submit_g("msg", "count", "queues", msginfo.msgmni);
   ipc_submit_g("msg", "count", "headers", msginfo.msgmap);
   ipc_submit_g("msg", "count", "space", msginfo.msgtql);
 
-  return (0);
+  return 0;
 }
 /* }}} int ipc_read_msg */
 
 static int ipc_init(void) /* {{{ */
 {
   pagesize_g = sysconf(_SC_PAGESIZE);
-  return (0);
+  return 0;
 }
 /* }}} */
 /* #endif KERNEL_LINUX */
@@ -190,7 +190,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
       char errbuf[1024];
       WARNING("ipc plugin: get_ipc_info: %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (NULL);
+      return NULL;
     }
   }
 
@@ -199,7 +199,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
 
   if (size % stsize) {
     ERROR("ipc plugin: ipc_get_info: missmatch struct size and buffer size");
-    return (NULL);
+    return NULL;
   }
 
   *nmemb = size / stsize;
@@ -207,7 +207,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
   buff = malloc(size);
   if (buff == NULL) {
     ERROR("ipc plugin: ipc_get_info malloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   if (get_ipc_info(cid, cmd, version, buff, &size) < 0) {
@@ -215,7 +215,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
     WARNING("ipc plugin: get_ipc_info: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
     free(buff);
-    return (NULL);
+    return NULL;
   }
 
   return buff;
@@ -242,7 +242,7 @@ static int ipc_read_sem(void) /* {{{ */
   ipc_submit_g("sem", "count", "arrays", sem_nsems);
   ipc_submit_g("sem", "count", "total", sems);
 
-  return (0);
+  return 0;
 } /* }}} int ipc_read_sem */
 
 static int ipc_read_shm(void) /* {{{ */
@@ -267,7 +267,7 @@ static int ipc_read_shm(void) /* {{{ */
   ipc_submit_g("shm", "segments", NULL, shm_segments);
   ipc_submit_g("shm", "bytes", "total", shm_bytes);
 
-  return (0);
+  return 0;
 }
 /* }}} int ipc_read_shm */
 
@@ -295,7 +295,7 @@ static int ipc_read_msg(void) /* {{{ */
   ipc_submit_g("msg", "count", "headers", msg_qnum);
   ipc_submit_g("msg", "count", "space", msg_used_space);
 
-  return (0);
+  return 0;
 }
 /* }}} */
 #endif /* KERNEL_AIX */
@@ -307,7 +307,7 @@ static int ipc_read(void) /* {{{ */
   x |= ipc_read_sem();
   x |= ipc_read_msg();
 
-  return (x);
+  return x;
 }
 /* }}} */
 

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -253,7 +253,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
 
   /* Both `ignorelist' and `plugin_instance' may be NULL. */
   if (ignorelist_match(ignorelist, sensor_name_ptr) != 0)
-    return (0);
+    return 0;
 
   /* FIXME: Use rate unit or base unit to scale the value */
 
@@ -283,7 +283,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
          "because I don't know how to handle its type (%#x, %s). "
          "If you need this sensor, please file a bug report.",
          sensor_name_ptr, sensor_type, sensor_type_str);
-    return (-1);
+    return -1;
   }
   } /* switch (sensor_type) */
 
@@ -299,13 +299,13 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
 
   if (list_item != NULL) {
     pthread_mutex_unlock(&sensor_list_lock);
-    return (0);
+    return 0;
   }
 
   list_item = (c_ipmi_sensor_list_t *)calloc(1, sizeof(c_ipmi_sensor_list_t));
   if (list_item == NULL) {
     pthread_mutex_unlock(&sensor_list_lock);
-    return (-1);
+    return -1;
   }
 
   list_item->sensor_id = ipmi_sensor_convert_to_id(sensor);
@@ -333,7 +333,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     plugin_dispatch_notification(&n);
   }
 
-  return (0);
+  return 0;
 } /* int sensor_list_add */
 
 static int sensor_list_remove(ipmi_sensor_t *sensor) {
@@ -355,7 +355,7 @@ static int sensor_list_remove(ipmi_sensor_t *sensor) {
 
   if (list_item == NULL) {
     pthread_mutex_unlock(&sensor_list_lock);
-    return (-1);
+    return -1;
   }
 
   if (list_prev == NULL)
@@ -382,7 +382,7 @@ static int sensor_list_remove(ipmi_sensor_t *sensor) {
   }
 
   free(list_item);
-  return (0);
+  return 0;
 } /* int sensor_list_remove */
 
 static int sensor_list_read_all(void) {
@@ -396,7 +396,7 @@ static int sensor_list_read_all(void) {
 
   pthread_mutex_unlock(&sensor_list_lock);
 
-  return (0);
+  return 0;
 } /* int sensor_list_read_all */
 
 static int sensor_list_remove_all(void) {
@@ -417,7 +417,7 @@ static int sensor_list_remove_all(void) {
     list_item = list_next;
   } /* while (list_item) */
 
-  return (0);
+  return 0;
 } /* int sensor_list_remove_all */
 
 /*
@@ -487,7 +487,7 @@ static int thread_init(os_handler_t **ret_os_handler) {
   os_handler = ipmi_posix_thread_setup_os_handler(SIGIO);
   if (os_handler == NULL) {
     ERROR("ipmi plugin: ipmi_posix_thread_setup_os_handler failed.");
-    return (-1);
+    return -1;
   }
 
   ipmi_init(os_handler);
@@ -496,7 +496,7 @@ static int thread_init(os_handler_t **ret_os_handler) {
                               /* user data = */ NULL, &smi_connection);
   if (status != 0) {
     c_ipmi_error("ipmi_smi_setup_con", status);
-    return (-1);
+    return -1;
   }
 
   ipmi_open_option_t open_option[1] = {[0] = {.option = IPMI_OPEN_OPTION_ALL,
@@ -509,11 +509,11 @@ static int thread_init(os_handler_t **ret_os_handler) {
       sizeof(open_option) / sizeof(open_option[0]), &domain_id);
   if (status != 0) {
     c_ipmi_error("ipmi_open_domain", status);
-    return (-1);
+    return -1;
   }
 
   *ret_os_handler = os_handler;
-  return (0);
+  return 0;
 } /* int thread_init */
 
 static void *thread_main(void __attribute__((unused)) * user_data) {
@@ -523,7 +523,7 @@ static void *thread_main(void __attribute__((unused)) * user_data) {
   status = thread_init(&os_handler);
   if (status != 0) {
     ERROR("ipmi plugin: thread_init failed.\n");
-    return ((void *)-1);
+    return (void *)-1;
   }
 
   while (c_ipmi_active != 0) {
@@ -533,14 +533,14 @@ static void *thread_main(void __attribute__((unused)) * user_data) {
 
   ipmi_posix_thread_free_os_handler(os_handler);
 
-  return ((void *)0);
+  return (void *)0;
 } /* void *thread_main */
 
 static int c_ipmi_config(const char *key, const char *value) {
   if (ignorelist == NULL)
     ignorelist = ignorelist_create(/* invert = */ 1);
   if (ignorelist == NULL)
-    return (1);
+    return 1;
 
   if (strcasecmp("Sensor", key) == 0) {
     ignorelist_add(ignorelist, value);
@@ -559,10 +559,10 @@ static int c_ipmi_config(const char *key, const char *value) {
     if (IS_TRUE(value))
       c_ipmi_nofiy_notpresent = 1;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int c_ipmi_config */
 
 static int c_ipmi_init(void) {
@@ -580,16 +580,16 @@ static int c_ipmi_init(void) {
     c_ipmi_active = 0;
     thread_id = (pthread_t)0;
     ERROR("ipmi plugin: pthread_create failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int c_ipmi_init */
 
 static int c_ipmi_read(void) {
   if ((c_ipmi_active == 0) || (thread_id == (pthread_t)0)) {
     INFO("ipmi plugin: c_ipmi_read: I'm not active, returning false.");
-    return (-1);
+    return -1;
   }
 
   sensor_list_read_all();
@@ -599,7 +599,7 @@ static int c_ipmi_read(void) {
   else
     c_ipmi_init_in_progress = 0;
 
-  return (0);
+  return 0;
 } /* int c_ipmi_read */
 
 static int c_ipmi_shutdown(void) {
@@ -612,7 +612,7 @@ static int c_ipmi_shutdown(void) {
 
   sensor_list_remove_all();
 
-  return (0);
+  return 0;
 } /* int c_ipmi_shutdown */
 
 void module_register(void) {

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -98,7 +98,7 @@ static int iptables_config(const char *key, const char *value) {
   else if (strcasecmp(key, "Chain6") == 0)
     ip_version = IPV6;
   else
-    return (1);
+    return 1;
 
   ip_chain_t temp = {0};
   ip_chain_t * final, **list;
@@ -115,7 +115,7 @@ static int iptables_config(const char *key, const char *value) {
   if (value_copy == NULL) {
     char errbuf[1024];
     ERROR("strdup failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   /*
@@ -131,7 +131,7 @@ static int iptables_config(const char *key, const char *value) {
   fields_num = strsplit(value_copy, fields, 4);
   if (fields_num < 2) {
     free(value_copy);
-    return (1);
+    return 1;
   }
 
   table = fields[0];
@@ -141,7 +141,7 @@ static int iptables_config(const char *key, const char *value) {
   if ((unsigned int)table_len > sizeof(temp.table)) {
     ERROR("Table `%s' too long.", table);
     free(value_copy);
-    return (1);
+    return 1;
   }
   sstrncpy(temp.table, table, table_len);
 
@@ -149,7 +149,7 @@ static int iptables_config(const char *key, const char *value) {
   if ((unsigned int)chain_len > sizeof(temp.chain)) {
     ERROR("Chain `%s' too long.", chain);
     free(value_copy);
-    return (1);
+    return 1;
   }
   sstrncpy(temp.chain, chain, chain_len);
 
@@ -164,7 +164,7 @@ static int iptables_config(const char *key, const char *value) {
       temp.rule.comment = strdup(comment);
       if (temp.rule.comment == NULL) {
         free(value_copy);
-        return (1);
+        return 1;
       }
       temp.rule_type = RTYPE_COMMENT;
     }
@@ -185,7 +185,7 @@ static int iptables_config(const char *key, const char *value) {
     char errbuf[1024];
     ERROR("realloc failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
     sfree(temp.rule.comment);
-    return (1);
+    return 1;
   }
 
   chain_list = list;
@@ -194,7 +194,7 @@ static int iptables_config(const char *key, const char *value) {
     char errbuf[1024];
     ERROR("malloc failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
     sfree(temp.rule.comment);
-    return (1);
+    return 1;
   }
   memcpy(final, &temp, sizeof(temp));
   chain_list[chain_num] = final;
@@ -203,7 +203,7 @@ static int iptables_config(const char *key, const char *value) {
   DEBUG("Chain #%i: table = %s; chain = %s;", chain_num, final->table,
         final->chain);
 
-  return (0);
+  return 0;
 } /* int iptables_config */
 
 static int submit6_match(const struct ip6t_entry_match *match,
@@ -215,13 +215,13 @@ static int submit6_match(const struct ip6t_entry_match *match,
   /* Select the rules to collect */
   if (chain->rule_type == RTYPE_NUM) {
     if (chain->rule.num != rule_num)
-      return (0);
+      return 0;
   } else {
     if (strcmp(match->u.user.name, "comment") != 0)
-      return (0);
+      return 0;
     if ((chain->rule_type == RTYPE_COMMENT) &&
         (strcmp(chain->rule.comment, (char *)match->data) != 0))
-      return (0);
+      return 0;
   }
 
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
@@ -229,7 +229,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                      chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
-    return (0);
+    return 0;
 
   if (chain->name[0] != '\0') {
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
@@ -250,7 +250,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   vl.values = &(value_t){.derive = (derive_t)entry->counters.pcnt};
   plugin_dispatch_values(&vl);
 
-  return (0);
+  return 0;
 } /* int submit6_match */
 
 /* This needs to return `int' for IPT_MATCH_ITERATE to work. */
@@ -263,13 +263,13 @@ static int submit_match(const struct ipt_entry_match *match,
   /* Select the rules to collect */
   if (chain->rule_type == RTYPE_NUM) {
     if (chain->rule.num != rule_num)
-      return (0);
+      return 0;
   } else {
     if (strcmp(match->u.user.name, "comment") != 0)
-      return (0);
+      return 0;
     if ((chain->rule_type == RTYPE_COMMENT) &&
         (strcmp(chain->rule.comment, (char *)match->data) != 0))
-      return (0);
+      return 0;
   }
 
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
@@ -277,7 +277,7 @@ static int submit_match(const struct ipt_entry_match *match,
   status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                      chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
-    return (0);
+    return 0;
 
   if (chain->name[0] != '\0') {
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
@@ -298,7 +298,7 @@ static int submit_match(const struct ipt_entry_match *match,
   vl.values = &(value_t){.derive = (derive_t)entry->counters.pcnt};
   plugin_dispatch_values(&vl);
 
-  return (0);
+  return 0;
 } /* int submit_match */
 
 /* ipv6 submit_chain */
@@ -407,7 +407,7 @@ static int iptables_read(void) {
       num_failures++;
   } /* for (i = 0 .. chain_num) */
 
-  return ((num_failures < chain_num) ? 0 : -1);
+  return (num_failures < chain_num) ? 0 : -1;
 } /* int iptables_read */
 
 static int iptables_shutdown(void) {
@@ -418,7 +418,7 @@ static int iptables_shutdown(void) {
   }
   sfree(chain_list);
 
-  return (0);
+  return 0;
 } /* int iptables_shutdown */
 
 static int iptables_init(void) {
@@ -435,7 +435,7 @@ static int iptables_init(void) {
               "running \"setcap cap_net_admin=ep\" on the collectd binary.");
   }
 #endif
-  return (0);
+  return 0;
 } /* int iptables_init */
 
 void module_register(void) {

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -295,7 +295,7 @@ static int cipvs_read(void) {
   struct ip_vs_get_services *services = NULL;
 
   if (sockfd < 0)
-    return (-1);
+    return -1;
 
   if (NULL == (services = ipvs_get_services()))
     return -1;

--- a/src/irq.c
+++ b/src/irq.c
@@ -54,10 +54,10 @@ static int irq_config(const char *key, const char *value) {
       invert = 0;
     ignorelist_set_invert(ignorelist, invert);
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void irq_submit(const char *irq_name, derive_t value) {
@@ -93,7 +93,7 @@ static int irq_read(void) {
     char errbuf[1024];
     ERROR("irq plugin: fopen (/proc/interrupts): %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   /* Get CPU count from the first line */
@@ -103,7 +103,7 @@ static int irq_read(void) {
     ERROR("irq plugin: unable to get CPU count from first line "
           "of /proc/interrupts");
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -165,7 +165,7 @@ static int irq_read(void) {
 
   fclose(fh);
 
-  return (0);
+  return 0;
 } /* int irq_read */
 
 void module_register(void) {

--- a/src/java.c
+++ b/src/java.c
@@ -137,7 +137,7 @@ static int ctoj_string(JNIEnv *jvm_env, /* {{{ */
   o_string = (*jvm_env)->NewStringUTF(jvm_env, (string != NULL) ? string : "");
   if (o_string == NULL) {
     ERROR("java plugin: ctoj_string: NewStringUTF failed.");
-    return (-1);
+    return -1;
   }
 
   /* Search for the `void setFoo (String s)' method. */
@@ -147,7 +147,7 @@ static int ctoj_string(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_string: Cannot find method `void %s (String)'.",
           method_name);
     (*jvm_env)->DeleteLocalRef(jvm_env, o_string);
-    return (-1);
+    return -1;
   }
 
   /* Call the method. */
@@ -156,7 +156,7 @@ static int ctoj_string(JNIEnv *jvm_env, /* {{{ */
   /* Decrease reference counter on the java.lang.String object. */
   (*jvm_env)->DeleteLocalRef(jvm_env, o_string);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_string */
 
 static jstring ctoj_output_string(JNIEnv *jvm_env, /* {{{ */
@@ -170,7 +170,7 @@ static jstring ctoj_output_string(JNIEnv *jvm_env, /* {{{ */
     return NULL;
   }
 
-  return (o_string);
+  return o_string;
 } /* }}} int ctoj_output_string */
 
 static int ctoj_int(JNIEnv *jvm_env, /* {{{ */
@@ -183,12 +183,12 @@ static int ctoj_int(JNIEnv *jvm_env, /* {{{ */
   if (m_set == NULL) {
     ERROR("java plugin: ctoj_int: Cannot find method `void %s (int)'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   (*jvm_env)->CallVoidMethod(jvm_env, object_ptr, m_set, value);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_int */
 
 static int ctoj_long(JNIEnv *jvm_env, /* {{{ */
@@ -201,12 +201,12 @@ static int ctoj_long(JNIEnv *jvm_env, /* {{{ */
   if (m_set == NULL) {
     ERROR("java plugin: ctoj_long: Cannot find method `void %s (long)'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   (*jvm_env)->CallVoidMethod(jvm_env, object_ptr, m_set, value);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_long */
 
 static int ctoj_double(JNIEnv *jvm_env, /* {{{ */
@@ -219,12 +219,12 @@ static int ctoj_double(JNIEnv *jvm_env, /* {{{ */
   if (m_set == NULL) {
     ERROR("java plugin: ctoj_double: Cannot find method `void %s (double)'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   (*jvm_env)->CallVoidMethod(jvm_env, object_ptr, m_set, value);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_double */
 
 /* Convert a jlong to a java.lang.Number */
@@ -238,7 +238,7 @@ static jobject ctoj_jlong_to_number(JNIEnv *jvm_env, jlong value) /* {{{ */
   if (c_long == NULL) {
     ERROR("java plugin: ctoj_jlong_to_number: Looking up the "
           "java.lang.Long class failed.");
-    return (NULL);
+    return NULL;
   }
 
   m_long_constructor =
@@ -246,10 +246,10 @@ static jobject ctoj_jlong_to_number(JNIEnv *jvm_env, jlong value) /* {{{ */
   if (m_long_constructor == NULL) {
     ERROR("java plugin: ctoj_jlong_to_number: Looking up the "
           "`Long (long)' constructor failed.");
-    return (NULL);
+    return NULL;
   }
 
-  return ((*jvm_env)->NewObject(jvm_env, c_long, m_long_constructor, value));
+  return (*jvm_env)->NewObject(jvm_env, c_long, m_long_constructor, value);
 } /* }}} jobject ctoj_jlong_to_number */
 
 /* Convert a jdouble to a java.lang.Number */
@@ -263,7 +263,7 @@ static jobject ctoj_jdouble_to_number(JNIEnv *jvm_env, jdouble value) /* {{{ */
   if (c_double == NULL) {
     ERROR("java plugin: ctoj_jdouble_to_number: Looking up the "
           "java.lang.Double class failed.");
-    return (NULL);
+    return NULL;
   }
 
   m_double_constructor =
@@ -271,26 +271,25 @@ static jobject ctoj_jdouble_to_number(JNIEnv *jvm_env, jdouble value) /* {{{ */
   if (m_double_constructor == NULL) {
     ERROR("java plugin: ctoj_jdouble_to_number: Looking up the "
           "`Double (double)' constructor failed.");
-    return (NULL);
+    return NULL;
   }
 
-  return (
-      (*jvm_env)->NewObject(jvm_env, c_double, m_double_constructor, value));
+  return (*jvm_env)->NewObject(jvm_env, c_double, m_double_constructor, value);
 } /* }}} jobject ctoj_jdouble_to_number */
 
 /* Convert a value_t to a java.lang.Number */
 static jobject ctoj_value_to_number(JNIEnv *jvm_env, /* {{{ */
                                     value_t value, int ds_type) {
   if (ds_type == DS_TYPE_COUNTER)
-    return (ctoj_jlong_to_number(jvm_env, (jlong)value.counter));
+    return ctoj_jlong_to_number(jvm_env, (jlong)value.counter);
   else if (ds_type == DS_TYPE_GAUGE)
-    return (ctoj_jdouble_to_number(jvm_env, (jdouble)value.gauge));
+    return ctoj_jdouble_to_number(jvm_env, (jdouble)value.gauge);
   if (ds_type == DS_TYPE_DERIVE)
-    return (ctoj_jlong_to_number(jvm_env, (jlong)value.derive));
+    return ctoj_jlong_to_number(jvm_env, (jlong)value.derive);
   if (ds_type == DS_TYPE_ABSOLUTE)
-    return (ctoj_jlong_to_number(jvm_env, (jlong)value.absolute));
+    return ctoj_jlong_to_number(jvm_env, (jlong)value.absolute);
   else
-    return (NULL);
+    return NULL;
 } /* }}} jobject ctoj_value_to_number */
 
 /* Convert a data_source_t to a org/collectd/api/DataSource */
@@ -306,7 +305,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
   if (c_datasource == NULL) {
     ERROR("java plugin: ctoj_data_source: "
           "FindClass (org/collectd/api/DataSource) failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Lookup the `ValueList ()' constructor. */
@@ -315,7 +314,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
   if (m_datasource_constructor == NULL) {
     ERROR("java plugin: ctoj_data_source: Cannot find the "
           "`DataSource ()' constructor.");
-    return (NULL);
+    return NULL;
   }
 
   /* Create a new instance. */
@@ -324,7 +323,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
   if (o_datasource == NULL) {
     ERROR("java plugin: ctoj_data_source: "
           "Creating a new DataSource instance failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Set name via `void setName (String name)' */
@@ -334,7 +333,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_data_source: "
           "ctoj_string (setName) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_datasource);
-    return (NULL);
+    return NULL;
   }
 
   /* Set type via `void setType (int type)' */
@@ -343,7 +342,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_data_source: "
           "ctoj_int (setType) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_datasource);
-    return (NULL);
+    return NULL;
   }
 
   /* Set min via `void setMin (double min)' */
@@ -353,7 +352,7 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_data_source: "
           "ctoj_double (setMin) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_datasource);
-    return (NULL);
+    return NULL;
   }
 
   /* Set max via `void setMax (double max)' */
@@ -363,10 +362,10 @@ static jobject ctoj_data_source(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_data_source: "
           "ctoj_double (setMax) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_datasource);
-    return (NULL);
+    return NULL;
   }
 
-  return (o_datasource);
+  return o_datasource;
 } /* }}} jobject ctoj_data_source */
 
 /* Convert a oconfig_value_t to a org/collectd/api/OConfigValue */
@@ -384,7 +383,7 @@ static jobject ctoj_oconfig_value(JNIEnv *jvm_env, /* {{{ */
   if (c_ocvalue == NULL) {
     ERROR("java plugin: ctoj_oconfig_value: "
           "FindClass (org/collectd/api/OConfigValue) failed.");
-    return (NULL);
+    return NULL;
   }
 
   if (ocvalue.type == OCONFIG_TYPE_BOOLEAN) {
@@ -397,11 +396,11 @@ static jobject ctoj_oconfig_value(JNIEnv *jvm_env, /* {{{ */
     if (m_ocvalue_constructor == NULL) {
       ERROR("java plugin: ctoj_oconfig_value: Cannot find the "
             "`OConfigValue (boolean)' constructor.");
-      return (NULL);
+      return NULL;
     }
 
-    return ((*jvm_env)->NewObject(jvm_env, c_ocvalue, m_ocvalue_constructor,
-                                  tmp_boolean));
+    return (*jvm_env)->NewObject(jvm_env, c_ocvalue, m_ocvalue_constructor,
+                                 tmp_boolean);
   } /* if (ocvalue.type == OCONFIG_TYPE_BOOLEAN) */
   else if (ocvalue.type == OCONFIG_TYPE_STRING) {
     m_ocvalue_constructor = (*jvm_env)->GetMethodID(
@@ -409,14 +408,14 @@ static jobject ctoj_oconfig_value(JNIEnv *jvm_env, /* {{{ */
     if (m_ocvalue_constructor == NULL) {
       ERROR("java plugin: ctoj_oconfig_value: Cannot find the "
             "`OConfigValue (String)' constructor.");
-      return (NULL);
+      return NULL;
     }
 
     o_argument = (*jvm_env)->NewStringUTF(jvm_env, ocvalue.value.string);
     if (o_argument == NULL) {
       ERROR("java plugin: ctoj_oconfig_value: "
             "Creating a String object failed.");
-      return (NULL);
+      return NULL;
     }
   } else if (ocvalue.type == OCONFIG_TYPE_NUMBER) {
     m_ocvalue_constructor = (*jvm_env)->GetMethodID(
@@ -424,17 +423,17 @@ static jobject ctoj_oconfig_value(JNIEnv *jvm_env, /* {{{ */
     if (m_ocvalue_constructor == NULL) {
       ERROR("java plugin: ctoj_oconfig_value: Cannot find the "
             "`OConfigValue (Number)' constructor.");
-      return (NULL);
+      return NULL;
     }
 
     o_argument = ctoj_jdouble_to_number(jvm_env, (jdouble)ocvalue.value.number);
     if (o_argument == NULL) {
       ERROR("java plugin: ctoj_oconfig_value: "
             "Creating a Number object failed.");
-      return (NULL);
+      return NULL;
     }
   } else {
-    return (NULL);
+    return NULL;
   }
 
   assert(m_ocvalue_constructor != NULL);
@@ -446,11 +445,11 @@ static jobject ctoj_oconfig_value(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_oconfig_value: "
           "Creating an OConfigValue object failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_argument);
-    return (NULL);
+    return NULL;
   }
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_argument);
-  return (o_ocvalue);
+  return o_ocvalue;
 } /* }}} jobject ctoj_oconfig_value */
 
 /* Convert a oconfig_item_t to a org/collectd/api/OConfigItem */
@@ -467,7 +466,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
   if (c_ocitem == NULL) {
     ERROR("java plugin: ctoj_oconfig_item: "
           "FindClass (org/collectd/api/OConfigItem) failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Get the required methods: m_ocitem_constructor, m_addvalue, and m_addchild
@@ -477,7 +476,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
   if (m_ocitem_constructor == NULL) {
     ERROR("java plugin: ctoj_oconfig_item: Cannot find the "
           "`OConfigItem (String)' constructor.");
-    return (NULL);
+    return NULL;
   }
 
   m_addvalue = (*jvm_env)->GetMethodID(jvm_env, c_ocitem, "addValue",
@@ -485,7 +484,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
   if (m_addvalue == NULL) {
     ERROR("java plugin: ctoj_oconfig_item: Cannot find the "
           "`addValue (OConfigValue)' method.");
-    return (NULL);
+    return NULL;
   }
 
   m_addchild = (*jvm_env)->GetMethodID(jvm_env, c_ocitem, "addChild",
@@ -493,7 +492,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
   if (m_addchild == NULL) {
     ERROR("java plugin: ctoj_oconfig_item: Cannot find the "
           "`addChild (OConfigItem)' method.");
-    return (NULL);
+    return NULL;
   }
   /* }}} */
 
@@ -503,7 +502,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
   if (o_key == NULL) {
     ERROR("java plugin: ctoj_oconfig_item: "
           "Creating String object failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Create an OConfigItem object */
@@ -513,7 +512,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_oconfig_item: "
           "Creating an OConfigItem object failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_key);
-    return (NULL);
+    return NULL;
   }
 
   /* We don't need the String object any longer.. */
@@ -529,7 +528,7 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
       ERROR("java plugin: ctoj_oconfig_item: "
             "Creating an OConfigValue object failed.");
       (*jvm_env)->DeleteLocalRef(jvm_env, o_ocitem);
-      return (NULL);
+      return NULL;
     }
 
     (*jvm_env)->CallVoidMethod(jvm_env, o_ocitem, m_addvalue, o_value);
@@ -546,14 +545,14 @@ static jobject ctoj_oconfig_item(JNIEnv *jvm_env, /* {{{ */
       ERROR("java plugin: ctoj_oconfig_item: "
             "Creating an OConfigItem object failed.");
       (*jvm_env)->DeleteLocalRef(jvm_env, o_ocitem);
-      return (NULL);
+      return NULL;
     }
 
     (*jvm_env)->CallVoidMethod(jvm_env, o_ocitem, m_addchild, o_child);
     (*jvm_env)->DeleteLocalRef(jvm_env, o_child);
   } /* }}} for (i = 0; i < ci->children_num; i++) */
 
-  return (o_ocitem);
+  return o_ocitem;
 } /* }}} jobject ctoj_oconfig_item */
 
 /* Convert a data_set_t to a org/collectd/api/DataSet */
@@ -570,7 +569,7 @@ static jobject ctoj_data_set(JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
   if (c_dataset == NULL) {
     ERROR("java plugin: ctoj_data_set: Looking up the "
           "org/collectd/api/DataSet class failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Search for the `DataSet (String type)' constructor. */
@@ -579,7 +578,7 @@ static jobject ctoj_data_set(JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
   if (m_constructor == NULL) {
     ERROR("java plugin: ctoj_data_set: Looking up the "
           "`DataSet (String)' constructor failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Search for the `void addDataSource (DataSource)' method. */
@@ -588,20 +587,20 @@ static jobject ctoj_data_set(JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
   if (m_add == NULL) {
     ERROR("java plugin: ctoj_data_set: Looking up the "
           "`addDataSource (DataSource)' method failed.");
-    return (NULL);
+    return NULL;
   }
 
   o_type = (*jvm_env)->NewStringUTF(jvm_env, ds->type);
   if (o_type == NULL) {
     ERROR("java plugin: ctoj_data_set: Creating a String object failed.");
-    return (NULL);
+    return NULL;
   }
 
   o_dataset = (*jvm_env)->NewObject(jvm_env, c_dataset, m_constructor, o_type);
   if (o_dataset == NULL) {
     ERROR("java plugin: ctoj_data_set: Creating a DataSet object failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_type);
-    return (NULL);
+    return NULL;
   }
 
   /* Decrease reference counter on the java.lang.String object. */
@@ -615,7 +614,7 @@ static jobject ctoj_data_set(JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
       ERROR("java plugin: ctoj_data_set: ctoj_data_source (%s.%s) failed",
             ds->type, ds->ds[i].name);
       (*jvm_env)->DeleteLocalRef(jvm_env, o_dataset);
-      return (NULL);
+      return NULL;
     }
 
     (*jvm_env)->CallVoidMethod(jvm_env, o_dataset, m_add, o_datasource);
@@ -623,7 +622,7 @@ static jobject ctoj_data_set(JNIEnv *jvm_env, const data_set_t *ds) /* {{{ */
     (*jvm_env)->DeleteLocalRef(jvm_env, o_datasource);
   } /* for (i = 0; i < ds->ds_num; i++) */
 
-  return (o_dataset);
+  return o_dataset;
 } /* }}} jobject ctoj_data_set */
 
 static int ctoj_value_list_add_value(JNIEnv *jvm_env, /* {{{ */
@@ -637,21 +636,21 @@ static int ctoj_value_list_add_value(JNIEnv *jvm_env, /* {{{ */
   if (m_addvalue == NULL) {
     ERROR("java plugin: ctoj_value_list_add_value: "
           "Cannot find method `void addValue (Number)'.");
-    return (-1);
+    return -1;
   }
 
   o_number = ctoj_value_to_number(jvm_env, value, ds_type);
   if (o_number == NULL) {
     ERROR("java plugin: ctoj_value_list_add_value: "
           "ctoj_value_to_number failed.");
-    return (-1);
+    return -1;
   }
 
   (*jvm_env)->CallVoidMethod(jvm_env, object_ptr, m_addvalue, o_number);
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_number);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_value_list_add_value */
 
 static int ctoj_value_list_add_data_set(JNIEnv *jvm_env, /* {{{ */
@@ -666,7 +665,7 @@ static int ctoj_value_list_add_data_set(JNIEnv *jvm_env, /* {{{ */
   if (m_setdataset == NULL) {
     ERROR("java plugin: ctoj_value_list_add_data_set: "
           "Cannot find the `void setDataSet (DataSet)' method.");
-    return (-1);
+    return -1;
   }
 
   /* Create a DataSet object. */
@@ -675,7 +674,7 @@ static int ctoj_value_list_add_data_set(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_value_list_add_data_set: "
           "ctoj_data_set (%s) failed.",
           ds->type);
-    return (-1);
+    return -1;
   }
 
   /* Actually call the method. */
@@ -684,7 +683,7 @@ static int ctoj_value_list_add_data_set(JNIEnv *jvm_env, /* {{{ */
   /* Decrease reference counter on the List<DataSource> object. */
   (*jvm_env)->DeleteLocalRef(jvm_env, o_dataset);
 
-  return (0);
+  return 0;
 } /* }}} int ctoj_value_list_add_data_set */
 
 /* Convert a value_list_t (and data_set_t) to a org/collectd/api/ValueList */
@@ -701,7 +700,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
   if (c_valuelist == NULL) {
     ERROR("java plugin: ctoj_value_list: "
           "FindClass (org/collectd/api/ValueList) failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Lookup the `ValueList ()' constructor. */
@@ -710,7 +709,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
   if (m_valuelist_constructor == NULL) {
     ERROR("java plugin: ctoj_value_list: Cannot find the "
           "`ValueList ()' constructor.");
-    return (NULL);
+    return NULL;
   }
 
   /* Create a new instance. */
@@ -719,7 +718,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
   if (o_valuelist == NULL) {
     ERROR("java plugin: ctoj_value_list: Creating a new ValueList instance "
           "failed.");
-    return (NULL);
+    return NULL;
   }
 
   status = ctoj_value_list_add_data_set(jvm_env, c_valuelist, o_valuelist, ds);
@@ -727,7 +726,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: ctoj_value_list: "
           "ctoj_value_list_add_data_set failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_valuelist);
-    return (NULL);
+    return NULL;
   }
 
 /* Set the strings.. */
@@ -738,7 +737,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
       ERROR("java plugin: ctoj_value_list: ctoj_string (%s) failed.",          \
             method_name);                                                      \
       (*jvm_env)->DeleteLocalRef(jvm_env, o_valuelist);                        \
-      return (NULL);                                                           \
+      return NULL;                                                             \
     }                                                                          \
   } while (0)
 
@@ -756,7 +755,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
   if (status != 0) {
     ERROR("java plugin: ctoj_value_list: ctoj_long (setTime) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_valuelist);
-    return (NULL);
+    return NULL;
   }
 
   /* Set the `interval' member.. */
@@ -765,7 +764,7 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
   if (status != 0) {
     ERROR("java plugin: ctoj_value_list: ctoj_long (setInterval) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_valuelist);
-    return (NULL);
+    return NULL;
   }
 
   for (size_t i = 0; i < vl->values_len; i++) {
@@ -775,11 +774,11 @@ static jobject ctoj_value_list(JNIEnv *jvm_env, /* {{{ */
       ERROR("java plugin: ctoj_value_list: "
             "ctoj_value_list_add_value failed.");
       (*jvm_env)->DeleteLocalRef(jvm_env, o_valuelist);
-      return (NULL);
+      return NULL;
     }
   }
 
-  return (o_valuelist);
+  return o_valuelist;
 } /* }}} jobject ctoj_value_list */
 
 /* Convert a notification_t to a org/collectd/api/Notification */
@@ -797,7 +796,7 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
   if (c_notification == NULL) {
     ERROR("java plugin: ctoj_notification: "
           "FindClass (org/collectd/api/Notification) failed.");
-    return (NULL);
+    return NULL;
   }
 
   /* Lookup the `Notification ()' constructor. */
@@ -806,7 +805,7 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
   if (m_constructor == NULL) {
     ERROR("java plugin: ctoj_notification: Cannot find the "
           "`Notification ()' constructor.");
-    return (NULL);
+    return NULL;
   }
 
   /* Create a new instance. */
@@ -815,7 +814,7 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
   if (o_notification == NULL) {
     ERROR("java plugin: ctoj_notification: Creating a new Notification "
           "instance failed.");
-    return (NULL);
+    return NULL;
   }
 
 /* Set the strings.. */
@@ -827,7 +826,7 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
       ERROR("java plugin: ctoj_notification: ctoj_string (%s) failed.",        \
             method_name);                                                      \
       (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);                     \
-      return (NULL);                                                           \
+      return NULL;                                                             \
     }                                                                          \
   } while (0)
 
@@ -846,7 +845,7 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
   if (status != 0) {
     ERROR("java plugin: ctoj_notification: ctoj_long (setTime) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);
-    return (NULL);
+    return NULL;
   }
 
   /* Set the `severity' member.. */
@@ -855,10 +854,10 @@ static jobject ctoj_notification(JNIEnv *jvm_env, /* {{{ */
   if (status != 0) {
     ERROR("java plugin: ctoj_notification: ctoj_int (setSeverity) failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);
-    return (NULL);
+    return NULL;
   }
 
-  return (o_notification);
+  return o_notification;
 } /* }}} jobject ctoj_notification */
 
 /*
@@ -878,24 +877,24 @@ static int jtoc_string(JNIEnv *jvm_env, /* {{{ */
   if (method_id == NULL) {
     ERROR("java plugin: jtoc_string: Cannot find method `String %s ()'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   string_obj = (*jvm_env)->CallObjectMethod(jvm_env, object_ptr, method_id);
   if ((string_obj == NULL) && (empty_okay == 0)) {
     ERROR("java plugin: jtoc_string: CallObjectMethod (%s) failed.",
           method_name);
-    return (-1);
+    return -1;
   } else if ((string_obj == NULL) && (empty_okay != 0)) {
     memset(buffer, 0, buffer_size);
-    return (0);
+    return 0;
   }
 
   c_str = (*jvm_env)->GetStringUTFChars(jvm_env, string_obj, 0);
   if (c_str == NULL) {
     ERROR("java plugin: jtoc_string: GetStringUTFChars failed.");
     (*jvm_env)->DeleteLocalRef(jvm_env, string_obj);
-    return (-1);
+    return -1;
   }
 
   sstrncpy(buffer, c_str, buffer_size);
@@ -903,7 +902,7 @@ static int jtoc_string(JNIEnv *jvm_env, /* {{{ */
   (*jvm_env)->ReleaseStringUTFChars(jvm_env, string_obj, c_str);
   (*jvm_env)->DeleteLocalRef(jvm_env, string_obj);
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_string */
 
 /* Call an `int <method> ()' method. */
@@ -916,12 +915,12 @@ static int jtoc_int(JNIEnv *jvm_env, /* {{{ */
   if (method_id == NULL) {
     ERROR("java plugin: jtoc_int: Cannot find method `int %s ()'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   *ret_value = (*jvm_env)->CallIntMethod(jvm_env, object_ptr, method_id);
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_int */
 
 /* Call a `long <method> ()' method. */
@@ -934,12 +933,12 @@ static int jtoc_long(JNIEnv *jvm_env, /* {{{ */
   if (method_id == NULL) {
     ERROR("java plugin: jtoc_long: Cannot find method `long %s ()'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   *ret_value = (*jvm_env)->CallLongMethod(jvm_env, object_ptr, method_id);
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_long */
 
 /* Call a `double <method> ()' method. */
@@ -952,12 +951,12 @@ static int jtoc_double(JNIEnv *jvm_env, /* {{{ */
   if (method_id == NULL) {
     ERROR("java plugin: jtoc_double: Cannot find method `double %s ()'.",
           method_name);
-    return (-1);
+    return -1;
   }
 
   *ret_value = (*jvm_env)->CallDoubleMethod(jvm_env, object_ptr, method_id);
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_double */
 
 static int jtoc_value(JNIEnv *jvm_env, /* {{{ */
@@ -975,7 +974,7 @@ static int jtoc_value(JNIEnv *jvm_env, /* {{{ */
     if (status != 0) {
       ERROR("java plugin: jtoc_value: "
             "jtoc_double failed.");
-      return (-1);
+      return -1;
     }
     (*ret_value).gauge = (gauge_t)tmp_double;
   } else {
@@ -985,7 +984,7 @@ static int jtoc_value(JNIEnv *jvm_env, /* {{{ */
     if (status != 0) {
       ERROR("java plugin: jtoc_value: "
             "jtoc_long failed.");
-      return (-1);
+      return -1;
     }
 
     if (ds_type == DS_TYPE_DERIVE)
@@ -996,7 +995,7 @@ static int jtoc_value(JNIEnv *jvm_env, /* {{{ */
       (*ret_value).counter = (counter_t)tmp_long;
   }
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_value */
 
 /* Read a List<Number>, convert it to `value_t' and add it to the given
@@ -1024,7 +1023,7 @@ static int jtoc_values_array(JNIEnv *jvm_env, /* {{{ */
     (*jvm_env)->DeleteLocalRef(jvm_env, o_number_array);                       \
   if (o_list != NULL)                                                          \
     (*jvm_env)->DeleteLocalRef(jvm_env, o_list);                               \
-  return (status);
+  return status;
 
   /* Call: List<Number> ValueList.getValues () */
   m_getvalues = (*jvm_env)->GetMethodID(jvm_env, class_ptr, "getValues",
@@ -1093,7 +1092,7 @@ static int jtoc_values_array(JNIEnv *jvm_env, /* {{{ */
 #undef BAIL_OUT
   (*jvm_env)->DeleteLocalRef(jvm_env, o_number_array);
   (*jvm_env)->DeleteLocalRef(jvm_env, o_list);
-  return (0);
+  return 0;
 } /* }}} int jtoc_values_array */
 
 /* Convert a org/collectd/api/ValueList to a value_list_t. */
@@ -1107,7 +1106,7 @@ static int jtoc_value_list(JNIEnv *jvm_env, value_list_t *vl, /* {{{ */
   class_ptr = (*jvm_env)->GetObjectClass(jvm_env, object_ptr);
   if (class_ptr == NULL) {
     ERROR("java plugin: jtoc_value_list: GetObjectClass failed.");
-    return (-1);
+    return -1;
   }
 
 /* eo == empty okay */
@@ -1117,7 +1116,7 @@ static int jtoc_value_list(JNIEnv *jvm_env, value_list_t *vl, /* {{{ */
                          object_ptr, method);                                  \
     if (status != 0) {                                                         \
       ERROR("java plugin: jtoc_value_list: jtoc_string (%s) failed.", method); \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
   } while (0)
 
@@ -1128,7 +1127,7 @@ static int jtoc_value_list(JNIEnv *jvm_env, value_list_t *vl, /* {{{ */
     ERROR("java plugin: jtoc_value_list: Data-set `%s' is not defined. "
           "Please consult the types.db(5) manpage for mor information.",
           vl->type);
-    return (-1);
+    return -1;
   }
 
   SET_STRING(vl->host, "getHost", /* empty = */ 0);
@@ -1141,7 +1140,7 @@ static int jtoc_value_list(JNIEnv *jvm_env, value_list_t *vl, /* {{{ */
   status = jtoc_long(jvm_env, &tmp_long, class_ptr, object_ptr, "getTime");
   if (status != 0) {
     ERROR("java plugin: jtoc_value_list: jtoc_long (getTime) failed.");
-    return (-1);
+    return -1;
   }
   /* Java measures time in milliseconds. */
   vl->time = MS_TO_CDTIME_T(tmp_long);
@@ -1149,17 +1148,17 @@ static int jtoc_value_list(JNIEnv *jvm_env, value_list_t *vl, /* {{{ */
   status = jtoc_long(jvm_env, &tmp_long, class_ptr, object_ptr, "getInterval");
   if (status != 0) {
     ERROR("java plugin: jtoc_value_list: jtoc_long (getInterval) failed.");
-    return (-1);
+    return -1;
   }
   vl->interval = MS_TO_CDTIME_T(tmp_long);
 
   status = jtoc_values_array(jvm_env, ds, vl, class_ptr, object_ptr);
   if (status != 0) {
     ERROR("java plugin: jtoc_value_list: jtoc_values_array failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_value_list */
 
 /* Convert a org/collectd/api/Notification to a notification_t. */
@@ -1173,7 +1172,7 @@ static int jtoc_notification(JNIEnv *jvm_env, notification_t *n, /* {{{ */
   class_ptr = (*jvm_env)->GetObjectClass(jvm_env, object_ptr);
   if (class_ptr == NULL) {
     ERROR("java plugin: jtoc_notification: GetObjectClass failed.");
-    return (-1);
+    return -1;
   }
 
 /* eo == empty okay */
@@ -1184,7 +1183,7 @@ static int jtoc_notification(JNIEnv *jvm_env, notification_t *n, /* {{{ */
     if (status != 0) {                                                         \
       ERROR("java plugin: jtoc_notification: jtoc_string (%s) failed.",        \
             method);                                                           \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
   } while (0)
 
@@ -1200,7 +1199,7 @@ static int jtoc_notification(JNIEnv *jvm_env, notification_t *n, /* {{{ */
   status = jtoc_long(jvm_env, &tmp_long, class_ptr, object_ptr, "getTime");
   if (status != 0) {
     ERROR("java plugin: jtoc_notification: jtoc_long (getTime) failed.");
-    return (-1);
+    return -1;
   }
   /* Java measures time in milliseconds. */
   n->time = MS_TO_CDTIME_T(tmp_long);
@@ -1208,11 +1207,11 @@ static int jtoc_notification(JNIEnv *jvm_env, notification_t *n, /* {{{ */
   status = jtoc_int(jvm_env, &tmp_int, class_ptr, object_ptr, "getSeverity");
   if (status != 0) {
     ERROR("java plugin: jtoc_notification: jtoc_int (getSeverity) failed.");
-    return (-1);
+    return -1;
   }
   n->severity = (int)tmp_int;
 
-  return (0);
+  return 0;
 } /* }}} int jtoc_notification */
   /*
    * Functions accessible from Java
@@ -1227,14 +1226,14 @@ static jint JNICALL cjni_api_dispatch_values(JNIEnv *jvm_env, /* {{{ */
   status = jtoc_value_list(jvm_env, &vl, java_vl);
   if (status != 0) {
     ERROR("java plugin: cjni_api_dispatch_values: jtoc_value_list failed.");
-    return (-1);
+    return -1;
   }
 
   status = plugin_dispatch_values(&vl);
 
   sfree(vl.values);
 
-  return (status);
+  return status;
 } /* }}} jint cjni_api_dispatch_values */
 
 static jint JNICALL cjni_api_dispatch_notification(JNIEnv *jvm_env, /* {{{ */
@@ -1247,12 +1246,12 @@ static jint JNICALL cjni_api_dispatch_notification(JNIEnv *jvm_env, /* {{{ */
   if (status != 0) {
     ERROR("java plugin: cjni_api_dispatch_notification: jtoc_notification "
           "failed.");
-    return (-1);
+    return -1;
   }
 
   status = plugin_dispatch_notification(&n);
 
-  return (status);
+  return status;
 } /* }}} jint cjni_api_dispatch_notification */
 
 static jobject JNICALL cjni_api_get_ds(JNIEnv *jvm_env, /* {{{ */
@@ -1264,7 +1263,7 @@ static jobject JNICALL cjni_api_get_ds(JNIEnv *jvm_env, /* {{{ */
   ds_name = (*jvm_env)->GetStringUTFChars(jvm_env, o_string_type, 0);
   if (ds_name == NULL) {
     ERROR("java plugin: cjni_api_get_ds: GetStringUTFChars failed.");
-    return (NULL);
+    return NULL;
   }
 
   ds = plugin_get_ds(ds_name);
@@ -1275,22 +1274,22 @@ static jobject JNICALL cjni_api_get_ds(JNIEnv *jvm_env, /* {{{ */
   (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_string_type, ds_name);
 
   if (ds == NULL)
-    return (NULL);
+    return NULL;
 
   o_dataset = ctoj_data_set(jvm_env, ds);
-  return (o_dataset);
+  return o_dataset;
 } /* }}} jint cjni_api_get_ds */
 
 static jint JNICALL cjni_api_register_config(JNIEnv *jvm_env, /* {{{ */
                                              jobject this, jobject o_name,
                                              jobject o_config) {
-  return (cjni_callback_register(jvm_env, o_name, o_config, CB_TYPE_CONFIG));
+  return cjni_callback_register(jvm_env, o_name, o_config, CB_TYPE_CONFIG);
 } /* }}} jint cjni_api_register_config */
 
 static jint JNICALL cjni_api_register_init(JNIEnv *jvm_env, /* {{{ */
                                            jobject this, jobject o_name,
                                            jobject o_config) {
-  return (cjni_callback_register(jvm_env, o_name, o_config, CB_TYPE_INIT));
+  return cjni_callback_register(jvm_env, o_name, o_config, CB_TYPE_INIT);
 } /* }}} jint cjni_api_register_init */
 
 static jint JNICALL cjni_api_register_read(JNIEnv *jvm_env, /* {{{ */
@@ -1300,7 +1299,7 @@ static jint JNICALL cjni_api_register_read(JNIEnv *jvm_env, /* {{{ */
 
   cbi = cjni_callback_info_create(jvm_env, o_name, o_read, CB_TYPE_READ);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("java plugin: Registering new read callback: %s", cbi->name);
 
@@ -1313,7 +1312,7 @@ static jint JNICALL cjni_api_register_read(JNIEnv *jvm_env, /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_read);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_read */
 
 static jint JNICALL cjni_api_register_write(JNIEnv *jvm_env, /* {{{ */
@@ -1323,7 +1322,7 @@ static jint JNICALL cjni_api_register_write(JNIEnv *jvm_env, /* {{{ */
 
   cbi = cjni_callback_info_create(jvm_env, o_name, o_write, CB_TYPE_WRITE);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("java plugin: Registering new write callback: %s", cbi->name);
 
@@ -1335,7 +1334,7 @@ static jint JNICALL cjni_api_register_write(JNIEnv *jvm_env, /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_write);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_write */
 
 static jint JNICALL cjni_api_register_flush(JNIEnv *jvm_env, /* {{{ */
@@ -1345,7 +1344,7 @@ static jint JNICALL cjni_api_register_flush(JNIEnv *jvm_env, /* {{{ */
 
   cbi = cjni_callback_info_create(jvm_env, o_name, o_flush, CB_TYPE_FLUSH);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("java plugin: Registering new flush callback: %s", cbi->name);
 
@@ -1357,14 +1356,13 @@ static jint JNICALL cjni_api_register_flush(JNIEnv *jvm_env, /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_flush);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_flush */
 
 static jint JNICALL cjni_api_register_shutdown(JNIEnv *jvm_env, /* {{{ */
                                                jobject this, jobject o_name,
                                                jobject o_shutdown) {
-  return (
-      cjni_callback_register(jvm_env, o_name, o_shutdown, CB_TYPE_SHUTDOWN));
+  return cjni_callback_register(jvm_env, o_name, o_shutdown, CB_TYPE_SHUTDOWN);
 } /* }}} jint cjni_api_register_shutdown */
 
 static jint JNICALL cjni_api_register_log(JNIEnv *jvm_env, /* {{{ */
@@ -1374,7 +1372,7 @@ static jint JNICALL cjni_api_register_log(JNIEnv *jvm_env, /* {{{ */
 
   cbi = cjni_callback_info_create(jvm_env, o_name, o_log, CB_TYPE_LOG);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("java plugin: Registering new log callback: %s", cbi->name);
 
@@ -1385,7 +1383,7 @@ static jint JNICALL cjni_api_register_log(JNIEnv *jvm_env, /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_log);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_log */
 
 static jint JNICALL cjni_api_register_notification(JNIEnv *jvm_env, /* {{{ */
@@ -1396,7 +1394,7 @@ static jint JNICALL cjni_api_register_notification(JNIEnv *jvm_env, /* {{{ */
   cbi = cjni_callback_info_create(jvm_env, o_name, o_notification,
                                   CB_TYPE_NOTIFICATION);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
   DEBUG("java plugin: Registering new notification callback: %s", cbi->name);
 
@@ -1408,7 +1406,7 @@ static jint JNICALL cjni_api_register_notification(JNIEnv *jvm_env, /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_notification */
 
 static jint JNICALL cjni_api_register_match_target(JNIEnv *jvm_env, /* {{{ */
@@ -1421,13 +1419,13 @@ static jint JNICALL cjni_api_register_match_target(JNIEnv *jvm_env, /* {{{ */
   if (c_name == NULL) {
     ERROR("java plugin: cjni_api_register_match_target: "
           "GetStringUTFChars failed.");
-    return (-1);
+    return -1;
   }
 
   status = cjni_callback_register(jvm_env, o_name, o_match, type);
   if (status != 0) {
     (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
-    return (-1);
+    return -1;
   }
 
   if (type == CB_TYPE_MATCH) {
@@ -1450,7 +1448,7 @@ static jint JNICALL cjni_api_register_match_target(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: cjni_api_register_match_target: "
           "Don't know whether to create a match or a target.");
     (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
-    return (-1);
+    return -1;
   }
 
   if (status != 0) {
@@ -1458,26 +1456,26 @@ static jint JNICALL cjni_api_register_match_target(JNIEnv *jvm_env, /* {{{ */
           "%s failed.",
           (type == CB_TYPE_MATCH) ? "fc_register_match" : "fc_register_target");
     (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
-    return (-1);
+    return -1;
   }
 
   (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
 
-  return (0);
+  return 0;
 } /* }}} jint cjni_api_register_match_target */
 
 static jint JNICALL cjni_api_register_match(JNIEnv *jvm_env, /* {{{ */
                                             jobject this, jobject o_name,
                                             jobject o_match) {
-  return (cjni_api_register_match_target(jvm_env, this, o_name, o_match,
-                                         CB_TYPE_MATCH));
+  return cjni_api_register_match_target(jvm_env, this, o_name, o_match,
+                                        CB_TYPE_MATCH);
 } /* }}} jint cjni_api_register_match */
 
 static jint JNICALL cjni_api_register_target(JNIEnv *jvm_env, /* {{{ */
                                              jobject this, jobject o_name,
                                              jobject o_target) {
-  return (cjni_api_register_match_target(jvm_env, this, o_name, o_target,
-                                         CB_TYPE_TARGET));
+  return cjni_api_register_match_target(jvm_env, this, o_name, o_target,
+                                        CB_TYPE_TARGET);
 } /* }}} jint cjni_api_register_target */
 
 static void JNICALL cjni_api_log(JNIEnv *jvm_env, /* {{{ */
@@ -1635,21 +1633,21 @@ cjni_callback_info_create(JNIEnv *jvm_env, /* {{{ */
 
   default:
     ERROR("java plugin: cjni_callback_info_create: Unknown type: %#x", type);
-    return (NULL);
+    return NULL;
   }
 
   c_name = (*jvm_env)->GetStringUTFChars(jvm_env, o_name, 0);
   if (c_name == NULL) {
     ERROR("java plugin: cjni_callback_info_create: "
           "GetStringUTFChars failed.");
-    return (NULL);
+    return NULL;
   }
 
   cbi = calloc(1, sizeof(*cbi));
   if (cbi == NULL) {
     ERROR("java plugin: cjni_callback_info_create: calloc failed.");
     (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
-    return (NULL);
+    return NULL;
   }
   cbi->type = type;
 
@@ -1659,7 +1657,7 @@ cjni_callback_info_create(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: cjni_callback_info_create: strdup failed.");
     (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
     sfree(cbi);
-    return (NULL);
+    return NULL;
   }
 
   (*jvm_env)->ReleaseStringUTFChars(jvm_env, o_name, c_name);
@@ -1669,7 +1667,7 @@ cjni_callback_info_create(JNIEnv *jvm_env, /* {{{ */
     ERROR("java plugin: cjni_callback_info_create: NewGlobalRef failed.");
     sfree(cbi->name);
     sfree(cbi);
-    return (NULL);
+    return NULL;
   }
 
   cbi->class = (*jvm_env)->GetObjectClass(jvm_env, cbi->object);
@@ -1678,7 +1676,7 @@ cjni_callback_info_create(JNIEnv *jvm_env, /* {{{ */
     (*jvm_env)->DeleteGlobalRef(jvm_env, cbi->object);
     sfree(cbi->name);
     sfree(cbi);
-    return (NULL);
+    return NULL;
   }
 
   cbi->method = (*jvm_env)->GetMethodID(jvm_env, cbi->class, method_name,
@@ -1690,10 +1688,10 @@ cjni_callback_info_create(JNIEnv *jvm_env, /* {{{ */
     (*jvm_env)->DeleteGlobalRef(jvm_env, cbi->object);
     sfree(cbi->name);
     sfree(cbi);
-    return (NULL);
+    return NULL;
   }
 
-  return (cbi);
+  return cbi;
 } /* }}} cjni_callback_info_t cjni_callback_info_create */
 
 /* Allocate a `cjni_callback_info_t' via `cjni_callback_info_create' and add it
@@ -1710,7 +1708,7 @@ static int cjni_callback_register(JNIEnv *jvm_env, /* {{{ */
 
   cbi = cjni_callback_info_create(jvm_env, o_name, o_callback, type);
   if (cbi == NULL)
-    return (-1);
+    return -1;
 
 #if COLLECT_DEBUG
   switch (type) {
@@ -1751,7 +1749,7 @@ static int cjni_callback_register(JNIEnv *jvm_env, /* {{{ */
     (*jvm_env)->DeleteGlobalRef(jvm_env, cbi->object);
     free(cbi);
 
-    return (-1);
+    return -1;
   }
   java_callbacks = tmp;
   java_callbacks[java_callbacks_num] = *cbi;
@@ -1760,7 +1758,7 @@ static int cjni_callback_register(JNIEnv *jvm_env, /* {{{ */
   pthread_mutex_unlock(&java_callbacks_lock);
 
   free(cbi);
-  return (0);
+  return 0;
 } /* }}} int cjni_callback_register */
 
 /* Callback for `pthread_key_create'. It frees the data contained in
@@ -1801,17 +1799,17 @@ static int cjni_init_native(JNIEnv *jvm_env) /* {{{ */
     ERROR("cjni_init_native: Cannot find the API class \"org.collectd.api"
           ".Collectd\". Please set the correct class path "
           "using 'JVMArg \"-Djava.class.path=...\"'.");
-    return (-1);
+    return -1;
   }
 
   status = (*jvm_env)->RegisterNatives(
       jvm_env, api_class_ptr, jni_api_functions, (jint)jni_api_functions_num);
   if (status != 0) {
     ERROR("cjni_init_native: RegisterNatives failed with status %i.", status);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cjni_init_native */
 
 /* Create the JVM. This is called when the first thread tries to access the JVM
@@ -1825,14 +1823,14 @@ static int cjni_create_jvm(void) /* {{{ */
   int status;
 
   if (jvm != NULL)
-    return (0);
+    return 0;
 
   status = pthread_key_create(&jvm_env_key, cjni_jvm_env_destroy);
   if (status != 0) {
     ERROR("java plugin: cjni_create_jvm: pthread_key_create failed "
           "with status %i.",
           status);
-    return (-1);
+    return -1;
   }
 
   jvm_env = NULL;
@@ -1851,7 +1849,7 @@ static int cjni_create_jvm(void) /* {{{ */
     ERROR("java plugin: cjni_create_jvm: "
           "JNI_CreateJavaVM failed with status %i.",
           status);
-    return (-1);
+    return -1;
   }
   assert(jvm != NULL);
   assert(jvm_env != NULL);
@@ -1860,11 +1858,11 @@ static int cjni_create_jvm(void) /* {{{ */
   status = cjni_init_native(jvm_env);
   if (status != 0) {
     ERROR("java plugin: cjni_create_jvm: cjni_init_native failed.");
-    return (-1);
+    return -1;
   }
 
   DEBUG("java plugin: The JVM has been created.");
-  return (0);
+  return 0;
 } /* }}} int cjni_create_jvm */
 
 /* Increase the reference counter to the JVM for this thread. If it was zero,
@@ -1882,7 +1880,7 @@ static JNIEnv *cjni_thread_attach(void) /* {{{ */
     status = cjni_create_jvm();
     if (status != 0) {
       ERROR("java plugin: cjni_thread_attach: cjni_create_jvm failed.");
-      return (NULL);
+      return NULL;
     }
   }
   assert(jvm != NULL);
@@ -1893,7 +1891,7 @@ static JNIEnv *cjni_thread_attach(void) /* {{{ */
     cjni_env = calloc(1, sizeof(*cjni_env));
     if (cjni_env == NULL) {
       ERROR("java plugin: cjni_thread_attach: calloc failed.");
-      return (NULL);
+      return NULL;
     }
     cjni_env->reference_counter = 0;
     cjni_env->jvm_env = NULL;
@@ -1917,7 +1915,7 @@ static JNIEnv *cjni_thread_attach(void) /* {{{ */
       ERROR("java plugin: cjni_thread_attach: AttachCurrentThread failed "
             "with status %i.",
             status);
-      return (NULL);
+      return NULL;
     }
 
     cjni_env->reference_counter = 1;
@@ -1927,7 +1925,7 @@ static JNIEnv *cjni_thread_attach(void) /* {{{ */
   DEBUG("java plugin: cjni_thread_attach: cjni_env->reference_counter = %i",
         cjni_env->reference_counter);
   assert(jvm_env != NULL);
-  return (jvm_env);
+  return jvm_env;
 } /* }}} JNIEnv *cjni_thread_attach */
 
 /* Decrease the reference counter of this thread. If it reaches zero, detach
@@ -1940,7 +1938,7 @@ static int cjni_thread_detach(void) /* {{{ */
   cjni_env = pthread_getspecific(jvm_env_key);
   if (cjni_env == NULL) {
     ERROR("java plugin: cjni_thread_detach: pthread_getspecific failed.");
-    return (-1);
+    return -1;
   }
 
   assert(cjni_env->reference_counter > 0);
@@ -1951,7 +1949,7 @@ static int cjni_thread_detach(void) /* {{{ */
         cjni_env->reference_counter);
 
   if (cjni_env->reference_counter > 0)
-    return (0);
+    return 0;
 
   status = (*jvm)->DetachCurrentThread(jvm);
   if (status != 0) {
@@ -1963,7 +1961,7 @@ static int cjni_thread_detach(void) /* {{{ */
   cjni_env->reference_counter = 0;
   cjni_env->jvm_env = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int cjni_thread_detach */
 
 static int cjni_config_add_jvm_arg(oconfig_item_t *ci) /* {{{ */
@@ -1972,7 +1970,7 @@ static int cjni_config_add_jvm_arg(oconfig_item_t *ci) /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("java plugin: `JVMArg' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   if (jvm != NULL) {
@@ -1980,24 +1978,24 @@ static int cjni_config_add_jvm_arg(oconfig_item_t *ci) /* {{{ */
           "`LoadPlugin' options! The JVM is already started and I have to "
           "ignore this argument: %s",
           ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   tmp = realloc(jvm_argv, sizeof(char *) * (jvm_argc + 1));
   if (tmp == NULL) {
     ERROR("java plugin: realloc failed.");
-    return (-1);
+    return -1;
   }
   jvm_argv = tmp;
 
   jvm_argv[jvm_argc] = strdup(ci->values[0].value.string);
   if (jvm_argv[jvm_argc] == NULL) {
     ERROR("java plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
   jvm_argc++;
 
-  return (0);
+  return 0;
 } /* }}} int cjni_config_add_jvm_arg */
 
 static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
@@ -2009,19 +2007,19 @@ static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("java plugin: `LoadPlugin' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   class = realloc(java_classes_list,
                   (java_classes_list_len + 1) * sizeof(*java_classes_list));
   if (class == NULL) {
     ERROR("java plugin: realloc failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
   java_classes_list = class;
   class = java_classes_list + java_classes_list_len;
@@ -2031,7 +2029,7 @@ static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
   if (class->name == NULL) {
     ERROR("java plugin: strdup failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
   class->class = NULL;
   class->object = NULL;
@@ -2052,7 +2050,7 @@ static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
           class->name);
     cjni_thread_detach();
     free(class->name);
-    return (-1);
+    return -1;
   }
 
   constructor_id =
@@ -2063,7 +2061,7 @@ static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
           class->name);
     cjni_thread_detach();
     free(class->name);
-    return (-1);
+    return -1;
   }
 
   tmp_object = (*jvm_env)->NewObject(jvm_env, class->class, constructor_id);
@@ -2077,14 +2075,14 @@ static int cjni_config_load_plugin(oconfig_item_t *ci) /* {{{ */
           class->name);
     cjni_thread_detach();
     free(class->name);
-    return (-1);
+    return -1;
   }
 
   cjni_thread_detach();
 
   java_classes_list_len++;
 
-  return (0);
+  return 0;
 } /* }}} int cjni_config_load_plugin */
 
 static int cjni_config_plugin_block(oconfig_item_t *ci) /* {{{ */
@@ -2100,7 +2098,7 @@ static int cjni_config_plugin_block(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("java plugin: `Plugin' blocks "
             "need exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   name = ci->values[0].value.string;
@@ -2122,20 +2120,20 @@ static int cjni_config_plugin_block(oconfig_item_t *ci) /* {{{ */
            "configuration callback has been registered. Please make sure, the "
            "`LoadPlugin' lines precede the `Plugin' blocks.",
            name);
-    return (0);
+    return 0;
   }
 
   DEBUG("java plugin: Configuring %s", name);
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   o_ocitem = ctoj_oconfig_item(jvm_env, ci);
   if (o_ocitem == NULL) {
     ERROR("java plugin: cjni_config_plugin_block: ctoj_oconfig_item failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   class = (*jvm_env)->GetObjectClass(jvm_env, cbi->object);
@@ -2146,7 +2144,7 @@ static int cjni_config_plugin_block(oconfig_item_t *ci) /* {{{ */
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_ocitem);
   cjni_thread_detach();
-  return (0);
+  return 0;
 } /* }}} int cjni_config_plugin_block */
 
 static int cjni_config_perform(oconfig_item_t *ci) /* {{{ */
@@ -2190,10 +2188,10 @@ static int cjni_config_perform(oconfig_item_t *ci) /* {{{ */
 
   if ((success == 0) && (errors > 0)) {
     ERROR("java plugin: All statements failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cjni_config_perform */
 
 /* Copy the children of `ci' to the global `config_block' variable. */
@@ -2204,17 +2202,17 @@ static int cjni_config_callback(oconfig_item_t *ci) /* {{{ */
 
   assert(ci != NULL);
   if (ci->children_num == 0)
-    return (0); /* nothing to do */
+    return 0; /* nothing to do */
 
   ci_copy = oconfig_clone(ci);
   if (ci_copy == NULL) {
     ERROR("java plugin: oconfig_clone failed.");
-    return (-1);
+    return -1;
   }
 
   if (config_block == NULL) {
     config_block = ci_copy;
-    return (0);
+    return 0;
   }
 
   tmp = realloc(config_block->children,
@@ -2223,7 +2221,7 @@ static int cjni_config_callback(oconfig_item_t *ci) /* {{{ */
   if (tmp == NULL) {
     ERROR("java plugin: realloc failed.");
     oconfig_free(ci_copy);
-    return (-1);
+    return -1;
   }
   config_block->children = tmp;
 
@@ -2239,7 +2237,7 @@ static int cjni_config_callback(oconfig_item_t *ci) /* {{{ */
 
   oconfig_free(ci_copy);
 
-  return (0);
+  return 0;
 } /* }}} int cjni_config_callback */
 
 /* Free the data contained in the `user_data_t' pointer passed to `cjni_read'
@@ -2289,24 +2287,24 @@ static int cjni_read(user_data_t *ud) /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_read: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("java plugin: cjni_read: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cbi = (cjni_callback_info_t *)ud->data;
 
   ret_status = (*jvm_env)->CallIntMethod(jvm_env, cbi->object, cbi->method);
 
   cjni_thread_detach();
-  return (ret_status);
+  return ret_status;
 } /* }}} int cjni_read */
 
 /* Call the CB_TYPE_WRITE callback pointed to by the `user_data_t' pointer. */
@@ -2319,17 +2317,17 @@ static int cjni_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_write: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("java plugin: cjni_write: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cbi = (cjni_callback_info_t *)ud->data;
 
@@ -2337,7 +2335,7 @@ static int cjni_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (vl_java == NULL) {
     ERROR("java plugin: cjni_write: ctoj_value_list failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   ret_status =
@@ -2346,7 +2344,7 @@ static int cjni_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   (*jvm_env)->DeleteLocalRef(jvm_env, vl_java);
 
   cjni_thread_detach();
-  return (ret_status);
+  return ret_status;
 } /* }}} int cjni_write */
 
 /* Call the CB_TYPE_FLUSH callback pointed to by the `user_data_t' pointer. */
@@ -2360,17 +2358,17 @@ static int cjni_flush(cdtime_t timeout, const char *identifier, /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_flush: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("java plugin: cjni_flush: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cbi = (cjni_callback_info_t *)ud->data;
 
@@ -2380,7 +2378,7 @@ static int cjni_flush(cdtime_t timeout, const char *identifier, /* {{{ */
     ERROR("java plugin: cjni_flush: Converting double "
           "to Number object failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   o_identifier = NULL;
@@ -2390,7 +2388,7 @@ static int cjni_flush(cdtime_t timeout, const char *identifier, /* {{{ */
       (*jvm_env)->DeleteLocalRef(jvm_env, o_timeout);
       ERROR("java plugin: cjni_flush: NewStringUTF failed.");
       cjni_thread_detach();
-      return (-1);
+      return -1;
     }
   }
 
@@ -2401,7 +2399,7 @@ static int cjni_flush(cdtime_t timeout, const char *identifier, /* {{{ */
   (*jvm_env)->DeleteLocalRef(jvm_env, o_timeout);
 
   cjni_thread_detach();
-  return (ret_status);
+  return ret_status;
 } /* }}} int cjni_flush */
 
 /* Call the CB_TYPE_LOG callback pointed to by the `user_data_t' pointer. */
@@ -2448,17 +2446,17 @@ static int cjni_notification(const notification_t *n, /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_read: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("java plugin: cjni_read: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cbi = (cjni_callback_info_t *)ud->data;
 
@@ -2466,7 +2464,7 @@ static int cjni_notification(const notification_t *n, /* {{{ */
   if (o_notification == NULL) {
     ERROR("java plugin: cjni_notification: ctoj_notification failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   ret_status = (*jvm_env)->CallIntMethod(jvm_env, cbi->object, cbi->method,
@@ -2475,7 +2473,7 @@ static int cjni_notification(const notification_t *n, /* {{{ */
   (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);
 
   cjni_thread_detach();
-  return (ret_status);
+  return ret_status;
 } /* }}} int cjni_notification */
 
 /* Callbacks for matches implemented in Java */
@@ -2507,12 +2505,12 @@ static int cjni_match_target_create(const oconfig_item_t *ci, /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_read: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   /* Find out whether to create a match or a target. */
   if (strcasecmp("Match", ci->key) == 0)
@@ -2617,7 +2615,7 @@ static int cjni_match_target_create(const oconfig_item_t *ci, /* {{{ */
         cbi_ret->name, (type == CB_TYPE_MATCH) ? "match" : "target");
 
   /* Success! */
-  return (0);
+  return 0;
 #undef BAIL_OUT
 } /* }}} int cjni_match_target_create */
 
@@ -2626,7 +2624,7 @@ static int cjni_match_target_destroy(void **user_data) /* {{{ */
   cjni_callback_info_destroy(*user_data);
   *user_data = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int cjni_match_target_destroy */
 
 static int cjni_match_target_invoke(const data_set_t *ds, /* {{{ */
@@ -2642,12 +2640,12 @@ static int cjni_match_target_invoke(const data_set_t *ds, /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_match_target_invoke: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cbi = (cjni_callback_info_t *)*user_data;
 
@@ -2655,14 +2653,14 @@ static int cjni_match_target_invoke(const data_set_t *ds, /* {{{ */
   if (o_vl == NULL) {
     ERROR("java plugin: cjni_match_target_invoke: ctoj_value_list failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   o_ds = ctoj_data_set(jvm_env, ds);
   if (o_ds == NULL) {
     ERROR("java plugin: cjni_match_target_invoke: ctoj_value_list failed.");
     cjni_thread_detach();
-    return (-1);
+    return -1;
   }
 
   ret_status =
@@ -2693,7 +2691,7 @@ static int cjni_match_target_invoke(const data_set_t *ds, /* {{{ */
   } /* if (cbi->type == CB_TYPE_TARGET) */
 
   cjni_thread_detach();
-  return (ret_status);
+  return ret_status;
 } /* }}} int cjni_match_target_invoke */
 
 /* Iterate over `java_callbacks' and call all CB_TYPE_INIT callbacks. */
@@ -2717,7 +2715,7 @@ static int cjni_init_plugins(JNIEnv *jvm_env) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int cjni_init_plugins */
 
 /* Iterate over `java_callbacks' and call all CB_TYPE_SHUTDOWN callbacks. */
@@ -2739,7 +2737,7 @@ static int cjni_shutdown_plugins(JNIEnv *jvm_env) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int cjni_shutdown_plugins */
 
 static int cjni_shutdown(void) /* {{{ */
@@ -2749,7 +2747,7 @@ static int cjni_shutdown(void) /* {{{ */
   int status;
 
   if (jvm == NULL)
-    return (0);
+    return 0;
 
   jvm_env = NULL;
   args.version = JNI_VERSION_1_2;
@@ -2759,7 +2757,7 @@ static int cjni_shutdown(void) /* {{{ */
     ERROR("java plugin: cjni_shutdown: AttachCurrentThread failed with status "
           "%i.",
           status);
-    return (-1);
+    return -1;
   }
 
   /* Execute all the shutdown functions registered by plugins. */
@@ -2801,7 +2799,7 @@ static int cjni_shutdown(void) /* {{{ */
   jvm_argc = 0;
   sfree(jvm_argv);
 
-  return (0);
+  return 0;
 } /* }}} int cjni_shutdown */
 
 /* Initialization: Create a JVM, load all configured classes and call their
@@ -2813,7 +2811,7 @@ static int cjni_init(void) /* {{{ */
   if ((config_block == NULL) && (jvm == NULL)) {
     ERROR("java plugin: cjni_init: No configuration block for "
           "the java plugin was found.");
-    return (-1);
+    return -1;
   }
 
   if (config_block != NULL) {
@@ -2823,17 +2821,17 @@ static int cjni_init(void) /* {{{ */
 
   if (jvm == NULL) {
     ERROR("java plugin: cjni_init: jvm == NULL");
-    return (-1);
+    return -1;
   }
 
   jvm_env = cjni_thread_attach();
   if (jvm_env == NULL)
-    return (-1);
+    return -1;
 
   cjni_init_plugins(jvm_env);
 
   cjni_thread_detach();
-  return (0);
+  return 0;
 } /* }}} int cjni_init */
 
 void module_register(void) {

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -165,18 +165,18 @@ static char *sstrerror(int errnum, char *buf, size_t buflen) {
 
   buf[buflen - 1] = 0;
 
-  return (buf);
+  return buf;
 } /* char *sstrerror */
 
 static int lcc_set_errno(lcc_connection_t *c, int err) /* {{{ */
 {
   if (c == NULL)
-    return (-1);
+    return -1;
 
   sstrerror(err, c->errbuf, sizeof(c->errbuf));
   c->errbuf[sizeof(c->errbuf) - 1] = 0;
 
-  return (0);
+  return 0;
 } /* }}} int lcc_set_errno */
 
 static char *lcc_strescape(char *dest, const char *src,
@@ -186,7 +186,7 @@ static char *lcc_strescape(char *dest, const char *src,
   size_t src_pos;
 
   if ((dest == NULL) || (src == NULL))
-    return (NULL);
+    return NULL;
 
   dest_pos = 0;
   src_pos = 0;
@@ -223,7 +223,7 @@ static char *lcc_strescape(char *dest, const char *src,
   dest_pos++;
   src_pos++;
 
-  return (dest);
+  return dest;
 } /* }}} char *lcc_strescape */
 
 /* lcc_chomp: Removes all control-characters at the end of a string. */
@@ -260,11 +260,11 @@ static int lcc_send(lcc_connection_t *c, const char *command) /* {{{ */
   status = fprintf(c->fh, "%s\r\n", command);
   if (status < 0) {
     lcc_set_errno(c, errno);
-    return (-1);
+    return -1;
   }
   fflush(c->fh);
 
-  return (0);
+  return 0;
 } /* }}} int lcc_send */
 
 static int lcc_receive(lcc_connection_t *c, /* {{{ */
@@ -278,7 +278,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
   ptr = fgets(buffer, sizeof(buffer), c->fh);
   if (ptr == NULL) {
     lcc_set_errno(c, errno);
-    return (-1);
+    return -1;
   }
   lcc_chomp(buffer);
   lcc_tracef("receive: <-- %s\n", buffer);
@@ -290,7 +290,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
   res.status = (int)strtol(buffer, &ptr, 0);
   if ((errno != 0) || (ptr == &buffer[0])) {
     lcc_set_errno(c, errno);
-    return (-1);
+    return -1;
   }
 
   /* Skip white spaces after the status number */
@@ -304,7 +304,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
   /* Error or no lines follow: We're done. */
   if (res.status <= 0) {
     memcpy(ret_res, &res, sizeof(res));
-    return (0);
+    return 0;
   }
 
   /* Allocate space for the char-pointers */
@@ -313,7 +313,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
   res.lines = malloc(res.lines_num * sizeof(*res.lines));
   if (res.lines == NULL) {
     lcc_set_errno(c, ENOMEM);
-    return (-1);
+    return -1;
   }
 
   /* Now receive all the lines */
@@ -340,11 +340,11 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
       free(res.lines[i]);
     }
     free(res.lines);
-    return (-1);
+    return -1;
   }
 
   memcpy(ret_res, &res, sizeof(res));
-  return (0);
+  return 0;
 } /* }}} int lcc_receive */
 
 static int lcc_sendreceive(lcc_connection_t *c, /* {{{ */
@@ -354,18 +354,18 @@ static int lcc_sendreceive(lcc_connection_t *c, /* {{{ */
 
   if (c->fh == NULL) {
     lcc_set_errno(c, EBADF);
-    return (-1);
+    return -1;
   }
 
   status = lcc_send(c, command);
   if (status != 0)
-    return (status);
+    return status;
 
   status = lcc_receive(c, &res);
   if (status == 0)
     memcpy(ret_res, &res, sizeof(*ret_res));
 
-  return (status);
+  return status;
 } /* }}} int lcc_sendreceive */
 
 static int lcc_open_unixsocket(lcc_connection_t *c, const char *path) /* {{{ */
@@ -383,7 +383,7 @@ static int lcc_open_unixsocket(lcc_connection_t *c, const char *path) /* {{{ */
   fd = socket(AF_UNIX, SOCK_STREAM, /* protocol = */ 0);
   if (fd < 0) {
     lcc_set_errno(c, errno);
-    return (-1);
+    return -1;
   }
 
   sa.sun_family = AF_UNIX;
@@ -393,17 +393,17 @@ static int lcc_open_unixsocket(lcc_connection_t *c, const char *path) /* {{{ */
   if (status != 0) {
     lcc_set_errno(c, errno);
     close(fd);
-    return (-1);
+    return -1;
   }
 
   c->fh = fdopen(fd, "r+");
   if (c->fh == NULL) {
     lcc_set_errno(c, errno);
     close(fd);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int lcc_open_unixsocket */
 
 static int lcc_open_netsocket(lcc_connection_t *c, /* {{{ */
@@ -432,7 +432,7 @@ static int lcc_open_netsocket(lcc_connection_t *c, /* {{{ */
     port = strchr(addr, ']');
     if (port == NULL) {
       LCC_SET_ERRSTR(c, "malformed address: %s", addr_orig);
-      return (-1);
+      return -1;
     }
     *port = 0;
     port++;
@@ -443,7 +443,7 @@ static int lcc_open_netsocket(lcc_connection_t *c, /* {{{ */
       port = NULL;
     else {
       LCC_SET_ERRSTR(c, "garbage after address: %s", port);
-      return (-1);
+      return -1;
     }
   }                                   /* if (*addr = ']') */
   else if (strchr(addr, '.') != NULL) /* Hostname or IPv4 */
@@ -463,7 +463,7 @@ static int lcc_open_netsocket(lcc_connection_t *c, /* {{{ */
                        &ai_res);
   if (status != 0) {
     LCC_SET_ERRSTR(c, "getaddrinfo: %s", gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_res; ai_ptr != NULL;
@@ -495,11 +495,11 @@ static int lcc_open_netsocket(lcc_connection_t *c, /* {{{ */
   if (status != 0) {
     lcc_set_errno(c, status);
     freeaddrinfo(ai_res);
-    return (-1);
+    return -1;
   }
 
   freeaddrinfo(ai_res);
-  return (0);
+  return 0;
 } /* }}} int lcc_open_netsocket */
 
 static int lcc_open_socket(lcc_connection_t *c, const char *addr) /* {{{ */
@@ -507,7 +507,7 @@ static int lcc_open_socket(lcc_connection_t *c, const char *addr) /* {{{ */
   int status = 0;
 
   if (addr == NULL)
-    return (-1);
+    return -1;
 
   assert(c != NULL);
   assert(c->fh == NULL);
@@ -520,7 +520,7 @@ static int lcc_open_socket(lcc_connection_t *c, const char *addr) /* {{{ */
   else
     status = lcc_open_netsocket(c, addr);
 
-  return (status);
+  return status;
 } /* }}} int lcc_open_socket */
 
 /*
@@ -528,17 +528,17 @@ static int lcc_open_socket(lcc_connection_t *c, const char *addr) /* {{{ */
  */
 unsigned int lcc_version(void) /* {{{ */
 {
-  return (LCC_VERSION);
+  return LCC_VERSION;
 } /* }}} unsigned int lcc_version */
 
 const char *lcc_version_string(void) /* {{{ */
 {
-  return (LCC_VERSION_STRING);
+  return LCC_VERSION_STRING;
 } /* }}} const char *lcc_version_string */
 
 const char *lcc_version_extra(void) /* {{{ */
 {
-  return (LCC_VERSION_EXTRA);
+  return LCC_VERSION_EXTRA;
 } /* }}} const char *lcc_version_extra */
 
 int lcc_connect(const char *address, lcc_connection_t **ret_con) /* {{{ */
@@ -547,29 +547,29 @@ int lcc_connect(const char *address, lcc_connection_t **ret_con) /* {{{ */
   int status;
 
   if (address == NULL)
-    return (-1);
+    return -1;
 
   if (ret_con == NULL)
-    return (-1);
+    return -1;
 
   c = calloc(1, sizeof(*c));
   if (c == NULL)
-    return (-1);
+    return -1;
 
   status = lcc_open_socket(c, address);
   if (status != 0) {
     lcc_disconnect(c);
-    return (status);
+    return status;
   }
 
   *ret_con = c;
-  return (0);
+  return 0;
 } /* }}} int lcc_connect */
 
 int lcc_disconnect(lcc_connection_t *c) /* {{{ */
 {
   if (c == NULL)
-    return (-1);
+    return -1;
 
   if (c->fh != NULL) {
     fclose(c->fh);
@@ -577,7 +577,7 @@ int lcc_disconnect(lcc_connection_t *c) /* {{{ */
   }
 
   free(c);
-  return (0);
+  return 0;
 } /* }}} int lcc_disconnect */
 
 int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
@@ -596,17 +596,17 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
   int status;
 
   if (c == NULL)
-    return (-1);
+    return -1;
 
   if (ident == NULL) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   /* Build a commend with an escaped version of the identifier string. */
   status = lcc_identifier_to_string(c, ident_str, sizeof(ident_str), ident);
   if (status != 0)
-    return (status);
+    return status;
 
   snprintf(command, sizeof(command), "GETVAL %s",
            lcc_strescape(ident_esc, ident_str, sizeof(ident_esc)));
@@ -615,12 +615,12 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
   /* Send talk to the daemon.. */
   status = lcc_sendreceive(c, command, &res);
   if (status != 0)
-    return (status);
+    return status;
 
   if (res.status != 0) {
     LCC_SET_ERRSTR(c, "Server error: %s", res.message);
     lcc_response_free(&res);
-    return (-1);
+    return -1;
   }
 
   values_num = res.lines_num;
@@ -636,7 +636,7 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
     }                                                                          \
     free(values_names);                                                        \
     lcc_response_free(&res);                                                   \
-    return (-1);                                                               \
+    return -1;                                                                 \
   } while (0)
 
   /* If neither the values nor the names are requested, return here.. */
@@ -644,7 +644,7 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
     if (ret_values_num != NULL)
       *ret_values_num = values_num;
     lcc_response_free(&res);
-    return (0);
+    return 0;
   }
 
   /* Allocate space for the values */
@@ -698,7 +698,7 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
 
   lcc_response_free(&res);
 
-  return (0);
+  return 0;
 } /* }}} int lcc_getval */
 
 int lcc_putval(lcc_connection_t *c, const lcc_value_list_t *vl) /* {{{ */
@@ -712,13 +712,13 @@ int lcc_putval(lcc_connection_t *c, const lcc_value_list_t *vl) /* {{{ */
   if ((c == NULL) || (vl == NULL) || (vl->values_len < 1) ||
       (vl->values == NULL) || (vl->values_types == NULL)) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   status = lcc_identifier_to_string(c, ident_str, sizeof(ident_str),
                                     &vl->identifier);
   if (status != 0)
-    return (status);
+    return status;
 
   SSTRCATF(command, "PUTVAL %s",
            lcc_strescape(ident_esc, ident_str, sizeof(ident_esc)));
@@ -748,16 +748,16 @@ int lcc_putval(lcc_connection_t *c, const lcc_value_list_t *vl) /* {{{ */
 
   status = lcc_sendreceive(c, command, &res);
   if (status != 0)
-    return (status);
+    return status;
 
   if (res.status != 0) {
     LCC_SET_ERRSTR(c, "Server error: %s", res.message);
     lcc_response_free(&res);
-    return (-1);
+    return -1;
   }
 
   lcc_response_free(&res);
-  return (0);
+  return 0;
 } /* }}} int lcc_putval */
 
 int lcc_flush(lcc_connection_t *c, const char *plugin, /* {{{ */
@@ -768,7 +768,7 @@ int lcc_flush(lcc_connection_t *c, const char *plugin, /* {{{ */
 
   if (c == NULL) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   SSTRCPY(command, "FLUSH");
@@ -788,7 +788,7 @@ int lcc_flush(lcc_connection_t *c, const char *plugin, /* {{{ */
 
     status = lcc_identifier_to_string(c, ident_str, sizeof(ident_str), ident);
     if (status != 0)
-      return (status);
+      return status;
 
     SSTRCATF(command, " identifier=%s",
              lcc_strescape(ident_esc, ident_str, sizeof(ident_esc)));
@@ -796,16 +796,16 @@ int lcc_flush(lcc_connection_t *c, const char *plugin, /* {{{ */
 
   status = lcc_sendreceive(c, command, &res);
   if (status != 0)
-    return (status);
+    return status;
 
   if (res.status != 0) {
     LCC_SET_ERRSTR(c, "Server error: %s", res.message);
     lcc_response_free(&res);
-    return (-1);
+    return -1;
   }
 
   lcc_response_free(&res);
-  return (0);
+  return 0;
 } /* }}} int lcc_flush */
 
 /* TODO: Implement lcc_putnotif */
@@ -819,21 +819,21 @@ int lcc_listval(lcc_connection_t *c, /* {{{ */
   size_t ident_num;
 
   if (c == NULL)
-    return (-1);
+    return -1;
 
   if ((ret_ident == NULL) || (ret_ident_num == NULL)) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   status = lcc_sendreceive(c, "LISTVAL", &res);
   if (status != 0)
-    return (status);
+    return status;
 
   if (res.status != 0) {
     LCC_SET_ERRSTR(c, "Server error: %s", res.message);
     lcc_response_free(&res);
-    return (-1);
+    return -1;
   }
 
   ident_num = res.lines_num;
@@ -841,7 +841,7 @@ int lcc_listval(lcc_connection_t *c, /* {{{ */
   if (ident == NULL) {
     lcc_response_free(&res);
     lcc_set_errno(c, ENOMEM);
-    return (-1);
+    return -1;
   }
 
   for (size_t i = 0; i < res.lines_num; i++) {
@@ -875,20 +875,20 @@ int lcc_listval(lcc_connection_t *c, /* {{{ */
 
   if (status != 0) {
     free(ident);
-    return (-1);
+    return -1;
   }
 
   *ret_ident = ident;
   *ret_ident_num = ident_num;
 
-  return (0);
+  return 0;
 } /* }}} int lcc_listval */
 
 const char *lcc_strerror(lcc_connection_t *c) /* {{{ */
 {
   if (c == NULL)
-    return ("Invalid object");
-  return (c->errbuf);
+    return "Invalid object";
+  return c->errbuf;
 } /* }}} const char *lcc_strerror */
 
 int lcc_identifier_to_string(lcc_connection_t *c, /* {{{ */
@@ -896,7 +896,7 @@ int lcc_identifier_to_string(lcc_connection_t *c, /* {{{ */
                              const lcc_identifier_t *ident) {
   if ((string == NULL) || (string_size < 6) || (ident == NULL)) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   if (ident->plugin_instance[0] == 0) {
@@ -917,7 +917,7 @@ int lcc_identifier_to_string(lcc_connection_t *c, /* {{{ */
   }
 
   string[string_size - 1] = 0;
-  return (0);
+  return 0;
 } /* }}} int lcc_identifier_to_string */
 
 int lcc_string_to_identifier(lcc_connection_t *c, /* {{{ */
@@ -932,7 +932,7 @@ int lcc_string_to_identifier(lcc_connection_t *c, /* {{{ */
   string_copy = strdup(string);
   if (string_copy == NULL) {
     lcc_set_errno(c, ENOMEM);
-    return (-1);
+    return -1;
   }
 
   host = string_copy;
@@ -940,7 +940,7 @@ int lcc_string_to_identifier(lcc_connection_t *c, /* {{{ */
   if (plugin == NULL) {
     LCC_SET_ERRSTR(c, "Malformed identifier string: %s", string);
     free(string_copy);
-    return (-1);
+    return -1;
   }
   *plugin = 0;
   plugin++;
@@ -949,7 +949,7 @@ int lcc_string_to_identifier(lcc_connection_t *c, /* {{{ */
   if (type == NULL) {
     LCC_SET_ERRSTR(c, "Malformed identifier string: %s", string);
     free(string_copy);
-    return (-1);
+    return -1;
   }
   *type = 0;
   type++;
@@ -977,7 +977,7 @@ int lcc_string_to_identifier(lcc_connection_t *c, /* {{{ */
     SSTRCPY(ident->type_instance, type_instance);
 
   free(string_copy);
-  return (0);
+  return 0;
 } /* }}} int lcc_string_to_identifier */
 
 int lcc_identifier_compare(const void *a, /* {{{ */
@@ -987,17 +987,17 @@ int lcc_identifier_compare(const void *a, /* {{{ */
   int status;
 
   if ((i0 == NULL) && (i1 == NULL))
-    return (0);
+    return 0;
   else if (i0 == NULL)
-    return (-1);
+    return -1;
   else if (i1 == NULL)
-    return (1);
+    return 1;
 
 #define CMP_FIELD(f)                                                           \
   do {                                                                         \
     status = strcmp(i0->f, i1->f);                                             \
     if (status != 0)                                                           \
-      return (status);                                                         \
+      return status;                                                           \
   } while (0);
 
   CMP_FIELD(host);
@@ -1008,16 +1008,16 @@ int lcc_identifier_compare(const void *a, /* {{{ */
 
 #undef CMP_FIELD
 
-  return (0);
+  return 0;
 } /* }}} int lcc_identifier_compare */
 
 int lcc_sort_identifiers(lcc_connection_t *c, /* {{{ */
                          lcc_identifier_t *idents, size_t idents_num) {
   if (idents == NULL) {
     lcc_set_errno(c, EINVAL);
-    return (-1);
+    return -1;
   }
 
   qsort(idents, idents_num, sizeof(*idents), lcc_identifier_compare);
-  return (0);
+  return 0;
 } /* }}} int lcc_sort_identifiers */

--- a/src/libcollectdclient/network.c
+++ b/src/libcollectdclient/network.c
@@ -81,10 +81,10 @@ struct lcc_server_s {
 static int server_close_socket(lcc_server_t *srv) /* {{{ */
 {
   if (srv == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (srv->fd < 0)
-    return (0);
+    return 0;
 
   close(srv->fd);
   srv->fd = -1;
@@ -92,7 +92,7 @@ static int server_close_socket(lcc_server_t *srv) /* {{{ */
   srv->sa = NULL;
   srv->sa_len = 0;
 
-  return (0);
+  return 0;
 } /* }}} int server_close_socket */
 
 static void int_server_destroy(lcc_server_t *srv) /* {{{ */
@@ -121,7 +121,7 @@ static int server_open_socket(lcc_server_t *srv) /* {{{ */
   int status;
 
   if (srv == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (srv->fd >= 0)
     server_close_socket(srv);
@@ -132,7 +132,7 @@ static int server_open_socket(lcc_server_t *srv) /* {{{ */
 
   status = getaddrinfo(srv->node, srv->service, &ai_hints, &ai_list);
   if (status != 0)
-    return (status);
+    return status;
   assert(ai_list != NULL);
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -189,8 +189,8 @@ static int server_open_socket(lcc_server_t *srv) /* {{{ */
   freeaddrinfo(ai_list);
 
   if (srv->fd < 0)
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* }}} int server_open_socket */
 
 static int server_send_buffer(lcc_server_t *srv) /* {{{ */
@@ -202,7 +202,7 @@ static int server_send_buffer(lcc_server_t *srv) /* {{{ */
   if (srv->fd < 0) {
     status = server_open_socket(srv);
     if (status != 0)
-      return (status);
+      return status;
   }
 
   buffer_size = sizeof(buffer);
@@ -210,14 +210,14 @@ static int server_send_buffer(lcc_server_t *srv) /* {{{ */
   status = lcc_network_buffer_finalize(srv->buffer);
   if (status != 0) {
     lcc_network_buffer_initialize(srv->buffer);
-    return (status);
+    return status;
   }
 
   status = lcc_network_buffer_get(srv->buffer, buffer, &buffer_size);
   lcc_network_buffer_initialize(srv->buffer);
 
   if (status != 0)
-    return (status);
+    return status;
 
   if (buffer_size > sizeof(buffer))
     buffer_size = sizeof(buffer);
@@ -234,8 +234,8 @@ static int server_send_buffer(lcc_server_t *srv) /* {{{ */
   }
 
   if (status < 0)
-    return (status);
-  return (0);
+    return status;
+  return 0;
 } /* }}} int server_send_buffer */
 
 static int server_value_add(lcc_server_t *srv, /* {{{ */
@@ -244,10 +244,10 @@ static int server_value_add(lcc_server_t *srv, /* {{{ */
 
   status = lcc_network_buffer_add_value(srv->buffer, vl);
   if (status == 0)
-    return (0);
+    return 0;
 
   server_send_buffer(srv);
-  return (lcc_network_buffer_add_value(srv->buffer, vl));
+  return lcc_network_buffer_add_value(srv->buffer, vl);
 } /* }}} int server_value_add */
 
 /*
@@ -259,11 +259,11 @@ lcc_network_t *lcc_network_create(void) /* {{{ */
 
   net = calloc(1, sizeof(*net));
   if (net == NULL)
-    return (NULL);
+    return NULL;
 
   net->servers = NULL;
 
-  return (net);
+  return net;
 } /* }}} lcc_network_t *lcc_network_create */
 
 void lcc_network_destroy(lcc_network_t *net) /* {{{ */
@@ -279,13 +279,13 @@ lcc_server_t *lcc_server_create(lcc_network_t *net, /* {{{ */
   lcc_server_t *srv;
 
   if ((net == NULL) || (node == NULL))
-    return (NULL);
+    return NULL;
   if (service == NULL)
     service = NET_DEFAULT_PORT;
 
   srv = calloc(1, sizeof(*srv));
   if (srv == NULL)
-    return (NULL);
+    return NULL;
 
   srv->fd = -1;
   srv->security_level = NONE;
@@ -296,14 +296,14 @@ lcc_server_t *lcc_server_create(lcc_network_t *net, /* {{{ */
   srv->node = strdup(node);
   if (srv->node == NULL) {
     free(srv);
-    return (NULL);
+    return NULL;
   }
 
   srv->service = strdup(service);
   if (srv->service == NULL) {
     free(srv->node);
     free(srv);
-    return (NULL);
+    return NULL;
   }
 
   srv->buffer = lcc_network_buffer_create(/* size = */ 0);
@@ -311,7 +311,7 @@ lcc_server_t *lcc_server_create(lcc_network_t *net, /* {{{ */
     free(srv->service);
     free(srv->node);
     free(srv);
-    return (NULL);
+    return NULL;
   }
 
   if (net->servers == NULL) {
@@ -325,13 +325,13 @@ lcc_server_t *lcc_server_create(lcc_network_t *net, /* {{{ */
     last->next = srv;
   }
 
-  return (srv);
+  return srv;
 } /* }}} lcc_server_t *lcc_server_create */
 
 int lcc_server_destroy(lcc_network_t *net, lcc_server_t *srv) /* {{{ */
 {
   if ((net == NULL) || (srv == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (net->servers == srv) {
     net->servers = srv->next;
@@ -343,7 +343,7 @@ int lcc_server_destroy(lcc_network_t *net, lcc_server_t *srv) /* {{{ */
       prev = prev->next;
 
     if (prev == NULL)
-      return (ENOENT);
+      return ENOENT;
 
     prev->next = srv->next;
     srv->next = NULL;
@@ -351,17 +351,17 @@ int lcc_server_destroy(lcc_network_t *net, lcc_server_t *srv) /* {{{ */
 
   int_server_destroy(srv);
 
-  return (0);
+  return 0;
 } /* }}} int lcc_server_destroy */
 
 int lcc_server_set_ttl(lcc_server_t *srv, uint8_t ttl) /* {{{ */
 {
   if (srv == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   srv->ttl = (int)ttl;
 
-  return (0);
+  return 0;
 } /* }}} int lcc_server_set_ttl */
 
 int lcc_server_set_interface(lcc_server_t *srv, char const *interface) /* {{{ */
@@ -370,11 +370,11 @@ int lcc_server_set_interface(lcc_server_t *srv, char const *interface) /* {{{ */
   int status;
 
   if ((srv == NULL) || (interface == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if_index = if_nametoindex(interface);
   if (if_index == 0)
-    return (ENOENT);
+    return ENOENT;
 
   /* IPv4 multicast */
   if (srv->sa->sa_family == AF_INET) {
@@ -398,9 +398,9 @@ int lcc_server_set_interface(lcc_server_t *srv, char const *interface) /* {{{ */
       status =
           setsockopt(srv->fd, IPPROTO_IP, IP_MULTICAST_IF, &mreq, sizeof(mreq));
       if (status != 0)
-        return (status);
+        return status;
 
-      return (0);
+      return 0;
     }
   }
 
@@ -412,9 +412,9 @@ int lcc_server_set_interface(lcc_server_t *srv, char const *interface) /* {{{ */
       status = setsockopt(srv->fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &if_index,
                           sizeof(if_index));
       if (status != 0)
-        return (status);
+        return status;
 
-      return (0);
+      return 0;
     }
   }
 
@@ -423,26 +423,26 @@ int lcc_server_set_interface(lcc_server_t *srv, char const *interface) /* {{{ */
   status = setsockopt(srv->fd, SOL_SOCKET, SO_BINDTODEVICE, interface,
                       (socklen_t)(strlen(interface) + 1));
   if (status != 0)
-    return (-1);
+    return -1;
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int lcc_server_set_interface */
 
 int lcc_server_set_security_level(lcc_server_t *srv, /* {{{ */
                                   lcc_security_level_t level,
                                   const char *username, const char *password) {
-  return (lcc_network_buffer_set_security_level(srv->buffer, level, username,
-                                                password));
+  return lcc_network_buffer_set_security_level(srv->buffer, level, username,
+                                               password);
 } /* }}} int lcc_server_set_security_level */
 
 int lcc_network_values_send(lcc_network_t *net, /* {{{ */
                             const lcc_value_list_t *vl) {
   if ((net == NULL) || (vl == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   for (lcc_server_t *srv = net->servers; srv != NULL; srv = srv->next)
     server_value_add(srv, vl);
 
-  return (0);
+  return 0;
 } /* }}} int lcc_network_values_send */

--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -128,27 +128,27 @@ static _Bool have_gcrypt(void) /* {{{ */
   static _Bool need_init = 1;
 
   if (!need_init)
-    return (result);
+    return result;
   need_init = 0;
 
 #if HAVE_GCRYPT_H
 #if GCRYPT_VERSION_NUMBER < 0x010600
   if (gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread))
-    return (0);
+    return 0;
 #endif
 
   if (!gcry_check_version(GCRYPT_VERSION))
-    return (0);
+    return 0;
 
   if (!gcry_control(GCRYCTL_INIT_SECMEM, 32768, 0))
-    return (0);
+    return 0;
 
   gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
 
   result = 1;
-  return (1);
+  return 1;
 #else
-  return (0);
+  return 0;
 #endif
 } /* }}} _Bool have_gcrypt */
 
@@ -171,7 +171,7 @@ static uint64_t htonll(uint64_t val) /* {{{ */
   }
 
   if (config == 1)
-    return (val);
+    return val;
 
   hi = (uint32_t)(val >> 32);
   lo = (uint32_t)(val & 0x00000000FFFFFFFF);
@@ -179,7 +179,7 @@ static uint64_t htonll(uint64_t val) /* {{{ */
   hi = htonl(hi);
   lo = htonl(lo);
 
-  return ((((uint64_t)lo) << 32) | ((uint64_t)hi));
+  return (((uint64_t)lo) << 32) | ((uint64_t)hi);
 } /* }}} uint64_t htonll */
 #endif
 
@@ -222,9 +222,9 @@ static double htond(double val) /* {{{ */
     out.byte[4] = out.byte[5] = 0x00;
     out.byte[6] = 0xf8;
     out.byte[7] = 0x7f;
-    return (out.floating);
+    return out.floating;
   } else if (config == 1)
-    return (val);
+    return val;
   else if (config == 2) {
     in.floating = val;
     out.byte[0] = in.byte[7];
@@ -235,7 +235,7 @@ static double htond(double val) /* {{{ */
     out.byte[5] = in.byte[2];
     out.byte[6] = in.byte[1];
     out.byte[7] = in.byte[0];
-    return (out.floating);
+    return out.floating;
   } else if (config == 3) {
     in.floating = val;
     out.byte[0] = in.byte[4];
@@ -246,10 +246,10 @@ static double htond(double val) /* {{{ */
     out.byte[5] = in.byte[1];
     out.byte[6] = in.byte[2];
     out.byte[7] = in.byte[3];
-    return (out.floating);
+    return out.floating;
   } else {
     /* If in doubt, just copy the value back to the caller. */
-    return (val);
+    return val;
   }
 } /* }}} double htond */
 
@@ -270,7 +270,7 @@ static int nb_add_values(char **ret_buffer, /* {{{ */
                sizeof(pkg_values_types) + sizeof(pkg_values);
 
   if (*ret_buffer_len < packet_len)
-    return (ENOMEM);
+    return ENOMEM;
 
   pkg_type = htons(TYPE_VALUES);
   pkg_length = htons((uint16_t)packet_len);
@@ -296,7 +296,7 @@ static int nb_add_values(char **ret_buffer, /* {{{ */
       break;
 
     default:
-      return (EINVAL);
+      return EINVAL;
     } /* switch (vl->values_types[i]) */
   }   /* for (vl->values_len) */
 
@@ -322,7 +322,7 @@ static int nb_add_values(char **ret_buffer, /* {{{ */
 
   *ret_buffer = packet_ptr + packet_len;
   *ret_buffer_len -= packet_len;
-  return (0);
+  return 0;
 } /* }}} int nb_add_values */
 
 static int nb_add_number(char **ret_buffer, /* {{{ */
@@ -340,7 +340,7 @@ static int nb_add_number(char **ret_buffer, /* {{{ */
   packet_len = sizeof(pkg_type) + sizeof(pkg_length) + sizeof(pkg_value);
 
   if (*ret_buffer_len < packet_len)
-    return (ENOMEM);
+    return ENOMEM;
 
   pkg_type = htons(type);
   pkg_length = htons((uint16_t)packet_len);
@@ -359,14 +359,14 @@ static int nb_add_number(char **ret_buffer, /* {{{ */
 
   *ret_buffer = packet_ptr + packet_len;
   *ret_buffer_len -= packet_len;
-  return (0);
+  return 0;
 } /* }}} int nb_add_number */
 
 static int nb_add_time(char **ret_buffer, /* {{{ */
                        size_t *ret_buffer_len, uint16_t type, double value) {
   /* Convert to collectd's "cdtime" representation. */
   uint64_t cdtime_value = (uint64_t)(value * 1073741824.0);
-  return (nb_add_number(ret_buffer, ret_buffer_len, type, cdtime_value));
+  return nb_add_number(ret_buffer, ret_buffer_len, type, cdtime_value);
 } /* }}} int nb_add_time */
 
 static int nb_add_string(char **ret_buffer, /* {{{ */
@@ -382,7 +382,7 @@ static int nb_add_string(char **ret_buffer, /* {{{ */
 
   packet_len = sizeof(pkg_type) + sizeof(pkg_length) + str_len + 1;
   if (*ret_buffer_len < packet_len)
-    return (ENOMEM);
+    return ENOMEM;
 
   pkg_type = htons(type);
   pkg_length = htons((uint16_t)packet_len);
@@ -402,7 +402,7 @@ static int nb_add_string(char **ret_buffer, /* {{{ */
 
   *ret_buffer = packet_ptr + packet_len;
   *ret_buffer_len -= packet_len;
-  return (0);
+  return 0;
 } /* }}} int nb_add_string */
 
 static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
@@ -419,14 +419,14 @@ static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
   if (strcmp(ident_dst->host, ident_src->host) != 0) {
     if (nb_add_string(&buffer, &buffer_size, TYPE_HOST, ident_src->host,
                       strlen(ident_src->host)) != 0)
-      return (-1);
+      return -1;
     SSTRNCPY(ident_dst->host, ident_src->host, sizeof(ident_dst->host));
   }
 
   if (strcmp(ident_dst->plugin, ident_src->plugin) != 0) {
     if (nb_add_string(&buffer, &buffer_size, TYPE_PLUGIN, ident_src->plugin,
                       strlen(ident_src->plugin)) != 0)
-      return (-1);
+      return -1;
     SSTRNCPY(ident_dst->plugin, ident_src->plugin, sizeof(ident_dst->plugin));
   }
 
@@ -434,7 +434,7 @@ static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
     if (nb_add_string(&buffer, &buffer_size, TYPE_PLUGIN_INSTANCE,
                       ident_src->plugin_instance,
                       strlen(ident_src->plugin_instance)) != 0)
-      return (-1);
+      return -1;
     SSTRNCPY(ident_dst->plugin_instance, ident_src->plugin_instance,
              sizeof(ident_dst->plugin_instance));
   }
@@ -442,7 +442,7 @@ static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
   if (strcmp(ident_dst->type, ident_src->type) != 0) {
     if (nb_add_string(&buffer, &buffer_size, TYPE_TYPE, ident_src->type,
                       strlen(ident_src->type)) != 0)
-      return (-1);
+      return -1;
     SSTRNCPY(ident_dst->type, ident_src->type, sizeof(ident_dst->type));
   }
 
@@ -450,29 +450,29 @@ static int nb_add_value_list(lcc_network_buffer_t *nb, /* {{{ */
     if (nb_add_string(&buffer, &buffer_size, TYPE_TYPE_INSTANCE,
                       ident_src->type_instance,
                       strlen(ident_src->type_instance)) != 0)
-      return (-1);
+      return -1;
     SSTRNCPY(ident_dst->type_instance, ident_src->type_instance,
              sizeof(ident_dst->type_instance));
   }
 
   if (nb->state.time != vl->time) {
     if (nb_add_time(&buffer, &buffer_size, TYPE_TIME_HR, vl->time))
-      return (-1);
+      return -1;
     nb->state.time = vl->time;
   }
 
   if (nb->state.interval != vl->interval) {
     if (nb_add_time(&buffer, &buffer_size, TYPE_INTERVAL_HR, vl->interval))
-      return (-1);
+      return -1;
     nb->state.interval = vl->interval;
   }
 
   if (nb_add_values(&buffer, &buffer_size, vl) != 0)
-    return (-1);
+    return -1;
 
   nb->ptr = buffer;
   nb->free = buffer_size;
-  return (0);
+  return 0;
 } /* }}} int nb_add_value_list */
 
 #if HAVE_GCRYPT_H
@@ -497,27 +497,27 @@ static int nb_add_signature(lcc_network_buffer_t *nb) /* {{{ */
   hd = NULL;
   err = gcry_md_open(&hd, GCRY_MD_SHA256, GCRY_MD_FLAG_HMAC);
   if (err != 0)
-    return (-1);
+    return -1;
 
   assert(nb->password != NULL);
   err = gcry_md_setkey(hd, nb->password, strlen(nb->password));
   if (err != 0) {
     gcry_md_close(hd);
-    return (-1);
+    return -1;
   }
 
   gcry_md_write(hd, buffer, buffer_size);
   hash = gcry_md_read(hd, GCRY_MD_SHA256);
   if (hash == NULL) {
     gcry_md_close(hd);
-    return (-1);
+    return -1;
   }
 
   assert(((2 * sizeof(uint16_t)) + hash_length) == PART_SIGNATURE_SHA256_SIZE);
   memcpy(nb->buffer + (2 * sizeof(uint16_t)), hash, hash_length);
 
   gcry_md_close(hd);
-  return (0);
+  return 0;
 } /* }}} int nb_add_signature */
 
 static int nb_add_encryption(lcc_network_buffer_t *nb) /* {{{ */
@@ -556,7 +556,7 @@ static int nb_add_encryption(lcc_network_buffer_t *nb) /* {{{ */
     err = gcry_cipher_open(&nb->encr_cypher, GCRY_CIPHER_AES256,
                            GCRY_CIPHER_MODE_OFB, /* flags = */ 0);
     if (err != 0)
-      return (-1);
+      return -1;
 
     /* Calculate our 256bit key used for AES */
     gcry_md_hash_buffer(GCRY_MD_SHA256, password_hash, nb->password,
@@ -567,7 +567,7 @@ static int nb_add_encryption(lcc_network_buffer_t *nb) /* {{{ */
     if (err != 0) {
       gcry_cipher_close(nb->encr_cypher);
       nb->encr_cypher = NULL;
-      return (-1);
+      return -1;
     }
   } else /* if (nb->encr_cypher != NULL) */
   {
@@ -579,7 +579,7 @@ static int nb_add_encryption(lcc_network_buffer_t *nb) /* {{{ */
   if (err != 0) {
     gcry_cipher_close(nb->encr_cypher);
     nb->encr_cypher = NULL;
-    return (-1);
+    return -1;
   }
 
   /* Encrypt the buffer in-place */
@@ -588,10 +588,10 @@ static int nb_add_encryption(lcc_network_buffer_t *nb) /* {{{ */
   if (err != 0) {
     gcry_cipher_close(nb->encr_cypher);
     nb->encr_cypher = NULL;
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int nb_add_encryption */
 #endif
 
@@ -607,18 +607,18 @@ lcc_network_buffer_t *lcc_network_buffer_create(size_t size) /* {{{ */
 
   if (size < 128) {
     errno = EINVAL;
-    return (NULL);
+    return NULL;
   }
 
   nb = calloc(1, sizeof(*nb));
   if (nb == NULL)
-    return (NULL);
+    return NULL;
 
   nb->size = size;
   nb->buffer = calloc(1, nb->size);
   if (nb->buffer == NULL) {
     free(nb);
-    return (NULL);
+    return NULL;
   }
 
   nb->ptr = nb->buffer;
@@ -628,7 +628,7 @@ lcc_network_buffer_t *lcc_network_buffer_create(size_t size) /* {{{ */
   nb->username = NULL;
   nb->password = NULL;
 
-  return (nb);
+  return nb;
 } /* }}} lcc_network_buffer_t *lcc_network_buffer_create */
 
 void lcc_network_buffer_destroy(lcc_network_buffer_t *nb) /* {{{ */
@@ -654,18 +654,18 @@ int lcc_network_buffer_set_security_level(lcc_network_buffer_t *nb, /* {{{ */
     nb->password = NULL;
     nb->seclevel = NONE;
     lcc_network_buffer_initialize(nb);
-    return (0);
+    return 0;
   }
 
   if (!have_gcrypt())
-    return (ENOTSUP);
+    return ENOTSUP;
 
   username_copy = strdup(username);
   password_copy = strdup(password);
   if ((username_copy == NULL) || (password_copy == NULL)) {
     free(username_copy);
     free(password_copy);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   free(nb->username);
@@ -675,13 +675,13 @@ int lcc_network_buffer_set_security_level(lcc_network_buffer_t *nb, /* {{{ */
   nb->seclevel = level;
 
   lcc_network_buffer_initialize(nb);
-  return (0);
+  return 0;
 } /* }}} int lcc_network_buffer_set_security_level */
 
 int lcc_network_buffer_initialize(lcc_network_buffer_t *nb) /* {{{ */
 {
   if (nb == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   memset(nb->buffer, 0, nb->size);
   memset(&nb->state, 0, sizeof(nb->state));
@@ -731,13 +731,13 @@ int lcc_network_buffer_initialize(lcc_network_buffer_t *nb) /* {{{ */
   }
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int lcc_network_buffer_initialize */
 
 int lcc_network_buffer_finalize(lcc_network_buffer_t *nb) /* {{{ */
 {
   if (nb == NULL)
-    return (EINVAL);
+    return EINVAL;
 
 #if HAVE_GCRYPT_H
   if (nb->seclevel == SIGN)
@@ -746,7 +746,7 @@ int lcc_network_buffer_finalize(lcc_network_buffer_t *nb) /* {{{ */
     return nb_add_encryption(nb);
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int lcc_network_buffer_finalize */
 
 int lcc_network_buffer_add_value(lcc_network_buffer_t *nb, /* {{{ */
@@ -754,10 +754,10 @@ int lcc_network_buffer_add_value(lcc_network_buffer_t *nb, /* {{{ */
   int status;
 
   if ((nb == NULL) || (vl == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   status = nb_add_value_list(nb, vl);
-  return (status);
+  return status;
 } /* }}} int lcc_network_buffer_add_value */
 
 int lcc_network_buffer_get(lcc_network_buffer_t *nb, /* {{{ */
@@ -766,7 +766,7 @@ int lcc_network_buffer_get(lcc_network_buffer_t *nb, /* {{{ */
   size_t sz_available;
 
   if ((nb == NULL) || (buffer_size == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   assert(nb->size >= nb->free);
   sz_required = nb->size - nb->free;
@@ -777,5 +777,5 @@ int lcc_network_buffer_get(lcc_network_buffer_t *nb, /* {{{ */
     memcpy(buffer, nb->buffer,
            (sz_available < sz_required) ? sz_available : sz_required);
 
-  return (0);
+  return 0;
 } /* }}} int lcc_network_buffer_get */

--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -62,7 +62,7 @@ static oconfig_item_t *oconfig_parse_fh(FILE *fh) {
   status = yyparse();
   if (status != 0) {
     fprintf(stderr, "yyparse returned error #%i\n", status);
-    return (NULL);
+    return NULL;
   }
 
   c_file = NULL;
@@ -71,7 +71,7 @@ static oconfig_item_t *oconfig_parse_fh(FILE *fh) {
   ci_root = NULL;
   yyset_in((FILE *)0);
 
-  return (ret);
+  return ret;
 } /* oconfig_item_t *oconfig_parse_fh */
 
 oconfig_item_t *oconfig_parse_file(const char *file) {
@@ -83,7 +83,7 @@ oconfig_item_t *oconfig_parse_file(const char *file) {
   fh = fopen(file, "r");
   if (fh == NULL) {
     fprintf(stderr, "fopen (%s) failed: %s\n", file, strerror(errno));
-    return (NULL);
+    return NULL;
   }
 
   ret = oconfig_parse_fh(fh);
@@ -91,7 +91,7 @@ oconfig_item_t *oconfig_parse_file(const char *file) {
 
   c_file = NULL;
 
-  return (ret);
+  return ret;
 } /* oconfig_item_t *oconfig_parse_file */
 
 oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
@@ -100,7 +100,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
   ci_copy = calloc(1, sizeof(*ci_copy));
   if (ci_copy == NULL) {
     fprintf(stderr, "calloc failed.\n");
-    return (NULL);
+    return NULL;
   }
   ci_copy->values = NULL;
   ci_copy->parent = NULL;
@@ -110,7 +110,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
   if (ci_copy->key == NULL) {
     fprintf(stderr, "strdup failed.\n");
     free(ci_copy);
-    return (NULL);
+    return NULL;
   }
 
   if (ci_orig->values_num > 0) /* {{{ */
@@ -121,7 +121,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
       fprintf(stderr, "calloc failed.\n");
       free(ci_copy->key);
       free(ci_copy);
-      return (NULL);
+      return NULL;
     }
     ci_copy->values_num = ci_orig->values_num;
 
@@ -133,7 +133,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
         if (ci_copy->values[i].value.string == NULL) {
           fprintf(stderr, "strdup failed.\n");
           oconfig_free(ci_copy);
-          return (NULL);
+          return NULL;
         }
       } else /* ci_copy->values[i].type != OCONFIG_TYPE_STRING) */
       {
@@ -149,7 +149,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
     if (ci_copy->children == NULL) {
       fprintf(stderr, "calloc failed.\n");
       oconfig_free(ci_copy);
-      return (NULL);
+      return NULL;
     }
     ci_copy->children_num = ci_orig->children_num;
 
@@ -159,7 +159,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
       child = oconfig_clone(ci_orig->children + i);
       if (child == NULL) {
         oconfig_free(ci_copy);
-        return (NULL);
+        return NULL;
       }
       child->parent = ci_copy;
       ci_copy->children[i] = *child;
@@ -167,7 +167,7 @@ oconfig_item_t *oconfig_clone(const oconfig_item_t *ci_orig) {
     } /* for (i = 0; i < ci_copy->children_num; i++) */
   }   /* }}} if (ci_orig->children_num > 0) */
 
-  return (ci_copy);
+  return ci_copy;
 } /* oconfig_item_t *oconfig_clone */
 
 static void oconfig_free_all(oconfig_item_t *ci) {

--- a/src/load.c
+++ b/src/load.c
@@ -69,7 +69,7 @@ static int load_config(const char *key, const char *value) {
             "is not available, because I can't determine the "
             "number of CPUS on this system. Sorry.");
 #endif
-  return (-1);
+  return -1;
 }
 static void load_submit(gauge_t snum, gauge_t mnum, gauge_t lnum) {
   int cores = 0;
@@ -131,14 +131,14 @@ static int load_read(void) {
   if ((loadavg = fopen("/proc/loadavg", "r")) == NULL) {
     char errbuf[1024];
     WARNING("load: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (fgets(buffer, 16, loadavg) == NULL) {
     char errbuf[1024];
     WARNING("load: fgets: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
     fclose(loadavg);
-    return (-1);
+    return -1;
   }
 
   if (fclose(loadavg)) {
@@ -149,7 +149,7 @@ static int load_read(void) {
   numfields = strsplit(buffer, fields, 8);
 
   if (numfields < 3)
-    return (-1);
+    return -1;
 
   snum = atof(fields[0]);
   mnum = atof(fields[1]);
@@ -180,7 +180,7 @@ static int load_read(void) {
     char errbuf[1024];
     WARNING("load: perfstat_cpu : %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   snum = (float)cputotal.loadavg[0] / (float)(1 << SBITS);
@@ -193,7 +193,7 @@ static int load_read(void) {
 #error "No applicable input method."
 #endif
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/log_logstash.c
+++ b/src/log_logstash.c
@@ -236,7 +236,7 @@ static int log_logstash_notification(const notification_t *n,
 
   if (g == NULL) {
     fprintf(stderr, "Could not allocate JSON generator.\n");
-    return (0);
+    return 0;
   }
 
   if (yajl_gen_map_open(g) != yajl_gen_status_ok)
@@ -323,12 +323,12 @@ static int log_logstash_notification(const notification_t *n,
   }
 
   log_logstash_print(g, LOG_INFO, (n->time != 0) ? n->time : cdtime());
-  return (0);
+  return 0;
 
 err:
   yajl_gen_free(g);
   fprintf(stderr, "Could not correctly generate JSON notification\n");
-  return (0);
+  return 0;
 } /* int log_logstash_notification */
 
 void module_register(void) {

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -53,7 +53,7 @@ static int logfile_config(const char *key, const char *value) {
     if (log_level < 0) {
       log_level = LOG_INFO;
       ERROR("logfile: invalid loglevel [%s] defaulting to 'info'", value);
-      return (1);
+      return 1;
     }
   } else if (0 == strcasecmp(key, "File")) {
     sfree(log_file);
@@ -194,7 +194,7 @@ static int logfile_notification(const notification_t *n,
 
   logfile_print(buf, LOG_INFO, (n->time != 0) ? n->time : cdtime());
 
-  return (0);
+  return 0;
 } /* int logfile_notification */
 
 void module_register(void) {

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -61,10 +61,10 @@ static int lpar_config(const char *key, const char *value) {
     else
       report_by_serial = 0;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int lpar_config */
 
 static int lpar_init(void) {
@@ -79,7 +79,7 @@ static int lpar_init(void) {
     char errbuf[1024];
     ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)",
           sstrerror(errno, errbuf, sizeof(errbuf)), status);
-    return (-1);
+    return -1;
   }
 
 #if PERFSTAT_SUPPORTS_DONATION
@@ -95,7 +95,7 @@ static int lpar_init(void) {
     pool_stats = 0;
   }
 
-  return (0);
+  return 0;
 } /* int lpar_init */
 
 static void lpar_submit(const char *type_instance, double value) {
@@ -128,7 +128,7 @@ static int lpar_read(void) {
      from chassis to chassis through Live Partition Mobility (LPM). */
   if (uname(&name) != 0) {
     ERROR("lpar plugin: uname failed.");
-    return (-1);
+    return -1;
   }
   sstrncpy(serial, name.machine, sizeof(serial));
 
@@ -141,7 +141,7 @@ static int lpar_read(void) {
     char errbuf[1024];
     ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)",
           sstrerror(errno, errbuf, sizeof(errbuf)), status);
-    return (-1);
+    return -1;
   }
 
   /* Number of ticks since we last run. */
@@ -149,7 +149,7 @@ static int lpar_read(void) {
   if (ticks == 0) {
     /* The stats have not been updated. Return now to avoid
      * dividing by zero */
-    return (0);
+    return 0;
   }
 
   /*
@@ -235,7 +235,7 @@ static int lpar_read(void) {
 
   memcpy(&lparstats_old, &lparstats, sizeof(lparstats_old));
 
-  return (0);
+  return 0;
 } /* int lpar_read */
 
 void module_register(void) {

--- a/src/lua.c
+++ b/src/lua.c
@@ -79,10 +79,10 @@ static int clua_load_callback(lua_State *L, int callback_ref) /* {{{ */
 
   if (!lua_isfunction(L, -1)) {
     lua_pop(L, 1);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int clua_load_callback */
 
 /* Store the threads in a global variable so they are not cleaned up by the
@@ -96,12 +96,12 @@ static int clua_store_thread(lua_State *L, int idx) /* {{{ */
   lua_pushvalue(L, idx); /* +1 = 3 */
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 3); /* -3 = 0 */
-    return (-1);
+    return -1;
   }
 
   luaL_ref(L, LUA_REGISTRYINDEX);
   lua_pop(L, 1); /* -1 = 0 */
-  return (0);
+  return 0;
 } /* }}} int clua_store_thread */
 
 static int clua_read(user_data_t *ud) /* {{{ */
@@ -117,7 +117,7 @@ static int clua_read(user_data_t *ud) /* {{{ */
     ERROR("Lua plugin: Unable to load callback \"%s\" (id %i).",
           cb->lua_function_name, cb->callback_id);
     pthread_mutex_unlock(&cb->lock);
-    return (-1);
+    return -1;
   }
   /* +1 = 1 */
 
@@ -131,7 +131,7 @@ static int clua_read(user_data_t *ud) /* {{{ */
       ERROR("Lua plugin: Calling a read callback failed: %s", errmsg);
     lua_pop(L, 1);
     pthread_mutex_unlock(&cb->lock);
-    return (-1);
+    return -1;
   }
 
   if (!lua_isnumber(L, -1)) {
@@ -147,7 +147,7 @@ static int clua_read(user_data_t *ud) /* {{{ */
   lua_pop(L, 1); /* -1 = 0 */
 
   pthread_mutex_unlock(&cb->lock);
-  return (status);
+  return status;
 } /* }}} int clua_read */
 
 static int clua_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
@@ -163,7 +163,7 @@ static int clua_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     ERROR("Lua plugin: Unable to load callback \"%s\" (id %i).",
           cb->lua_function_name, cb->callback_id);
     pthread_mutex_unlock(&cb->lock);
-    return (-1);
+    return -1;
   }
   /* +1 = 1 */
 
@@ -172,7 +172,7 @@ static int clua_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     lua_pop(L, 1); /* -1 = 0 */
     pthread_mutex_unlock(&cb->lock);
     ERROR("Lua plugin: luaC_pushvaluelist failed.");
-    return (-1);
+    return -1;
   }
   /* +1 = 2 */
 
@@ -186,7 +186,7 @@ static int clua_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
       ERROR("Lua plugin: Calling the write callback failed:\n%s", errmsg);
     lua_pop(L, 1); /* -1 = 0 */
     pthread_mutex_unlock(&cb->lock);
-    return (-1);
+    return -1;
   }
 
   if (!lua_isnumber(L, -1)) {
@@ -200,7 +200,7 @@ static int clua_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
 
   lua_pop(L, 1); /* -1 = 0 */
   pthread_mutex_unlock(&cb->lock);
-  return (status);
+  return status;
 } /* }}} int clua_write */
 
 /*
@@ -404,7 +404,7 @@ static int lua_script_init(lua_script_t *script) /* {{{ */
   script->lua_state = luaL_newstate();
   if (script->lua_state == NULL) {
     ERROR("Lua plugin: luaL_newstate() failed.");
-    return (-1);
+    return -1;
   }
 
   /* Open up all the standard Lua libraries. */
@@ -437,7 +437,7 @@ static int lua_script_init(lua_script_t *script) /* {{{ */
     lua_pop(script->lua_state, 1);
   }
 
-  return (0);
+  return 0;
 } /* }}} int lua_script_init */
 
 static int lua_script_load(const char *script_path) /* {{{ */
@@ -445,20 +445,20 @@ static int lua_script_load(const char *script_path) /* {{{ */
   lua_script_t *script = malloc(sizeof(*script));
   if (script == NULL) {
     ERROR("Lua plugin: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   int status = lua_script_init(script);
   if (status != 0) {
     lua_script_free(script);
-    return (status);
+    return status;
   }
 
   script->script_path = strdup(script_path);
   if (script->script_path == NULL) {
     ERROR("Lua plugin: strdup failed.");
     lua_script_free(script);
-    return (-1);
+    return -1;
   }
 
   status = luaL_loadfile(script->lua_state, script->script_path);
@@ -467,7 +467,7 @@ static int lua_script_load(const char *script_path) /* {{{ */
           lua_tostring(script->lua_state, -1));
     lua_pop(script->lua_state, 1);
     lua_script_free(script);
-    return (-1);
+    return -1;
   }
 
   status = lua_pcall(script->lua_state,
@@ -486,7 +486,7 @@ static int lua_script_load(const char *script_path) /* {{{ */
             script->script_path, errmsg);
 
     lua_script_free(script);
-    return (-1);
+    return -1;
   }
 
   /* Append this script to the global list of scripts. */
@@ -500,14 +500,14 @@ static int lua_script_load(const char *script_path) /* {{{ */
     scripts = script;
   }
 
-  return (0);
+  return 0;
 } /* }}} int lua_script_load */
 
 static int lua_config_base_path(const oconfig_item_t *ci) /* {{{ */
 {
   int status = cf_util_get_string_buffer(ci, base_path, sizeof(base_path));
   if (status != 0)
-    return (status);
+    return status;
 
   size_t len = strlen(base_path);
   while ((len > 0) && (base_path[len - 1] == '/')) {
@@ -517,7 +517,7 @@ static int lua_config_base_path(const oconfig_item_t *ci) /* {{{ */
 
   DEBUG("Lua plugin: base_path = \"%s\";", base_path);
 
-  return (0);
+  return 0;
 } /* }}} int lua_config_base_path */
 
 static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
@@ -526,7 +526,7 @@ static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
 
   int status = cf_util_get_string_buffer(ci, rel_path, sizeof(rel_path));
   if (status != 0)
-    return (status);
+    return status;
 
   char abs_path[PATH_MAX];
 
@@ -539,7 +539,7 @@ static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
 
   status = lua_script_load(abs_path);
   if (status != 0)
-    return (status);
+    return status;
 
   INFO("Lua plugin: File \"%s\" loaded successfully", abs_path);
 
@@ -576,7 +576,7 @@ static int lua_shutdown(void) /* {{{ */
 {
   lua_script_free(scripts);
 
-  return (0);
+  return 0;
 } /* }}} int lua_shutdown */
 
 void module_register(void) {

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -156,14 +156,14 @@ static int lvm_read(void) {
   lvm = lvm_init(NULL);
   if (!lvm) {
     ERROR("lvm plugin: lvm_init failed.");
-    return (-1);
+    return -1;
   }
 
   vg_names = lvm_list_vg_names(lvm);
   if (!vg_names) {
     ERROR("lvm plugin lvm_list_vg_name failed %s", lvm_errmsg(lvm));
     lvm_quit(lvm);
-    return (-1);
+    return -1;
   }
 
   dm_list_iterate_items(name_list, vg_names) {
@@ -181,7 +181,7 @@ static int lvm_read(void) {
   }
 
   lvm_quit(lvm);
-  return (0);
+  return 0;
 } /*lvm_read */
 
 void module_register(void) {

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -418,7 +418,7 @@ static int madwifi_real_init(void) {
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(bounds); i++)
     bounds[i]++;
 
-  return (0);
+  return 0;
 }
 
 static int madwifi_config(const char *key, const char *value) {
@@ -461,7 +461,7 @@ static int madwifi_config(const char *key, const char *value) {
     int id = watchitem_find(value);
 
     if (id < 0)
-      return (-1);
+      return -1;
     else
       watchlist_add(watch_items, id);
   }
@@ -470,7 +470,7 @@ static int madwifi_config(const char *key, const char *value) {
     int id = watchitem_find(value);
 
     if (id < 0)
-      return (-1);
+      return -1;
     else
       watchlist_remove(watch_items, id);
   }
@@ -488,7 +488,7 @@ static int madwifi_config(const char *key, const char *value) {
     int id = watchitem_find(value);
 
     if (id < 0)
-      return (-1);
+      return -1;
     else
       watchlist_add(misc_items, id);
   }
@@ -497,15 +497,15 @@ static int madwifi_config(const char *key, const char *value) {
     int id = watchitem_find(value);
 
     if (id < 0)
-      return (-1);
+      return -1;
     else
       watchlist_remove(misc_items, id);
   }
 
   else
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 }
 
 static void submit(const char *dev, const char *type, const char *ti1,
@@ -600,7 +600,7 @@ static int process_athstats(int sk, const char *dev) {
           "SIOCGATHSTATS to device %s "
           "failed with status %i.",
           dev, status);
-    return (status);
+    return status;
   }
 
   /* These stats are handled as a special case, because they are
@@ -616,7 +616,7 @@ static int process_athstats(int sk, const char *dev) {
 
   /* All other ath statistics */
   process_stat_struct(ATH_STAT, &stats, dev, NULL, "ath_stat", "ast_misc");
-  return (0);
+  return 0;
 }
 
 static int process_80211stats(int sk, const char *dev) {
@@ -633,11 +633,11 @@ static int process_80211stats(int sk, const char *dev) {
           "SIOCG80211STATS to device %s "
           "failed with status %i.",
           dev, status);
-    return (status);
+    return status;
   }
 
   process_stat_struct(IFA_STAT, &stats, dev, NULL, "ath_stat", "is_misc");
-  return (0);
+  return 0;
 }
 
 static int process_station(int sk, const char *dev,
@@ -668,7 +668,7 @@ static int process_station(int sk, const char *dev,
           "IEEE80211_IOCTL_STA_STATS to device %s "
           "failed with status %i.",
           dev, status);
-    return (status);
+    return status;
   }
 
   /* These two stats are handled as a special case as they are
@@ -685,7 +685,7 @@ static int process_station(int sk, const char *dev,
 
   /* All other node statistics */
   process_stat_struct(NOD_STAT, ns, dev, mac, "node_stat", "ns_misc");
-  return (0);
+  return 0;
 }
 
 static int process_stations(int sk, const char *dev) {
@@ -706,7 +706,7 @@ static int process_stations(int sk, const char *dev) {
           "IEEE80211_IOCTL_STA_INFO to device %s "
           "failed with status %i.",
           dev, status);
-    return (status);
+    return status;
   }
 
   len = iwr.u.data.length;
@@ -723,7 +723,7 @@ static int process_stations(int sk, const char *dev) {
 
   if (item_watched(STAT_ATH_NODES))
     submit_gauge(dev, "ath_nodes", NULL, NULL, nodes);
-  return (0);
+  return 0;
 }
 
 static int process_device(int sk, const char *dev) {
@@ -742,7 +742,7 @@ static int process_device(int sk, const char *dev) {
   if (status == 0)
     num_success++;
 
-  return ((num_success == 0) ? -1 : 0);
+  return (num_success == 0) ? -1 : 0;
 }
 
 static int check_devname(const char *dev) {
@@ -777,7 +777,7 @@ static int sysfs_iterate(int sk) {
   nets = opendir("/sys/class/net/");
   if (nets == NULL) {
     WARNING("madwifi plugin: opening /sys/class/net failed");
-    return (-1);
+    return -1;
   }
 
   num_success = 0;
@@ -803,8 +803,8 @@ static int sysfs_iterate(int sk) {
   closedir(nets);
 
   if ((num_success == 0) && (num_fail != 0))
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 }
 
 static int procfs_iterate(int sk) {
@@ -817,7 +817,7 @@ static int procfs_iterate(int sk) {
 
   if ((fh = fopen("/proc/net/dev", "r")) == NULL) {
     WARNING("madwifi plugin: opening /proc/net/dev failed");
-    return (-1);
+    return -1;
   }
 
   num_success = 0;
@@ -852,7 +852,7 @@ static int procfs_iterate(int sk) {
   fclose(fh);
 
   if ((num_success == 0) && (num_fail != 0))
-    return (-1);
+    return -1;
   return 0;
 }
 
@@ -866,7 +866,7 @@ static int madwifi_read(void) {
 
   sk = socket(AF_INET, SOCK_DGRAM, 0);
   if (sk < 0)
-    return (-1);
+    return -1;
 
   /* procfs iteration is not safe because it does not check whether given
      interface is madwifi interface and there are private ioctls used, which

--- a/src/match_empty_counter.c
+++ b/src/match_empty_counter.c
@@ -40,12 +40,12 @@ static int mec_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   }
 
   *user_data = NULL;
-  return (0);
+  return 0;
 } /* }}} int mec_create */
 
 static int mec_destroy(__attribute__((unused)) void **user_data) /* {{{ */
 {
-  return (0);
+  return 0;
 } /* }}} int mec_destroy */
 
 static int mec_match(__attribute__((unused)) const data_set_t *ds, /* {{{ */
@@ -67,9 +67,9 @@ static int mec_match(__attribute__((unused)) const data_set_t *ds, /* {{{ */
   }
 
   if ((num_counters != 0) && (num_counters == num_empty))
-    return (FC_MATCH_MATCHES);
+    return FC_MATCH_MATCHES;
 
-  return (FC_MATCH_NO_MATCH);
+  return FC_MATCH_NO_MATCH;
 } /* }}} int mec_match */
 
 void module_register(void) {

--- a/src/match_hashed.c
+++ b/src/match_hashed.c
@@ -56,19 +56,19 @@ static int mh_config_match(const oconfig_item_t *ci, /* {{{ */
       (ci->values[1].type != OCONFIG_TYPE_NUMBER)) {
     ERROR("hashed match: The `Match' option requires "
           "exactly two numeric arguments.");
-    return (-1);
+    return -1;
   }
 
   if ((ci->values[0].value.number < 0) || (ci->values[1].value.number < 0)) {
     ERROR("hashed match: The arguments of the `Match' "
           "option must be positive.");
-    return (-1);
+    return -1;
   }
 
   tmp = realloc(m->matches, sizeof(*tmp) * (m->matches_num + 1));
   if (tmp == NULL) {
     ERROR("hashed match: realloc failed.");
-    return (-1);
+    return -1;
   }
   m->matches = tmp;
   tmp = m->matches + m->matches_num;
@@ -79,12 +79,12 @@ static int mh_config_match(const oconfig_item_t *ci, /* {{{ */
   if (tmp->match >= tmp->total) {
     ERROR("hashed match: The first argument of the `Match' option "
           "must be smaller than the second argument.");
-    return (-1);
+    return -1;
   }
   assert(tmp->total != 0);
 
   m->matches_num++;
-  return (0);
+  return 0;
 } /* }}} int mh_config_match */
 
 static int mh_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -94,7 +94,7 @@ static int mh_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   m = calloc(1, sizeof(*m));
   if (m == NULL) {
     ERROR("mh_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -110,11 +110,11 @@ static int mh_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
     sfree(m->matches);
     sfree(m);
     ERROR("hashed match: No matches were configured. Not creating match.");
-    return (-1);
+    return -1;
   }
 
   *user_data = m;
-  return (0);
+  return 0;
 } /* }}} int mh_create */
 
 static int mh_destroy(void **user_data) /* {{{ */
@@ -122,13 +122,13 @@ static int mh_destroy(void **user_data) /* {{{ */
   mh_match_t *mh;
 
   if ((user_data == NULL) || (*user_data == NULL))
-    return (0);
+    return 0;
 
   mh = *user_data;
   sfree(mh->matches);
   sfree(mh);
 
-  return (0);
+  return 0;
 } /* }}} int mh_destroy */
 
 static int mh_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
@@ -139,7 +139,7 @@ static int mh_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
   uint32_t hash_val;
 
   if ((user_data == NULL) || (*user_data == NULL))
-    return (-1);
+    return -1;
 
   m = *user_data;
 
@@ -153,9 +153,9 @@ static int mh_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
 
   for (size_t i = 0; i < m->matches_num; i++)
     if ((hash_val % m->matches[i].total) == m->matches[i].match)
-      return (FC_MATCH_MATCHES);
+      return FC_MATCH_MATCHES;
 
-  return (FC_MATCH_NO_MATCH);
+  return FC_MATCH_NO_MATCH;
 } /* }}} int mh_match */
 
 void module_register(void) {

--- a/src/match_timediff.c
+++ b/src/match_timediff.c
@@ -53,7 +53,7 @@ static int mt_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   m = calloc(1, sizeof(*m));
   if (m == NULL) {
     ERROR("mt_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   m->future = 0;
@@ -91,11 +91,11 @@ static int mt_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     free(m);
-    return (status);
+    return status;
   }
 
   *user_data = m;
-  return (0);
+  return 0;
 } /* }}} int mt_create */
 
 static int mt_destroy(void **user_data) /* {{{ */
@@ -104,7 +104,7 @@ static int mt_destroy(void **user_data) /* {{{ */
     sfree(*user_data);
   }
 
-  return (0);
+  return 0;
 } /* }}} int mt_destroy */
 
 static int mt_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
@@ -115,22 +115,22 @@ static int mt_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
   cdtime_t now;
 
   if ((user_data == NULL) || (*user_data == NULL))
-    return (-1);
+    return -1;
 
   m = *user_data;
   now = cdtime();
 
   if (m->future != 0) {
     if (vl->time >= (now + m->future))
-      return (FC_MATCH_MATCHES);
+      return FC_MATCH_MATCHES;
   }
 
   if (m->past != 0) {
     if (vl->time <= (now - m->past))
-      return (FC_MATCH_MATCHES);
+      return FC_MATCH_MATCHES;
   }
 
-  return (FC_MATCH_NO_MATCH);
+  return FC_MATCH_NO_MATCH;
 } /* }}} int mt_match */
 
 void module_register(void) {

--- a/src/match_value.c
+++ b/src/match_value.c
@@ -74,7 +74,7 @@ static int mv_config_add_satisfy(mv_match_t *m, /* {{{ */
                                  oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     ERROR("`value' match: `%s' needs exactly one string argument.", ci->key);
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp("All", ci->values[0].value.string) == 0)
@@ -85,10 +85,10 @@ static int mv_config_add_satisfy(mv_match_t *m, /* {{{ */
     ERROR("`value' match: Passing `%s' to the `%s' option is invalid. "
           "The argument must either be `All' or `Any'.",
           ci->values[0].value.string, ci->key);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int mv_config_add_satisfy */
 
 static int mv_config_add_data_source(mv_match_t *m, /* {{{ */
@@ -99,7 +99,7 @@ static int mv_config_add_data_source(mv_match_t *m, /* {{{ */
   /* Check number of arbuments. */
   if (ci->values_num < 1) {
     ERROR("`value' match: `%s' needs at least one argument.", ci->key);
-    return (-1);
+    return -1;
   }
 
   /* Check type of arguments */
@@ -112,7 +112,7 @@ static int mv_config_add_data_source(mv_match_t *m, /* {{{ */
           ci->key, i + 1,
           (ci->values[i].type == OCONFIG_TYPE_BOOLEAN) ? "truth value"
                                                        : "number");
-    return (-1);
+    return -1;
   }
 
   /* Allocate space for the char pointers */
@@ -120,7 +120,7 @@ static int mv_config_add_data_source(mv_match_t *m, /* {{{ */
   temp = realloc(m->data_sources, new_data_sources_num * sizeof(char *));
   if (temp == NULL) {
     ERROR("`value' match: realloc failed.");
-    return (-1);
+    return -1;
   }
   m->data_sources = temp;
 
@@ -138,7 +138,7 @@ static int mv_config_add_data_source(mv_match_t *m, /* {{{ */
     m->data_sources_num++;
   }
 
-  return (0);
+  return 0;
 } /* }}} int mv_config_add_data_source */
 
 static int mv_config_add_gauge(gauge_t *ret_value, /* {{{ */
@@ -146,12 +146,12 @@ static int mv_config_add_gauge(gauge_t *ret_value, /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)) {
     ERROR("`value' match: `%s' needs exactly one numeric argument.", ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret_value = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* }}} int mv_config_add_gauge */
 
 static int mv_config_add_boolean(int *ret_value, /* {{{ */
@@ -159,7 +159,7 @@ static int mv_config_add_boolean(int *ret_value, /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_BOOLEAN)) {
     ERROR("`value' match: `%s' needs exactly one boolean argument.", ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.boolean)
@@ -167,7 +167,7 @@ static int mv_config_add_boolean(int *ret_value, /* {{{ */
   else
     *ret_value = 0;
 
-  return (0);
+  return 0;
 } /* }}} int mv_config_add_boolean */
 
 static int mv_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -178,7 +178,7 @@ static int mv_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   m = calloc(1, sizeof(*m));
   if (m == NULL) {
     ERROR("mv_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   m->min = NAN;
@@ -226,18 +226,18 @@ static int mv_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     mv_free_match(m);
-    return (status);
+    return status;
   }
 
   *user_data = m;
-  return (0);
+  return 0;
 } /* }}} int mv_create */
 
 static int mv_destroy(void **user_data) /* {{{ */
 {
   if ((user_data != NULL) && (*user_data != NULL))
     mv_free_match(*user_data);
-  return (0);
+  return 0;
 } /* }}} int mv_destroy */
 
 static int mv_match(const data_set_t *ds, const value_list_t *vl, /* {{{ */
@@ -248,7 +248,7 @@ static int mv_match(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   int status;
 
   if ((user_data == NULL) || (*user_data == NULL))
-    return (-1);
+    return -1;
 
   m = *user_data;
 
@@ -256,7 +256,7 @@ static int mv_match(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (values == NULL) {
     ERROR("`value' match: Retrieving the current rate from the cache "
           "failed.");
-    return (-1);
+    return -1;
   }
 
   status = FC_MATCH_NO_MATCH;
@@ -305,7 +305,7 @@ static int mv_match(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   } /* for (i = 0; i < ds->ds_num; i++) */
 
   free(values);
-  return (status);
+  return status;
 } /* }}} int mv_match */
 
 void module_register(void) {

--- a/src/mbmon.c
+++ b/src/mbmon.c
@@ -99,7 +99,7 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
     ERROR("mbmon: getaddrinfo (%s, %s): %s", host, port,
           (ai_return == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                     : gai_strerror(ai_return));
-    return (-1);
+    return -1;
   }
 
   fd = -1;
@@ -132,7 +132,7 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
 
   if (fd < 0) {
     ERROR("mbmon: Could not connect to daemon.");
-    return (-1);
+    return -1;
   }
 
   /* receive data from the mbmon daemon */
@@ -150,7 +150,7 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
       ERROR("mbmon: Error reading from socket: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
       close(fd);
-      return (-1);
+      return -1;
     }
     buffer_fill += status;
 
@@ -166,11 +166,11 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
             "Buffer: `%s'",
             buffer);
     close(fd);
-    return (-1);
+    return -1;
   }
 
   close(fd);
-  return (0);
+  return 0;
 }
 
 static int mbmon_config(const char *key, const char *value) {
@@ -183,10 +183,10 @@ static int mbmon_config(const char *key, const char *value) {
       free(mbmon_port);
     mbmon_port = strdup(value);
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void mbmon_submit(const char *type, const char *type_instance,
@@ -214,7 +214,7 @@ static int mbmon_read(void) {
 
   /* get data from daemon */
   if (mbmon_query_daemon(buf, sizeof(buf)) < 0)
-    return (-1);
+    return -1;
 
   s = buf;
   while ((t = strchr(s, ':')) != NULL) {
@@ -254,7 +254,7 @@ static int mbmon_read(void) {
     s = nextc + 1;
   }
 
-  return (0);
+  return 0;
 } /* void mbmon_read */
 
 /* module_register

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -106,22 +106,22 @@ static int mcelog_config(oconfig_item_t *ci) {
           0) {
         ERROR(MCELOG_PLUGIN ": Invalid configuration option: \"%s\".",
               child->key);
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("McelogLogfile", child->key) == 0) {
       if (cf_util_get_string_buffer(child, g_mcelog_config.logfile,
                                     sizeof(g_mcelog_config.logfile)) < 0) {
         ERROR(MCELOG_PLUGIN ": Invalid configuration option: \"%s\".",
               child->key);
-        return (-1);
+        return -1;
       }
     } else {
       ERROR(MCELOG_PLUGIN ": Invalid configuration option: \"%s\".",
             child->key);
-      return (-1);
+      return -1;
     }
   }
-  return (0);
+  return 0;
 }
 
 static int socket_close(socket_adapter_t *self) {
@@ -141,7 +141,7 @@ static int socket_close(socket_adapter_t *self) {
     }
   }
   pthread_rwlock_unlock(&self->lock);
-  return (ret);
+  return ret;
 }
 
 static int socket_write(socket_adapter_t *self, const char *msg,
@@ -151,7 +151,7 @@ static int socket_write(socket_adapter_t *self, const char *msg,
   if (swrite(self->sock_fd, msg, len) < 0)
     ret = -1;
   pthread_rwlock_unlock(&self->lock);
-  return (ret);
+  return ret;
 }
 
 static void mcelog_dispatch_notification(notification_t *n) {
@@ -181,7 +181,7 @@ static int socket_reinit(socket_adapter_t *self) {
     ERROR(MCELOG_PLUGIN ": Could not create a socket. %s",
           sstrerror(errno, errbuff, sizeof(errbuff)));
     pthread_rwlock_unlock(&self->lock);
-    return (ret);
+    return ret;
   }
 
   /* Set socket timeout option */
@@ -209,38 +209,38 @@ static int socket_reinit(socket_adapter_t *self) {
                           .type_instance = "mcelog_status"});
   }
   pthread_rwlock_unlock(&self->lock);
-  return (ret);
+  return ret;
 }
 
 static int mcelog_prepare_notification(notification_t *n,
                                        const mcelog_memory_rec_t *mr) {
   if (n == NULL || mr == NULL)
-    return (-1);
+    return -1;
 
   if ((mr->location[0] != '\0') &&
       (plugin_notification_meta_add_string(n, MCELOG_SOCKET_STR, mr->location) <
        0)) {
     ERROR(MCELOG_PLUGIN ": add memory location meta data failed");
-    return (-1);
+    return -1;
   }
   if ((mr->dimm_name[0] != '\0') &&
       (plugin_notification_meta_add_string(n, MCELOG_DIMM_NAME, mr->dimm_name) <
        0)) {
     ERROR(MCELOG_PLUGIN ": add DIMM name meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if (plugin_notification_meta_add_signed_int(n, MCELOG_CORRECTED_ERR,
                                               mr->corrected_err_total) < 0) {
     ERROR(MCELOG_PLUGIN ": add corrected errors meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if (plugin_notification_meta_add_signed_int(
           n, "corrected memory timed errors", mr->corrected_err_timed) < 0) {
     ERROR(MCELOG_PLUGIN ": add corrected timed errors meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if ((mr->corrected_err_timed_period[0] != '\0') &&
       (plugin_notification_meta_add_string(n, "corrected errors time period",
@@ -248,20 +248,20 @@ static int mcelog_prepare_notification(notification_t *n,
        0)) {
     ERROR(MCELOG_PLUGIN ": add corrected errors period meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if (plugin_notification_meta_add_signed_int(n, MCELOG_UNCORRECTED_ERR,
                                               mr->uncorrected_err_total) < 0) {
     ERROR(MCELOG_PLUGIN ": add corrected errors meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if (plugin_notification_meta_add_signed_int(n,
                                               "uncorrected memory timed errors",
                                               mr->uncorrected_err_timed) < 0) {
     ERROR(MCELOG_PLUGIN ": add corrected timed errors meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
   if ((mr->uncorrected_err_timed_period[0] != '\0') &&
       (plugin_notification_meta_add_string(n, "uncorrected errors time period",
@@ -269,17 +269,17 @@ static int mcelog_prepare_notification(notification_t *n,
        0)) {
     ERROR(MCELOG_PLUGIN ": add corrected errors period meta data failed");
     plugin_notification_meta_free(n->meta);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static int mcelog_submit(const mcelog_memory_rec_t *mr) {
 
   if (!mr) {
     ERROR(MCELOG_PLUGIN ": %s: NULL pointer", __FUNCTION__);
-    return (-1);
+    return -1;
   }
 
   value_list_t vl = {
@@ -314,7 +314,7 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_timed};
   plugin_dispatch_values(&vl);
 
-  return (0);
+  return 0;
 }
 
 static int parse_memory_info(FILE *p_file, mcelog_memory_rec_t *memory_record) {
@@ -323,7 +323,7 @@ static int parse_memory_info(FILE *p_file, mcelog_memory_rec_t *memory_record) {
     /* Got empty line or "done" */
     if ((!strncmp("\n", buf, strlen(buf))) ||
         (!strncmp(buf, "done\n", strlen(buf))))
-      return (1);
+      return 1;
     if (strlen(buf) < 5)
       continue;
     if (!strncmp(buf, MCELOG_SOCKET_STR, strlen(MCELOG_SOCKET_STR))) {
@@ -379,7 +379,7 @@ static int parse_memory_info(FILE *p_file, mcelog_memory_rec_t *memory_record) {
     memset(buf, 0, sizeof(buf));
   }
   /* parsing definitely finished */
-  return (0);
+  return 0;
 }
 
 static void poll_worker_cleanup(void *arg) {
@@ -404,7 +404,7 @@ static int socket_receive(socket_adapter_t *self, FILE **pp_file) {
             sstrerror(errno, errbuf, sizeof(errbuf)));
     }
     pthread_rwlock_unlock(&self->lock);
-    return (res);
+    return res;
   }
 
   if (poll_fd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
@@ -419,20 +419,20 @@ static int socket_receive(socket_adapter_t *self, FILE **pp_file) {
                             .type_instance = "mcelog_status"});
     }
     pthread_rwlock_unlock(&self->lock);
-    return (-1);
+    return -1;
   }
 
   if (!(poll_fd.revents & (POLLIN | POLLPRI))) {
     INFO(MCELOG_PLUGIN ": No data to read");
     pthread_rwlock_unlock(&self->lock);
-    return (0);
+    return 0;
   }
 
   if ((*pp_file = fdopen(dup(self->sock_fd), "r")) == NULL)
     res = -1;
 
   pthread_rwlock_unlock(&self->lock);
-  return (res);
+  return res;
 }
 
 static void *poll_worker(__attribute__((unused)) void *arg) {
@@ -492,21 +492,21 @@ static void *poll_worker(__attribute__((unused)) void *arg) {
 
   mcelog_thread_running = 0;
   pthread_cleanup_pop(1);
-  return (NULL);
+  return NULL;
 }
 
 static int mcelog_init(void) {
   if (socket_adapter.reinit(&socket_adapter) != 0) {
     ERROR(MCELOG_PLUGIN ": Cannot connect to client socket");
-    return (-1);
+    return -1;
   }
 
   if (plugin_thread_create(&g_mcelog_config.tid, NULL, poll_worker, NULL,
                            NULL) != 0) {
     ERROR(MCELOG_PLUGIN ": Error creating poll thread.");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 static int get_memory_machine_checks(void) {
@@ -516,7 +516,7 @@ static int get_memory_machine_checks(void) {
     ERROR(MCELOG_PLUGIN ": SENT DUMP REQUEST FAILED");
   else
     DEBUG(MCELOG_PLUGIN ": SENT DUMP REQUEST OK");
-  return (ret);
+  return ret;
 }
 
 static int mcelog_read(__attribute__((unused)) user_data_t *ud) {
@@ -525,7 +525,7 @@ static int mcelog_read(__attribute__((unused)) user_data_t *ud) {
   if (get_memory_machine_checks() != 0)
     ERROR(MCELOG_PLUGIN ": MACHINE CHECK INFO NOT AVAILABLE");
 
-  return (0);
+  return 0;
 }
 
 static int mcelog_shutdown(void) {
@@ -540,7 +540,7 @@ static int mcelog_shutdown(void) {
 
   ret = socket_adapter.close(&socket_adapter) || ret;
   pthread_rwlock_destroy(&(socket_adapter.lock));
-  return (-ret);
+  return -ret;
 }
 
 void module_register(void) {

--- a/src/md.c
+++ b/src/md.c
@@ -46,17 +46,17 @@ static int md_config(const char *key, const char *value) {
   if (ignorelist == NULL)
     ignorelist = ignorelist_create(/* invert = */ 1);
   if (ignorelist == NULL)
-    return (1);
+    return 1;
 
   if (strcasecmp(key, "Device") == 0) {
     ignorelist_add(ignorelist, value);
   } else if (strcasecmp(key, "IgnoreSelected") == 0) {
     ignorelist_set_invert(ignorelist, IS_TRUE(value) ? 0 : 1);
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void md_submit(const int minor, const char *type_instance,
@@ -149,7 +149,7 @@ static int md_read(void) {
     char errbuf[1024];
     WARNING("md: Unable to open %s: %s", PROC_DISKSTATS,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   /* Iterate md devices */
@@ -187,7 +187,7 @@ static int md_read(void) {
 
   fclose(fh);
 
-  return (0);
+  return 0;
 } /* int md_read */
 
 void module_register(void) {

--- a/src/memcachec.c
+++ b/src/memcachec.c
@@ -111,29 +111,29 @@ static int cmc_page_init_memc(web_page_t *wp) /* {{{ */
   wp->memc = memcached_create(NULL);
   if (wp->memc == NULL) {
     ERROR("memcachec plugin: memcached_create failed.");
-    return (-1);
+    return -1;
   }
 
   server = memcached_servers_parse(wp->server);
   memcached_server_push(wp->memc, server);
   memcached_server_list_free(server);
 
-  return (0);
+  return 0;
 } /* }}} int cmc_page_init_memc */
 
 static int cmc_config_add_string(const char *name, char **dest, /* {{{ */
                                  oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("memcachec plugin: `%s' needs exactly one string argument.", name);
-    return (-1);
+    return -1;
   }
 
   sfree(*dest);
   *dest = strdup(ci->values[0].value.string);
   if (*dest == NULL)
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 } /* }}} int cmc_config_add_string */
 
 static int cmc_config_add_match_dstype(int *dstype_ret, /* {{{ */
@@ -142,7 +142,7 @@ static int cmc_config_add_match_dstype(int *dstype_ret, /* {{{ */
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("memcachec plugin: `DSType' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   if (strncasecmp("Gauge", ci->values[0].value.string, strlen("Gauge")) == 0) {
@@ -175,11 +175,11 @@ static int cmc_config_add_match_dstype(int *dstype_ret, /* {{{ */
   if (dstype == 0) {
     WARNING("memcachec plugin: `%s' is not a valid argument to `DSType'.",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   *dstype_ret = dstype;
-  return (0);
+  return 0;
 } /* }}} int cmc_config_add_match_dstype */
 
 static int cmc_config_add_match(web_page_t *page, /* {{{ */
@@ -194,7 +194,7 @@ static int cmc_config_add_match(web_page_t *page, /* {{{ */
   match = calloc(1, sizeof(*match));
   if (match == NULL) {
     ERROR("memcachec plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -242,7 +242,7 @@ static int cmc_config_add_match(web_page_t *page, /* {{{ */
 
   if (status != 0) {
     cmc_web_match_free(match);
-    return (status);
+    return status;
   }
 
   match->match =
@@ -250,7 +250,7 @@ static int cmc_config_add_match(web_page_t *page, /* {{{ */
   if (match->match == NULL) {
     ERROR("memcachec plugin: match_create_simple failed.");
     cmc_web_match_free(match);
-    return (-1);
+    return -1;
   } else {
     web_match_t *prev;
 
@@ -264,7 +264,7 @@ static int cmc_config_add_match(web_page_t *page, /* {{{ */
       prev->next = match;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cmc_config_add_match */
 
 static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
@@ -275,13 +275,13 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING(
         "memcachec plugin: `Page' blocks need exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   page = calloc(1, sizeof(*page));
   if (page == NULL) {
     ERROR("memcachec plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   page->server = NULL;
   page->key = NULL;
@@ -290,7 +290,7 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
   if (page->instance == NULL) {
     ERROR("memcachec plugin: strdup failed.");
     sfree(page);
-    return (-1);
+    return -1;
   }
 
   /* Process all children */
@@ -342,7 +342,7 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     cmc_web_page_free(page);
-    return (status);
+    return status;
   }
 
   /* Add the new page to the linked list */
@@ -357,7 +357,7 @@ static int cmc_config_add_page(oconfig_item_t *ci) /* {{{ */
     prev->next = page;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cmc_config_add_page */
 
 static int cmc_config(oconfig_item_t *ci) /* {{{ */
@@ -386,19 +386,19 @@ static int cmc_config(oconfig_item_t *ci) /* {{{ */
 
   if ((success == 0) && (errors > 0)) {
     ERROR("memcachec plugin: All statements failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cmc_config */
 
 static int cmc_init(void) /* {{{ */
 {
   if (pages_g == NULL) {
     INFO("memcachec plugin: No pages have been defined.");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* }}} int cmc_init */
 
 static void cmc_submit(const web_page_t *wp, const web_match_t *wm, /* {{{ */
@@ -423,14 +423,14 @@ static int cmc_read_page(web_page_t *wp) /* {{{ */
   int status;
 
   if (wp->memc == NULL)
-    return (-1);
+    return -1;
 
   wp->buffer = memcached_get(wp->memc, wp->key, strlen(wp->key), &string_length,
                              &flags, &rc);
   if (rc != MEMCACHED_SUCCESS) {
     ERROR("memcachec plugin: memcached_get failed: %s",
           memcached_strerror(wp->memc, rc));
-    return (-1);
+    return -1;
   }
 
   for (web_match_t *wm = wp->matches; wm != NULL; wm = wm->next) {
@@ -454,7 +454,7 @@ static int cmc_read_page(web_page_t *wp) /* {{{ */
 
   sfree(wp->buffer);
 
-  return (0);
+  return 0;
 } /* }}} int cmc_read_page */
 
 static int cmc_read(void) /* {{{ */
@@ -462,7 +462,7 @@ static int cmc_read(void) /* {{{ */
   for (web_page_t *wp = pages_g; wp != NULL; wp = wp->next)
     cmc_read_page(wp);
 
-  return (0);
+  return 0;
 } /* }}} int cmc_read */
 
 static int cmc_shutdown(void) /* {{{ */
@@ -470,7 +470,7 @@ static int cmc_shutdown(void) /* {{{ */
   cmc_web_page_free(pages_g);
   pages_g = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int cmc_shutdown */
 
 void module_register(void) {

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -78,7 +78,7 @@ static int memcached_connect_unix(memcached_t *st) {
     char errbuf[1024];
     ERROR("memcached plugin: memcached_connect_unix: socket(2) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   /* connect to the memcached daemon */
@@ -89,7 +89,7 @@ static int memcached_connect_unix(memcached_t *st) {
     fd = -1;
   }
 
-  return (fd);
+  return fd;
 } /* int memcached_connect_unix */
 
 static int memcached_connect_inet(memcached_t *st) {
@@ -109,7 +109,7 @@ static int memcached_connect_inet(memcached_t *st) {
           st->connhost, st->connport,
           (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                  : gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -138,14 +138,14 @@ static int memcached_connect_inet(memcached_t *st) {
   }
 
   freeaddrinfo(ai_list);
-  return (fd);
+  return fd;
 } /* int memcached_connect_inet */
 
 static int memcached_connect(memcached_t *st) {
   if (st->socket != NULL)
-    return (memcached_connect_unix(st));
+    return memcached_connect_unix(st);
   else
-    return (memcached_connect_inet(st));
+    return memcached_connect_inet(st);
 }
 
 static int memcached_query_daemon(char *buffer, size_t buffer_size,
@@ -167,7 +167,7 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     shutdown(fd, SHUT_RDWR);
     close(fd);
-    return (-1);
+    return -1;
   }
 
   /* receive data from the memcached daemon */
@@ -188,7 +188,7 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
             sstrerror(errno, errbuf, sizeof(errbuf)));
       shutdown(fd, SHUT_RDWR);
       close(fd);
-      return (-1);
+      return -1;
     }
 
     buffer_fill += (size_t)status;
@@ -212,7 +212,7 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
 
   shutdown(fd, SHUT_RDWR);
   close(fd);
-  return (status);
+  return status;
 } /* int memcached_query_daemon */
 
 static void memcached_init_vl(value_list_t *vl, memcached_t const *st) {
@@ -489,7 +489,7 @@ static int memcached_add_read_callback(memcached_t *st) {
     if (st->host) {
       st->connhost = strdup(st->host);
       if (st->connhost == NULL)
-        return (ENOMEM);
+        return ENOMEM;
 
       if ((strcmp("127.0.0.1", st->host) == 0) ||
           (strcmp("localhost", st->host) == 0))
@@ -497,14 +497,14 @@ static int memcached_add_read_callback(memcached_t *st) {
     } else {
       st->connhost = strdup(MEMCACHED_DEF_HOST);
       if (st->connhost == NULL)
-        return (ENOMEM);
+        return ENOMEM;
     }
   }
 
   if (st->connport == NULL) {
     st->connport = strdup(MEMCACHED_DEF_PORT);
     if (st->connport == NULL)
-      return (ENOMEM);
+      return ENOMEM;
   }
 
   assert(st->connhost != NULL);
@@ -518,7 +518,7 @@ static int memcached_add_read_callback(memcached_t *st) {
                                .data = st, .free_func = memcached_free,
                            });
 
-  return (status);
+  return status;
 } /* int memcached_add_read_callback */
 
 /* Configuration handling functiions
@@ -540,7 +540,7 @@ static int config_add_instance(oconfig_item_t *ci) {
   st = calloc(1, sizeof(*st));
   if (st == NULL) {
     ERROR("memcached plugin: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   st->name = NULL;
@@ -554,7 +554,7 @@ static int config_add_instance(oconfig_item_t *ci) {
 
   if (status != 0) {
     sfree(st);
-    return (status);
+    return status;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -582,10 +582,10 @@ static int config_add_instance(oconfig_item_t *ci) {
 
   if (status != 0) {
     memcached_free(st);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static int memcached_config(oconfig_item_t *ci) {
@@ -601,7 +601,7 @@ static int memcached_config(oconfig_item_t *ci) {
     } else if (!have_instance_block) {
       /* Non-instance option: Assume legacy configuration (without <Instance />
        * blocks) and call config_add_instance() with the <Plugin /> block. */
-      return (config_add_instance(ci));
+      return config_add_instance(ci);
     } else
       WARNING("memcached plugin: The configuration option "
               "\"%s\" is not allowed here. Did you "
@@ -610,7 +610,7 @@ static int memcached_config(oconfig_item_t *ci) {
               child->key);
   } /* for (ci->children) */
 
-  return (status);
+  return status;
 }
 
 static int memcached_init(void) {
@@ -618,12 +618,12 @@ static int memcached_init(void) {
   int status;
 
   if (memcached_have_instances)
-    return (0);
+    return 0;
 
   /* No instances were configured, lets start a default instance. */
   st = calloc(1, sizeof(*st));
   if (st == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   st->name = NULL;
   st->host = NULL;
   st->socket = NULL;
@@ -636,7 +636,7 @@ static int memcached_init(void) {
   else
     memcached_free(st);
 
-  return (status);
+  return status;
 } /* int memcached_init */
 
 void module_register(void) {

--- a/src/memory.c
+++ b/src/memory.c
@@ -111,7 +111,7 @@ static int memory_config(oconfig_item_t *ci) /* {{{ */
             child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int memory_config */
 
 static int memory_init(void) {
@@ -133,11 +133,11 @@ static int memory_init(void) {
   pagesize = getpagesize();
   if (get_kstat(&ksp, "unix", 0, "system_pages") != 0) {
     ksp = NULL;
-    return (-1);
+    return -1;
   }
   if (get_kstat(&ksz, "zfs", 0, "arcstats") != 0) {
     ksz = NULL;
-    return (-1);
+    return -1;
   }
 
 /* #endif HAVE_LIBKSTAT */
@@ -146,7 +146,7 @@ static int memory_init(void) {
   pagesize = getpagesize();
   if (pagesize <= 0) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
-    return (-1);
+    return -1;
   }
 /* #endif HAVE_SYSCTL */
 
@@ -157,7 +157,7 @@ static int memory_init(void) {
 #elif HAVE_PERFSTAT
   pagesize = getpagesize();
 #endif /* HAVE_PERFSTAT */
-  return (0);
+  return 0;
 } /* int memory_init */
 
 #define MEMORY_SUBMIT(...)                                                     \
@@ -180,14 +180,14 @@ static int memory_read_internal(value_list_t *vl) {
   gauge_t free;
 
   if (!port_host || !pagesize)
-    return (-1);
+    return -1;
 
   vm_data_len = sizeof(vm_data) / sizeof(natural_t);
   if ((status = host_statistics(port_host, HOST_VM_INFO, (host_info_t)&vm_data,
                                 &vm_data_len)) != KERN_SUCCESS) {
     ERROR("memory-plugin: host_statistics failed and returned the value %i",
           (int)status);
-    return (-1);
+    return -1;
   }
 
   /*
@@ -282,7 +282,7 @@ static int memory_read_internal(value_list_t *vl) {
   if ((fh = fopen("/proc/meminfo", "r")) == NULL) {
     char errbuf[1024];
     WARNING("memory: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -320,7 +320,7 @@ static int memory_read_internal(value_list_t *vl) {
   }
 
   if (mem_total < (mem_free + mem_buffered + mem_cached + mem_slab_total))
-    return (-1);
+    return -1;
 
   mem_used =
       mem_total - (mem_free + mem_buffered + mem_cached + mem_slab_total);
@@ -353,9 +353,9 @@ static int memory_read_internal(value_list_t *vl) {
   long long availrmem;
 
   if (ksp == NULL)
-    return (-1);
+    return -1;
   if (ksz == NULL)
-    return (-1);
+    return -1;
 
   mem_used = get_kstat_value(ksp, "pagestotal");
   mem_free = get_kstat_value(ksp, "pagesfree");
@@ -370,7 +370,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   if ((mem_used < 0LL) || (mem_free < 0LL) || (mem_lock < 0LL)) {
     WARNING("memory plugin: one of used, free or locked is negative.");
-    return (-1);
+    return -1;
   }
 
   mem_unus = physmem - mem_used;
@@ -424,7 +424,7 @@ static int memory_read_internal(value_list_t *vl) {
     char errbuf[1024];
     WARNING("memory plugin: sysctl failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   assert(pagesize > 0);
@@ -441,7 +441,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   ios = sg_get_mem_stats();
   if (ios == NULL)
-    return (-1);
+    return -1;
 
   MEMORY_SUBMIT("used", (gauge_t)ios->used, "cached", (gauge_t)ios->cache,
                 "free", (gauge_t)ios->free);
@@ -454,7 +454,7 @@ static int memory_read_internal(value_list_t *vl) {
     char errbuf[1024];
     WARNING("memory plugin: perfstat_memory_total failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   /* Unfortunately, the AIX documentation is not very clear on how these
@@ -473,7 +473,7 @@ static int memory_read_internal(value_list_t *vl) {
                 (gauge_t)(pmemory.real_process * pagesize));
 #endif /* HAVE_PERFSTAT */
 
-  return (0);
+  return 0;
 } /* }}} int memory_read_internal */
 
 static int memory_read(void) /* {{{ */
@@ -487,7 +487,7 @@ static int memory_read(void) /* {{{ */
   sstrncpy(vl.type, "memory", sizeof(vl.type));
   vl.time = cdtime();
 
-  return (memory_read_internal(&vl));
+  return memory_read_internal(&vl);
 } /* }}} int memory_read */
 
 void module_register(void) {

--- a/src/mic.c
+++ b/src/mic.c
@@ -63,7 +63,7 @@ static int mic_init(void) {
   U32 mic_count;
 
   if (mic_handle)
-    return (0);
+    return 0;
 
   mic_count = (U32)STATIC_ARRAY_SIZE(mics);
   ret = MicInitAPI(&mic_handle, eTARGET_SCIF_DRIVER, mics, &mic_count);
@@ -75,10 +75,10 @@ static int mic_init(void) {
 
   if (mic_count < 0 || mic_count >= MAX_MICS) {
     ERROR("mic plugin: No Intel MICs in system");
-    return (1);
+    return 1;
   } else {
     num_mics = mic_count;
-    return (0);
+    return 0;
   }
 }
 
@@ -88,7 +88,7 @@ static int mic_config(const char *key, const char *value) {
   if (power_ignore == NULL)
     power_ignore = ignorelist_create(1);
   if (temp_ignore == NULL || power_ignore == NULL)
-    return (1);
+    return 1;
 
   if (strcasecmp("ShowCPU", key) == 0) {
     show_cpu = IS_TRUE(value);
@@ -115,9 +115,9 @@ static int mic_config(const char *key, const char *value) {
       invert = 0;
     ignorelist_set_invert(power_ignore, invert);
   } else {
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 static void mic_submit_memory_use(int micnumber, const char *type_instance,
@@ -148,13 +148,13 @@ static int mic_read_memory(int mic) {
   if (ret != MIC_ACCESS_API_SUCCESS) {
     ERROR("mic plugin: Problem getting Memory Utilization: %s",
           MicGetErrorString(ret));
-    return (1);
+    return 1;
   }
   mic_submit_memory_use(mic, "free", mem_free);
   mic_submit_memory_use(mic, "used", mem_total - mem_free - mem_bufs);
   mic_submit_memory_use(mic, "buffered", mem_bufs);
   DEBUG("mic plugin: Memory Read: %u %u %u", mem_total, mem_free, mem_bufs);
-  return (0);
+  return 0;
 }
 
 static void mic_submit_temp(int micnumber, const char *type, gauge_t value) {
@@ -191,11 +191,11 @@ static int mic_read_temps(int mic) {
       ERROR("mic plugin: Error reading temperature \"%s\": "
             "%s",
             name, MicGetErrorString(status));
-      return (1);
+      return 1;
     }
     mic_submit_temp(mic, name, temp_buffer);
   }
-  return (0);
+  return 0;
 }
 
 static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
@@ -231,7 +231,7 @@ static int mic_read_cpu(int mic) {
   if (status != MIC_ACCESS_API_SUCCESS) {
     ERROR("mic plugin: Problem getting CPU utilization: %s",
           MicGetErrorString(status));
-    return (-1);
+    return -1;
   }
 
   if (show_cpu) {
@@ -249,7 +249,7 @@ static int mic_read_cpu(int mic) {
       mic_submit_cpu(mic, "idle", j, core_jiffs[j].idle);
     }
   }
-  return (0);
+  return 0;
 }
 
 static void mic_submit_power(int micnumber, const char *type,
@@ -277,7 +277,7 @@ static int mic_read_power(int mic) {
   if (ret != MIC_ACCESS_API_SUCCESS) {
     ERROR("mic plugin: Problem getting Power Usage: %s",
           MicGetErrorString(ret));
-    return (1);
+    return 1;
   }
 
 /* power is in uWatts, current in mA, voltage in uVolts..   convert to
@@ -311,7 +311,7 @@ static int mic_read_power(int mic) {
   SUB_VOLTS(vddg);
   SUB_VOLTS(vddq);
 
-  return (0);
+  return 0;
 }
 
 static int mic_read(void) {
@@ -357,7 +357,7 @@ static int mic_shutdown(void) {
     MicCloseAPI(&mic_handle);
   mic_handle = NULL;
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -156,13 +156,13 @@ static mb_data_t *data_definitions = NULL;
 static mb_data_t *data_get_by_name(mb_data_t *src, /* {{{ */
                                    const char *name) {
   if (name == NULL)
-    return (NULL);
+    return NULL;
 
   for (mb_data_t *ptr = src; ptr != NULL; ptr = ptr->next)
     if (strcasecmp(ptr->name, name) == 0)
-      return (ptr);
+      return ptr;
 
-  return (NULL);
+  return NULL;
 } /* }}} mb_data_t *data_get_by_name */
 
 static int data_append(mb_data_t **dst, mb_data_t *src) /* {{{ */
@@ -170,13 +170,13 @@ static int data_append(mb_data_t **dst, mb_data_t *src) /* {{{ */
   mb_data_t *ptr;
 
   if ((dst == NULL) || (src == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   ptr = *dst;
 
   if (ptr == NULL) {
     *dst = src;
-    return (0);
+    return 0;
   }
 
   while (ptr->next != NULL)
@@ -184,7 +184,7 @@ static int data_append(mb_data_t **dst, mb_data_t *src) /* {{{ */
 
   ptr->next = src;
 
-  return (0);
+  return 0;
 } /* }}} int data_append */
 
 /* Copy a single mb_data_t and append it to another list. */
@@ -194,11 +194,11 @@ static int data_copy(mb_data_t **dst, const mb_data_t *src) /* {{{ */
   int status;
 
   if ((dst == NULL) || (src == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   tmp = malloc(sizeof(*tmp));
   if (tmp == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   memcpy(tmp, src, sizeof(*tmp));
   tmp->name = NULL;
   tmp->next = NULL;
@@ -206,17 +206,17 @@ static int data_copy(mb_data_t **dst, const mb_data_t *src) /* {{{ */
   tmp->name = strdup(src->name);
   if (tmp->name == NULL) {
     sfree(tmp);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   status = data_append(dst, tmp);
   if (status != 0) {
     sfree(tmp->name);
     sfree(tmp);
-    return (status);
+    return status;
   }
 
-  return (0);
+  return 0;
 } /* }}} int data_copy */
 
 /* Lookup a single mb_data_t instance, copy it and append the copy to another
@@ -226,13 +226,13 @@ static int data_copy_by_name(mb_data_t **dst, mb_data_t *src, /* {{{ */
   mb_data_t *ptr;
 
   if ((dst == NULL) || (src == NULL) || (name == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   ptr = data_get_by_name(src, name);
   if (ptr == NULL)
-    return (ENOENT);
+    return ENOENT;
 
-  return (data_copy(dst, ptr));
+  return data_copy(dst, ptr);
 } /* }}} int data_copy_by_name */
 
 /* Read functions */
@@ -242,7 +242,7 @@ static int mb_submit(mb_host_t *host, mb_slave_t *slave, /* {{{ */
   value_list_t vl = VALUE_LIST_INIT;
 
   if ((host == NULL) || (slave == NULL) || (data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->interval == 0)
     host->interval = plugin_get_interval();
@@ -259,7 +259,7 @@ static int mb_submit(mb_host_t *host, mb_slave_t *slave, /* {{{ */
   sstrncpy(vl.type, data->type, sizeof(vl.type));
   sstrncpy(vl.type_instance, data->instance, sizeof(vl.type_instance));
 
-  return (plugin_dispatch_values(&vl));
+  return plugin_dispatch_values(&vl);
 } /* }}} int mb_submit */
 
 static float mb_register_to_float(uint16_t hi, uint16_t lo) /* {{{ */
@@ -283,7 +283,7 @@ static float mb_register_to_float(uint16_t hi, uint16_t lo) /* {{{ */
   conv.b[0] = (hi >> 8) & 0x00ff;
 #endif
 
-  return (conv.f);
+  return conv.f;
 } /* }}} float mb_register_to_float */
 
 #if LEGACY_LIBMODBUS
@@ -293,7 +293,7 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
   int status;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
 #if COLLECT_DEBUG
   modbus_set_debug(&host->connection, 1);
@@ -325,11 +325,11 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
   if (status != 0) {
     ERROR("Modbus plugin: modbus_connect (%s, %i) failed with status %i.",
           host->node, host->port ? host->port : host->baudrate, status);
-    return (status);
+    return status;
   }
 
   host->is_connected = 1;
-  return (0);
+  return 0;
 } /* }}} int mb_init_connection */
 /* #endif LEGACY_LIBMODBUS */
 
@@ -340,10 +340,10 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
   int status;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (host->connection != NULL)
-    return (0);
+    return 0;
 
   if (host->conntype == MBCONN_TCP) {
     if ((host->port < 1) || (host->port > 65535))
@@ -355,7 +355,7 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
     host->connection = modbus_new_tcp(host->node, host->port);
     if (host->connection == NULL) {
       ERROR("Modbus plugin: Creating new Modbus/TCP object failed.");
-      return (-1);
+      return -1;
     }
   } else {
     DEBUG("Modbus plugin: Trying to connect to \"%s\", baudrate %i.",
@@ -364,7 +364,7 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
     host->connection = modbus_new_rtu(host->node, host->baudrate, 'N', 8, 1);
     if (host->connection == NULL) {
       ERROR("Modbus plugin: Creating new Modbus/RTU object failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -381,10 +381,10 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
           host->node, host->port ? host->port : host->baudrate, status);
     modbus_free(host->connection);
     host->connection = NULL;
-    return (status);
+    return status;
   }
 
-  return (0);
+  return 0;
 } /* }}} int mb_init_connection */
 #endif /* !LEGACY_LIBMODBUS */
 
@@ -408,19 +408,19 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
   int status = 0;
 
   if ((host == NULL) || (slave == NULL) || (data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   ds = plugin_get_ds(data->type);
   if (ds == NULL) {
     ERROR("Modbus plugin: Type \"%s\" is not defined.", data->type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num != 1) {
     ERROR("Modbus plugin: The type \"%s\" has %zu data sources. "
           "I can only handle data sets with only one data source.",
           data->type, ds->ds_num);
-    return (-1);
+    return -1;
   }
 
   if ((ds->ds[0].type != DS_TYPE_GAUGE) &&
@@ -458,7 +458,7 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
             host->node);
       host->is_connected = 0;
       host->connection = NULL;
-      return (-1);
+      return -1;
     }
   } else if (status != 0) {
 #if LEGACY_LIBMODBUS
@@ -480,7 +480,7 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
   if (status != 0) {
     ERROR("Modbus plugin: modbus_set_slave (%i) failed with status %i.",
           slave->id, status);
-    return (-1);
+    return -1;
   }
 #endif
   if (data->modbus_register_type == MREG_INPUT) {
@@ -505,7 +505,7 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
     modbus_free(host->connection);
 #endif
     host->connection = NULL;
-    return (-1);
+    return -1;
   }
 
   DEBUG("Modbus plugin: mb_read_data: Success! "
@@ -575,7 +575,7 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
     mb_submit(host, slave, data, vt);
   }
 
-  return (0);
+  return 0;
 } /* }}} int mb_read_data */
 
 static int mb_read_slave(mb_host_t *host, mb_slave_t *slave) /* {{{ */
@@ -584,7 +584,7 @@ static int mb_read_slave(mb_host_t *host, mb_slave_t *slave) /* {{{ */
   int status;
 
   if ((host == NULL) || (slave == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   success = 0;
   for (mb_data_t *data = slave->collect; data != NULL; data = data->next) {
@@ -594,9 +594,9 @@ static int mb_read_slave(mb_host_t *host, mb_slave_t *slave) /* {{{ */
   }
 
   if (success == 0)
-    return (-1);
+    return -1;
   else
-    return (0);
+    return 0;
 } /* }}} int mb_read_slave */
 
 static int mb_read(user_data_t *user_data) /* {{{ */
@@ -606,7 +606,7 @@ static int mb_read(user_data_t *user_data) /* {{{ */
   int status;
 
   if ((user_data == NULL) || (user_data->data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   host = user_data->data;
 
@@ -618,9 +618,9 @@ static int mb_read(user_data_t *user_data) /* {{{ */
   }
 
   if (success == 0)
-    return (-1);
+    return -1;
   else
-    return (0);
+    return 0;
 } /* }}} int mb_read */
 
 /* Free functions */
@@ -681,7 +681,7 @@ static int mb_config_add_data(oconfig_item_t *ci) /* {{{ */
 
   status = cf_util_get_string(ci, &data.name);
   if (status != 0)
-    return (status);
+    return status;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
@@ -752,7 +752,7 @@ static int mb_config_add_data(oconfig_item_t *ci) /* {{{ */
 
   sfree(data.name);
 
-  return (status);
+  return status;
 } /* }}} int mb_config_add_data */
 
 static int mb_config_set_host_address(mb_host_t *host, /* {{{ */
@@ -761,7 +761,7 @@ static int mb_config_set_host_address(mb_host_t *host, /* {{{ */
   int status;
 
   if ((host == NULL) || (address == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   struct addrinfo ai_hints = {
       /* XXX: libmodbus can only handle IPv4 addresses. */
@@ -774,7 +774,7 @@ static int mb_config_set_host_address(mb_host_t *host, /* {{{ */
     ERROR("Modbus plugin: getaddrinfo failed: %s",
           (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                  : gai_strerror(status));
-    return (status);
+    return status;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -797,7 +797,7 @@ static int mb_config_set_host_address(mb_host_t *host, /* {{{ */
           host->node);
   }
 
-  return (status);
+  return status;
 } /* }}} int mb_config_set_host_address */
 
 static int mb_config_add_slave(mb_host_t *host, oconfig_item_t *ci) /* {{{ */
@@ -806,11 +806,11 @@ static int mb_config_add_slave(mb_host_t *host, oconfig_item_t *ci) /* {{{ */
   int status;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   slave = realloc(host->slaves, sizeof(*slave) * (host->slaves_num + 1));
   if (slave == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   host->slaves = slave;
   slave = host->slaves + host->slaves_num;
   memset(slave, 0, sizeof(*slave));
@@ -818,7 +818,7 @@ static int mb_config_add_slave(mb_host_t *host, oconfig_item_t *ci) /* {{{ */
 
   status = cf_util_get_int(ci, &slave->id);
   if (status != 0)
-    return (status);
+    return status;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
@@ -852,7 +852,7 @@ static int mb_config_add_slave(mb_host_t *host, oconfig_item_t *ci) /* {{{ */
   else /* if (status != 0) */
     data_free_all(slave->collect);
 
-  return (status);
+  return status;
 } /* }}} int mb_config_add_slave */
 
 static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
@@ -862,17 +862,17 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
 
   host = calloc(1, sizeof(*host));
   if (host == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   host->slaves = NULL;
 
   status = cf_util_get_string_buffer(ci, host->host, sizeof(host->host));
   if (status != 0) {
     sfree(host);
-    return (status);
+    return status;
   }
   if (host->host[0] == 0) {
     sfree(host);
-    return (EINVAL);
+    return EINVAL;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -946,13 +946,13 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
     host_free(host);
   }
 
-  return (status);
+  return status;
 } /* }}} int mb_config_add_host */
 
 static int mb_config(oconfig_item_t *ci) /* {{{ */
 {
   if (ci == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
@@ -965,7 +965,7 @@ static int mb_config(oconfig_item_t *ci) /* {{{ */
       ERROR("Modbus plugin: Unknown configuration option: %s", child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int mb_config */
 
 /* ========= */
@@ -975,7 +975,7 @@ static int mb_shutdown(void) /* {{{ */
   data_free_all(data_definitions);
   data_definitions = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int mb_shutdown */
 
 void module_register(void) {

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -49,7 +49,7 @@ static int multimeter_read_value(double *value) {
       char errbuf[1024];
       ERROR("multimeter plugin: gettimeofday failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
     time_end.tv_sec++;
 
@@ -64,7 +64,7 @@ static int multimeter_read_value(double *value) {
       status = swrite(fd, "D", 1);
       if (status < 0) {
         ERROR("multimeter plugin: swrite failed.");
-        return (-1);
+        return -1;
       }
 
       FD_ZERO(&rfds);
@@ -75,7 +75,7 @@ static int multimeter_read_value(double *value) {
         ERROR("multimeter plugin: "
               "gettimeofday failed: %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
       if (timeval_cmp(time_end, time_now, &timeout) < 0)
         break;
@@ -120,9 +120,9 @@ static int multimeter_read_value(double *value) {
               break;
             }
           } else
-            return (-1); /* Overflow */
+            return -1; /* Overflow */
 
-          return (0); /* value received */
+          return 0; /* value received */
         } else
           break;
       } else if (!status) /* Timeout */
@@ -141,7 +141,7 @@ static int multimeter_read_value(double *value) {
     }
   } while (--retry);
 
-  return (-2); /* no value received */
+  return -2; /* no value received */
 } /* int multimeter_read_value */
 
 static int multimeter_init(void) {
@@ -173,13 +173,13 @@ static int multimeter_init(void) {
         INFO("multimeter plugin: Device "
              "found at %s",
              device);
-        return (0);
+        return 0;
       }
     }
   }
 
   ERROR("multimeter plugin: No device found");
-  return (-1);
+  return -1;
 }
 #undef LINE_LENGTH
 
@@ -198,13 +198,13 @@ static int multimeter_read(void) {
   double value;
 
   if (fd < 0)
-    return (-1);
+    return -1;
 
   if (multimeter_read_value(&value) != 0)
-    return (-1);
+    return -1;
 
   multimeter_submit(value);
-  return (0);
+  return 0;
 } /* int multimeter_read */
 
 static int multimeter_shutdown(void) {
@@ -213,7 +213,7 @@ static int multimeter_shutdown(void) {
     fd = -1;
   }
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -121,13 +121,13 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("mysql plugin: The `Database' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   db = calloc(1, sizeof(*db));
   if (db == NULL) {
     ERROR("mysql plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   /* initialize all the pointers */
@@ -153,7 +153,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
   status = cf_util_get_string(ci, &db->instance);
   if (status != 0) {
     sfree(db);
-    return (status);
+    return status;
   }
   assert(db->instance != NULL);
 
@@ -229,16 +229,16 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
         });
   } else {
     mysql_database_free(db);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int mysql_config_database */
 
 static int mysql_config(oconfig_item_t *ci) /* {{{ */
 {
   if (ci == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* Fill the `mysql_database_t' structure.. */
   for (int i = 0; i < ci->children_num; i++) {
@@ -250,7 +250,7 @@ static int mysql_config(oconfig_item_t *ci) /* {{{ */
       WARNING("mysql plugin: Option \"%s\" not allowed here.", child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int mysql_config */
 
 /* }}} End of configuration handling functions */
@@ -263,7 +263,7 @@ static MYSQL *getconnection(mysql_database_t *db) {
 
     status = mysql_ping(db->con);
     if (status == 0)
-      return (db->con);
+      return db->con;
 
     WARNING("mysql plugin: Lost connection to instance \"%s\": %s",
             db->instance, mysql_error(db->con));
@@ -274,7 +274,7 @@ static MYSQL *getconnection(mysql_database_t *db) {
     db->con = mysql_init(NULL);
     if (db->con == NULL) {
       ERROR("mysql plugin: mysql_init failed: %s", mysql_error(db->con));
-      return (NULL);
+      return NULL;
     }
   }
 
@@ -289,7 +289,7 @@ static MYSQL *getconnection(mysql_database_t *db) {
           "at server %s: %s",
           (db->database != NULL) ? db->database : "<none>",
           (db->host != NULL) ? db->host : "localhost", mysql_error(db->con));
-    return (NULL);
+    return NULL;
   }
 
   cipher = mysql_get_ssl_cipher(db->con);
@@ -302,7 +302,7 @@ static MYSQL *getconnection(mysql_database_t *db) {
        mysql_get_server_info(db->con), mysql_get_proto_info(db->con));
 
   db->is_connected = 1;
-  return (db->con);
+  return db->con;
 } /* static MYSQL *getconnection (mysql_database_t *db) */
 
 static void set_host(mysql_database_t *db, char *buf, size_t buflen) {
@@ -364,17 +364,17 @@ static MYSQL_RES *exec_query(MYSQL *con, const char *query) {
   if (mysql_real_query(con, query, query_len)) {
     ERROR("mysql plugin: Failed to execute query: %s", mysql_error(con));
     INFO("mysql plugin: SQL query was: %s", query);
-    return (NULL);
+    return NULL;
   }
 
   res = mysql_store_result(con);
   if (res == NULL) {
     ERROR("mysql plugin: Failed to store query result: %s", mysql_error(con));
     INFO("mysql plugin: SQL query was: %s", query);
-    return (NULL);
+    return NULL;
   }
 
-  return (res);
+  return res;
 } /* exec_query */
 
 static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
@@ -389,7 +389,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
 
   res = exec_query(con, query);
   if (res == NULL)
-    return (-1);
+    return -1;
 
   row = mysql_fetch_row(res);
   if (row == NULL) {
@@ -397,7 +397,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
           "`%s' did not return any rows.",
           query);
     mysql_free_result(res);
-    return (-1);
+    return -1;
   }
 
   field_num = mysql_num_fields(res);
@@ -406,7 +406,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
           "`%s' returned less than two columns.",
           query);
     mysql_free_result(res);
-    return (-1);
+    return -1;
   }
 
   position = atoll(row[1]);
@@ -420,7 +420,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
 
   mysql_free_result(res);
 
-  return (0);
+  return 0;
 } /* mysql_read_master_stats */
 
 static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
@@ -442,7 +442,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
 
   res = exec_query(con, query);
   if (res == NULL)
-    return (-1);
+    return -1;
 
   row = mysql_fetch_row(res);
   if (row == NULL) {
@@ -450,7 +450,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
           "`%s' did not return any rows.",
           query);
     mysql_free_result(res);
-    return (-1);
+    return -1;
   }
 
   field_num = mysql_num_fields(res);
@@ -459,7 +459,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
           "`%s' returned less than 33 columns.",
           query);
     mysql_free_result(res);
-    return (-1);
+    return -1;
   }
 
   if (db->slave_stats) {
@@ -532,7 +532,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
 
   mysql_free_result(res);
 
-  return (0);
+  return 0;
 } /* mysql_read_slave_stats */
 
 static int mysql_read_innodb_stats(mysql_database_t *db, MYSQL *con) {
@@ -591,7 +591,7 @@ static int mysql_read_innodb_stats(mysql_database_t *db, MYSQL *con) {
 
   res = exec_query(con, query);
   if (res == NULL)
-    return (-1);
+    return -1;
 
   while ((row = mysql_fetch_row(res))) {
     int i;
@@ -621,7 +621,7 @@ static int mysql_read_innodb_stats(mysql_database_t *db, MYSQL *con) {
   }
 
   mysql_free_result(res);
-  return (0);
+  return 0;
 }
 
 static int mysql_read_wsrep_stats(mysql_database_t *db, MYSQL *con) {
@@ -670,7 +670,7 @@ static int mysql_read_wsrep_stats(mysql_database_t *db, MYSQL *con) {
 
   res = exec_query(con, query);
   if (res == NULL)
-    return (-1);
+    return -1;
 
   row = mysql_fetch_row(res);
   if (row == NULL) {
@@ -678,7 +678,7 @@ static int mysql_read_wsrep_stats(mysql_database_t *db, MYSQL *con) {
           "`%s' did not return any rows.",
           query);
     mysql_free_result(res);
-    return (-1);
+    return -1;
   }
 
   while ((row = mysql_fetch_row(res))) {
@@ -706,7 +706,7 @@ static int mysql_read_wsrep_stats(mysql_database_t *db, MYSQL *con) {
   }
 
   mysql_free_result(res);
-  return (0);
+  return 0;
 } /* mysql_read_wsrep_stats */
 
 static int mysql_read(user_data_t *ud) {
@@ -733,14 +733,14 @@ static int mysql_read(user_data_t *ud) {
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("mysql plugin: mysql_database_read: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   db = (mysql_database_t *)ud->data;
 
   /* An error message will have been printed in this case */
   if ((con = getconnection(db)) == NULL)
-    return (-1);
+    return -1;
 
   mysql_version = mysql_get_server_version(con);
 
@@ -750,7 +750,7 @@ static int mysql_read(user_data_t *ud) {
 
   res = exec_query(con, query);
   if (res == NULL)
-    return (-1);
+    return -1;
 
   while ((row = mysql_fetch_row(res))) {
     char *key;
@@ -938,7 +938,7 @@ static int mysql_read(user_data_t *ud) {
   if (db->wsrep_stats)
     mysql_read_wsrep_stats(db, con);
 
-  return (0);
+  return 0;
 } /* int mysql_read */
 
 void module_register(void) {

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -459,7 +459,7 @@ static disk_t *get_disk(cfg_disk_t *cd, const char *name) /* {{{ */
   disk_t *d;
 
   if ((cd == NULL) || (name == NULL))
-    return (NULL);
+    return NULL;
 
   for (d = cd->disks; d != NULL; d = d->next) {
     if (strcmp(d->name, name) == 0)
@@ -468,13 +468,13 @@ static disk_t *get_disk(cfg_disk_t *cd, const char *name) /* {{{ */
 
   d = calloc(1, sizeof(*d));
   if (d == NULL)
-    return (NULL);
+    return NULL;
   d->next = NULL;
 
   d->name = strdup(name);
   if (d->name == NULL) {
     sfree(d);
-    return (NULL);
+    return NULL;
   }
 
   d->next = cd->disks;
@@ -492,12 +492,12 @@ static data_volume_usage_t *get_volume_usage(cfg_volume_usage_t *cvu, /* {{{ */
   int ignore_snapshot = 0;
 
   if ((cvu == NULL) || (name == NULL))
-    return (NULL);
+    return NULL;
 
   last = cvu->volumes;
   while (last != NULL) {
     if (strcmp(last->name, name) == 0)
-      return (last);
+      return last;
 
     if (last->next == NULL)
       break;
@@ -510,18 +510,18 @@ static data_volume_usage_t *get_volume_usage(cfg_volume_usage_t *cvu, /* {{{ */
   ignore_capacity = ignorelist_match(cvu->il_capacity, name);
   ignore_snapshot = ignorelist_match(cvu->il_snapshot, name);
   if ((ignore_capacity != 0) && (ignore_snapshot != 0))
-    return (NULL);
+    return NULL;
 
   /* Not found: allocate. */
   new = calloc(1, sizeof(*new));
   if (new == NULL)
-    return (NULL);
+    return NULL;
   new->next = NULL;
 
   new->name = strdup(name);
   if (new->name == NULL) {
     sfree(new);
-    return (NULL);
+    return NULL;
   }
 
   if (ignore_capacity == 0)
@@ -541,7 +541,7 @@ static data_volume_usage_t *get_volume_usage(cfg_volume_usage_t *cvu, /* {{{ */
   else
     last->next = new;
 
-  return (new);
+  return new;
 } /* }}} data_volume_usage_t *get_volume_usage */
 
 static data_volume_perf_t *get_volume_perf(cfg_volume_perf_t *cvp, /* {{{ */
@@ -554,12 +554,12 @@ static data_volume_perf_t *get_volume_perf(cfg_volume_perf_t *cvp, /* {{{ */
   int ignore_latency = 0;
 
   if ((cvp == NULL) || (name == NULL))
-    return (NULL);
+    return NULL;
 
   last = cvp->volumes;
   while (last != NULL) {
     if (strcmp(last->name, name) == 0)
-      return (last);
+      return last;
 
     if (last->next == NULL)
       break;
@@ -573,18 +573,18 @@ static data_volume_perf_t *get_volume_perf(cfg_volume_perf_t *cvp, /* {{{ */
   ignore_operations = ignorelist_match(cvp->il_operations, name);
   ignore_latency = ignorelist_match(cvp->il_latency, name);
   if ((ignore_octets != 0) || (ignore_operations != 0) || (ignore_latency != 0))
-    return (NULL);
+    return NULL;
 
   /* Not found: allocate. */
   new = calloc(1, sizeof(*new));
   if (new == NULL)
-    return (NULL);
+    return NULL;
   new->next = NULL;
 
   new->name = strdup(name);
   if (new->name == NULL) {
     sfree(new);
-    return (NULL);
+    return NULL;
   }
 
   if (ignore_octets == 0)
@@ -600,7 +600,7 @@ static data_volume_perf_t *get_volume_perf(cfg_volume_perf_t *cvp, /* {{{ */
   else
     last->next = new;
 
-  return (new);
+  return new;
 } /* }}} data_volume_perf_t *get_volume_perf */
 
 /*
@@ -634,7 +634,7 @@ static int submit_values(const char *host, /* {{{ */
   if (type_inst != NULL)
     sstrncpy(vl.type_instance, type_inst, sizeof(vl.type_instance));
 
-  return (plugin_dispatch_values(&vl));
+  return plugin_dispatch_values(&vl);
 } /* }}} int submit_uint64 */
 
 static int submit_two_derive(const char *host,
@@ -646,16 +646,17 @@ static int submit_two_derive(const char *host,
       {.derive = val0}, {.derive = val1},
   };
 
-  return (submit_values(host, plugin_inst, type, type_inst, values,
-                        STATIC_ARRAY_SIZE(values), timestamp, interval));
+  return submit_values(host, plugin_inst, type, type_inst, values,
+                       STATIC_ARRAY_SIZE(values), timestamp, interval);
 } /* }}} int submit_two_derive */
 
 static int submit_derive(const char *host, const char *plugin_inst, /* {{{ */
                          const char *type, const char *type_inst,
                          derive_t counter, cdtime_t timestamp,
                          cdtime_t interval) {
-  return (submit_values(host, plugin_inst, type, type_inst,
-                        &(value_t){.derive = counter}, 1, timestamp, interval));
+  return submit_values(host, plugin_inst, type, type_inst, &(value_t){
+      .derive=counter,
+    }, 1, timestamp, interval);
 } /* }}} int submit_derive */
 
 static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
@@ -666,15 +667,16 @@ static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
       {.gauge = val0}, {.gauge = val1},
   };
 
-  return (submit_values(host, plugin_inst, type, type_inst, values,
-                        STATIC_ARRAY_SIZE(values), timestamp, interval));
+  return submit_values(host, plugin_inst, type, type_inst, values,
+                       STATIC_ARRAY_SIZE(values), timestamp, interval);
 } /* }}} int submit_two_gauge */
 
 static int submit_double(const char *host, const char *plugin_inst, /* {{{ */
                          const char *type, const char *type_inst, double d,
                          cdtime_t timestamp, cdtime_t interval) {
-  return (submit_values(host, plugin_inst, type, type_inst,
-                        &(value_t){.gauge = d}, 1, timestamp, interval));
+  return submit_values(host, plugin_inst, type, type_inst, &(value_t){
+      .gauge=d,
+    }, 1, timestamp, interval);
 } /* }}} int submit_uint64 */
 
 /* Calculate hit ratio from old and new counters and submit the resulting
@@ -696,8 +698,8 @@ static int submit_cache_ratio(const char *host, /* {{{ */
     v.gauge = 100.0 * ((gauge_t)hits) / ((gauge_t)(hits + misses));
   }
 
-  return (submit_values(host, plugin_inst, "cache_ratio", type_inst, &v, 1,
-                        timestamp, interval));
+  return submit_values(host, plugin_inst, "cache_ratio", type_inst, &v, 1,
+                       timestamp, interval);
 } /* }}} int submit_cache_ratio */
 
 /* Submits all the caches used by WAFL. Uses "submit_cache_ratio". */
@@ -753,7 +755,7 @@ static int submit_wafl_data(const char *hostname,
   /* Copy HAVE_* flags */
   old_data->flags |= (new_data->flags & HAVE_WAFL_ALL);
 
-  return (0);
+  return 0;
 } /* }}} int submit_wafl_data */
 
 /* Submits volume performance data to the daemon, taking care to honor and
@@ -765,7 +767,7 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   char plugin_instance[DATA_MAX_NAME_LEN];
 
   if ((hostname == NULL) || (old_data == NULL) || (new_data == NULL))
-    return (-1);
+    return -1;
 
   ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
             old_data->name);
@@ -853,7 +855,7 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   /* Copy the HAVE_* flags */
   old_data->flags |= (new_data->flags & HAVE_VOLUME_PERF_ALL);
 
-  return (0);
+  return 0;
 } /* }}} int submit_volume_perf_data */
 
 static cdtime_t cna_child_get_cdtime(na_elem_t *data) /* {{{ */
@@ -862,7 +864,7 @@ static cdtime_t cna_child_get_cdtime(na_elem_t *data) /* {{{ */
 
   t = (time_t)na_child_get_uint64(data, "timestamp", /* default = */ 0);
 
-  return (TIME_T_TO_CDTIME_T(t));
+  return TIME_T_TO_CDTIME_T(t);
 } /* }}} cdtime_t cna_child_get_cdtime */
 
 /*
@@ -889,7 +891,7 @@ static int cna_handle_wafl_data(const char *hostname,
           "na_elem_child (\"instances\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   plugin_inst = na_child_get_string(instances, "name");
@@ -898,7 +900,7 @@ static int cna_handle_wafl_data(const char *hostname,
           "na_child_get_string (\"name\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   /* Iterate over all counters */
@@ -948,8 +950,8 @@ static int cna_handle_wafl_data(const char *hostname,
     }
   }
 
-  return (
-      submit_wafl_data(hostname, plugin_inst, cfg_wafl, &perf_data, interval));
+  return submit_wafl_data(hostname, plugin_inst, cfg_wafl, &perf_data,
+                          interval);
 } /* }}} void cna_handle_wafl_data */
 
 static int cna_setup_wafl(cfg_wafl_t *cw) /* {{{ */
@@ -957,15 +959,15 @@ static int cna_setup_wafl(cfg_wafl_t *cw) /* {{{ */
   na_elem_t *e;
 
   if (cw == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cw->query != NULL)
-    return (0);
+    return 0;
 
   cw->query = na_elem_new("perf-object-get-instances");
   if (cw->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(cw->query, "objectname", "wafl");
 
@@ -974,7 +976,7 @@ static int cna_setup_wafl(cfg_wafl_t *cw) /* {{{ */
     na_elem_free(cw->query);
     cw->query = NULL;
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(e, "counter", "name_cache_hit");
   na_child_add_string(e, "counter", "name_cache_miss");
@@ -987,7 +989,7 @@ static int cna_setup_wafl(cfg_wafl_t *cw) /* {{{ */
 
   na_child_add(cw->query, e);
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_wafl */
 
 static int cna_query_wafl(host_config_t *host) /* {{{ */
@@ -997,20 +999,20 @@ static int cna_query_wafl(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If WAFL was not configured, return without doing anything. */
   if (host->cfg_wafl == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_wafl->interval.interval + host->cfg_wafl->interval.last_read) >
       now)
-    return (0);
+    return 0;
 
   status = cna_setup_wafl(host->cfg_wafl);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_wafl->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_wafl->query);
@@ -1019,7 +1021,7 @@ static int cna_query_wafl(host_config_t *host) /* {{{ */
           "host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_wafl_data(host->name, host->cfg_wafl, data,
@@ -1029,7 +1031,7 @@ static int cna_query_wafl(host_config_t *host) /* {{{ */
     host->cfg_wafl->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_wafl */
 
 /* Data corresponding to <Disks /> */
@@ -1042,7 +1044,7 @@ static int cna_handle_disk_data(const char *hostname, /* {{{ */
   disk_t *worst_disk = NULL;
 
   if ((cfg_disk == NULL) || (data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   timestamp = cna_child_get_cdtime(data);
 
@@ -1052,7 +1054,7 @@ static int cna_handle_disk_data(const char *hostname, /* {{{ */
           "na_elem_child (\"instances\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   /* Iterate over all children */
@@ -1137,7 +1139,7 @@ static int cna_handle_disk_data(const char *hostname, /* {{{ */
     submit_double(hostname, "system", "percent", "disk_busy",
                   worst_disk->disk_busy_percent, timestamp, interval);
 
-  return (0);
+  return 0;
 } /* }}} int cna_handle_disk_data */
 
 static int cna_setup_disk(cfg_disk_t *cd) /* {{{ */
@@ -1145,15 +1147,15 @@ static int cna_setup_disk(cfg_disk_t *cd) /* {{{ */
   na_elem_t *e;
 
   if (cd == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cd->query != NULL)
-    return (0);
+    return 0;
 
   cd->query = na_elem_new("perf-object-get-instances");
   if (cd->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(cd->query, "objectname", "disk");
 
@@ -1162,13 +1164,13 @@ static int cna_setup_disk(cfg_disk_t *cd) /* {{{ */
     na_elem_free(cd->query);
     cd->query = NULL;
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(e, "counter", "disk_busy");
   na_child_add_string(e, "counter", "base_for_disk_busy");
   na_child_add(cd->query, e);
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_disk */
 
 static int cna_query_disk(host_config_t *host) /* {{{ */
@@ -1178,21 +1180,21 @@ static int cna_query_disk(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If the user did not configure disk statistics, return without doing
    * anything. */
   if (host->cfg_disk == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_disk->interval.interval + host->cfg_disk->interval.last_read) >
       now)
-    return (0);
+    return 0;
 
   status = cna_setup_disk(host->cfg_disk);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_disk->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_disk->query);
@@ -1201,7 +1203,7 @@ static int cna_query_disk(host_config_t *host) /* {{{ */
           "host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_disk_data(host->name, host->cfg_disk, data,
@@ -1211,7 +1213,7 @@ static int cna_query_disk(host_config_t *host) /* {{{ */
     host->cfg_disk->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_disk */
 
 /* Data corresponding to <VolumePerf /> */
@@ -1230,7 +1232,7 @@ static int cna_handle_volume_perf_data(const char *hostname, /* {{{ */
           "na_elem_child (\"instances\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   iter_instances = na_child_iterator(elem_instances);
@@ -1299,7 +1301,7 @@ static int cna_handle_volume_perf_data(const char *hostname, /* {{{ */
     submit_volume_perf_data(hostname, v, &perf_data, interval);
   } /* for (volume) */
 
-  return (0);
+  return 0;
 } /* }}} int cna_handle_volume_perf_data */
 
 static int cna_setup_volume_perf(cfg_volume_perf_t *cd) /* {{{ */
@@ -1307,15 +1309,15 @@ static int cna_setup_volume_perf(cfg_volume_perf_t *cd) /* {{{ */
   na_elem_t *e;
 
   if (cd == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cd->query != NULL)
-    return (0);
+    return 0;
 
   cd->query = na_elem_new("perf-object-get-instances");
   if (cd->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(cd->query, "objectname", "volume");
 
@@ -1324,7 +1326,7 @@ static int cna_setup_volume_perf(cfg_volume_perf_t *cd) /* {{{ */
     na_elem_free(cd->query);
     cd->query = NULL;
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(e, "counter", "read_ops");
   na_child_add_string(e, "counter", "write_ops");
@@ -1334,7 +1336,7 @@ static int cna_setup_volume_perf(cfg_volume_perf_t *cd) /* {{{ */
   na_child_add_string(e, "counter", "write_latency");
   na_child_add(cd->query, e);
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_volume_perf */
 
 static int cna_query_volume_perf(host_config_t *host) /* {{{ */
@@ -1344,21 +1346,21 @@ static int cna_query_volume_perf(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If the user did not configure volume performance statistics, return
    * without doing anything. */
   if (host->cfg_volume_perf == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_volume_perf->interval.interval +
        host->cfg_volume_perf->interval.last_read) > now)
-    return (0);
+    return 0;
 
   status = cna_setup_volume_perf(host->cfg_volume_perf);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_volume_perf->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_volume_perf->query);
@@ -1367,7 +1369,7 @@ static int cna_query_volume_perf(host_config_t *host) /* {{{ */
           "for host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status =
@@ -1378,7 +1380,7 @@ static int cna_query_volume_perf(host_config_t *host) /* {{{ */
     host->cfg_volume_perf->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_volume_perf */
 
 /* Data corresponding to <VolumeUsage /> */
@@ -1472,7 +1474,7 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
     v->flags &= ~HAVE_VOLUME_USAGE_ALL;
   } /* for (v = cfg_volume->volumes) */
 
-  return (0);
+  return 0;
 } /* }}} int cna_submit_volume_usage_data */
 
 /* Switch the state of a volume between online and offline and send out a
@@ -1498,7 +1500,7 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
 
-  return (plugin_dispatch_notification(&n));
+  return plugin_dispatch_notification(&n);
 } /* }}} int cna_change_volume_status */
 
 static void cna_handle_volume_snap_usage(const host_config_t *host, /* {{{ */
@@ -1661,7 +1663,7 @@ static int cna_handle_volume_usage_data(const host_config_t *host, /* {{{ */
           "na_elem_child (\"volumes\") failed "
           "for host %s.",
           host->name);
-    return (-1);
+    return -1;
   }
 
   iter_volume = na_child_iterator(elem_volumes);
@@ -1721,25 +1723,25 @@ static int cna_handle_volume_usage_data(const host_config_t *host, /* {{{ */
     }
   } /* for (elem_volume) */
 
-  return (cna_submit_volume_usage_data(
-      host->name, cfg_volume, host->cfg_volume_usage->interval.interval));
+  return cna_submit_volume_usage_data(host->name, cfg_volume,
+                                      host->cfg_volume_usage->interval.interval);
 } /* }}} int cna_handle_volume_usage_data */
 
 static int cna_setup_volume_usage(cfg_volume_usage_t *cvu) /* {{{ */
 {
   if (cvu == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cvu->query != NULL)
-    return (0);
+    return 0;
 
   cvu->query = na_elem_new("volume-list-info");
   if (cvu->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_volume_usage */
 
 static int cna_query_volume_usage(host_config_t *host) /* {{{ */
@@ -1749,21 +1751,21 @@ static int cna_query_volume_usage(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If the user did not configure volume_usage statistics, return without
    * doing anything. */
   if (host->cfg_volume_usage == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_volume_usage->interval.interval +
        host->cfg_volume_usage->interval.last_read) > now)
-    return (0);
+    return 0;
 
   status = cna_setup_volume_usage(host->cfg_volume_usage);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_volume_usage->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_volume_usage->query);
@@ -1772,7 +1774,7 @@ static int cna_query_volume_usage(host_config_t *host) /* {{{ */
           "for host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_volume_usage_data(host, host->cfg_volume_usage, data);
@@ -1781,7 +1783,7 @@ static int cna_query_volume_usage(host_config_t *host) /* {{{ */
     host->cfg_volume_usage->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_volume_usage */
 
 /* Data corresponding to <Quota /> */
@@ -1796,7 +1798,7 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
           "na_elem_child (\"quotas\") failed "
           "for host %s.",
           host->name);
-    return (-1);
+    return -1;
   }
 
   iter_quota = na_child_iterator(elem_quotas);
@@ -1844,24 +1846,24 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
     }
   } /* for (elem_quota) */
 
-  return (0);
+  return 0;
 } /* }}} int cna_handle_volume_usage_data */
 
 static int cna_setup_quota(cfg_quota_t *cq) /* {{{ */
 {
   if (cq == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cq->query != NULL)
-    return (0);
+    return 0;
 
   cq->query = na_elem_new("quota-report");
   if (cq->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_quota */
 
 static int cna_query_quota(host_config_t *host) /* {{{ */
@@ -1871,21 +1873,21 @@ static int cna_query_quota(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If the user did not configure quota statistics, return without
    * doing anything. */
   if (host->cfg_quota == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_quota->interval.interval +
        host->cfg_quota->interval.last_read) > now)
-    return (0);
+    return 0;
 
   status = cna_setup_quota(host->cfg_quota);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_quota->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_quota->query);
@@ -1894,7 +1896,7 @@ static int cna_query_quota(host_config_t *host) /* {{{ */
           "host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_quota_data(host, host->cfg_quota, data);
@@ -1903,7 +1905,7 @@ static int cna_query_quota(host_config_t *host) /* {{{ */
     host->cfg_quota->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_quota */
 
 /* Data corresponding to <SnapVault /> */
@@ -1913,7 +1915,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
   na_elem_t *status_list = na_elem_child(data, "status-list");
   if (status_list == NULL) {
     ERROR("netapp plugin: SnapVault status record missing status-list");
-    return (0);
+    return 0;
   }
 
   na_elem_iter_t status_iter = na_child_iterator(status_list);
@@ -1957,7 +1959,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
     }
   } /* for (status) */
 
-  return (0);
+  return 0;
 } /* }}} int cna_handle_snapvault_data */
 
 static int cna_handle_snapvault_iter(host_config_t *host, /* {{{ */
@@ -1989,7 +1991,7 @@ static int cna_handle_snapvault_iter(host_config_t *host, /* {{{ */
             "na_server_invoke failed for host %s: %s",
             host->name, na_results_reason(data));
       na_elem_free(elem);
-      return (-1);
+      return -1;
     }
 
     cna_handle_snapvault_data(host->name, host->cfg_snapvault, elem,
@@ -2000,25 +2002,25 @@ static int cna_handle_snapvault_iter(host_config_t *host, /* {{{ */
   na_elem_free(na_server_invoke(
       host->srv, "snapvault-secondary-relationship-status-list-iter-end", "tag",
       tag, NULL));
-  return (0);
+  return 0;
 } /* }}} int cna_handle_snapvault_iter */
 
 static int cna_setup_snapvault(cfg_snapvault_t *sv) /* {{{ */
 {
   if (sv == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (sv->query != NULL)
-    return (0);
+    return 0;
 
   sv->query =
       na_elem_new("snapvault-secondary-relationship-status-list-iter-start");
   if (sv->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_snapvault */
 
 static int cna_query_snapvault(host_config_t *host) /* {{{ */
@@ -2036,11 +2038,11 @@ static int cna_query_snapvault(host_config_t *host) /* {{{ */
   now = cdtime();
   if ((host->cfg_snapvault->interval.interval +
        host->cfg_snapvault->interval.last_read) > now)
-    return (0);
+    return 0;
 
   status = cna_setup_snapvault(host->cfg_snapvault);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_snapvault->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_snapvault->query);
@@ -2049,7 +2051,7 @@ static int cna_query_snapvault(host_config_t *host) /* {{{ */
           "for host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_snapvault_iter(host, data);
@@ -2058,7 +2060,7 @@ static int cna_query_snapvault(host_config_t *host) /* {{{ */
     host->cfg_snapvault->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_snapvault */
 
 /* Data corresponding to <System /> */
@@ -2084,7 +2086,7 @@ static int cna_handle_system_data(const char *hostname, /* {{{ */
           "na_elem_child (\"instances\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   instance = na_child_get_string(instances, "name");
@@ -2093,7 +2095,7 @@ static int cna_handle_system_data(const char *hostname, /* {{{ */
           "na_child_get_string (\"name\") failed "
           "for host %s.",
           hostname);
-    return (-1);
+    return -1;
   }
 
   counter_iter = na_child_iterator(na_elem_child(instances, "counters"));
@@ -2154,25 +2156,25 @@ static int cna_handle_system_data(const char *hostname, /* {{{ */
                   timestamp, interval);
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_handle_system_data */
 
 static int cna_setup_system(cfg_system_t *cs) /* {{{ */
 {
   if (cs == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (cs->query != NULL)
-    return (0);
+    return 0;
 
   cs->query = na_elem_new("perf-object-get-instances");
   if (cs->query == NULL) {
     ERROR("netapp plugin: na_elem_new failed.");
-    return (-1);
+    return -1;
   }
   na_child_add_string(cs->query, "objectname", "system");
 
-  return (0);
+  return 0;
 } /* }}} int cna_setup_system */
 
 static int cna_query_system(host_config_t *host) /* {{{ */
@@ -2182,20 +2184,20 @@ static int cna_query_system(host_config_t *host) /* {{{ */
   cdtime_t now;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   /* If system statistics were not configured, return without doing anything. */
   if (host->cfg_system == NULL)
-    return (0);
+    return 0;
 
   now = cdtime();
   if ((host->cfg_system->interval.interval +
        host->cfg_system->interval.last_read) > now)
-    return (0);
+    return 0;
 
   status = cna_setup_system(host->cfg_system);
   if (status != 0)
-    return (status);
+    return status;
   assert(host->cfg_system->query != NULL);
 
   data = na_server_invoke_elem(host->srv, host->cfg_system->query);
@@ -2204,7 +2206,7 @@ static int cna_query_system(host_config_t *host) /* {{{ */
           "host %s: %s",
           host->name, na_results_reason(data));
     na_elem_free(data);
-    return (-1);
+    return -1;
   }
 
   status = cna_handle_system_data(host->name, host->cfg_system, data,
@@ -2214,7 +2216,7 @@ static int cna_query_system(host_config_t *host) /* {{{ */
     host->cfg_system->interval.last_read = now;
 
   na_elem_free(data);
-  return (status);
+  return status;
 } /* }}} int cna_query_system */
 
 /*
@@ -2225,12 +2227,12 @@ static int cna_query_system(host_config_t *host) /* {{{ */
 static int cna_config_bool_to_flag(const oconfig_item_t *ci, /* {{{ */
                                    uint32_t *flags, uint32_t flag) {
   if ((ci == NULL) || (flags == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_BOOLEAN)) {
     WARNING("netapp plugin: The %s option needs exactly one boolean argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.boolean)
@@ -2238,7 +2240,7 @@ static int cna_config_bool_to_flag(const oconfig_item_t *ci, /* {{{ */
   else
     *flags &= ~flag;
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_bool_to_flag */
 
 /* Handling of the "Interval" option which is allowed in every block. */
@@ -2249,12 +2251,12 @@ static int cna_config_get_interval(const oconfig_item_t *ci, /* {{{ */
 
   status = cf_util_get_cdtime(ci, &tmp);
   if (status != 0)
-    return (status);
+    return status;
 
   out_interval->interval = tmp;
   out_interval->last_read = 0;
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_get_interval */
 
 /* Handling of the "GetIO", "GetOps" and "GetLatency" options within a
@@ -2335,12 +2337,12 @@ static int cna_config_volume_performance(host_config_t *host, /* {{{ */
   cfg_volume_perf_t *cfg_volume_perf;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_volume_perf == NULL) {
     cfg_volume_perf = calloc(1, sizeof(*cfg_volume_perf));
     if (cfg_volume_perf == NULL)
-      return (ENOMEM);
+      return ENOMEM;
 
     /* Set default flags */
     cfg_volume_perf->query = NULL;
@@ -2349,14 +2351,14 @@ static int cna_config_volume_performance(host_config_t *host, /* {{{ */
     cfg_volume_perf->il_octets = ignorelist_create(/* invert = */ 1);
     if (cfg_volume_perf->il_octets == NULL) {
       sfree(cfg_volume_perf);
-      return (ENOMEM);
+      return ENOMEM;
     }
 
     cfg_volume_perf->il_operations = ignorelist_create(/* invert = */ 1);
     if (cfg_volume_perf->il_operations == NULL) {
       ignorelist_free(cfg_volume_perf->il_octets);
       sfree(cfg_volume_perf);
-      return (ENOMEM);
+      return ENOMEM;
     }
 
     cfg_volume_perf->il_latency = ignorelist_create(/* invert = */ 1);
@@ -2364,7 +2366,7 @@ static int cna_config_volume_performance(host_config_t *host, /* {{{ */
       ignorelist_free(cfg_volume_perf->il_octets);
       ignorelist_free(cfg_volume_perf->il_operations);
       sfree(cfg_volume_perf);
-      return (ENOMEM);
+      return ENOMEM;
     }
 
     host->cfg_volume_perf = cfg_volume_perf;
@@ -2395,7 +2397,7 @@ static int cna_config_volume_performance(host_config_t *host, /* {{{ */
               item->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_volume_performance */
 
 /* Handling of the "GetCapacity" and "GetSnapshot" options within a
@@ -2456,12 +2458,12 @@ static int cna_config_quota(host_config_t *host, oconfig_item_t *ci) /* {{{ */
   cfg_quota_t *cfg_quota;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_quota == NULL) {
     cfg_quota = calloc(1, sizeof(*cfg_quota));
     if (cfg_quota == NULL)
-      return (ENOMEM);
+      return ENOMEM;
     cfg_quota->query = NULL;
 
     host->cfg_quota = cfg_quota;
@@ -2479,7 +2481,7 @@ static int cna_config_quota(host_config_t *host, oconfig_item_t *ci) /* {{{ */
               item->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_quota */
 
 /* Corresponds to a <Disks /> block */
@@ -2487,12 +2489,12 @@ static int cna_config_disk(host_config_t *host, oconfig_item_t *ci) { /* {{{ */
   cfg_disk_t *cfg_disk;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_disk == NULL) {
     cfg_disk = calloc(1, sizeof(*cfg_disk));
     if (cfg_disk == NULL)
-      return (ENOMEM);
+      return ENOMEM;
 
     /* Set default flags */
     cfg_disk->flags = CFG_DISK_ALL;
@@ -2520,7 +2522,7 @@ static int cna_config_disk(host_config_t *host, oconfig_item_t *ci) { /* {{{ */
     host->cfg_disk = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_disk */
 
 /* Corresponds to a <WAFL /> block */
@@ -2529,12 +2531,12 @@ static int cna_config_wafl(host_config_t *host, oconfig_item_t *ci) /* {{{ */
   cfg_wafl_t *cfg_wafl;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_wafl == NULL) {
     cfg_wafl = calloc(1, sizeof(*cfg_wafl));
     if (cfg_wafl == NULL)
-      return (ENOMEM);
+      return ENOMEM;
 
     /* Set default flags */
     cfg_wafl->flags = CFG_WAFL_ALL;
@@ -2569,7 +2571,7 @@ static int cna_config_wafl(host_config_t *host, oconfig_item_t *ci) /* {{{ */
     host->cfg_wafl = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_wafl */
 
 /*
@@ -2594,12 +2596,12 @@ static int cna_config_volume_usage(host_config_t *host, /* {{{ */
   cfg_volume_usage_t *cfg_volume_usage;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_volume_usage == NULL) {
     cfg_volume_usage = calloc(1, sizeof(*cfg_volume_usage));
     if (cfg_volume_usage == NULL)
-      return (ENOMEM);
+      return ENOMEM;
 
     /* Set default flags */
     cfg_volume_usage->query = NULL;
@@ -2608,14 +2610,14 @@ static int cna_config_volume_usage(host_config_t *host, /* {{{ */
     cfg_volume_usage->il_capacity = ignorelist_create(/* invert = */ 1);
     if (cfg_volume_usage->il_capacity == NULL) {
       sfree(cfg_volume_usage);
-      return (ENOMEM);
+      return ENOMEM;
     }
 
     cfg_volume_usage->il_snapshot = ignorelist_create(/* invert = */ 1);
     if (cfg_volume_usage->il_snapshot == NULL) {
       ignorelist_free(cfg_volume_usage->il_capacity);
       sfree(cfg_volume_usage);
-      return (ENOMEM);
+      return ENOMEM;
     }
 
     host->cfg_volume_usage = cfg_volume_usage;
@@ -2642,7 +2644,7 @@ static int cna_config_volume_usage(host_config_t *host, /* {{{ */
               item->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_volume_usage */
 
 /* Corresponds to a <SnapVault /> block */
@@ -2684,12 +2686,12 @@ static int cna_config_system(host_config_t *host, /* {{{ */
   cfg_system_t *cfg_system;
 
   if ((host == NULL) || (ci == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   if (host->cfg_system == NULL) {
     cfg_system = calloc(1, sizeof(*cfg_system));
     if (cfg_system == NULL)
-      return (ENOMEM);
+      return ENOMEM;
 
     /* Set default flags */
     cfg_system->flags = CFG_SYSTEM_ALL;
@@ -2726,7 +2728,7 @@ static int cna_config_system(host_config_t *host, /* {{{ */
     host->cfg_system = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_config_system */
 
 /* Corresponds to a <Host /> block. */
@@ -2736,7 +2738,7 @@ static host_config_t *cna_alloc_host(void) /* {{{ */
 
   host = calloc(1, sizeof(*host));
   if (host == NULL)
-    return (NULL);
+    return NULL;
 
   host->name = NULL;
   host->protocol = NA_SERVER_TRANSPORT_HTTPS;
@@ -2753,7 +2755,7 @@ static host_config_t *cna_alloc_host(void) /* {{{ */
   host->cfg_snapvault = NULL;
   host->cfg_system = NULL;
 
-  return (host);
+  return host;
 } /* }}} host_config_t *cna_alloc_host */
 
 static host_config_t *cna_shallow_clone_host(host_config_t *host) /* {{{ */
@@ -2761,11 +2763,11 @@ static host_config_t *cna_shallow_clone_host(host_config_t *host) /* {{{ */
   host_config_t *clone;
 
   if (host == NULL)
-    return (NULL);
+    return NULL;
 
   clone = cna_alloc_host();
   if (clone == NULL)
-    return (NULL);
+    return NULL;
 
   if (host->name != NULL) {
     clone->name = strdup(host->name);
@@ -2804,7 +2806,7 @@ static host_config_t *cna_shallow_clone_host(host_config_t *host) /* {{{ */
 
   clone->interval = host->interval;
 
-  return (clone);
+  return clone;
 } /* }}} host_config_t *cna_shallow_clone_host */
 
 static int cna_read(user_data_t *ud);
@@ -2827,7 +2829,7 @@ static int cna_register_host(host_config_t *host) /* {{{ */
           .data = host, .free_func = (void *)free_host_config,
       });
 
-  return (0);
+  return 0;
 } /* }}} int cna_register_host */
 
 static int cna_config_host(host_config_t *host, /* {{{ */
@@ -2843,12 +2845,12 @@ static int cna_config_host(host_config_t *host, /* {{{ */
     WARNING("netapp plugin: \"%s\" needs exactly one string argument. Ignoring "
             "host block.",
             ci->key);
-    return (1);
+    return 1;
   }
 
   status = cf_util_get_string(ci, &host->name);
   if (status != 0)
-    return (1);
+    return 1;
 
   for (int i = 0; i < ci->children_num; ++i) {
     item = ci->children + i;
@@ -2871,7 +2873,7 @@ static int cna_config_host(host_config_t *host, /* {{{ */
         WARNING("netapp plugin: \"Protocol\" needs to be either \"http\" or "
                 "\"https\". Ignoring host block \"%s\".",
                 ci->values[0].value.string);
-        return (1);
+        return 1;
       }
       if (!strcasecmp(item->values[0].value.string, "http"))
         host->protocol = NA_SERVER_TRANSPORT_HTTP;
@@ -2947,7 +2949,7 @@ static int cna_config_host(host_config_t *host, /* {{{ */
   if (status != 0)
     return status;
 
-  return (0);
+  return 0;
 } /* }}} host_config_t *cna_config_host */
 
 /*
@@ -2961,10 +2963,10 @@ static int cna_init_host(host_config_t *host) /* {{{ */
   int major_version = 1, minor_version = 1;
 
   if (host == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (host->srv != NULL)
-    return (0);
+    return 0;
 
   if (host->vfiler != NULL) /* Request version 1.7 of the ONTAP API */
     minor_version = 7;
@@ -2972,7 +2974,7 @@ static int cna_init_host(host_config_t *host) /* {{{ */
   host->srv = na_server_open(host->host, major_version, minor_version);
   if (host->srv == NULL) {
     ERROR("netapp plugin: na_server_open (%s) failed.", host->host);
-    return (-1);
+    return -1;
   }
 
   na_server_set_transport_type(host->srv, host->protocol,
@@ -2986,14 +2988,14 @@ static int cna_init_host(host_config_t *host) /* {{{ */
     if (!na_server_set_vfiler(host->srv, host->vfiler)) {
       ERROR("netapp plugin: Failed to connect to VFiler '%s' on host '%s'.",
             host->vfiler, host->host);
-      return (-1);
+      return -1;
     } else {
       INFO("netapp plugin: Connected to VFiler '%s' on host '%s'.",
            host->vfiler, host->host);
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int cna_init_host */
 
 static int cna_init(void) /* {{{ */
@@ -3006,7 +3008,7 @@ static int cna_init(void) /* {{{ */
     return 1;
   }
 
-  return (0);
+  return 0;
 } /* }}} cna_init */
 
 static int cna_read_internal(host_config_t *host) { /* {{{ */
@@ -3014,31 +3016,31 @@ static int cna_read_internal(host_config_t *host) { /* {{{ */
 
   status = cna_query_wafl(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_disk(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_volume_perf(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_volume_usage(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_quota(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_snapvault(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_query_system(host);
   if (status != 0)
-    return (status);
+    return status;
 
   return 0;
 } /* }}} int cna_read_internal */
@@ -3048,13 +3050,13 @@ static int cna_read(user_data_t *ud) { /* {{{ */
   int status;
 
   if ((ud == NULL) || (ud->data == NULL))
-    return (-1);
+    return -1;
 
   host = ud->data;
 
   status = cna_init_host(host);
   if (status != 0)
-    return (status);
+    return status;
 
   status = cna_read_internal(host);
   if (status != 0) {
@@ -3101,7 +3103,7 @@ static int cna_shutdown(void) /* {{{ */
   /* Clean up system resources and stuff. */
   na_shutdown();
 
-  return (0);
+  return 0;
 } /* }}} int cna_shutdown */
 
 void module_register(void) {

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -108,13 +108,13 @@ static int add_ignorelist(const char *dev, const char *type, const char *inst) {
 
   entry = calloc(1, sizeof(*entry));
   if (entry == NULL)
-    return (-1);
+    return -1;
 
   if (strcasecmp(dev, "All") != 0) {
     entry->device = strdup(dev);
     if (entry->device == NULL) {
       sfree(entry);
-      return (-1);
+      return -1;
     }
   }
 
@@ -122,7 +122,7 @@ static int add_ignorelist(const char *dev, const char *type, const char *inst) {
   if (entry->type == NULL) {
     sfree(entry->device);
     sfree(entry);
-    return (-1);
+    return -1;
   }
 
   if (inst != NULL) {
@@ -131,14 +131,14 @@ static int add_ignorelist(const char *dev, const char *type, const char *inst) {
       sfree(entry->type);
       sfree(entry->device);
       sfree(entry);
-      return (-1);
+      return -1;
     }
   }
 
   entry->next = ir_ignorelist_head;
   ir_ignorelist_head = entry;
 
-  return (0);
+  return 0;
 } /* int add_ignorelist */
 
 /*
@@ -150,7 +150,7 @@ static int check_ignorelist(const char *dev, const char *type,
   assert((dev != NULL) && (type != NULL));
 
   if (ir_ignorelist_head == NULL)
-    return (ir_ignorelist_invert ? 0 : 1);
+    return ir_ignorelist_invert ? 0 : 1;
 
   for (ir_ignorelist_t *i = ir_ignorelist_head; i != NULL; i = i->next) {
     /* i->device == NULL  =>  match all devices */
@@ -171,10 +171,10 @@ static int check_ignorelist(const char *dev, const char *type,
           i->device == NULL ? "(nil)" : i->device, i->type,
           i->inst == NULL ? "(nil)" : i->inst);
 
-    return (ir_ignorelist_invert ? 0 : 1);
+    return ir_ignorelist_invert ? 0 : 1;
   } /* for i */
 
-  return (ir_ignorelist_invert);
+  return ir_ignorelist_invert;
 } /* int check_ignorelist */
 
 static void submit_one(const char *dev, const char *type,
@@ -221,7 +221,7 @@ static int update_iflist(struct ifinfomsg *msg, const char *dev) {
     temp = realloc(iflist, (msg->ifi_index + 1) * sizeof(char *));
     if (temp == NULL) {
       ERROR("netlink plugin: update_iflist: realloc failed.");
-      return (-1);
+      return -1;
     }
 
     memset(temp + iflist_len, '\0',
@@ -235,7 +235,7 @@ static int update_iflist(struct ifinfomsg *msg, const char *dev) {
     iflist[msg->ifi_index] = strdup(dev);
   }
 
-  return (0);
+  return 0;
 } /* int update_iflist */
 
 static void check_ignorelist_and_submit(const char *dev,
@@ -485,7 +485,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
   if (kind == NULL) {
     ERROR("netlink plugin: qos_filter_cb: kind == NULL");
-    return (-1);
+    return -1;
   }
 
   { /* The ID */
@@ -588,12 +588,12 @@ static int ir_config(const char *key, const char *value) {
 
   new_val = strdup(value);
   if (new_val == NULL)
-    return (-1);
+    return -1;
 
   fields_num = strsplit(new_val, fields, STATIC_ARRAY_SIZE(fields));
   if ((fields_num < 1) || (fields_num > 8)) {
     sfree(new_val);
-    return (-1);
+    return -1;
   }
 
   if ((strcasecmp(key, "Interface") == 0) ||
@@ -616,7 +616,7 @@ static int ir_config(const char *key, const char *value) {
       ERROR("netlink plugin: Invalid number of fields for option "
             "`%s'. Got %i, expected 1 or 2.",
             key, fields_num);
-      return (-1);
+      return -1;
     } else {
       add_ignorelist(fields[0], key, (fields_num == 2) ? fields[1] : NULL);
       status = 0;
@@ -638,22 +638,22 @@ static int ir_config(const char *key, const char *value) {
 
   sfree(new_val);
 
-  return (status);
+  return status;
 } /* int ir_config */
 
 static int ir_init(void) {
   nl = mnl_socket_open(NETLINK_ROUTE);
   if (nl == NULL) {
     ERROR("netlink plugin: ir_init: mnl_socket_open failed.");
-    return (-1);
+    return -1;
   }
 
   if (mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
     ERROR("netlink plugin: ir_init: mnl_socket_bind failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int ir_init */
 
 static int ir_read(void) {
@@ -677,7 +677,7 @@ static int ir_read(void) {
 
   if (mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
     ERROR("netlink plugin: ir_read: rtnl_wilddump_request failed.");
-    return (-1);
+    return -1;
   }
 
   ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
@@ -689,7 +689,7 @@ static int ir_read(void) {
   }
   if (ret < 0) {
     ERROR("netlink plugin: ir_read: mnl_socket_recvfrom failed.");
-    return (-1);
+    return -1;
   }
 
   /* `link_filter_cb' will update `iflist' which is used here to iterate
@@ -740,7 +740,7 @@ static int ir_read(void) {
     } /* for (type_index) */
   }   /* for (if_index) */
 
-  return (0);
+  return 0;
 } /* int ir_read */
 
 static int ir_shutdown(void) {
@@ -749,7 +749,7 @@ static int ir_shutdown(void) {
     nl = NULL;
   }
 
-  return (0);
+  return 0;
 } /* int ir_shutdown */
 
 void module_register(void) {

--- a/src/network.c
+++ b/src/network.c
@@ -324,9 +324,9 @@ static _Bool check_receive_okay(const value_list_t *vl) /* {{{ */
   /* This is a value we already sent. Don't allow it to be received again in
    * order to avoid looping. */
   if ((status == 0) && (time_sent >= ((uint64_t)vl->time)))
-    return (0);
+    return 0;
 
-  return (1);
+  return 1;
 } /* }}} _Bool check_receive_okay */
 
 static _Bool check_send_okay(const value_list_t *vl) /* {{{ */
@@ -335,24 +335,24 @@ static _Bool check_send_okay(const value_list_t *vl) /* {{{ */
   int status;
 
   if (network_config_forward)
-    return (1);
+    return 1;
 
   if (vl->meta == NULL)
-    return (1);
+    return 1;
 
   status = meta_data_get_boolean(vl->meta, "network:received", &received);
   if (status == -ENOENT)
-    return (1);
+    return 1;
   else if (status != 0) {
     ERROR("network plugin: check_send_okay: meta_data_get_boolean failed "
           "with status %i.",
           status);
-    return (1);
+    return 1;
   }
 
   /* By default, only *send* value lists that were not *received* by the
    * network plugin. */
-  return (!received);
+  return !received;
 } /* }}} _Bool check_send_okay */
 
 static _Bool check_notify_received(const notification_t *n) /* {{{ */
@@ -360,9 +360,9 @@ static _Bool check_notify_received(const notification_t *n) /* {{{ */
   for (notification_meta_t *ptr = n->meta; ptr != NULL; ptr = ptr->next)
     if ((strcmp("network:received", ptr->name) == 0) &&
         (ptr->type == NM_TYPE_BOOLEAN))
-      return ((_Bool)ptr->nm_value.nm_boolean);
+      return (_Bool)ptr->nm_value.nm_boolean;
 
-  return (0);
+  return 0;
 } /* }}} _Bool check_notify_received */
 
 static _Bool check_send_notify_okay(const notification_t *n) /* {{{ */
@@ -371,7 +371,7 @@ static _Bool check_send_notify_okay(const notification_t *n) /* {{{ */
   _Bool received = 0;
 
   if (n->meta == NULL)
-    return (1);
+    return 1;
 
   received = check_notify_received(n);
 
@@ -387,7 +387,7 @@ static _Bool check_send_notify_okay(const notification_t *n) /* {{{ */
 
   /* By default, only *send* value lists that were not *received* by the
    * network plugin. */
-  return (!received);
+  return !received;
 } /* }}} _Bool check_send_notify_okay */
 
 static int network_dispatch_values(value_list_t *vl, /* {{{ */
@@ -396,7 +396,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
 
   if ((vl->time == 0) || (strlen(vl->host) == 0) || (strlen(vl->plugin) == 0) ||
       (strlen(vl->type) == 0))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (!check_receive_okay(vl)) {
 #if COLLECT_DEBUG
@@ -408,7 +408,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
           name);
 #endif
     stats_values_not_dispatched++;
-    return (0);
+    return 0;
   }
 
   assert(vl->meta == NULL);
@@ -416,7 +416,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
   vl->meta = meta_data_create();
   if (vl->meta == NULL) {
     ERROR("network plugin: meta_data_create failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   status = meta_data_add_boolean(vl->meta, "network:received", 1);
@@ -424,7 +424,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
     ERROR("network plugin: meta_data_add_boolean failed.");
     meta_data_destroy(vl->meta);
     vl->meta = NULL;
-    return (status);
+    return status;
   }
 
   if (username != NULL) {
@@ -433,7 +433,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
       ERROR("network plugin: meta_data_add_string failed.");
       meta_data_destroy(vl->meta);
       vl->meta = NULL;
-      return (status);
+      return status;
     }
   }
 
@@ -443,7 +443,7 @@ static int network_dispatch_values(value_list_t *vl, /* {{{ */
   meta_data_destroy(vl->meta);
   vl->meta = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int network_dispatch_values */
 
 static int network_dispatch_notification(notification_t *n) /* {{{ */
@@ -457,7 +457,7 @@ static int network_dispatch_notification(notification_t *n) /* {{{ */
     ERROR("network plugin: plugin_notification_meta_add_boolean failed.");
     plugin_notification_meta_free(n->meta);
     n->meta = NULL;
-    return (status);
+    return status;
   }
 
   status = plugin_dispatch_notification(n);
@@ -465,7 +465,7 @@ static int network_dispatch_notification(notification_t *n) /* {{{ */
   plugin_notification_meta_free(n->meta);
   n->meta = NULL;
 
-  return (status);
+  return status;
 } /* }}} int network_dispatch_notification */
 
 #if HAVE_GCRYPT_H
@@ -477,7 +477,7 @@ static int network_init_gcrypt(void) /* {{{ */
    * Because you can't know in a library whether another library has
    * already initialized the library */
   if (gcry_control(GCRYCTL_ANY_INITIALIZATION_P))
-    return (0);
+    return 0;
 
 /* http://www.gnupg.org/documentation/manuals/gcrypt/Multi_002dThreading.html
  * To ensure thread-safety, it's important to set GCRYCTL_SET_THREAD_CBS
@@ -491,7 +491,7 @@ static int network_init_gcrypt(void) /* {{{ */
   if (err) {
     ERROR("network plugin: gcry_control (GCRYCTL_SET_THREAD_CBS) failed: %s",
           gcry_strerror(err));
-    return (-1);
+    return -1;
   }
 #endif
 
@@ -501,11 +501,11 @@ static int network_init_gcrypt(void) /* {{{ */
   if (err) {
     ERROR("network plugin: gcry_control (GCRYCTL_INIT_SECMEM) failed: %s",
           gcry_strerror(err));
-    return (-1);
+    return -1;
   }
 
   gcry_control(GCRYCTL_INITIALIZATION_FINISHED);
-  return (0);
+  return 0;
 } /* }}} int network_init_gcrypt */
 
 static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
@@ -525,11 +525,11 @@ static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
     cyper_ptr = &se->data.server.cypher;
 
     if (username == NULL)
-      return (NULL);
+      return NULL;
 
     secret = fbh_get(se->data.server.userdb, username);
     if (secret == NULL)
-      return (NULL);
+      return NULL;
 
     gcry_md_hash_buffer(GCRY_MD_SHA256, password_hash, secret, strlen(secret));
 
@@ -543,7 +543,7 @@ static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
       ERROR("network plugin: gcry_cipher_open returned: %s",
             gcry_strerror(err));
       *cyper_ptr = NULL;
-      return (NULL);
+      return NULL;
     }
   } else {
     gcry_cipher_reset(*cyper_ptr);
@@ -556,7 +556,7 @@ static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
           gcry_strerror(err));
     gcry_cipher_close(*cyper_ptr);
     *cyper_ptr = NULL;
-    return (NULL);
+    return NULL;
   }
 
   err = gcry_cipher_setiv(*cyper_ptr, iv, iv_size);
@@ -565,10 +565,10 @@ static gcry_cipher_hd_t network_get_aes256_cypher(sockent_t *se, /* {{{ */
           gcry_strerror(err));
     gcry_cipher_close(*cyper_ptr);
     *cyper_ptr = NULL;
-    return (NULL);
+    return NULL;
   }
 
-  return (*cyper_ptr);
+  return *cyper_ptr;
 } /* }}} int network_get_aes256_cypher */
 #endif /* HAVE_GCRYPT_H */
 
@@ -590,19 +590,19 @@ static int write_part_values(char **ret_buffer, size_t *ret_buffer_len,
                (num_values * sizeof(uint8_t)) + (num_values * sizeof(value_t));
 
   if (*ret_buffer_len < packet_len)
-    return (-1);
+    return -1;
 
   pkg_values_types = malloc(num_values * sizeof(*pkg_values_types));
   if (pkg_values_types == NULL) {
     ERROR("network plugin: write_part_values: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   pkg_values = malloc(num_values * sizeof(*pkg_values));
   if (pkg_values == NULL) {
     free(pkg_values_types);
     ERROR("network plugin: write_part_values: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   pkg_ph.type = htons(TYPE_VALUES);
@@ -635,7 +635,7 @@ static int write_part_values(char **ret_buffer, size_t *ret_buffer_len,
       ERROR("network plugin: write_part_values: "
             "Unknown data source type: %i",
             ds->ds[i].type);
-      return (-1);
+      return -1;
     } /* switch (ds->ds[i].type) */
   }   /* for (num_values) */
 
@@ -663,7 +663,7 @@ static int write_part_values(char **ret_buffer, size_t *ret_buffer_len,
   free(pkg_values_types);
   free(pkg_values);
 
-  return (0);
+  return 0;
 } /* int write_part_values */
 
 static int write_part_number(char **ret_buffer, size_t *ret_buffer_len,
@@ -679,7 +679,7 @@ static int write_part_number(char **ret_buffer, size_t *ret_buffer_len,
   packet_len = sizeof(pkg_head) + sizeof(pkg_value);
 
   if (*ret_buffer_len < packet_len)
-    return (-1);
+    return -1;
 
   pkg_head.type = htons(type);
   pkg_head.length = htons(packet_len);
@@ -697,7 +697,7 @@ static int write_part_number(char **ret_buffer, size_t *ret_buffer_len,
   *ret_buffer = packet_ptr + packet_len;
   *ret_buffer_len -= packet_len;
 
-  return (0);
+  return 0;
 } /* int write_part_number */
 
 static int write_part_string(char **ret_buffer, size_t *ret_buffer_len,
@@ -712,7 +712,7 @@ static int write_part_string(char **ret_buffer, size_t *ret_buffer_len,
 
   buffer_len = 2 * sizeof(uint16_t) + str_len + 1;
   if (*ret_buffer_len < buffer_len)
-    return (-1);
+    return -1;
 
   pkg_type = htons(type);
   pkg_length = htons(buffer_len);
@@ -733,7 +733,7 @@ static int write_part_string(char **ret_buffer, size_t *ret_buffer_len,
   *ret_buffer = buffer + buffer_len;
   *ret_buffer_len -= buffer_len;
 
-  return (0);
+  return 0;
 } /* int write_part_string */
 
 static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
@@ -755,7 +755,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
     NOTICE("network plugin: packet is too short: "
            "buffer_len = %zu",
            buffer_len);
-    return (-1);
+    return -1;
   }
 
   memcpy((void *)&tmp16, buffer, sizeof(tmp16));
@@ -780,7 +780,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
             "Chunk of size %zu expected, "
             "but buffer has only %zu bytes left.",
             exp_size, buffer_len);
-    return (-1);
+    return -1;
   }
   assert(pkg_numval <= ((buffer_len - 6) / 9));
 
@@ -788,7 +788,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
     WARNING("network plugin: parse_part_values: "
             "Length and number of values "
             "in the packet don't match.");
-    return (-1);
+    return -1;
   }
 
   pkg_types = calloc(pkg_numval, sizeof(*pkg_types));
@@ -797,7 +797,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
     sfree(pkg_types);
     sfree(pkg_values);
     ERROR("network plugin: parse_part_values: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   memcpy(pkg_types, buffer, pkg_numval * sizeof(*pkg_types));
@@ -829,7 +829,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
              pkg_types[i]);
       sfree(pkg_types);
       sfree(pkg_values);
-      return (-1);
+      return -1;
     } /* switch (pkg_types[i]) */
   }
 
@@ -840,7 +840,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
 
   sfree(pkg_types);
 
-  return (0);
+  return 0;
 } /* int parse_part_values */
 
 static int parse_part_number(void **ret_buffer, size_t *ret_buffer_len,
@@ -860,7 +860,7 @@ static int parse_part_number(void **ret_buffer, size_t *ret_buffer_len,
             "Chunk of size %zu expected, "
             "but buffer has only %zu bytes left.",
             exp_size, buffer_len);
-    return (-1);
+    return -1;
   }
 
   memcpy((void *)&tmp16, buffer, sizeof(tmp16));
@@ -878,7 +878,7 @@ static int parse_part_number(void **ret_buffer, size_t *ret_buffer_len,
   *ret_buffer = buffer;
   *ret_buffer_len = buffer_len - pkg_length;
 
-  return (0);
+  return 0;
 } /* int parse_part_number */
 
 static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
@@ -893,7 +893,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
   size_t payload_size;
 
   if (output_len == 0)
-    return (EINVAL);
+    return EINVAL;
 
   if (buffer_len < header_size) {
     WARNING("network plugin: parse_part_string: "
@@ -901,7 +901,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
             "Chunk of at least size %zu expected, "
             "but buffer has only %zu bytes left.",
             header_size, buffer_len);
-    return (-1);
+    return -1;
   }
 
   memcpy((void *)&tmp16, buffer, sizeof(tmp16));
@@ -920,7 +920,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
             "Chunk of size %" PRIu16 " received, "
             "but buffer has only %zu bytes left.",
             pkg_length, buffer_len);
-    return (-1);
+    return -1;
   }
 
   /* Check that pkg_length is in the valid range */
@@ -930,7 +930,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
             "Header claims this packet is only %hu "
             "bytes long.",
             pkg_length);
-    return (-1);
+    return -1;
   }
 
   /* Check that the package data fits into the output buffer.
@@ -943,7 +943,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
             "which is too small to hold the received "
             "%zu byte string.",
             output_len, payload_size);
-    return (-1);
+    return -1;
   }
 
   /* All sanity checks successfull, let's copy the data over */
@@ -956,13 +956,13 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
     WARNING("network plugin: parse_part_string: "
             "Received string does not end "
             "with a NULL-byte.");
-    return (-1);
+    return -1;
   }
 
   *ret_buffer = buffer;
   *ret_buffer_len = buffer_len - pkg_length;
 
-  return (0);
+  return 0;
 } /* int parse_part_string */
 
 /* Forward declaration: parse_part_sign_sha256 and parse_part_encr_aes256 call
@@ -1005,7 +1005,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
 
   /* Check if the buffer has enough data for this structure. */
   if (buffer_len <= PART_SIGNATURE_SHA256_SIZE)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   /* Read type and length header */
   BUFFER_READ(&pss.head.type, sizeof(pss.head.type));
@@ -1016,7 +1016,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   if ((pss_head_length <= PART_SIGNATURE_SHA256_SIZE) ||
       (pss_head_length > buffer_len)) {
     ERROR("network plugin: HMAC-SHA-256 with invalid length received.");
-    return (-1);
+    return -1;
   }
 
   if (se->data.server.userdb == NULL) {
@@ -1028,7 +1028,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
     *ret_buffer = buffer + pss_head_length;
     *ret_buffer_len -= pss_head_length;
 
-    return (0);
+    return 0;
   }
 
   /* Copy the hash. */
@@ -1038,7 +1038,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   username_len = pss_head_length - PART_SIGNATURE_SHA256_SIZE;
   pss.username = malloc(username_len + 1);
   if (pss.username == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   /* Read the username */
   BUFFER_READ(pss.username, username_len);
@@ -1051,7 +1051,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   if (secret == NULL) {
     ERROR("network plugin: Unknown user: %s", pss.username);
     sfree(pss.username);
-    return (-ENOENT);
+    return -ENOENT;
   }
 
   /* Create a hash device and check the HMAC */
@@ -1062,7 +1062,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
           gcry_strerror(err));
     sfree(secret);
     sfree(pss.username);
-    return (-1);
+    return -1;
   }
 
   err = gcry_md_setkey(hd, secret, strlen(secret));
@@ -1071,7 +1071,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
     gcry_md_close(hd);
     sfree(secret);
     sfree(pss.username);
-    return (-1);
+    return -1;
   }
 
   gcry_md_write(hd, buffer + PART_SIGNATURE_SHA256_SIZE,
@@ -1082,7 +1082,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
     gcry_md_close(hd);
     sfree(secret);
     sfree(pss.username);
-    return (-1);
+    return -1;
   }
   memcpy(hash, hash_ptr, sizeof(hash));
 
@@ -1105,7 +1105,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   *ret_buffer = buffer + buffer_len;
   *ret_buffer_len = 0;
 
-  return (0);
+  return 0;
 } /* }}} int parse_part_sign_sha256 */
 /* #endif HAVE_GCRYPT_H */
 
@@ -1127,14 +1127,14 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   buffer_offset = 0;
 
   if (buffer_size <= PART_SIGNATURE_SHA256_SIZE)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   BUFFER_READ(&pss.head.type, sizeof(pss.head.type));
   BUFFER_READ(&pss.head.length, sizeof(pss.head.length));
   part_len = ntohs(pss.head.length);
 
   if ((part_len <= PART_SIGNATURE_SHA256_SIZE) || (part_len > buffer_size))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (warning_has_been_printed == 0) {
     WARNING("network plugin: Received signed packet, but the network "
@@ -1149,7 +1149,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
   *ret_buffer = buffer + buffer_size;
   *ret_buffer_size = 0;
 
-  return (0);
+  return 0;
 } /* }}} int parse_part_sign_sha256 */
 #endif /* !HAVE_GCRYPT_H */
 
@@ -1173,7 +1173,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   if (buffer_len <= PART_ENCRYPTION_AES256_SIZE) {
     NOTICE("network plugin: parse_part_encr_aes256: "
            "Discarding short packet.");
-    return (-1);
+    return -1;
   }
 
   buffer_offset = 0;
@@ -1187,7 +1187,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   if ((part_size <= PART_ENCRYPTION_AES256_SIZE) || (part_size > buffer_len)) {
     NOTICE("network plugin: parse_part_encr_aes256: "
            "Discarding part with invalid size.");
-    return (-1);
+    return -1;
   }
 
   /* Read the username */
@@ -1198,13 +1198,13 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
       (username_len > (part_size - (PART_ENCRYPTION_AES256_SIZE + 1)))) {
     NOTICE("network plugin: parse_part_encr_aes256: "
            "Discarding part with invalid username length.");
-    return (-1);
+    return -1;
   }
 
   assert(username_len > 0);
   pea.username = malloc(username_len + 1);
   if (pea.username == NULL)
-    return (-ENOMEM);
+    return -ENOMEM;
   BUFFER_READ(pea.username, username_len);
   pea.username[username_len] = 0;
 
@@ -1219,7 +1219,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   if (cypher == NULL) {
     ERROR("network plugin: Failed to get cypher. Username: %s", pea.username);
     sfree(pea.username);
-    return (-1);
+    return -1;
   }
 
   payload_len = part_size - (PART_ENCRYPTION_AES256_SIZE + username_len);
@@ -1233,7 +1233,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
     sfree(pea.username);
     ERROR("network plugin: gcry_cipher_decrypt returned: %s. Username: %s",
           gcry_strerror(err), pea.username);
-    return (-1);
+    return -1;
   }
 
   /* Read the hash */
@@ -1248,7 +1248,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   if (memcmp(hash, pea.hash, sizeof(hash)) != 0) {
     ERROR("network plugin: Checksum mismatch. Username: %s", pea.username);
     sfree(pea.username);
-    return (-1);
+    return -1;
   }
 
   parse_packet(se, buffer + buffer_offset, payload_len, flags | PP_ENCRYPTED,
@@ -1262,7 +1262,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
 
   sfree(pea.username);
 
-  return (0);
+  return 0;
 } /* }}} int parse_part_encr_aes256 */
 /* #endif HAVE_GCRYPT_H */
 
@@ -1293,7 +1293,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   if ((ph_length <= PART_ENCRYPTION_AES256_SIZE) || (ph_length > buffer_size)) {
     ERROR("network plugin: AES-256 encrypted part "
           "with invalid length received.");
-    return (-1);
+    return -1;
   }
 
   if (warning_has_been_printed == 0) {
@@ -1306,7 +1306,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
   *ret_buffer = (void *)(((char *)*ret_buffer) + ph_length);
   *ret_buffer_size -= ph_length;
 
-  return (0);
+  return 0;
 } /* }}} int parse_part_encr_aes256 */
 #endif /* !HAVE_GCRYPT_H */
 
@@ -1493,7 +1493,7 @@ static int parse_packet(sockent_t *se, /* {{{ */
     WARNING("network plugin: parse_packet: Received truncated "
             "packet, try increasing `MaxPacketSize'");
 
-  return (status);
+  return status;
 } /* }}} int parse_packet */
 
 static void free_sockent_client(struct sockent_client *sec) /* {{{ */
@@ -1567,7 +1567,7 @@ static int network_set_ttl(const sockent_t *se, const struct addrinfo *ai) {
   assert(se->type == SOCKENT_TYPE_CLIENT);
 
   if ((network_config_ttl < 1) || (network_config_ttl > 255))
-    return (-1);
+    return -1;
 
   if (ai->ai_family == AF_INET) {
     struct sockaddr_in *addr = (struct sockaddr_in *)ai->ai_addr;
@@ -1583,7 +1583,7 @@ static int network_set_ttl(const sockent_t *se, const struct addrinfo *ai) {
       char errbuf[1024];
       ERROR("network plugin: setsockopt (ipv4-ttl): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   } else if (ai->ai_family == AF_INET6) {
     /* Useful example:
@@ -1601,11 +1601,11 @@ static int network_set_ttl(const sockent_t *se, const struct addrinfo *ai) {
       char errbuf[1024];
       ERROR("network plugin: setsockopt(ipv6-ttl): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   }
 
-  return (0);
+  return 0;
 } /* int network_set_ttl */
 
 static int network_set_interface(const sockent_t *se,
@@ -1639,10 +1639,10 @@ static int network_set_interface(const sockent_t *se,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (ipv4-multicast-if): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
-      return (0);
+      return 0;
     }
   } else if (ai->ai_family == AF_INET6) {
     struct sockaddr_in6 *addr = (struct sockaddr_in6 *)ai->ai_addr;
@@ -1653,10 +1653,10 @@ static int network_set_interface(const sockent_t *se,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (ipv6-multicast-if): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
-      return (0);
+      return 0;
     }
   }
 
@@ -1667,7 +1667,7 @@ static int network_set_interface(const sockent_t *se,
     char interface_name[IFNAMSIZ];
 
     if (if_indextoname(se->interface, interface_name) == NULL)
-      return (-1);
+      return -1;
 
     DEBUG("network plugin: Binding socket to interface %s", interface_name);
 
@@ -1676,7 +1676,7 @@ static int network_set_interface(const sockent_t *se,
       char errbuf[1024];
       ERROR("network plugin: setsockopt (bind-if): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
 /* #endif HAVE_IF_INDEXTONAME && SO_BINDTODEVICE */
 
@@ -1692,7 +1692,7 @@ static int network_set_interface(const sockent_t *se,
 #endif
   }
 
-  return (0);
+  return 0;
 } /* }}} network_set_interface */
 
 static int network_bind_socket(int fd, const struct addrinfo *ai,
@@ -1709,7 +1709,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
     char errbuf[1024];
     ERROR("network plugin: setsockopt (reuseaddr): %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   DEBUG("fd = %i; calling `bind'", fd);
@@ -1717,7 +1717,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
   if (bind(fd, ai->ai_addr, ai->ai_addrlen) == -1) {
     char errbuf[1024];
     ERROR("bind: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   if (ai->ai_family == AF_INET) {
@@ -1747,7 +1747,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (multicast-loop): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) ==
@@ -1755,10 +1755,10 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (add-membership): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
-      return (0);
+      return 0;
     }
   } else if (ai->ai_family == AF_INET6) {
     /* Useful example:
@@ -1787,7 +1787,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (ipv6-multicast-loop): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq,
@@ -1795,10 +1795,10 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
         char errbuf[1024];
         ERROR("network plugin: setsockopt (ipv6-add-membership): %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
-      return (0);
+      return 0;
     }
   }
 
@@ -1811,7 +1811,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
     char interface_name[IFNAMSIZ];
 
     if (if_indextoname(interface_idx, interface_name) == NULL)
-      return (-1);
+      return -1;
 
     DEBUG("fd = %i; Binding socket to interface %s", fd, interface_name);
 
@@ -1820,12 +1820,12 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
       char errbuf[1024];
       ERROR("network plugin: setsockopt (bind-if): %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   }
 #endif /* HAVE_IF_INDEXTONAME && SO_BINDTODEVICE */
 
-  return (0);
+  return 0;
 } /* int network_bind_socket */
 
 /* Initialize a sockent structure. `type' must be either `SOCKENT_TYPE_CLIENT'
@@ -1835,11 +1835,11 @@ static sockent_t *sockent_create(int type) /* {{{ */
   sockent_t *se;
 
   if ((type != SOCKENT_TYPE_CLIENT) && (type != SOCKENT_TYPE_SERVER))
-    return (NULL);
+    return NULL;
 
   se = calloc(1, sizeof(*se));
   if (se == NULL)
-    return (NULL);
+    return NULL;
 
   se->type = type;
   se->node = NULL;
@@ -1869,7 +1869,7 @@ static sockent_t *sockent_create(int type) /* {{{ */
 #endif
   }
 
-  return (se);
+  return se;
 } /* }}} sockent_t *sockent_create */
 
 static int sockent_init_crypto(sockent_t *se) /* {{{ */
@@ -1880,7 +1880,7 @@ static int sockent_init_crypto(sockent_t *se) /* {{{ */
       if (network_init_gcrypt() < 0) {
         ERROR("network plugin: Cannot configure client socket with "
               "security: Failed to initialize crypto library.");
-        return (-1);
+        return -1;
       }
 
       if ((se->data.client.username == NULL) ||
@@ -1888,7 +1888,7 @@ static int sockent_init_crypto(sockent_t *se) /* {{{ */
         ERROR("network plugin: Client socket with "
               "security requested, but no "
               "credentials are configured.");
-        return (-1);
+        return -1;
       }
       gcry_md_hash_buffer(GCRY_MD_SHA256, se->data.client.password_hash,
                           se->data.client.password,
@@ -1900,26 +1900,26 @@ static int sockent_init_crypto(sockent_t *se) /* {{{ */
         (se->data.server.auth_file == NULL)) {
       ERROR("network plugin: Server socket with security requested, "
             "but no \"AuthFile\" is configured.");
-      return (-1);
+      return -1;
     }
     if (se->data.server.auth_file != NULL) {
       if (network_init_gcrypt() < 0) {
         ERROR("network plugin: Cannot configure server socket with security: "
               "Failed to initialize crypto library.");
-        return (-1);
+        return -1;
       }
 
       se->data.server.userdb = fbh_create(se->data.server.auth_file);
       if (se->data.server.userdb == NULL) {
         ERROR("network plugin: Reading password file \"%s\" failed.",
               se->data.server.auth_file);
-        return (-1);
+        return -1;
       }
     }
   }
 #endif /* }}} HAVE_GCRYPT_H */
 
-  return (0);
+  return 0;
 } /* }}} int sockent_init_crypto */
 
 static int sockent_client_disconnect(sockent_t *se) /* {{{ */
@@ -1927,7 +1927,7 @@ static int sockent_client_disconnect(sockent_t *se) /* {{{ */
   struct sockent_client *client;
 
   if ((se == NULL) || (se->type != SOCKENT_TYPE_CLIENT))
-    return (EINVAL);
+    return EINVAL;
 
   client = &se->data.client;
   if (client->fd >= 0) /* connected */
@@ -1939,7 +1939,7 @@ static int sockent_client_disconnect(sockent_t *se) /* {{{ */
   sfree(client->addr);
   client->addrlen = 0;
 
-  return (0);
+  return 0;
 } /* }}} int sockent_client_disconnect */
 
 static int sockent_client_connect(sockent_t *se) /* {{{ */
@@ -1953,7 +1953,7 @@ static int sockent_client_connect(sockent_t *se) /* {{{ */
   cdtime_t now;
 
   if ((se == NULL) || (se->type != SOCKENT_TYPE_CLIENT))
-    return (EINVAL);
+    return EINVAL;
 
   client = &se->data.client;
 
@@ -1967,7 +1967,7 @@ static int sockent_client_connect(sockent_t *se) /* {{{ */
   }
 
   if (client->fd >= 0 && !reconnect) /* already connected and not stale*/
-    return (0);
+    return 0;
 
   struct addrinfo ai_hints = {.ai_family = AF_UNSPEC,
                               .ai_flags = AI_ADDRCONFIG,
@@ -1982,7 +1982,7 @@ static int sockent_client_connect(sockent_t *se) /* {{{ */
         LOG_ERR, &complaint, "network plugin: getaddrinfo (%s, %s) failed: %s",
         (se->node == NULL) ? "(null)" : se->node,
         (se->service == NULL) ? "(null)" : se->service, gai_strerror(status));
-    return (-1);
+    return -1;
   } else {
     c_release(LOG_NOTICE, &complaint,
               "network plugin: Successfully resolved \"%s\".", se->node);
@@ -2024,11 +2024,11 @@ static int sockent_client_connect(sockent_t *se) /* {{{ */
 
   freeaddrinfo(ai_list);
   if (client->fd < 0)
-    return (-1);
+    return -1;
 
   if (client->resolve_interval > 0)
     client->next_resolve_reconnect = now + client->resolve_interval;
-  return (0);
+  return 0;
 } /* }}} int sockent_client_connect */
 
 /* Open the file descriptors for a initialized sockent structure. */
@@ -2041,7 +2041,7 @@ static int sockent_server_listen(sockent_t *se) /* {{{ */
   const char *service;
 
   if (se == NULL)
-    return (-1);
+    return -1;
 
   assert(se->data.server.fd == NULL);
   assert(se->data.server.fd_num == 0);
@@ -2065,7 +2065,7 @@ static int sockent_server_listen(sockent_t *se) /* {{{ */
     ERROR("network plugin: getaddrinfo (%s, %s) failed: %s",
           (se->node == NULL) ? "(null)" : se->node,
           (se->service == NULL) ? "(null)" : se->service, gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -2103,8 +2103,8 @@ static int sockent_server_listen(sockent_t *se) /* {{{ */
   freeaddrinfo(ai_list);
 
   if (se->data.server.fd_num == 0)
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* }}} int sockent_server_listen */
 
 /* Add a sockent to the global list of sockets */
@@ -2113,7 +2113,7 @@ static int sockent_add(sockent_t *se) /* {{{ */
   sockent_t *last_ptr;
 
   if (se == NULL)
-    return (-1);
+    return -1;
 
   if (se->type == SOCKENT_TYPE_SERVER) {
     struct pollfd *tmp;
@@ -2122,7 +2122,7 @@ static int sockent_add(sockent_t *se) /* {{{ */
                   sizeof(*tmp) * (listen_sockets_num + se->data.server.fd_num));
     if (tmp == NULL) {
       ERROR("network plugin: realloc failed.");
-      return (-1);
+      return -1;
     }
     listen_sockets_pollfd = tmp;
     tmp = listen_sockets_pollfd + listen_sockets_num;
@@ -2138,14 +2138,14 @@ static int sockent_add(sockent_t *se) /* {{{ */
 
     if (listen_sockets == NULL) {
       listen_sockets = se;
-      return (0);
+      return 0;
     }
     last_ptr = listen_sockets;
   } else /* if (se->type == SOCKENT_TYPE_CLIENT) */
   {
     if (sending_sockets == NULL) {
       sending_sockets = se;
-      return (0);
+      return 0;
     }
     last_ptr = sending_sockets;
   }
@@ -2154,7 +2154,7 @@ static int sockent_add(sockent_t *se) /* {{{ */
     last_ptr = last_ptr->next;
   last_ptr->next = se;
 
-  return (0);
+  return 0;
 } /* }}} int sockent_add */
 
 static void *dispatch_thread(void __attribute__((unused)) * arg) /* {{{ */
@@ -2210,7 +2210,7 @@ static void *dispatch_thread(void __attribute__((unused)) * arg) /* {{{ */
     sfree(ent);
   } /* while (42) */
 
-  return (NULL);
+  return NULL;
 } /* }}} void *dispatch_thread */
 
 static int network_receive(void) /* {{{ */
@@ -2335,11 +2335,11 @@ static int network_receive(void) /* {{{ */
     pthread_mutex_unlock(&receive_list_lock);
   }
 
-  return (status);
+  return status;
 } /* }}} int network_receive */
 
 static void *receive_thread(void __attribute__((unused)) * arg) {
-  return (network_receive() ? (void *)1 : (void *)0);
+  return network_receive() ? (void *)1 : (void *)0;
 } /* void *receive_thread */
 
 static void network_init_buffer(void) {
@@ -2555,28 +2555,28 @@ static int add_to_buffer(char *buffer, size_t buffer_size, /* {{{ */
   if (strcmp(vl_def->host, vl->host) != 0) {
     if (write_part_string(&buffer, &buffer_size, TYPE_HOST, vl->host,
                           strlen(vl->host)) != 0)
-      return (-1);
+      return -1;
     sstrncpy(vl_def->host, vl->host, sizeof(vl_def->host));
   }
 
   if (vl_def->time != vl->time) {
     if (write_part_number(&buffer, &buffer_size, TYPE_TIME_HR,
                           (uint64_t)vl->time))
-      return (-1);
+      return -1;
     vl_def->time = vl->time;
   }
 
   if (vl_def->interval != vl->interval) {
     if (write_part_number(&buffer, &buffer_size, TYPE_INTERVAL_HR,
                           (uint64_t)vl->interval))
-      return (-1);
+      return -1;
     vl_def->interval = vl->interval;
   }
 
   if (strcmp(vl_def->plugin, vl->plugin) != 0) {
     if (write_part_string(&buffer, &buffer_size, TYPE_PLUGIN, vl->plugin,
                           strlen(vl->plugin)) != 0)
-      return (-1);
+      return -1;
     sstrncpy(vl_def->plugin, vl->plugin, sizeof(vl_def->plugin));
   }
 
@@ -2584,7 +2584,7 @@ static int add_to_buffer(char *buffer, size_t buffer_size, /* {{{ */
     if (write_part_string(&buffer, &buffer_size, TYPE_PLUGIN_INSTANCE,
                           vl->plugin_instance,
                           strlen(vl->plugin_instance)) != 0)
-      return (-1);
+      return -1;
     sstrncpy(vl_def->plugin_instance, vl->plugin_instance,
              sizeof(vl_def->plugin_instance));
   }
@@ -2592,22 +2592,22 @@ static int add_to_buffer(char *buffer, size_t buffer_size, /* {{{ */
   if (strcmp(vl_def->type, vl->type) != 0) {
     if (write_part_string(&buffer, &buffer_size, TYPE_TYPE, vl->type,
                           strlen(vl->type)) != 0)
-      return (-1);
+      return -1;
     sstrncpy(vl_def->type, ds->type, sizeof(vl_def->type));
   }
 
   if (strcmp(vl_def->type_instance, vl->type_instance) != 0) {
     if (write_part_string(&buffer, &buffer_size, TYPE_TYPE_INSTANCE,
                           vl->type_instance, strlen(vl->type_instance)) != 0)
-      return (-1);
+      return -1;
     sstrncpy(vl_def->type_instance, vl->type_instance,
              sizeof(vl_def->type_instance));
   }
 
   if (write_part_values(&buffer, &buffer_size, ds, vl) != 0)
-    return (-1);
+    return -1;
 
-  return (buffer - buffer_orig);
+  return buffer - buffer_orig;
 } /* }}} int add_to_buffer */
 
 static void flush_buffer(void) {
@@ -2645,7 +2645,7 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
     pthread_mutex_lock(&stats_lock);
     stats_values_not_sent++;
     pthread_mutex_unlock(&stats_lock);
-    return (0);
+    return 0;
   }
 
   uc_meta_data_add_unsigned_int(vl, "network:time_sent", (uint64_t)vl->time);
@@ -2688,7 +2688,7 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
 
   pthread_mutex_unlock(&send_buffer_lock);
 
-  return ((status < 0) ? -1 : 0);
+  return (status < 0) ? -1 : 0;
 } /* int network_write */
 
 static int network_config_set_ttl(const oconfig_item_t *ci) /* {{{ */
@@ -2696,15 +2696,15 @@ static int network_config_set_ttl(const oconfig_item_t *ci) /* {{{ */
   int tmp = 0;
 
   if (cf_util_get_int(ci, &tmp) != 0)
-    return (-1);
+    return -1;
   else if ((tmp > 0) && (tmp <= 255))
     network_config_ttl = tmp;
   else {
     WARNING("network plugin: The `TimeToLive' must be between 1 and 255.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config_set_ttl */
 
 static int network_config_set_interface(const oconfig_item_t *ci, /* {{{ */
@@ -2712,10 +2712,10 @@ static int network_config_set_interface(const oconfig_item_t *ci, /* {{{ */
   char if_name[256];
 
   if (cf_util_get_string_buffer(ci, if_name, sizeof(if_name)) != 0)
-    return (-1);
+    return -1;
 
   *interface = if_nametoindex(if_name);
-  return (0);
+  return 0;
 } /* }}} int network_config_set_interface */
 
 static int network_config_set_buffer_size(const oconfig_item_t *ci) /* {{{ */
@@ -2723,16 +2723,16 @@ static int network_config_set_buffer_size(const oconfig_item_t *ci) /* {{{ */
   int tmp = 0;
 
   if (cf_util_get_int(ci, &tmp) != 0)
-    return (-1);
+    return -1;
   else if ((tmp >= 1024) && (tmp <= 65535))
     network_config_packet_size = tmp;
   else {
     WARNING(
         "network plugin: The `MaxPacketSize' must be between 1024 and 65535.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config_set_buffer_size */
 
 #if HAVE_GCRYPT_H
@@ -2742,7 +2742,7 @@ static int network_config_set_security_level(oconfig_item_t *ci, /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("network plugin: The `SecurityLevel' config option needs exactly "
             "one string argument.");
-    return (-1);
+    return -1;
   }
 
   str = ci->values[0].value.string;
@@ -2754,10 +2754,10 @@ static int network_config_set_security_level(oconfig_item_t *ci, /* {{{ */
     *retval = SECURITY_LEVEL_NONE;
   else {
     WARNING("network plugin: Unknown security level: %s.", str);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config_set_security_level */
 #endif /* HAVE_GCRYPT_H */
 
@@ -2772,13 +2772,13 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
     ERROR("network plugin: The `%s' config option needs "
           "one or two string arguments.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   se = sockent_create(SOCKENT_TYPE_SERVER);
   if (se == NULL) {
     ERROR("network plugin: sockent_create failed.");
-    return (-1);
+    return -1;
   }
 
   se->node = strdup(ci->values[0].value.string);
@@ -2809,7 +2809,7 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
           "requested, but no AuthFile option was given. Cowardly refusing to "
           "open this socket!");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 #endif /* HAVE_GCRYPT_H */
 
@@ -2818,7 +2818,7 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
     ERROR("network plugin: network_config_add_listen: sockent_init_crypto() "
           "failed.");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 
   status = sockent_server_listen(se);
@@ -2826,17 +2826,17 @@ static int network_config_add_listen(const oconfig_item_t *ci) /* {{{ */
     ERROR("network plugin: network_config_add_listen: sockent_server_listen "
           "failed.");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 
   status = sockent_add(se);
   if (status != 0) {
     ERROR("network plugin: network_config_add_listen: sockent_add failed.");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config_add_listen */
 
 static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
@@ -2850,13 +2850,13 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
     ERROR("network plugin: The `%s' config option needs "
           "one or two string arguments.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   se = sockent_create(SOCKENT_TYPE_CLIENT);
   if (se == NULL) {
     ERROR("network plugin: sockent_create failed.");
-    return (-1);
+    return -1;
   }
 
   se->node = strdup(ci->values[0].value.string);
@@ -2892,7 +2892,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
           "requested, but no Username or Password option was given. "
           "Cowardly refusing to open this socket!");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 #endif /* HAVE_GCRYPT_H */
 
@@ -2901,7 +2901,7 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
     ERROR("network plugin: network_config_add_server: sockent_init_crypto() "
           "failed.");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 
   /* No call to sockent_client_connect() here -- it is called from
@@ -2911,10 +2911,10 @@ static int network_config_add_server(const oconfig_item_t *ci) /* {{{ */
   if (status != 0) {
     ERROR("network plugin: network_config_add_server: sockent_add failed.");
     sockent_destroy(se);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config_add_server */
 
 static int network_config(oconfig_item_t *ci) /* {{{ */
@@ -2946,7 +2946,7 @@ static int network_config(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int network_config */
 
 static int network_notification(const notification_t *n,
@@ -2958,63 +2958,63 @@ static int network_notification(const notification_t *n,
   int status;
 
   if (!check_send_notify_okay(n))
-    return (0);
+    return 0;
 
   memset(buffer, 0, sizeof(buffer));
 
   status = write_part_number(&buffer_ptr, &buffer_free, TYPE_TIME_HR,
                              (uint64_t)n->time);
   if (status != 0)
-    return (-1);
+    return -1;
 
   status = write_part_number(&buffer_ptr, &buffer_free, TYPE_SEVERITY,
                              (uint64_t)n->severity);
   if (status != 0)
-    return (-1);
+    return -1;
 
   if (strlen(n->host) > 0) {
     status = write_part_string(&buffer_ptr, &buffer_free, TYPE_HOST, n->host,
                                strlen(n->host));
     if (status != 0)
-      return (-1);
+      return -1;
   }
 
   if (strlen(n->plugin) > 0) {
     status = write_part_string(&buffer_ptr, &buffer_free, TYPE_PLUGIN,
                                n->plugin, strlen(n->plugin));
     if (status != 0)
-      return (-1);
+      return -1;
   }
 
   if (strlen(n->plugin_instance) > 0) {
     status = write_part_string(&buffer_ptr, &buffer_free, TYPE_PLUGIN_INSTANCE,
                                n->plugin_instance, strlen(n->plugin_instance));
     if (status != 0)
-      return (-1);
+      return -1;
   }
 
   if (strlen(n->type) > 0) {
     status = write_part_string(&buffer_ptr, &buffer_free, TYPE_TYPE, n->type,
                                strlen(n->type));
     if (status != 0)
-      return (-1);
+      return -1;
   }
 
   if (strlen(n->type_instance) > 0) {
     status = write_part_string(&buffer_ptr, &buffer_free, TYPE_TYPE_INSTANCE,
                                n->type_instance, strlen(n->type_instance));
     if (status != 0)
-      return (-1);
+      return -1;
   }
 
   status = write_part_string(&buffer_ptr, &buffer_free, TYPE_MESSAGE,
                              n->message, strlen(n->message));
   if (status != 0)
-    return (-1);
+    return -1;
 
   network_send_buffer(buffer, sizeof(buffer) - buffer_free);
 
-  return (0);
+  return 0;
 } /* int network_notification */
 
 static int network_shutdown(void) {
@@ -3055,7 +3055,7 @@ static int network_shutdown(void) {
   plugin_unregister_write("network");
   plugin_unregister_shutdown("network");
 
-  return (0);
+  return 0;
 } /* int network_shutdown */
 
 static int network_stats_read(void) /* {{{ */
@@ -3126,7 +3126,7 @@ static int network_stats_read(void) /* {{{ */
   vl.type_instance[0] = 0;
   plugin_dispatch_values(&vl);
 
-  return (0);
+  return 0;
 } /* }}} int network_stats_read */
 
 static int network_init(void) {
@@ -3135,7 +3135,7 @@ static int network_init(void) {
   /* Check if we were already initialized. If so, just return - there's
    * nothing more to do (for now, that is). */
   if (have_init)
-    return (0);
+    return 0;
   have_init = 1;
 
   if (network_config_stats)
@@ -3146,7 +3146,7 @@ static int network_init(void) {
   send_buffer = malloc(network_config_packet_size);
   if (send_buffer == NULL) {
     ERROR("network plugin: malloc failed.");
-    return (-1);
+    return -1;
   }
   network_init_buffer();
 
@@ -3161,7 +3161,7 @@ static int network_init(void) {
   /* If no threads need to be started, return here. */
   if ((listen_sockets_num == 0) ||
       ((dispatch_thread_running != 0) && (receive_thread_running != 0)))
-    return (0);
+    return 0;
 
   if (dispatch_thread_running == 0) {
     int status;
@@ -3191,7 +3191,7 @@ static int network_init(void) {
     }
   }
 
-  return (0);
+  return 0;
 } /* int network_init */
 
 /*
@@ -3211,14 +3211,14 @@ static int network_flush(cdtime_t timeout,
       cdtime_t now = cdtime();
       if ((send_buffer_last_update + timeout) > now) {
         pthread_mutex_unlock(&send_buffer_lock);
-        return (0);
+        return 0;
       }
     }
     flush_buffer();
   }
   pthread_mutex_unlock(&send_buffer_lock);
 
-  return (0);
+  return 0;
 } /* int network_flush */
 
 void module_register(void) {

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -296,7 +296,7 @@ static kstat_t *nfs4_ksp_server;
 #endif
 
 #if KERNEL_LINUX
-static int nfs_init(void) { return (0); }
+static int nfs_init(void) { return 0; }
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
@@ -309,7 +309,7 @@ static int nfs_init(void) {
   nfs4_ksp_server = NULL;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (kstat_t *ksp_chain = kc->kc_chain; ksp_chain != NULL;
        ksp_chain = ksp_chain->ks_next) {
@@ -329,7 +329,7 @@ static int nfs_init(void) {
       nfs4_ksp_client = ksp_chain;
   }
 
-  return (0);
+  return 0;
 } /* int nfs_init */
 #endif
 
@@ -374,12 +374,12 @@ static int nfs_submit_fields_safe(int nfs_version, const char *instance,
     WARNING("nfs plugin: Wrong number of fields for "
             "NFSv%i %s statistics. Expected %zu, got %zu.",
             nfs_version, instance, proc_names_num, fields_num);
-    return (EINVAL);
+    return EINVAL;
   }
 
   nfs_submit_fields(nfs_version, instance, fields, fields_num, proc_names);
 
-  return (0);
+  return 0;
 }
 
 static int nfs_submit_nfs4_server(const char *instance, char **fields,
@@ -398,7 +398,7 @@ static int nfs_submit_nfs4_server(const char *instance, char **fields,
       fields_num = NFS4_SERVER_MAX_PROC;
       suppress_warning = 1;
     } else {
-      return (EINVAL);
+      return EINVAL;
     }
   }
 
@@ -412,7 +412,7 @@ static int nfs_submit_nfs4_server(const char *instance, char **fields,
                       nfs4_server41_procedures_names);
   }
 
-  return (0);
+  return 0;
 }
 
 static int nfs_submit_nfs4_client(const char *instance, char **fields,
@@ -462,7 +462,7 @@ static int nfs_submit_nfs4_client(const char *instance, char **fields,
 
       suppress_warning = 1;
     } else {
-      return (EINVAL);
+      return EINVAL;
     }
   }
 
@@ -477,7 +477,7 @@ static int nfs_submit_nfs4_client(const char *instance, char **fields,
                       nfs4_client41_procedures_names);
   }
 
-  return (0);
+  return 0;
 }
 
 static void nfs_read_linux(FILE *fh, const char *inst) {
@@ -521,7 +521,7 @@ static int nfs_read_kstat(kstat_t *ksp, int nfs_version, const char *inst,
   value_t values[proc_names_num];
 
   if (ksp == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   ssnprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
             inst);
@@ -537,7 +537,7 @@ static int nfs_read_kstat(kstat_t *ksp, int nfs_version, const char *inst,
   }
 
   nfs_procedures_submit(plugin_instance, proc_names, values, proc_names_num);
-  return (0);
+  return 0;
 }
 #endif
 
@@ -555,7 +555,7 @@ static int nfs_read(void) {
     fclose(fh);
   }
 
-  return (0);
+  return 0;
 }
 /* #endif KERNEL_LINUX */
 
@@ -574,7 +574,7 @@ static int nfs_read(void) {
   nfs_read_kstat(nfs4_ksp_server, /* version = */ 4, "server",
                  nfs4_procedures_names, nfs4_procedures_names_num);
 
-  return (0);
+  return 0;
 }
 #endif /* HAVE_LIBKSTAT */
 

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -62,13 +62,13 @@ static size_t nginx_curl_callback(void *buf, size_t size, size_t nmemb,
   }
 
   if (len == 0)
-    return (len);
+    return len;
 
   memcpy(&nginx_buffer[nginx_buffer_len], buf, len);
   nginx_buffer_len += len;
   nginx_buffer[nginx_buffer_len] = 0;
 
-  return (len);
+  return len;
 }
 
 static int config_set(char **var, const char *value) {
@@ -78,28 +78,28 @@ static int config_set(char **var, const char *value) {
   }
 
   if ((*var = strdup(value)) == NULL)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 }
 
 static int config(const char *key, const char *value) {
   if (strcasecmp(key, "url") == 0)
-    return (config_set(&url, value));
+    return config_set(&url, value);
   else if (strcasecmp(key, "user") == 0)
-    return (config_set(&user, value));
+    return config_set(&user, value);
   else if (strcasecmp(key, "password") == 0)
-    return (config_set(&pass, value));
+    return config_set(&pass, value);
   else if (strcasecmp(key, "verifypeer") == 0)
-    return (config_set(&verify_peer, value));
+    return config_set(&verify_peer, value);
   else if (strcasecmp(key, "verifyhost") == 0)
-    return (config_set(&verify_host, value));
+    return config_set(&verify_host, value);
   else if (strcasecmp(key, "cacert") == 0)
-    return (config_set(&cacert, value));
+    return config_set(&cacert, value);
   else if (strcasecmp(key, "timeout") == 0)
-    return (config_set(&timeout, value));
+    return config_set(&timeout, value);
   else
-    return (-1);
+    return -1;
 } /* int config */
 
 static int init(void) {
@@ -108,7 +108,7 @@ static int init(void) {
 
   if ((curl = curl_easy_init()) == NULL) {
     ERROR("nginx plugin: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
@@ -126,7 +126,7 @@ static int init(void) {
                            pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");
-      return (-1);
+      return -1;
     }
 
     curl_easy_setopt(curl, CURLOPT_USERPWD, credentials);
@@ -165,7 +165,7 @@ static int init(void) {
   }
 #endif
 
-  return (0);
+  return 0;
 } /* void init */
 
 static void submit(const char *type, const char *inst, long long value) {
@@ -202,14 +202,14 @@ static int nginx_read(void) {
   int fields_num;
 
   if (curl == NULL)
-    return (-1);
+    return -1;
   if (url == NULL)
-    return (-1);
+    return -1;
 
   nginx_buffer_len = 0;
   if (curl_easy_perform(curl) != CURLE_OK) {
     WARNING("nginx plugin: curl_easy_perform failed: %s", nginx_curl_error);
-    return (-1);
+    return -1;
   }
 
   ptr = nginx_buffer;
@@ -259,7 +259,7 @@ static int nginx_read(void) {
 
   nginx_buffer_len = 0;
 
-  return (0);
+  return 0;
 } /* int nginx_read */
 
 void module_register(void) {

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -115,7 +115,7 @@ static int notify_email_init(void) {
   if (session == NULL) {
     pthread_mutex_unlock(&session_lock);
     ERROR("notify_email plugin: cannot create SMTP session");
-    return (-1);
+    return -1;
   }
 
   smtp_set_monitorcb(session, monitor_cb, NULL, 1);
@@ -131,11 +131,11 @@ static int notify_email_init(void) {
   if (!smtp_auth_set_context(session, authctx)) {
     pthread_mutex_unlock(&session_lock);
     ERROR("notify_email plugin: cannot set SMTP auth context");
-    return (-1);
+    return -1;
   }
 
   pthread_mutex_unlock(&session_lock);
-  return (0);
+  return 0;
 } /* int notify_email_init */
 
 static int notify_email_shutdown(void) {
@@ -152,7 +152,7 @@ static int notify_email_shutdown(void) {
   auth_client_exit();
 
   pthread_mutex_unlock(&session_lock);
-  return (0);
+  return 0;
 } /* int notify_email_shutdown */
 
 static int notify_email_config(const char *key, const char *value) {
@@ -162,14 +162,14 @@ static int notify_email_config(const char *key, const char *value) {
     tmp = realloc(recipients, (recipients_len + 1) * sizeof(char *));
     if (tmp == NULL) {
       ERROR("notify_email: realloc failed.");
-      return (-1);
+      return -1;
     }
 
     recipients = tmp;
     recipients[recipients_len] = strdup(value);
     if (recipients[recipients_len] == NULL) {
       ERROR("notify_email: strdup failed.");
-      return (-1);
+      return -1;
     }
     recipients_len++;
   } else if (0 == strcasecmp(key, "SMTPServer")) {
@@ -179,7 +179,7 @@ static int notify_email_config(const char *key, const char *value) {
     int port_tmp = atoi(value);
     if (port_tmp < 1 || port_tmp > 65535) {
       WARNING("notify_email plugin: Invalid SMTP port: %i", port_tmp);
-      return (1);
+      return 1;
     }
     smtp_port = port_tmp;
   } else if (0 == strcasecmp(key, "SMTPUser")) {
@@ -246,13 +246,13 @@ static int notify_email_notification(const notification_t *n,
   if (session == NULL) {
     /* Initialization failed or we're in the process of shutting down. */
     pthread_mutex_unlock(&session_lock);
-    return (-1);
+    return -1;
   }
 
   if (!(message = smtp_add_message(session))) {
     pthread_mutex_unlock(&session_lock);
     ERROR("notify_email plugin: cannot set SMTP message");
-    return (-1);
+    return -1;
   }
   smtp_set_reverse_path(message, email_from);
   smtp_set_header(message, "To", NULL, NULL);
@@ -266,7 +266,7 @@ static int notify_email_notification(const notification_t *n,
     ERROR("notify_email plugin: SMTP server problem: %s",
           smtp_strerror(smtp_errno(), buf, sizeof buf));
     pthread_mutex_unlock(&session_lock);
-    return (-1);
+    return -1;
   } else {
 #if COLLECT_DEBUG
     const smtp_status_t *status;
@@ -279,7 +279,7 @@ static int notify_email_notification(const notification_t *n,
   }
 
   pthread_mutex_unlock(&session_lock);
-  return (0);
+  return 0;
 } /* int notify_email_notification */
 
 void module_register(void) {

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -263,7 +263,7 @@ static int ntpd_config(const char *key, const char *value) {
     if (ntpd_host != NULL)
       free(ntpd_host);
     if ((ntpd_host = strdup(value)) == NULL)
-      return (1);
+      return 1;
   } else if (strcasecmp(key, "Port") == 0) {
     int port = (int)(atof(value));
     if ((port > 0) && (port <= 65535))
@@ -281,10 +281,10 @@ static int ntpd_config(const char *key, const char *value) {
     else
       include_unit_id = 0;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void ntpd_submit(const char *type, const char *type_inst,
@@ -319,7 +319,7 @@ static int ntpd_connect(void) {
   int status;
 
   if (sock_descr >= 0)
-    return (sock_descr);
+    return sock_descr;
 
   DEBUG("Opening a new socket");
 
@@ -341,7 +341,7 @@ static int ntpd_connect(void) {
     ERROR("ntpd plugin: getaddrinfo (%s, %s): %s", host, port,
           (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                  : gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -367,7 +367,7 @@ static int ntpd_connect(void) {
     ERROR("ntpd plugin: Unable to connect to server.");
   }
 
-  return (sock_descr);
+  return sock_descr;
 }
 
 /* For a description of the arguments see `ntpd_do_query' below. */
@@ -396,7 +396,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
   ssize_t pkt_padding; /* Padding in this packet */
 
   if ((sd = ntpd_connect()) < 0)
-    return (-1);
+    return -1;
 
   items = NULL;
   items_num = 0;
@@ -412,7 +412,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
     char errbuf[1024];
     ERROR("ntpd plugin: gettimeofday failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   time_end.tv_sec++; /* wait for a most one second */
 
@@ -424,7 +424,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       char errbuf[1024];
       ERROR("ntpd plugin: gettimeofday failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
 
     if (timeval_cmp(time_end, time_now, &time_left) <= 0)
@@ -450,7 +450,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       char errbuf[1024];
       ERROR("ntpd plugin: poll failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
 
     if (status == 0) /* timeout */
@@ -471,7 +471,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       DEBUG("Closing socket #%i", sd);
       close(sd);
       sock_descr = sd = -1;
-      return (-1);
+      return -1;
     }
 
     DEBUG("recv'd %i bytes", status);
@@ -513,7 +513,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
     if (INFO_ERR(res.err_nitems) != 0) {
       ERROR("ntpd plugin: Received error code %i",
             (int)INFO_ERR(res.err_nitems));
-      return ((int)INFO_ERR(res.err_nitems));
+      return (int)INFO_ERR(res.err_nitems);
     }
 
     /* extract number of items in this packet and the size of these items */
@@ -632,7 +632,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       done = 1;
   } /* while (done == 0) */
 
-  return (0);
+  return 0;
 } /* int ntpd_receive_response */
 
 /* For a description of the arguments see `ntpd_do_query' below. */
@@ -647,7 +647,7 @@ static int ntpd_send_request(int req_code, int req_items, int req_size,
   assert(req_size >= 0);
 
   if ((sd = ntpd_connect()) < 0)
-    return (-1);
+    return -1;
 
   req.rm_vn_mode = RM_VN_MODE(0, 0, 0);
   req.auth_seq = AUTH_SEQ(0, 0);
@@ -673,10 +673,10 @@ static int ntpd_send_request(int req_code, int req_items, int req_size,
     DEBUG("`swrite' failed. Closing socket #%i", sd);
     close(sd);
     sock_descr = sd = -1;
-    return (status);
+    return status;
   }
 
-  return (0);
+  return 0;
 }
 
 /*
@@ -701,10 +701,10 @@ static int ntpd_do_query(int req_code, int req_items, int req_size,
 
   status = ntpd_send_request(req_code, req_items, req_size, req_data);
   if (status != 0)
-    return (status);
+    return status;
 
   status = ntpd_receive_response(res_items, res_size, res_data, res_item_size);
-  return (status);
+  return status;
 }
 
 static double ntpd_read_fp(int32_t val_int) {
@@ -713,7 +713,7 @@ static double ntpd_read_fp(int32_t val_int) {
   val_int = ntohl(val_int);
   val_double = ((double)val_int) / FP_FRAC;
 
-  return (val_double);
+  return val_double;
 }
 
 static uint32_t
@@ -721,7 +721,7 @@ ntpd_get_refclock_id(struct info_peer_summary const *peer_info) {
   uint32_t addr = ntohl(peer_info->srcadr);
   uint32_t refclock_id = (addr >> 8) & 0x00FF;
 
-  return (refclock_id);
+  return refclock_id;
 }
 
 static int ntpd_get_name_from_address(char *buffer, size_t buffer_size,
@@ -767,10 +767,10 @@ static int ntpd_get_name_from_address(char *buffer, size_t buffer_size,
     ERROR("ntpd plugin: getnameinfo failed: %s",
           (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                  : gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* ntpd_get_name_from_address */
 
 static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
@@ -779,8 +779,7 @@ static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
   uint32_t unit_id = ntohl(peer_info->srcadr) & 0x00FF;
 
   if (((size_t)refclock_id) >= refclock_names_num)
-    return (ntpd_get_name_from_address(buffer, buffer_size, peer_info,
-                                       /* do_reverse_lookup = */ 0));
+    return ntpd_get_name_from_address(buffer, buffer_size, peer_info, 0);
 
   if (include_unit_id)
     ssnprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
@@ -788,7 +787,7 @@ static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
   else
     sstrncpy(buffer, refclock_names[refclock_id], buffer_size);
 
-  return (0);
+  return 0;
 } /* int ntpd_get_name_refclock */
 
 static int ntpd_get_name(char *buffer, size_t buffer_size,
@@ -796,10 +795,10 @@ static int ntpd_get_name(char *buffer, size_t buffer_size,
   uint32_t addr = ntohl(peer_info->srcadr);
 
   if (!peer_info->v6_flag && ((addr & REFCLOCK_MASK) == REFCLOCK_ADDR))
-    return (ntpd_get_name_refclock(buffer, buffer_size, peer_info));
+    return ntpd_get_name_refclock(buffer, buffer_size, peer_info);
   else
-    return (ntpd_get_name_from_address(buffer, buffer_size, peer_info,
-                                       do_reverse_lookups));
+    return ntpd_get_name_from_address(buffer, buffer_size, peer_info,
+                                      do_reverse_lookups);
 } /* int ntpd_addr_to_name */
 
 static int ntpd_read(void) {
@@ -833,12 +832,12 @@ static int ntpd_read(void) {
   if (status != 0) {
     ERROR("ntpd plugin: ntpd_do_query (REQ_GET_KERNEL) failed with status %i",
           status);
-    return (status);
+    return status;
   } else if ((ik == NULL) || (ik_num == 0) || (ik_size == 0)) {
     ERROR("ntpd plugin: ntpd_do_query returned unexpected data. "
           "(ik = %p; ik_num = %i; ik_size = %i)",
           (void *)ik, ik_num, ik_size);
-    return (-1);
+    return -1;
   }
 
   if (ntohs(ik->status) & STA_NANO) {
@@ -872,12 +871,12 @@ static int ntpd_read(void) {
     ERROR(
         "ntpd plugin: ntpd_do_query (REQ_PEER_LIST_SUM) failed with status %i",
         status);
-    return (status);
+    return status;
   } else if ((ps == NULL) || (ps_num == 0) || (ps_size == 0)) {
     ERROR("ntpd plugin: ntpd_do_query returned unexpected data. "
           "(ps = %p; ps_num = %i; ps_size = %i)",
           (void *)ps, ps_num, ps_size);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ps_num; i++) {
@@ -926,7 +925,7 @@ static int ntpd_read(void) {
   free(ps);
   ps = NULL;
 
-  return (0);
+  return 0;
 } /* int ntpd_read */
 
 void module_register(void) {

--- a/src/numa.c
+++ b/src/numa.c
@@ -69,7 +69,7 @@ static int numa_read_node(int node) /* {{{ */
     char errbuf[1024];
     ERROR("numa plugin: Reading node %i failed: open(%s): %s", node, path,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   success = 0;
@@ -95,7 +95,7 @@ static int numa_read_node(int node) /* {{{ */
   }
 
   fclose(fh);
-  return (success ? 0 : -1);
+  return success ? 0 : -1;
 } /* }}} int numa_read_node */
 
 static int numa_read(void) /* {{{ */
@@ -106,7 +106,7 @@ static int numa_read(void) /* {{{ */
 
   if (max_node < 0) {
     WARNING("numa plugin: No NUMA nodes were detected.");
-    return (-1);
+    return -1;
   }
 
   success = 0;
@@ -116,7 +116,7 @@ static int numa_read(void) /* {{{ */
       success++;
   }
 
-  return (success ? 0 : -1);
+  return success ? 0 : -1;
 } /* }}} int numa_read */
 
 static int numa_init(void) /* {{{ */
@@ -140,12 +140,12 @@ static int numa_init(void) /* {{{ */
       char errbuf[1024];
       ERROR("numa plugin: stat(%s) failed: %s", path,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   }
 
   DEBUG("numa plugin: Found %i nodes.", max_node + 1);
-  return (0);
+  return 0;
 } /* }}} int numa_init */
 
 void module_register(void) {

--- a/src/nut.c
+++ b/src/nut.c
@@ -79,14 +79,14 @@ static int nut_add_ups(const char *name) {
   ups = calloc(1, sizeof(*ups));
   if (ups == NULL) {
     ERROR("nut plugin: nut_add_ups: calloc failed.");
-    return (1);
+    return 1;
   }
 
   status = upscli_splitname(name, &ups->upsname, &ups->hostname, &ups->port);
   if (status != 0) {
     ERROR("nut plugin: nut_add_ups: upscli_splitname (%s) failed.", name);
     free_nut_ups_t(ups);
-    return (1);
+    return 1;
   }
 
   if (upslist_head == NULL)
@@ -98,7 +98,7 @@ static int nut_add_ups(const char *name) {
     last->next = ups;
   }
 
-  return (0);
+  return 0;
 } /* int nut_add_ups */
 
 static int nut_force_ssl(const char *value) {
@@ -111,7 +111,7 @@ static int nut_force_ssl(const char *value) {
     WARNING("nut plugin: nut_force_ssl: invalid FORCESSL value "
             "found. Defaulting to false.");
   }
-  return (0);
+  return 0;
 } /* int nut_parse_force_ssl */
 
 static int nut_verify_peer(const char *value) {
@@ -124,7 +124,7 @@ static int nut_verify_peer(const char *value) {
     WARNING("nut plugin: nut_verify_peer: invalid VERIFYPEER value "
             "found. Defaulting to false.");
   }
-  return (0);
+  return 0;
 } /* int nut_verify_peer */
 
 static int nut_ca_path(const char *value) {
@@ -134,20 +134,20 @@ static int nut_ca_path(const char *value) {
   } else {
     ca_path = NULL; // Should alread be set to NULL from initialization
   }
-  return (0);
+  return 0;
 } /* int nut_ca_path */
 
 static int nut_config(const char *key, const char *value) {
   if (strcasecmp(key, "UPS") == 0)
-    return (nut_add_ups(value));
+    return nut_add_ups(value);
   else if (strcasecmp(key, "FORCESSL") == 0)
-    return (nut_force_ssl(value));
+    return nut_force_ssl(value);
   else if (strcasecmp(key, "VERIFYPEER") == 0)
-    return (nut_verify_peer(value));
+    return nut_verify_peer(value);
   else if (strcasecmp(key, "CAPATH") == 0)
-    return (nut_ca_path(value));
+    return nut_ca_path(value);
   else
-    return (-1);
+    return -1;
 } /* int nut_config */
 
 static void nut_submit(nut_ups_t *ups, const char *type,
@@ -183,7 +183,7 @@ static int nut_connect(nut_ups_t *ups) {
   if (verify_peer == 1 && ca_path == NULL) {
     ERROR("nut plugin: nut_connect: VerifyPeer true but missing "
           "CAPath value.");
-    return (-1);
+    return -1;
   }
 
   if (verify_peer == 1) {
@@ -193,7 +193,7 @@ static int nut_connect(nut_ups_t *ups) {
       ERROR("nut plugin: nut_connect: upscli_init (%i, %s) failed: %s",
             verify_peer, ca_path, upscli_strerror(ups->conn));
       upscli_cleanup();
-      return (-1);
+      return -1;
     }
   } /* if (verify_peer == 1) */
 
@@ -211,7 +211,7 @@ static int nut_connect(nut_ups_t *ups) {
           ups->hostname, ups->port, upscli_strerror(ups->conn));
     sfree(ups->conn);
     upscli_cleanup();
-    return (-1);
+    return -1;
   } /* if (status != 0) */
 
   INFO("nut plugin: Connection to (%s, %i) established.", ups->hostname,
@@ -232,9 +232,9 @@ static int nut_connect(nut_ups_t *ups) {
           upscli_strerror(ups->conn));
     sfree(ups->conn);
     upscli_cleanup();
-    return (-1);
+    return -1;
   } /* if (ssl_status == 1 && verify_peer == 1) */
-  return (0);
+  return 0;
 
 #else /* #if HAVE_UPSCLI_INIT */
   int status;
@@ -258,7 +258,7 @@ static int nut_connect(nut_ups_t *ups) {
     ERROR("nut plugin: nut_connect: upscli_connect (%s, %i) failed: %s",
           ups->hostname, ups->port, upscli_strerror(ups->conn));
     sfree(ups->conn);
-    return (-1);
+    return -1;
   } /* if (status != 0) */
 
   INFO("nut plugin: Connection to (%s, %i) established.", ups->hostname,
@@ -275,9 +275,9 @@ static int nut_connect(nut_ups_t *ups) {
     ERROR("nut plugin: nut_connect: upscli_ssl failed: %s",
           upscli_strerror(ups->conn));
     sfree(ups->conn);
-    return (-1);
+    return -1;
   } /* if (ssl_status == 1 && verify_peer == 1) */
-  return (0);
+  return 0;
 #endif
 }
 
@@ -293,7 +293,7 @@ static int nut_read_one(nut_ups_t *ups) {
     ups->conn = malloc(sizeof(*ups->conn));
     if (ups->conn == NULL) {
       ERROR("nut plugin: malloc failed.");
-      return (-1);
+      return -1;
     }
 
     status = nut_connect(ups);
@@ -313,7 +313,7 @@ static int nut_read_one(nut_ups_t *ups) {
 #if HAVE_UPSCLI_INIT
     upscli_cleanup();
 #endif
-    return (-1);
+    return -1;
   }
 
   while ((status = upscli_list_next(ups->conn, query_num, query, &answer_num,
@@ -365,7 +365,7 @@ static int nut_read_one(nut_ups_t *ups) {
     }
   } /* while (upscli_list_next) */
 
-  return (0);
+  return 0;
 } /* int nut_read_one */
 
 static int nut_read(void) {
@@ -377,7 +377,7 @@ static int nut_read(void) {
   pthread_mutex_unlock(&read_lock);
 
   if (success != 0)
-    return (0);
+    return 0;
 
   for (nut_ups_t *ups = upslist_head; ups != NULL; ups = ups->next)
     if (nut_read_one(ups) == 0)
@@ -387,7 +387,7 @@ static int nut_read(void) {
   read_busy = 0;
   pthread_mutex_unlock(&read_lock);
 
-  return ((success != 0) ? 0 : -1);
+  return (success != 0) ? 0 : -1;
 } /* int nut_read */
 
 static int nut_shutdown(void) {
@@ -404,7 +404,7 @@ static int nut_shutdown(void) {
   upscli_cleanup();
 #endif
 
-  return (0);
+  return 0;
 } /* int nut_shutdown */
 
 void module_register(void) {

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -54,15 +54,15 @@ static int config_want_topology = OLSRD_WANT_SUMMARY;
 static const char *olsrd_get_node(void) /* {{{ */
 {
   if (config_node != NULL)
-    return (config_node);
-  return (OLSRD_DEFAULT_NODE);
+    return config_node;
+  return OLSRD_DEFAULT_NODE;
 } /* }}} const char *olsrd_get_node */
 
 static const char *olsrd_get_service(void) /* {{{ */
 {
   if (config_service != NULL)
-    return (config_service);
-  return (OLSRD_DEFAULT_SERVICE);
+    return config_service;
+  return OLSRD_DEFAULT_SERVICE;
 } /* }}} const char *olsrd_get_service */
 
 static void olsrd_set_node(const char *node) /* {{{ */
@@ -114,7 +114,7 @@ static size_t strchomp(char *buffer) /* {{{ */
     buffer[buffer_len] = 0;
   }
 
-  return (buffer_len);
+  return buffer_len;
 } /* }}} size_t strchomp */
 
 static size_t strtabsplit(char *string, char **fields, size_t size) /* {{{ */
@@ -134,7 +134,7 @@ static size_t strtabsplit(char *string, char **fields, size_t size) /* {{{ */
       break;
   }
 
-  return (i);
+  return i;
 } /* }}} size_t strtabsplit */
 
 static FILE *olsrd_connect(void) /* {{{ */
@@ -154,7 +154,7 @@ static FILE *olsrd_connect(void) /* {{{ */
   if (ai_return != 0) {
     ERROR("olsrd plugin: getaddrinfo (%s, %s) failed: %s", olsrd_get_node(),
           olsrd_get_service(), gai_strerror(ai_return));
-    return (NULL);
+    return NULL;
   }
 
   fh = NULL;
@@ -191,7 +191,7 @@ static FILE *olsrd_connect(void) /* {{{ */
 
   freeaddrinfo(ai_list);
 
-  return (fh);
+  return fh;
 } /* }}} FILE *olsrd_connect */
 
 __attribute__((nonnull(2))) static void
@@ -214,7 +214,7 @@ olsrd_submit(const char *plugin_instance, /* {{{ */
 
 static int olsrd_cb_ignore(int lineno, /* {{{ */
                            size_t fields_num, char **fields) {
-  return (0);
+  return 0;
 } /* }}} int olsrd_cb_ignore */
 
 static int olsrd_cb_links(int lineno, /* {{{ */
@@ -239,7 +239,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
   char *endptr;
 
   if (config_want_links == OLSRD_WANT_NOT)
-    return (0);
+    return 0;
 
   /* Special handling of the first line. */
   if (lineno <= 0) {
@@ -249,7 +249,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     nlq_sum = 0.0;
     nlq_num = 0;
 
-    return (0);
+    return 0;
   }
 
   /* Special handling of the last line. */
@@ -272,11 +272,11 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     olsrd_submit(/* p.-inst = */ "links", /* type = */ "signal_quality",
                  "average-nlq", nlq);
 
-    return (0);
+    return 0;
   }
 
   if (fields_num != 6)
-    return (-1);
+    return -1;
 
   links_num++;
 
@@ -328,7 +328,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_cb_links */
 
 static int olsrd_cb_routes(int lineno, /* {{{ */
@@ -351,7 +351,7 @@ static int olsrd_cb_routes(int lineno, /* {{{ */
   char *endptr;
 
   if (config_want_routes == OLSRD_WANT_NOT)
-    return (0);
+    return 0;
 
   /* Special handling of the first line */
   if (lineno <= 0) {
@@ -361,7 +361,7 @@ static int olsrd_cb_routes(int lineno, /* {{{ */
     etx_sum = 0.0;
     etx_num = 0;
 
-    return (0);
+    return 0;
   }
 
   /* Special handling after the last line */
@@ -386,11 +386,11 @@ static int olsrd_cb_routes(int lineno, /* {{{ */
     olsrd_submit(/* p.-inst = */ "routes", /* type = */ "route_etx", "average",
                  etx);
 
-    return (0);
+    return 0;
   }
 
   if (fields_num != 5)
-    return (-1);
+    return -1;
 
   routes_num++;
 
@@ -429,7 +429,7 @@ static int olsrd_cb_routes(int lineno, /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_cb_routes */
 
 static int olsrd_cb_topology(int lineno, /* {{{ */
@@ -450,7 +450,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
   char *endptr;
 
   if (config_want_topology == OLSRD_WANT_NOT)
-    return (0);
+    return 0;
 
   /* Special handling of the first line */
   if (lineno <= 0) {
@@ -458,7 +458,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     lq_num = 0;
     links_num = 0;
 
-    return (0);
+    return 0;
   }
 
   /* Special handling after the last line */
@@ -474,11 +474,11 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
                  /* t.-inst = */ "average", lq);
 
-    return (0);
+    return 0;
   }
 
   if (fields_num != 5)
-    return (-1);
+    return -1;
 
   links_num++;
 
@@ -523,7 +523,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_cb_topology */
 
 static int olsrd_read_table(FILE *fh, /* {{{ */
@@ -552,7 +552,7 @@ static int olsrd_read_table(FILE *fh, /* {{{ */
     lineno++;
   } /* while (fgets) */
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_read_table */
 
 static int olsrd_config(const char *key, const char *value) /* {{{ */
@@ -569,10 +569,10 @@ static int olsrd_config(const char *key, const char *value) /* {{{ */
     olsrd_set_detail(&config_want_topology, value, key);
   else {
     ERROR("olsrd plugin: Unknown configuration option given: %s", key);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_config */
 
 static int olsrd_read(void) /* {{{ */
@@ -583,7 +583,7 @@ static int olsrd_read(void) /* {{{ */
 
   fh = olsrd_connect();
   if (fh == NULL)
-    return (-1);
+    return -1;
 
   fputs("\r\n", fh);
   fflush(fh);
@@ -615,7 +615,7 @@ static int olsrd_read(void) /* {{{ */
 
   fclose(fh);
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_read */
 
 static int olsrd_shutdown(void) /* {{{ */
@@ -623,7 +623,7 @@ static int olsrd_shutdown(void) /* {{{ */
   sfree(config_node);
   sfree(config_service);
 
-  return (0);
+  return 0;
 } /* }}} int olsrd_shutdown */
 
 void module_register(void) {

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -123,7 +123,7 @@ static int timeval_subtract(struct timeval *result, struct timeval *t2,
   result->tv_sec = diff / 1000000;
   result->tv_usec = diff % 1000000;
 
-  return (diff < 0);
+  return diff < 0;
 }
 #endif /* COLLECT_DEBUG */
 
@@ -169,7 +169,7 @@ static int direct_list_insert(const char *config) {
     if (regcomp(&regex_direct, regexp_to_match, REG_EXTENDED)) {
       ERROR("onewire plugin: Cannot compile regex");
       direct_list_element_free(element);
-      return (1);
+      return 1;
     }
     regex_direct_initialized = 1;
     DEBUG("onewire plugin: Compiled regex!!");
@@ -242,7 +242,7 @@ static int cow_load_config(const char *key, const char *value) {
 
       if (ignorelist_add(sensor_list, value)) {
         ERROR("onewire plugin: Cannot add value to ignorelist.");
-        return (1);
+        return 1;
       }
     } else {
       DEBUG("onewire plugin: %s is a direct access", value);
@@ -257,7 +257,7 @@ static int cow_load_config(const char *key, const char *value) {
     temp = strdup(value);
     if (temp == NULL) {
       ERROR("onewire plugin: strdup failed.");
-      return (1);
+      return 1;
     }
     sfree(device_g);
     device_g = temp;
@@ -269,10 +269,10 @@ static int cow_load_config(const char *key, const char *value) {
     else
       ERROR("onewire plugin: Invalid `Interval' setting: %s", value);
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static int cow_read_values(const char *path, const char *name,
@@ -310,7 +310,7 @@ static int cow_read_values(const char *path, const char *name,
       ERROR("onewire plugin: OW_get (%s/%s) failed. error = %s;", path,
             family_info->features[i].filename,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
     DEBUG("Read onewire device %s as %s", file, buffer);
 
@@ -334,7 +334,7 @@ static int cow_read_values(const char *path, const char *name,
     free(buffer);
   } /* for (i = 0; i < features_num; i++) */
 
-  return ((success > 0) ? 0 : -1);
+  return (success > 0) ? 0 : -1;
 } /* int cow_read_values */
 
 /* Forward declaration so the recursion below works */
@@ -358,7 +358,7 @@ static int cow_read_ds2409(const char *path) {
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
-  return (0);
+  return 0;
 } /* int cow_read_ds2409 */
 
 static int cow_read_bus(const char *path) {
@@ -376,7 +376,7 @@ static int cow_read_bus(const char *path) {
   if (status < 0) {
     ERROR("onewire plugin: OW_get (%s) failed. error = %s;", path,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   DEBUG("onewire plugin: OW_get (%s) returned: %s", path, buffer);
 
@@ -415,7 +415,7 @@ static int cow_read_bus(const char *path) {
   } /* while (strtok_r) */
 
   free(buffer);
-  return (0);
+  return 0;
 } /* int cow_read_bus */
 
 /* ===================================================================================
@@ -439,7 +439,7 @@ static int cow_simple_read(void) {
     if (status < 0) {
       ERROR("onewire plugin: OW_get (%s) failed. status = %s;", traverse->path,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
     DEBUG("onewire plugin: Read onewire device %s as %s", traverse->path,
           buffer);
@@ -502,7 +502,7 @@ static int cow_shutdown(void) {
     regfree(&regex_direct);
   }
 
-  return (0);
+  return 0;
 } /* int cow_shutdown */
 
 static int cow_init(void) {
@@ -511,7 +511,7 @@ static int cow_init(void) {
 
   if (device_g == NULL) {
     ERROR("onewire plugin: cow_init: No device configured.");
-    return (-1);
+    return -1;
   }
 
   DEBUG("onewire plugin: about to init device <%s>.", device_g);
@@ -519,14 +519,14 @@ static int cow_init(void) {
   if (status != 0) {
     ERROR("onewire plugin: OW_init(%s) failed: %s.", device_g,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   plugin_register_complex_read(/* group = */ NULL, "onewire", cow_read,
                                ow_interval, /* user data = */ NULL);
   plugin_register_shutdown("onewire", cow_shutdown);
 
-  return (0);
+  return 0;
 } /* int cow_init */
 
 void module_register(void) {

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -85,7 +85,7 @@ static int cldap_init_host(cldap_t *st) /* {{{ */
 
   if (st->state && st->ld) {
     DEBUG("openldap plugin: Already connected to %s", st->url);
-    return (0);
+    return 0;
   }
 
   rc = ldap_initialize(&ld, st->url);
@@ -93,7 +93,7 @@ static int cldap_init_host(cldap_t *st) /* {{{ */
     ERROR("openldap plugin: ldap_initialize failed: %s", ldap_err2string(rc));
     st->state = 0;
     ldap_unbind_ext_s(ld, NULL, NULL);
-    return (-1);
+    return -1;
   }
 
   st->ld = ld;
@@ -120,7 +120,7 @@ static int cldap_init_host(cldap_t *st) /* {{{ */
             ldap_err2string(rc));
       st->state = 0;
       ldap_unbind_ext_s(st->ld, NULL, NULL);
-      return (-1);
+      return -1;
     }
   }
 
@@ -140,11 +140,11 @@ static int cldap_init_host(cldap_t *st) /* {{{ */
           ldap_err2string(rc));
     st->state = 0;
     ldap_unbind_ext_s(st->ld, NULL, NULL);
-    return (-1);
+    return -1;
   } else {
     DEBUG("openldap plugin: Successfully connected to %s", st->url);
     st->state = 1;
-    return (0);
+    return 0;
   }
 } /* }}} static cldap_init_host */
 
@@ -197,14 +197,14 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("openldap plugin: cldap_read_host: Invalid user data.");
-    return (-1);
+    return -1;
   }
 
   st = (cldap_t *)ud->data;
 
   status = cldap_init_host(st);
   if (status != 0)
-    return (-1);
+    return -1;
 
   rc = ldap_search_ext_s(st->ld, "cn=Monitor", LDAP_SCOPE_SUBTREE,
                          "(|(!(cn=* *))(cn=Database*))", attrs, 0, NULL, NULL,
@@ -215,7 +215,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
     ldap_msgfree(result);
     st->state = 0;
     ldap_unbind_ext_s(st->ld, NULL, NULL);
-    return (-1);
+    return -1;
   }
 
   for (LDAPMessage *e = ldap_first_entry(st->ld, result); e != NULL;
@@ -372,7 +372,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
   }
 
   ldap_msgfree(result);
-  return (0);
+  return 0;
 } /* }}} int cldap_read_host */
 
 /* Configuration handling functions {{{
@@ -393,13 +393,13 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
   st = calloc(1, sizeof(*st));
   if (st == NULL) {
     ERROR("openldap plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   status = cf_util_get_string(ci, &st->name);
   if (status != 0) {
     sfree(st);
-    return (status);
+    return status;
   }
 
   st->starttls = 0;
@@ -491,10 +491,10 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     cldap_free(st);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int cldap_config_add */
 
 static int cldap_config(oconfig_item_t *ci) /* {{{ */
@@ -514,7 +514,7 @@ static int cldap_config(oconfig_item_t *ci) /* {{{ */
               child->key);
   } /* for (ci->children) */
 
-  return (status);
+  return status;
 } /* }}} int cldap_config */
 
 /* }}} End of configuration handling functions */
@@ -525,7 +525,7 @@ static int cldap_init(void) /* {{{ */
    * ldap_initialize(3) */
   int debug_level;
   ldap_get_option(NULL, LDAP_OPT_DEBUG_LEVEL, &debug_level);
-  return (0);
+  return 0;
 } /* }}} int cldap_init */
 
 static int cldap_shutdown(void) /* {{{ */
@@ -536,7 +536,7 @@ static int cldap_shutdown(void) /* {{{ */
   sfree(databases);
   databases_num = 0;
 
-  return (0);
+  return 0;
 } /* }}} int cldap_shutdown */
 
 void module_register(void) /* {{{ */

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -88,7 +88,7 @@ static int openvpn_strsplit(char *string, char **fields, size_t size) {
       break;
   }
 
-  return (i);
+  return i;
 } /* int openvpn_strsplit */
 
 /* dispatches number of users */
@@ -225,7 +225,7 @@ static int single_read(const char *name, FILE *fh) {
 
   read = 1;
 
-  return (read);
+  return read;
 } /* int single_read */
 
 /* for reading status version 1 */
@@ -276,12 +276,12 @@ static int multi1_read(const char *name, FILE *fh) {
   }
 
   if (ferror(fh))
-    return (0);
+    return 0;
 
   if (collect_user_count)
     numusers_submit(name, name, sum_users);
 
-  return (1);
+  return 1;
 } /* int multi1_read */
 
 /* for reading status version 2 */
@@ -336,7 +336,7 @@ static int multi2_read(const char *name, FILE *fh) {
     read = 1;
   }
 
-  return (read);
+  return read;
 } /* int multi2_read */
 
 /* for reading status version 3 */
@@ -391,7 +391,7 @@ static int multi3_read(const char *name, FILE *fh) {
     read = 1;
   }
 
-  return (read);
+  return read;
 } /* int multi3_read */
 
 /* for reading status version 4 */
@@ -446,7 +446,7 @@ static int multi4_read(const char *name, FILE *fh) {
     read = 1;
   }
 
-  return (read);
+  return read;
 } /* int multi4_read */
 
 /* read callback */
@@ -457,7 +457,7 @@ static int openvpn_read(void) {
   read = 0;
 
   if (vpn_num == 0)
-    return (0);
+    return 0;
 
   /* call the right read function for every status entry in the list */
   for (int i = 0; i < vpn_num; i++) {
@@ -498,7 +498,7 @@ static int openvpn_read(void) {
     read += vpn_read;
   }
 
-  return (read ? 0 : -1);
+  return read ? 0 : -1;
 } /* int openvpn_read */
 
 static int version_detect(const char *filename) {
@@ -509,14 +509,14 @@ static int version_detect(const char *filename) {
   /* Sanity checking. We're called from the config handling routine, so
    * better play it save. */
   if ((filename == NULL) || (*filename == 0))
-    return (0);
+    return 0;
 
   fh = fopen(filename, "r");
   if (fh == NULL) {
     char errbuf[1024];
     WARNING("openvpn plugin: Unable to read \"%s\": %s", filename,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (0);
+    return 0;
   }
 
   /* now search for the specific multimode data format */
@@ -581,7 +581,7 @@ static int openvpn_config(const char *key, const char *value) {
       WARNING("openvpn plugin: unable to detect status version, "
               "discarding status file \"%s\".",
               value);
-      return (1);
+      return 1;
     }
 
     status_file = sstrdup(value);
@@ -589,7 +589,7 @@ static int openvpn_config(const char *key, const char *value) {
       char errbuf[1024];
       WARNING("openvpn plugin: sstrdup failed: %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (1);
+      return 1;
     }
 
     /* it determines the file name as string starting at location filename + 1
@@ -611,7 +611,7 @@ static int openvpn_config(const char *key, const char *value) {
                 "different one.",
                 status_name);
         sfree(status_file);
-        return (1);
+        return 1;
       }
     }
 
@@ -622,7 +622,7 @@ static int openvpn_config(const char *key, const char *value) {
       ERROR("openvpn plugin: malloc failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
       sfree(status_file);
-      return (1);
+      return 1;
     }
     temp->file = status_file;
     temp->version = status_version;
@@ -638,7 +638,7 @@ static int openvpn_config(const char *key, const char *value) {
       sfree(vpn_list);
       sfree(temp->file);
       sfree(temp);
-      return (1);
+      return 1;
     }
     vpn_list = tmp_list;
 
@@ -677,10 +677,10 @@ static int openvpn_config(const char *key, const char *value) {
       collect_individual_users = 1;
   } /* if (strcasecmp("CollectIndividualUsers", key) == 0) */
   else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int openvpn_config */
 
 /* shutdown callback */
@@ -692,7 +692,7 @@ static int openvpn_shutdown(void) {
 
   sfree(vpn_list);
 
-  return (0);
+  return 0;
 } /* int openvpn_shutdown */
 
 static int openvpn_init(void) {
@@ -701,13 +701,13 @@ static int openvpn_init(void) {
     WARNING("OpenVPN plugin: Neither `CollectIndividualUsers', "
             "`CollectCompression', nor `CollectUserCount' is true. There's no "
             "data left to collect.");
-    return (-1);
+    return -1;
   }
 
   plugin_register_read("openvpn", openvpn_read);
   plugin_register_shutdown("openvpn", openvpn_shutdown);
 
-  return (0);
+  return 0;
 } /* int openvpn_init */
 
 void module_register(void) {

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -179,13 +179,13 @@ static int o_config_add_database(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("oracle plugin: The `Database' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   db = calloc(1, sizeof(*db));
   if (db == NULL) {
     ERROR("oracle plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   db->name = NULL;
   db->host = NULL;
@@ -196,7 +196,7 @@ static int o_config_add_database(oconfig_item_t *ci) /* {{{ */
   status = cf_util_get_string(ci, &db->name);
   if (status != 0) {
     sfree(db);
-    return (status);
+    return status;
   }
 
   /* Fill the `o_database_t' structure.. */
@@ -282,10 +282,10 @@ static int o_config_add_database(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     o_database_free(db);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int o_config_add_database */
 
 static int o_config(oconfig_item_t *ci) /* {{{ */
@@ -310,7 +310,7 @@ static int o_config(oconfig_item_t *ci) /* {{{ */
     }
   } /* for (ci->children) */
 
-  return (0);
+  return 0;
 } /* }}} int o_config */
 
 /* }}} End of configuration handling functions */
@@ -320,7 +320,7 @@ static int o_init(void) /* {{{ */
   int status;
 
   if (oci_env != NULL)
-    return (0);
+    return 0;
 
   status = OCIEnvCreate(&oci_env,
                         /* mode = */ OCI_THREADED,
@@ -332,7 +332,7 @@ static int o_init(void) /* {{{ */
                         /* user_data_ptr  = */ NULL);
   if (status != 0) {
     ERROR("oracle plugin: OCIEnvCreate failed with status %i.", status);
-    return (-1);
+    return -1;
   }
 
   status = OCIHandleAlloc(oci_env, (void *)&oci_error, OCI_HTYPE_ERROR,
@@ -341,10 +341,10 @@ static int o_init(void) /* {{{ */
     ERROR("oracle plugin: OCIHandleAlloc (OCI_HTYPE_ERROR) failed "
           "with status %i.",
           status);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int o_init */
 
 static int o_read_database_query(o_database_t *db, /* {{{ */
@@ -378,7 +378,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
       o_report_error("o_read_database_query", db->name, udb_query_get_name(q),
                      "OCIHandleAlloc", oci_error);
       oci_statement = NULL;
-      return (-1);
+      return -1;
     }
 
     status = OCIStmtPrepare(oci_statement, oci_error, (text *)statement,
@@ -390,7 +390,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
                      "OCIStmtPrepare", oci_error);
       OCIHandleFree(oci_statement, OCI_HTYPE_STMT);
       oci_statement = NULL;
-      return (-1);
+      return -1;
     }
     udb_query_set_user_data(q, oci_statement);
 
@@ -411,7 +411,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
   if (status != OCI_SUCCESS) {
     o_report_error("o_read_database_query", db->name, udb_query_get_name(q),
                    "OCIStmtExecute", oci_error);
-    return (-1);
+    return -1;
   } /* }}} */
 
   /* Acquire the number of columns returned. */
@@ -424,7 +424,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
     if (status != OCI_SUCCESS) {
       o_report_error("o_read_database_query", db->name, udb_query_get_name(q),
                      "OCIAttrGet", oci_error);
-      return (-1);
+      return -1;
     } /* }}} */
 
     column_num = (size_t)param_counter;
@@ -461,7 +461,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
     if ((ptr) == NULL) {                                                       \
       FREE_ALL;                                                                \
       ERROR("oracle plugin: o_read_database_query: calloc failed.");           \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
   } while (0)
 
@@ -552,7 +552,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
           "udb_query_prepare_result failed.",
           db->name, udb_query_get_name(q));
     FREE_ALL;
-    return (-1);
+    return -1;
   }
 
   /* Fetch and handle all the rows that matched the query. */
@@ -582,7 +582,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
    * %s", q->statement); */
   FREE_ALL;
 
-  return (0);
+  return 0;
 #undef FREE_ALL
 #undef ALLOC_OR_FAIL
 } /* }}} int o_read_database_query */
@@ -602,7 +602,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
     if (status != OCI_SUCCESS) {
       o_report_error("o_read_database", db->name, NULL, "OCIAttrGet",
                      oci_error);
-      return (-1);
+      return -1;
     }
 
     if (server_handle == NULL) {
@@ -616,7 +616,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
       if (status != OCI_SUCCESS) {
         o_report_error("o_read_database", db->name, NULL, "OCIAttrGet",
                        oci_error);
-        return (-1);
+        return -1;
       }
     }
 
@@ -642,7 +642,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
       DEBUG("oracle plugin: OCILogon (%s): db->oci_service_context = %p;",
             db->connect_id, db->oci_service_context);
       db->oci_service_context = NULL;
-      return (-1);
+      return -1;
     } else if (status == OCI_SUCCESS_WITH_INFO) {
       /* TODO: Print NOTIFY message. */
     }
@@ -656,7 +656,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
   for (size_t i = 0; i < db->queries_num; i++)
     o_read_database_query(db, db->queries[i], db->q_prep_areas[i]);
 
-  return (0);
+  return 0;
 } /* }}} int o_read_database */
 
 static int o_read(void) /* {{{ */
@@ -666,7 +666,7 @@ static int o_read(void) /* {{{ */
   for (i = 0; i < databases_num; i++)
     o_read_database(databases[i]);
 
-  return (0);
+  return 0;
 } /* }}} int o_read */
 
 static int o_shutdown(void) /* {{{ */
@@ -696,7 +696,7 @@ static int o_shutdown(void) /* {{{ */
   queries = NULL;
   queries_num = 0;
 
-  return (0);
+  return 0;
 } /* }}} int o_shutdown */
 
 void module_register(void) /* {{{ */

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -99,7 +99,7 @@ static int ovs_events_plugin_read(user_data_t *u);
  */
 static int ovs_events_ctx_lock() {
   pthread_mutex_lock(&ovs_events_ctx.mutex);
-  return (1);
+  return 1;
 }
 
 /* This function is used only by "OVS_EVENTS_CTX_LOCK" define (see above).
@@ -107,7 +107,7 @@ static int ovs_events_ctx_lock() {
  */
 static int ovs_events_ctx_unlock() {
   pthread_mutex_unlock(&ovs_events_ctx.mutex);
-  return (0);
+  return 0;
 }
 
 /* Check if given interface name exists in configuration file. It
@@ -116,15 +116,15 @@ static int ovs_events_ctx_unlock() {
  */
 static int ovs_events_config_iface_exists(const char *ifname) {
   if (ovs_events_ctx.config.ifaces == NULL)
-    return (-1);
+    return -1;
 
   /* check if given interface exists */
   for (ovs_events_iface_list_t *iface = ovs_events_ctx.config.ifaces; iface;
        iface = iface->next)
     if (strcmp(ifname, iface->name) == 0)
-      return (1);
+      return 1;
 
-  return (0);
+  return 0;
 }
 
 /* Get OVS DB select parameter request based on rfc7047,
@@ -204,13 +204,13 @@ static int ovs_events_config_get_interfaces(const oconfig_item_t *ci) {
     if (ci->values[j].type != OCONFIG_TYPE_STRING) {
       ERROR(OVS_EVENTS_PLUGIN
             ": given interface name is not a string [idx=%d]", j);
-      return (-1);
+      return -1;
     }
     /* allocate memory for configured interface */
     ovs_events_iface_list_t *new_iface = calloc(1, sizeof(*new_iface));
     if (new_iface == NULL) {
       ERROR(OVS_EVENTS_PLUGIN ": calloc () copy interface name fail");
-      return (-1);
+      return -1;
     } else {
       /* store interface name */
       sstrncpy(new_iface->name, ci->values[j].value.string,
@@ -221,7 +221,7 @@ static int ovs_events_config_get_interfaces(const oconfig_item_t *ci) {
             new_iface->name);
     }
   }
-  return (0);
+  return 0;
 }
 
 /* Parse plugin configuration file and store the config
@@ -235,20 +235,20 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
       if (cf_util_get_boolean(child,
                               &ovs_events_ctx.config.send_notification) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Address", child->key) == 0) {
       if (cf_util_get_string_buffer(
               child, ovs_events_ctx.config.ovs_db_node,
               sizeof(ovs_events_ctx.config.ovs_db_node)) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Port", child->key) == 0) {
       char *service = NULL;
       if (cf_util_get_service(child, &service) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
       strncpy(ovs_events_ctx.config.ovs_db_serv, service,
               sizeof(ovs_events_ctx.config.ovs_db_serv));
@@ -258,22 +258,22 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
               child, ovs_events_ctx.config.ovs_db_unix,
               sizeof(ovs_events_ctx.config.ovs_db_unix)) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Interfaces", child->key) == 0) {
       if (ovs_events_config_get_interfaces(child) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("DispatchValues", child->key) == 0) {
       if (cf_util_get_boolean(child, &dispatch_values) != 0) {
         ovs_events_config_free();
-        return (-1);
+        return -1;
       }
     } else {
       ERROR(OVS_EVENTS_PLUGIN ": option '%s' is not allowed here", child->key);
       ovs_events_config_free();
-      return (-1);
+      return -1;
     }
   }
   /* Check and warn about invalid configuration */
@@ -287,7 +287,7 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
     return plugin_register_complex_read(NULL, OVS_EVENTS_PLUGIN,
                                         ovs_events_plugin_read, 0, NULL);
 
-  return (0);
+  return 0;
 }
 
 /* Dispatch OVS interface link status event to collectd */
@@ -396,7 +396,7 @@ static int ovs_events_get_iface_info(yajl_val jobject,
 
   /* check YAJL type */
   if (!YAJL_IS_OBJECT(jobject))
-    return (-1);
+    return -1;
 
   /* zero the interface info structure */
   memset(ifinfo, 0, sizeof(*ifinfo));
@@ -404,7 +404,7 @@ static int ovs_events_get_iface_info(yajl_val jobject,
   /* try to find external_ids, name and link_state fields */
   jexternal_ids = ovs_utils_get_value_by_key(jobject, "external_ids");
   if (jexternal_ids == NULL || ifinfo == NULL)
-    return (-1);
+    return -1;
 
   /* get iface-id from external_ids field */
   jvalue = ovs_utils_get_map_value(jexternal_ids, "iface-id");
@@ -422,16 +422,16 @@ static int ovs_events_get_iface_info(yajl_val jobject,
   jvalue = ovs_utils_get_value_by_key(jobject, "_uuid");
   if (jvalue == NULL || !YAJL_IS_ARRAY(jvalue) ||
       YAJL_GET_ARRAY(jvalue)->len != 2)
-    return (-1);
+    return -1;
   juuid = YAJL_GET_ARRAY(jvalue)->values[1];
   if (juuid == NULL || !YAJL_IS_STRING(juuid))
-    return (-1);
+    return -1;
   sstrncpy(ifinfo->uuid, YAJL_GET_STRING(juuid), sizeof(ifinfo->uuid));
 
   /* get interface name */
   jvalue = ovs_utils_get_value_by_key(jobject, "name");
   if (jvalue == NULL || !YAJL_IS_STRING(jvalue))
-    return (-1);
+    return -1;
   sstrncpy(ifinfo->name, YAJL_GET_STRING(jvalue), sizeof(ifinfo->name));
 
   /* get OVS DB interface link status */
@@ -443,7 +443,7 @@ static int ovs_events_get_iface_info(yajl_val jobject,
     else if (strcmp(state, "down") == 0)
       ifinfo->link_status = DOWN;
   }
-  return (0);
+  return 0;
 }
 
 /* Process OVS DB update table event. It handles link status update event(s)
@@ -593,9 +593,9 @@ static int ovs_events_plugin_read(__attribute__((unused)) user_data_t *u) {
                             ovs_events_ctx.ovs_db_select_params,
                             ovs_events_poll_result_cb) < 0) {
       ERROR(OVS_EVENTS_PLUGIN ": get interface info failed");
-      return (-1);
+      return -1;
     }
-  return (0);
+  return 0;
 }
 
 /* Initialize OVS plugin */
@@ -628,13 +628,13 @@ static int ovs_events_plugin_init(void) {
   OVS_EVENTS_CTX_LOCK { ovs_events_ctx.ovs_db = ovs_db; }
 
   DEBUG(OVS_EVENTS_PLUGIN ": plugin has been initialized");
-  return (0);
+  return 0;
 
 ovs_events_failure:
   ERROR(OVS_EVENTS_PLUGIN ": plugin initialize failed");
   /* release allocated memory */
   ovs_events_config_free();
-  return (-1);
+  return -1;
 }
 
 /* Shutdown OVS plugin */
@@ -647,7 +647,7 @@ static int ovs_events_plugin_shutdown(void) {
   ovs_events_config_free();
 
   DEBUG(OVS_EVENTS_PLUGIN ": plugin has been destroyed");
-  return (0);
+  return 0;
 }
 
 /* Register OVS plugin callbacks */

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -308,7 +308,7 @@ static int ovs_stats_del_bridge(yajl_val bridge) {
     }
   } else
     WARNING("%s: Incorrect data for deleting bridge", plugin_name);
-  return (0);
+  return 0;
 }
 
 /* Update Bridge. Create bridge ports*/
@@ -330,7 +330,7 @@ static int ovs_stats_update_bridge(yajl_val bridge) {
           br = (bridge_list_t *)calloc(1, sizeof(bridge_list_t));
           if (!br) {
             ERROR("%s: Error allocating memory for bridge", plugin_name);
-            return (-1);
+            return -1;
           }
           char *tmp = YAJL_GET_STRING(br_name);
 
@@ -339,7 +339,7 @@ static int ovs_stats_update_bridge(yajl_val bridge) {
           if (br->name == NULL) {
             sfree(br);
             pthread_mutex_unlock(&g_stats_lock);
-            return (-1);
+            return -1;
           }
           br->next = g_bridge_list_head;
           g_bridge_list_head = br;
@@ -364,9 +364,9 @@ static int ovs_stats_update_bridge(yajl_val bridge) {
     }
   } else {
     ERROR("Incorrect JSON Bridge data");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 /* Handle JSON with Bridge Table change event */
@@ -457,9 +457,9 @@ static int ovs_stats_update_port(const char *uuid, yajl_val port) {
     }
   } else {
     ERROR("Incorrect JSON Port data");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 /* Delete port from global port list */
@@ -476,7 +476,7 @@ static int ovs_stats_del_port(const char *uuid) {
       break;
     }
   }
-  return (0);
+  return 0;
 }
 
 /* Handle JSON with Port Table change event */
@@ -540,7 +540,7 @@ static int ovs_stats_update_iface_stats(port_list_t *port, yajl_val stats) {
     for (size_t i = 0; i < YAJL_GET_ARRAY(stats)->len; i++) {
       stat = YAJL_GET_ARRAY(stats)->values[i];
       if (!YAJL_IS_ARRAY(stat))
-        return (-1);
+        return -1;
       counter_name = YAJL_GET_STRING(YAJL_GET_ARRAY(stat)->values[0]);
       counter_index = ovs_stats_counter_name_to_type(counter_name);
       counter_value = YAJL_GET_INTEGER(YAJL_GET_ARRAY(stat)->values[1]);
@@ -549,7 +549,7 @@ static int ovs_stats_update_iface_stats(port_list_t *port, yajl_val stats) {
       port->stats[counter_index] = counter_value;
     }
 
-  return (0);
+  return 0;
 }
 
 /* Update interface external_ids */
@@ -562,7 +562,7 @@ static int ovs_stats_update_iface_ext_ids(port_list_t *port, yajl_val ext_ids) {
     for (size_t i = 0; i < YAJL_GET_ARRAY(ext_ids)->len; i++) {
       ext_id = YAJL_GET_ARRAY(ext_ids)->values[i];
       if (!YAJL_IS_ARRAY(ext_id))
-        return (-1);
+        return -1;
       key = YAJL_GET_STRING(YAJL_GET_ARRAY(ext_id)->values[0]);
       value = YAJL_GET_STRING(YAJL_GET_ARRAY(ext_id)->values[1]);
       if (key && value) {
@@ -573,7 +573,7 @@ static int ovs_stats_update_iface_ext_ids(port_list_t *port, yajl_val ext_ids) {
       }
     }
 
-  return (0);
+  return 0;
 }
 
 /* Get interface statistic and external_ids */
@@ -590,7 +590,7 @@ static int ovs_stats_update_iface(yajl_val iface) {
       if (iface_name && YAJL_IS_STRING(iface_name)) {
         port = ovs_stats_get_port_by_name(YAJL_GET_STRING(iface_name));
         if (port == NULL)
-          return (0);
+          return 0;
       }
       /*
        * {
@@ -626,9 +626,9 @@ static int ovs_stats_update_iface(yajl_val iface) {
     }
   } else {
     ERROR("Incorrect JSON Port data");
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 /* Handle JSON with Interface Table change event */
@@ -745,11 +745,11 @@ static void ovs_stats_initialize(ovs_db_t *pdb) {
 static int ovs_stats_is_monitored_bridge(const char *br_name) {
   /* if no bridges are configured, return true */
   if (g_monitored_bridge_list_head == NULL)
-    return (1);
+    return 1;
 
   /* check if given bridge exists */
   if (ovs_stats_get_bridge(g_monitored_bridge_list_head, br_name) != NULL)
-    return (1);
+    return 1;
 
   return 0;
 }
@@ -797,19 +797,19 @@ static int ovs_stats_plugin_config(oconfig_item_t *ci) {
       if (cf_util_get_string_buffer(child, ovs_stats_cfg.ovs_db_node,
                                     OVS_DB_ADDR_NODE_SIZE) != 0) {
         ERROR("%s: parse '%s' option failed", plugin_name, child->key);
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Port", child->key) == 0) {
       if (cf_util_get_string_buffer(child, ovs_stats_cfg.ovs_db_serv,
                                     OVS_DB_ADDR_SERVICE_SIZE) != 0) {
         ERROR("%s: parse '%s' option failed", plugin_name, child->key);
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Socket", child->key) == 0) {
       if (cf_util_get_string_buffer(child, ovs_stats_cfg.ovs_db_unix,
                                     OVS_DB_ADDR_UNIX_SIZE) != 0) {
         ERROR("%s: parse '%s' option failed", plugin_name, child->key);
-        return (-1);
+        return -1;
       }
     } else if (strcasecmp("Bridges", child->key) == 0) {
       for (int j = 0; j < child->values_num; j++) {
@@ -846,11 +846,11 @@ static int ovs_stats_plugin_config(oconfig_item_t *ci) {
       goto cleanup_fail;
     }
   }
-  return (0);
+  return 0;
 
 cleanup_fail:
   ovs_stats_free_bridge_list(g_monitored_bridge_list_head);
-  return (-1);
+  return -1;
 }
 
 /* Initialize OvS Stats plugin*/
@@ -866,15 +866,15 @@ static int ovs_stats_plugin_init(void) {
                              ovs_stats_cfg.ovs_db_serv,
                        ovs_stats_cfg.ovs_db_unix, &cb)) == NULL) {
     ERROR("%s: plugin: failed to connect to OvS DB server", plugin_name);
-    return (-1);
+    return -1;
   }
   int err = pthread_mutex_init(&g_stats_lock, NULL);
   if (err < 0) {
     ERROR("%s: plugin: failed to initialize cache lock", plugin_name);
     ovs_db_destroy(g_ovs_db);
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 }
 
 /* OvS stats read callback. Read bridge/port information and submit it*/
@@ -964,7 +964,7 @@ static int ovs_stats_plugin_read(__attribute__((unused)) user_data_t *ud) {
       continue;
   }
   pthread_mutex_unlock(&g_stats_lock);
-  return (0);
+  return 0;
 }
 
 /* Shutdown OvS Stats plugin */
@@ -977,7 +977,7 @@ static int ovs_stats_plugin_shutdown(void) {
   ovs_stats_free_port_list(g_port_list_head);
   pthread_mutex_unlock(&g_stats_lock);
   pthread_mutex_destroy(&g_stats_lock);
-  return (0);
+  return 0;
 }
 
 /* Register OvS Stats plugin callbacks */

--- a/src/perl.c
+++ b/src/perl.c
@@ -877,8 +877,8 @@ static char *get_module_name(char *buf, size_t buf_len, const char *module) {
   else
     status = ssnprintf(buf, buf_len, "%s::%s", base_name, module);
   if ((status < 0) || ((unsigned int)status >= buf_len))
-    return (NULL);
-  return (buf);
+    return NULL;
+  return buf;
 } /* char *get_module_name */
 
 /*
@@ -2489,7 +2489,7 @@ static int perl_config_loadplugin(pTHX_ oconfig_item_t *ci) {
 
   if (NULL == get_module_name(module_name, sizeof(module_name), value)) {
     log_err("Invalid module name %s", value);
-    return (1);
+    return 1;
   }
 
   if (0 != init_pi(perl_argc, perl_argv))

--- a/src/pf.c
+++ b/src/pf.c
@@ -86,7 +86,7 @@ static int pf_read(void) {
     char errbuf[1024];
     ERROR("pf plugin: Unable to open %s: %s", pf_device,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   status = ioctl(fd, DIOCGETSTATUS, &state);
@@ -95,14 +95,14 @@ static int pf_read(void) {
     ERROR("pf plugin: ioctl(DIOCGETSTATUS) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(fd);
-    return (-1);
+    return -1;
   }
 
   close(fd);
 
   if (!state.running) {
     WARNING("pf plugin: PF is not running.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < PFRES_MAX; i++)
@@ -121,7 +121,7 @@ static int pf_read(void) {
   pf_submit("pf_states", "current", (uint32_t)state.states,
             /* is gauge = */ 1);
 
-  return (0);
+  return 0;
 } /* int pf_read */
 
 void module_register(void) { plugin_register_read("pf", pf_read); }

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -141,7 +141,7 @@ static derive_t float_counter_get(const float_counter_t *fc, /* {{{ */
   ret = (derive_t)(fc->i * factor);
   ret += (derive_t)(fc->n / (1000000000 / factor));
 
-  return (ret);
+  return ret;
 } /* }}} derive_t float_counter_get */
 
 static void strset(char **str, const char *new) /* {{{ */
@@ -218,7 +218,7 @@ static unsigned int service_statnode_collect(pinba_statnode_t *res, /* {{{ */
   /* reset node */
   node->mem_peak = NAN;
 
-  return (index + 1);
+  return index + 1;
 } /* }}} unsigned int service_statnode_collect */
 
 static void service_statnode_process(pinba_statnode_t *node, /* {{{ */
@@ -263,7 +263,7 @@ static void service_process_request(Pinba__Request *request) /* {{{ */
 static int pb_del_socket(pinba_socket_t *s, /* {{{ */
                          nfds_t index) {
   if (index >= s->fd_num)
-    return (EINVAL);
+    return EINVAL;
 
   close(s->fd[index].fd);
   s->fd[index].fd = -1;
@@ -275,7 +275,7 @@ static int pb_del_socket(pinba_socket_t *s, /* {{{ */
   }
 
   s->fd_num--;
-  return (0);
+  return 0;
 } /* }}} int pb_del_socket */
 
 static int pb_add_socket(pinba_socket_t *s, /* {{{ */
@@ -289,7 +289,7 @@ static int pb_add_socket(pinba_socket_t *s, /* {{{ */
             "%i sockets. Please complain to the collectd developers so we can "
             "raise the limit.",
             PINBA_MAX_SOCKETS);
-    return (-1);
+    return -1;
   }
 
   fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
@@ -297,7 +297,7 @@ static int pb_add_socket(pinba_socket_t *s, /* {{{ */
     char errbuf[1024];
     ERROR("pinba plugin: socket(2) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (0);
+    return 0;
   }
 
   tmp = 1;
@@ -314,7 +314,7 @@ static int pb_add_socket(pinba_socket_t *s, /* {{{ */
     ERROR("pinba plugin: bind(2) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(fd);
-    return (0);
+    return 0;
   }
 
   s->fd[s->fd_num].fd = fd;
@@ -322,7 +322,7 @@ static int pb_add_socket(pinba_socket_t *s, /* {{{ */
   s->fd[s->fd_num].revents = 0;
   s->fd_num++;
 
-  return (0);
+  return 0;
 } /* }}} int pb_add_socket */
 
 static pinba_socket_t *pinba_socket_open(const char *node, /* {{{ */
@@ -344,7 +344,7 @@ static pinba_socket_t *pinba_socket_open(const char *node, /* {{{ */
   status = getaddrinfo(node, service, &ai_hints, &ai_list);
   if (status != 0) {
     ERROR("pinba plugin: getaddrinfo(3) failed: %s", gai_strerror(status));
-    return (NULL);
+    return NULL;
   }
   assert(ai_list != NULL);
 
@@ -352,7 +352,7 @@ static pinba_socket_t *pinba_socket_open(const char *node, /* {{{ */
   if (s == NULL) {
     freeaddrinfo(ai_list);
     ERROR("pinba plugin: calloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   for (struct addrinfo *ai_ptr = ai_list; ai_ptr != NULL;
@@ -370,7 +370,7 @@ static pinba_socket_t *pinba_socket_open(const char *node, /* {{{ */
     s = NULL;
   }
 
-  return (s);
+  return s;
 } /* }}} pinba_socket_open */
 
 static void pinba_socket_free(pinba_socket_t *socket) /* {{{ */
@@ -395,12 +395,12 @@ static int pinba_process_stats_packet(const uint8_t *buffer, /* {{{ */
   request = pinba__request__unpack(NULL, buffer_size, buffer);
 
   if (!request)
-    return (-1);
+    return -1;
 
   service_process_request(request);
   pinba__request__free_unpacked(request, NULL);
 
-  return (0);
+  return 0;
 } /* }}} int pinba_process_stats_packet */
 
 static int pinba_udp_read_callback_fn(int sock) /* {{{ */
@@ -426,10 +426,10 @@ static int pinba_udp_read_callback_fn(int sock) /* {{{ */
 
       WARNING("pinba plugin: recvfrom(2) failed: %s",
               sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     } else if (status == 0) {
       DEBUG("pinba plugin: recvfrom(2) returned unexpected status zero.");
-      return (-1);
+      return -1;
     } else /* if (status > 0) */
     {
       assert(((size_t)status) < buffer_size);
@@ -439,13 +439,13 @@ static int pinba_udp_read_callback_fn(int sock) /* {{{ */
       status = pinba_process_stats_packet(buffer, buffer_size);
       if (status != 0)
         DEBUG("pinba plugin: Parsing packet failed.");
-      return (status);
+      return status;
     }
   } /* while (42) */
 
   /* not reached */
   assert(23 == 42);
-  return (-1);
+  return -1;
 } /* }}} void pinba_udp_read_callback_fn */
 
 static int receive_loop(void) /* {{{ */
@@ -455,7 +455,7 @@ static int receive_loop(void) /* {{{ */
   s = pinba_socket_open(conf_node, conf_service);
   if (s == NULL) {
     ERROR("pinba plugin: Collector thread is exiting prematurely.");
-    return (-1);
+    return -1;
   }
 
   while (!collector_thread_do_shutdown) {
@@ -477,7 +477,7 @@ static int receive_loop(void) /* {{{ */
       ERROR("pinba plugin: poll(2) failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
       pinba_socket_free(s);
-      return (-1);
+      return -1;
     }
 
     for (nfds_t i = 0; i < s->fd_num; i++) {
@@ -493,7 +493,7 @@ static int receive_loop(void) /* {{{ */
   pinba_socket_free(s);
   s = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int receive_loop */
 
 static void *collector_thread(void *arg) /* {{{ */
@@ -503,7 +503,7 @@ static void *collector_thread(void *arg) /* {{{ */
   memset(&collector_thread_id, 0, sizeof(collector_thread_id));
   collector_thread_running = 0;
   pthread_exit(NULL);
-  return (NULL);
+  return NULL;
 } /* }}} void *collector_thread */
 
 /*
@@ -519,7 +519,7 @@ static int pinba_config_view(const oconfig_item_t *ci) /* {{{ */
 
   status = cf_util_get_string(ci, &name);
   if (status != 0)
-    return (status);
+    return status;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
@@ -547,7 +547,7 @@ static int pinba_config_view(const oconfig_item_t *ci) /* {{{ */
   sfree(server);
   sfree(script);
 
-  return (status);
+  return status;
 } /* }}} int pinba_config_view */
 
 static int plugin_config(oconfig_item_t *ci) /* {{{ */
@@ -571,7 +571,7 @@ static int plugin_config(oconfig_item_t *ci) /* {{{ */
 
   pthread_mutex_unlock(&stat_nodes_lock);
 
-  return (0);
+  return 0;
 } /* }}} int pinba_config */
 
 static int plugin_init(void) /* {{{ */
@@ -587,7 +587,7 @@ static int plugin_init(void) /* {{{ */
   }
 
   if (collector_thread_running)
-    return (0);
+    return 0;
 
   status = plugin_thread_create(&collector_thread_id,
                                 /* attrs = */ NULL, collector_thread,
@@ -596,11 +596,11 @@ static int plugin_init(void) /* {{{ */
     char errbuf[1024];
     ERROR("pinba plugin: pthread_create(3) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
   collector_thread_running = 1;
 
-  return (0);
+  return 0;
 } /* }}} */
 
 static int plugin_shutdown(void) /* {{{ */
@@ -622,7 +622,7 @@ static int plugin_shutdown(void) /* {{{ */
     collector_thread_do_shutdown = 0;
   } /* if (collector_thread_running) */
 
-  return (0);
+  return 0;
 } /* }}} int plugin_shutdown */
 
 static int plugin_submit(const pinba_statnode_t *res) /* {{{ */
@@ -663,7 +663,7 @@ static int plugin_submit(const pinba_statnode_t *res) /* {{{ */
   sstrncpy(vl.type_instance, "peak", sizeof(vl.type_instance));
   plugin_dispatch_values(&vl);
 
-  return (0);
+  return 0;
 } /* }}} int plugin_submit */
 
 static int plugin_read(void) /* {{{ */

--- a/src/ping.c
+++ b/src/ping.c
@@ -219,7 +219,7 @@ static int ping_dispatch_all(pingobj_t *pingobj) /* {{{ */
     } /* }}} ping_max_missed */
   }   /* }}} for (iter) */
 
-  return (0);
+  return 0;
 } /* }}} int ping_dispatch_all */
 
 static void *ping_thread(void *arg) /* {{{ */
@@ -242,7 +242,7 @@ static void *ping_thread(void *arg) /* {{{ */
     ERROR("ping plugin: ping_construct failed.");
     ping_thread_error = 1;
     pthread_mutex_unlock(&ping_lock);
-    return ((void *)-1);
+    return (void *)-1;
   }
 
   if (ping_source != NULL)
@@ -278,7 +278,7 @@ static void *ping_thread(void *arg) /* {{{ */
     ERROR("ping plugin: No host could be added to ping object. Giving up.");
     ping_thread_error = 1;
     pthread_mutex_unlock(&ping_lock);
-    return ((void *)-1);
+    return (void *)-1;
   }
 
   /* Set up `ts_int' */
@@ -342,7 +342,7 @@ static void *ping_thread(void *arg) /* {{{ */
   pthread_mutex_unlock(&ping_lock);
   ping_destroy(pingobj);
 
-  return ((void *)0);
+  return (void *)0;
 } /* }}} void *ping_thread */
 
 static int start_thread(void) /* {{{ */
@@ -353,7 +353,7 @@ static int start_thread(void) /* {{{ */
 
   if (ping_thread_loop != 0) {
     pthread_mutex_unlock(&ping_lock);
-    return (0);
+    return 0;
   }
 
   ping_thread_loop = 1;
@@ -364,11 +364,11 @@ static int start_thread(void) /* {{{ */
     ping_thread_loop = 0;
     ERROR("ping plugin: Starting thread failed.");
     pthread_mutex_unlock(&ping_lock);
-    return (-1);
+    return -1;
   }
 
   pthread_mutex_unlock(&ping_lock);
-  return (0);
+  return 0;
 } /* }}} int start_thread */
 
 static int stop_thread(void) /* {{{ */
@@ -379,7 +379,7 @@ static int stop_thread(void) /* {{{ */
 
   if (ping_thread_loop == 0) {
     pthread_mutex_unlock(&ping_lock);
-    return (-1);
+    return -1;
   }
 
   ping_thread_loop = 0;
@@ -397,14 +397,14 @@ static int stop_thread(void) /* {{{ */
   ping_thread_error = 0;
   pthread_mutex_unlock(&ping_lock);
 
-  return (status);
+  return status;
 } /* }}} int stop_thread */
 
 static int ping_init(void) /* {{{ */
 {
   if (hostlist_head == NULL) {
     NOTICE("ping plugin: No hosts have been configured.");
-    return (-1);
+    return -1;
   }
 
   if (ping_timeout > ping_interval) {
@@ -427,7 +427,7 @@ static int ping_init(void) /* {{{ */
   }
 #endif
 
-  return (start_thread());
+  return start_thread();
 } /* }}} int ping_init */
 
 static int config_set_string(const char *name, /* {{{ */
@@ -439,13 +439,13 @@ static int config_set_string(const char *name, /* {{{ */
     char errbuf[1024];
     ERROR("ping plugin: Setting `%s' to `%s' failed: strdup failed: %s", name,
           value, sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (1);
+    return 1;
   }
 
   if (*var != NULL)
     free(*var);
   *var = tmp;
-  return (0);
+  return 0;
 } /* }}} int config_set_string */
 
 static int ping_config(const char *key, const char *value) /* {{{ */
@@ -459,7 +459,7 @@ static int ping_config(const char *key, const char *value) /* {{{ */
       char errbuf[1024];
       ERROR("ping plugin: malloc failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (1);
+      return 1;
     }
 
     host = strdup(value);
@@ -468,7 +468,7 @@ static int ping_config(const char *key, const char *value) /* {{{ */
       sfree(hl);
       ERROR("ping plugin: strdup failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (1);
+      return 1;
     }
 
     hl->host = host;
@@ -482,13 +482,13 @@ static int ping_config(const char *key, const char *value) /* {{{ */
   } else if (strcasecmp(key, "SourceAddress") == 0) {
     int status = config_set_string(key, &ping_source, value);
     if (status != 0)
-      return (status);
+      return status;
   }
 #ifdef HAVE_OPING_1_3
   else if (strcasecmp(key, "Device") == 0) {
     int status = config_set_string(key, &ping_device, value);
     if (status != 0)
-      return (status);
+      return status;
   }
 #endif
   else if (strcasecmp(key, "TTL") == 0) {
@@ -514,7 +514,7 @@ static int ping_config(const char *key, const char *value) /* {{{ */
       ping_data = malloc(size + 1);
       if (ping_data == NULL) {
         ERROR("ping plugin: malloc failed.");
-        return (1);
+        return 1;
       }
 
       /* Note: By default oping is using constant string
@@ -546,10 +546,10 @@ static int ping_config(const char *key, const char *value) /* {{{ */
     if (ping_max_missed < 0)
       INFO("ping plugin: MaxMissed < 0, disabled re-resolving of hosts");
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ping_config */
 
 static void submit(const char *host, const char *type, /* {{{ */
@@ -581,7 +581,7 @@ static int ping_read(void) /* {{{ */
 
     start_thread();
 
-    return (-1);
+    return -1;
   } /* if (ping_thread_error != 0) */
 
   for (hostlist_t *hl = hostlist_head; hl != NULL; hl = hl->next) /* {{{ */
@@ -642,7 +642,7 @@ static int ping_read(void) /* {{{ */
     submit(hl->host, "ping_droprate", droprate);
   } /* }}} for (hl = hostlist_head; hl != NULL; hl = hl->next) */
 
-  return (0);
+  return 0;
 } /* }}} int ping_read */
 
 static int ping_shutdown(void) /* {{{ */
@@ -651,7 +651,7 @@ static int ping_shutdown(void) /* {{{ */
 
   INFO("ping plugin: Shutting down thread.");
   if (stop_thread() < 0)
-    return (-1);
+    return -1;
 
   hl = hostlist_head;
   while (hl != NULL) {
@@ -670,7 +670,7 @@ static int ping_shutdown(void) /* {{{ */
     ping_data = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ping_shutdown */
 
 void module_register(void) {

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -407,7 +407,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
   char interval[64];
 
   if ((data == NULL) || (data->params_num == 0))
-    return (c_psql_exec_query_noparams(db, q));
+    return c_psql_exec_query_noparams(db, q);
 
   assert(db->max_params_num >= data->params_num);
 
@@ -438,8 +438,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
   }
 
   return PQexecParams(db->conn, udb_query_get_statement(q), data->params_num,
-                      NULL, (const char *const *)params, NULL, NULL,
-                      /* return text data */ 0);
+                      NULL, (const char *const*)params, NULL, NULL, 0);
 } /* c_psql_exec_query_params */
 
 /* db->db_lock must be locked when calling this function */
@@ -1009,7 +1008,7 @@ static int config_query_param_add(udb_query_t *q, oconfig_item_t *ci) {
   }
 
   data->params_num++;
-  return (0);
+  return 0;
 } /* config_query_param_add */
 
 static int config_query_callback(udb_query_t *q, oconfig_item_t *ci) {
@@ -1018,7 +1017,7 @@ static int config_query_callback(udb_query_t *q, oconfig_item_t *ci) {
 
   log_err("Option not allowed within a Query block: `%s'", ci->key);
 
-  return (-1);
+  return -1;
 } /* config_query_callback */
 
 static int config_add_writer(oconfig_item_t *ci, c_psql_writer_t *src_writers,

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -395,7 +395,7 @@ static int powerdns_get_data_dgram(list_item_t *item, /* {{{ */
   sd = socket(PF_UNIX, item->socktype, 0);
   if (sd < 0) {
     FUNC_ERROR("socket");
-    return (-1);
+    return -1;
   }
 
   sa_unix.sun_family = AF_UNIX;
@@ -407,7 +407,7 @@ static int powerdns_get_data_dgram(list_item_t *item, /* {{{ */
   if ((status != 0) && (errno != ENOENT)) {
     SOCK_ERROR("unlink", sa_unix.sun_path);
     close(sd);
-    return (-1);
+    return -1;
   }
 
   do /* while (0) */
@@ -465,13 +465,13 @@ static int powerdns_get_data_dgram(list_item_t *item, /* {{{ */
   unlink(sa_unix.sun_path);
 
   if (status != 0)
-    return (-1);
+    return -1;
 
   assert(buffer_size > 0);
   buffer = malloc(buffer_size);
   if (buffer == NULL) {
     FUNC_ERROR("malloc");
-    return (-1);
+    return -1;
   }
 
   memcpy(buffer, temp, buffer_size - 1);
@@ -480,7 +480,7 @@ static int powerdns_get_data_dgram(list_item_t *item, /* {{{ */
   *ret_buffer = buffer;
   *ret_buffer_size = buffer_size;
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_get_data_dgram */
 
 static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
@@ -496,7 +496,7 @@ static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
   sd = socket(PF_UNIX, item->socktype, 0);
   if (sd < 0) {
     FUNC_ERROR("socket");
-    return (-1);
+    return -1;
   }
 
   struct timeval timeout;
@@ -506,7 +506,7 @@ static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
   if (status != 0) {
     FUNC_ERROR("setsockopt");
     close(sd);
-    return (-1);
+    return -1;
   }
 
   status =
@@ -514,7 +514,7 @@ static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
   if (status != 0) {
     SOCK_ERROR("connect", item->sockaddr.sun_path);
     close(sd);
-    return (-1);
+    return -1;
   }
 
   /* strlen + 1, because we need to send the terminating NULL byte, too. */
@@ -523,7 +523,7 @@ static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
   if (status < 0) {
     SOCK_ERROR("send", item->sockaddr.sun_path);
     close(sd);
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -558,18 +558,18 @@ static int powerdns_get_data_stream(list_item_t *item, /* {{{ */
     *ret_buffer_size = buffer_size;
   }
 
-  return (status);
+  return status;
 } /* }}} int powerdns_get_data_stream */
 
 static int powerdns_get_data(list_item_t *item, char **ret_buffer,
                              size_t *ret_buffer_size) {
   if (item->socktype == SOCK_DGRAM)
-    return (powerdns_get_data_dgram(item, ret_buffer, ret_buffer_size));
+    return powerdns_get_data_dgram(item, ret_buffer, ret_buffer_size);
   else if (item->socktype == SOCK_STREAM)
-    return (powerdns_get_data_stream(item, ret_buffer, ret_buffer_size));
+    return powerdns_get_data_stream(item, ret_buffer, ret_buffer_size);
   else {
     ERROR("powerdns plugin: Unknown socket type: %i", (int)item->socktype);
-    return (-1);
+    return -1;
   }
 } /* int powerdns_get_data */
 
@@ -592,12 +592,12 @@ static int powerdns_read_server(list_item_t *item) /* {{{ */
     item->command = strdup(SERVER_COMMAND);
   if (item->command == NULL) {
     ERROR("powerdns plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   status = powerdns_get_data(item, &buffer, &buffer_size);
   if (status != 0)
-    return (-1);
+    return -1;
 
   if (item->fields_num != 0) {
     fields = (const char *const *)item->fields;
@@ -640,7 +640,7 @@ static int powerdns_read_server(list_item_t *item) /* {{{ */
 
   sfree(buffer);
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_read_server */
 
 /*
@@ -656,7 +656,7 @@ static int powerdns_update_recursor_command(list_item_t *li) /* {{{ */
   int status;
 
   if (li == NULL)
-    return (0);
+    return 0;
 
   if (li->fields_num < 1) {
     sstrncpy(buffer, RECURSOR_COMMAND, sizeof(buffer));
@@ -667,7 +667,7 @@ static int powerdns_update_recursor_command(list_item_t *li) /* {{{ */
                      /* seperator = */ " ");
     if (status < 0) {
       ERROR("powerdns plugin: strjoin failed.");
-      return (-1);
+      return -1;
     }
     buffer[sizeof(buffer) - 1] = 0;
     size_t len = strlen(buffer);
@@ -682,10 +682,10 @@ static int powerdns_update_recursor_command(list_item_t *li) /* {{{ */
   li->command = strdup(buffer);
   if (li->command == NULL) {
     ERROR("powerdns plugin: strdup failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_update_recursor_command */
 
 static int powerdns_read_recursor(list_item_t *item) /* {{{ */
@@ -706,7 +706,7 @@ static int powerdns_read_recursor(list_item_t *item) /* {{{ */
     status = powerdns_update_recursor_command(item);
     if (status != 0) {
       ERROR("powerdns plugin: powerdns_update_recursor_command failed.");
-      return (-1);
+      return -1;
     }
 
     DEBUG("powerdns plugin: powerdns_read_recursor: item->command = %s;",
@@ -717,14 +717,14 @@ static int powerdns_read_recursor(list_item_t *item) /* {{{ */
   status = powerdns_get_data(item, &buffer, &buffer_size);
   if (status != 0) {
     ERROR("powerdns plugin: powerdns_get_data failed.");
-    return (-1);
+    return -1;
   }
 
   keys_list = strdup(item->command);
   if (keys_list == NULL) {
     FUNC_ERROR("strdup");
     sfree(buffer);
-    return (-1);
+    return -1;
   }
 
   key_saveptr = NULL;
@@ -747,7 +747,7 @@ static int powerdns_read_recursor(list_item_t *item) /* {{{ */
   sfree(buffer);
   sfree(keys_list);
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_read_recursor */
 
 static int powerdns_config_add_collect(list_item_t *li, /* {{{ */
@@ -757,21 +757,21 @@ static int powerdns_config_add_collect(list_item_t *li, /* {{{ */
   if (ci->values_num < 1) {
     WARNING("powerdns plugin: The `Collect' option needs "
             "at least one argument.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; i++)
     if (ci->values[i].type != OCONFIG_TYPE_STRING) {
       WARNING("powerdns plugin: Only string arguments are allowed to "
               "the `Collect' option.");
-      return (-1);
+      return -1;
     }
 
   temp =
       realloc(li->fields, sizeof(char *) * (li->fields_num + ci->values_num));
   if (temp == NULL) {
     WARNING("powerdns plugin: realloc failed.");
-    return (-1);
+    return -1;
   }
   li->fields = temp;
 
@@ -787,7 +787,7 @@ static int powerdns_config_add_collect(list_item_t *li, /* {{{ */
   /* Invalidate a previously computed command */
   sfree(li->command);
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_config_add_collect */
 
 static int powerdns_config_add_server(oconfig_item_t *ci) /* {{{ */
@@ -800,20 +800,20 @@ static int powerdns_config_add_server(oconfig_item_t *ci) /* {{{ */
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("powerdns plugin: `%s' needs exactly one string argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   item = calloc(1, sizeof(*item));
   if (item == NULL) {
     ERROR("powerdns plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   item->instance = strdup(ci->values[0].value.string);
   if (item->instance == NULL) {
     ERROR("powerdns plugin: strdup failed.");
     sfree(item);
-    return (-1);
+    return -1;
   }
 
   /*
@@ -832,7 +832,7 @@ static int powerdns_config_add_server(oconfig_item_t *ci) /* {{{ */
   } else {
     /* We must never get here.. */
     assert(0);
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -879,13 +879,13 @@ static int powerdns_config_add_server(oconfig_item_t *ci) /* {{{ */
   if (status != 0) {
     sfree(socket_temp);
     sfree(item);
-    return (-1);
+    return -1;
   }
 
   DEBUG("powerdns plugin: Add server: instance = %s;", item->instance);
 
   sfree(socket_temp);
-  return (0);
+  return 0;
 } /* }}} int powerdns_config_add_server */
 
 static int powerdns_config(oconfig_item_t *ci) /* {{{ */
@@ -897,7 +897,7 @@ static int powerdns_config(oconfig_item_t *ci) /* {{{ */
 
     if (list == NULL) {
       ERROR("powerdns plugin: `llist_create' failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -915,7 +915,7 @@ static int powerdns_config(oconfig_item_t *ci) /* {{{ */
       } else {
         char *temp = strdup(option->values[0].value.string);
         if (temp == NULL)
-          return (1);
+          return 1;
         sfree(local_sockpath);
         local_sockpath = temp;
       }
@@ -924,7 +924,7 @@ static int powerdns_config(oconfig_item_t *ci) /* {{{ */
     }
   } /* for (i = 0; i < ci->children_num; i++) */
 
-  return (0);
+  return 0;
 } /* }}} int powerdns_config */
 
 static int powerdns_read(void) {
@@ -933,12 +933,12 @@ static int powerdns_read(void) {
     item->func(item);
   }
 
-  return (0);
+  return 0;
 } /* static int powerdns_read */
 
 static int powerdns_shutdown(void) {
   if (list == NULL)
-    return (0);
+    return 0;
 
   for (llentry_t *e = llist_head(list); e != NULL; e = e->next) {
     list_item_t *item = (list_item_t *)e->value;
@@ -952,7 +952,7 @@ static int powerdns_shutdown(void) {
   llist_destroy(list);
   list = NULL;
 
-  return (0);
+  return 0;
 } /* static int powerdns_shutdown */
 
 void module_register(void) {

--- a/src/processes.c
+++ b/src/processes.c
@@ -302,7 +302,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
   new = calloc(1, sizeof(*new));
   if (new == NULL) {
     ERROR("processes plugin: ps_list_register: calloc failed.");
-    return (NULL);
+    return NULL;
   }
   sstrncpy(new->name, name, sizeof(new->name));
 
@@ -324,7 +324,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
     if (new->re == NULL) {
       ERROR("processes plugin: ps_list_register: malloc failed.");
       sfree(new);
-      return (NULL);
+      return NULL;
     }
 
     status = regcomp(new->re, regexp, REG_EXTENDED | REG_NOSUB);
@@ -333,7 +333,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
             regexp);
       sfree(new->re);
       sfree(new);
-      return (NULL);
+      return NULL;
     }
   }
 #else
@@ -344,7 +344,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
           "has been disabled at compile time.",
           regexp);
     sfree(new);
-    return (NULL);
+    return NULL;
   }
 #endif
 
@@ -359,7 +359,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
       sfree(new->re);
 #endif
       sfree(new);
-      return (NULL);
+      return NULL;
     }
 
     if (ptr->next == NULL)
@@ -371,7 +371,7 @@ static procstat_t *ps_list_register(const char *name, const char *regexp) {
   else
     ptr->next = new;
 
-  return (new);
+  return new;
 } /* void ps_list_register */
 
 /* try to match name against entry, returns 1 if success */
@@ -393,13 +393,13 @@ static int ps_list_match(const char *name, const char *cmdline,
                      /* pmatch = */ NULL,
                      /* eflags = */ 0);
     if (status == 0)
-      return (1);
+      return 1;
   } else
 #endif
       if (strcmp(ps->name, name) == 0)
-    return (1);
+    return 1;
 
-  return (0);
+  return 0;
 } /* int ps_list_match */
 
 static void ps_update_counter(derive_t *group_counter, derive_t *curr_counter,
@@ -614,7 +614,7 @@ static int ps_config(oconfig_item_t *ci) {
     }
   }
 
-  return (0);
+  return 0;
 }
 
 static int ps_init(void) {
@@ -636,7 +636,7 @@ static int ps_init(void) {
     ERROR("host_processor_sets failed: %s\n", mach_error_string(status));
     pset_list = NULL;
     pset_list_len = 0;
-    return (-1);
+    return -1;
   }
 /* #endif HAVE_THREAD_INFO */
 
@@ -655,7 +655,7 @@ static int ps_init(void) {
   pagesize = getpagesize();
 #endif /* HAVE_PROCINFO_H */
 
-  return (0);
+  return 0;
 } /* int ps_init */
 
 /* submit global state (e.g.: qty of zombies, running, etc..) */
@@ -809,7 +809,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
-    return (-1);
+    return -1;
   }
 
   while ((ent = readdir(dh)) != NULL) {
@@ -863,7 +863,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
   ps->cswitch_vol = cswitch_vol;
   ps->cswitch_invol = cswitch_invol;
 
-  return (0);
+  return 0;
 } /* int *ps_read_tasks_status */
 
 /* Read data from /proc/pid/status */
@@ -880,7 +880,7 @@ static int ps_read_status(long pid, process_entry_t *ps) {
 
   ssnprintf(filename, sizeof(filename), "/proc/%li/status", pid);
   if ((fh = fopen(filename, "r")) == NULL)
-    return (-1);
+    return -1;
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
     unsigned long tmp;
@@ -920,7 +920,7 @@ static int ps_read_status(long pid, process_entry_t *ps) {
   if (threads != 0)
     ps->num_lwp = threads;
 
-  return (0);
+  return 0;
 } /* int *ps_read_status */
 
 static int ps_read_io(process_entry_t *ps) {
@@ -934,7 +934,7 @@ static int ps_read_io(process_entry_t *ps) {
   ssnprintf(filename, sizeof(filename), "/proc/%li/io", ps->id);
   if ((fh = fopen(filename, "r")) == NULL) {
     DEBUG("ps_read_io: Failed to open file `%s'", filename);
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -971,7 +971,7 @@ static int ps_read_io(process_entry_t *ps) {
     char errbuf[1024];
     WARNING("processes: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
   }
-  return (0);
+  return 0;
 } /* int ps_read_io (...) */
 
 static int ps_count_fd(int pid) {
@@ -984,7 +984,7 @@ static int ps_count_fd(int pid) {
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
-    return (-1);
+    return -1;
   }
   while ((ent = readdir(dh)) != NULL) {
     if (!isdigit((int)ent->d_name[0]))
@@ -994,7 +994,7 @@ static int ps_count_fd(int pid) {
   }
   closedir(dh);
 
-  return ((count >= 1) ? count : 1);
+  return (count >= 1) ? count : 1;
 } /* int ps_count_fd (pid) */
 
 static void ps_fill_details(const procstat_t *ps, process_entry_t *entry) {
@@ -1045,7 +1045,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   status = read_file_contents(filename, buffer, sizeof(buffer) - 1);
   if (status <= 0)
-    return (-1);
+    return -1;
   buffer_len = (size_t)status;
   buffer[buffer_len] = 0;
 
@@ -1067,7 +1067,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   if (name_start_pos >= name_end_pos) {
     ERROR("processes plugin: name_start_pos = %zu >= name_end_pos = %zu",
           name_start_pos, name_end_pos);
-    return (-1);
+    return -1;
   }
 
   name_len = (name_end_pos - name_start_pos) - 1;
@@ -1077,7 +1077,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   sstrncpy(ps->name, &buffer[name_start_pos + 1], name_len + 1);
 
   if ((buffer_len - name_end_pos) < 2)
-    return (-1);
+    return -1;
   buffer_ptr = &buffer[name_end_pos + 2];
 
   fields_len = strsplit(buffer_ptr, fields, STATIC_ARRAY_SIZE(fields));
@@ -1085,7 +1085,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
     DEBUG("processes plugin: ps_read_process (pid = %li):"
           " `%s' has only %i fields..",
           pid, filename, fields_len);
-    return (-1);
+    return -1;
   }
 
   *state = fields[0][0];
@@ -1111,7 +1111,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
     DEBUG("processes plugin: This is only a zombie: pid = %li; "
           "name = %s;",
           pid, ps->name);
-    return (0);
+    return 0;
   }
 
   cpu_user_counter = atoll(fields[11]);
@@ -1150,7 +1150,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   ps->cswitch_invol = -1;
 
   /* success */
-  return (0);
+  return 0;
 } /* int ps_read_process (...) */
 
 static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
@@ -1257,7 +1257,7 @@ static int read_fork_rate(void) {
     char errbuf[1024];
     ERROR("processes plugin: fopen (/proc/stat) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), proc_stat) != NULL) {
@@ -1281,10 +1281,10 @@ static int read_fork_rate(void) {
   fclose(proc_stat);
 
   if (!value_valid)
-    return (-1);
+    return -1;
 
   ps_submit_fork_rate(value.derive);
-  return (0);
+  return 0;
 }
 #endif /*KERNEL_LINUX */
 
@@ -1304,13 +1304,13 @@ static char *ps_get_cmdline(long pid,
           "while reading \"%s\": "
           "Returned %zd but expected %zu.",
           path, status, buffer_size);
-    return (NULL);
+    return NULL;
   }
 
   info.pr_psargs[sizeof(info.pr_psargs) - 1] = 0;
   sstrncpy(buffer, info.pr_psargs, buffer_size);
 
-  return (buffer);
+  return buffer;
 } /* }}} int ps_get_cmdline */
 
 /*
@@ -1355,7 +1355,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
     sfree(myStatus);
     sfree(myInfo);
     sfree(myUsage);
-    return (0);
+    return 0;
   } else {
     ps->num_proc = 1;
     ps->num_lwp = myInfo->pr_nlwp;
@@ -1432,7 +1432,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   sfree(myInfo);
   sfree(myUsage);
 
-  return (0);
+  return 0;
 }
 
 /*
@@ -1445,7 +1445,7 @@ static int read_fork_rate(void) {
   derive_t result = 0;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (kstat_t *ksp_chain = kc->kc_chain; ksp_chain != NULL;
        ksp_chain = ksp_chain->ks_next) {
@@ -1463,7 +1463,7 @@ static int read_fork_rate(void) {
   }
 
   ps_submit_fork_rate(result);
-  return (0);
+  return 0;
 }
 #endif /* KERNEL_SOLARIS */
 
@@ -1480,12 +1480,12 @@ static int mach_get_task_name(task_t t, int *pid, char *name,
   mib[2] = KERN_PROC_PID;
 
   if (pid_for_task(t, pid) != KERN_SUCCESS)
-    return (-1);
+    return -1;
   mib[3] = *pid;
 
   kp_size = sizeof(kp);
   if (sysctl(mib, 4, &kp, &kp_size, NULL, 0) != 0)
-    return (-1);
+    return -1;
 
   if (name_max_len > (MAXCOMLEN + 1))
     name_max_len = MAXCOMLEN + 1;
@@ -1499,7 +1499,7 @@ static int mach_get_task_name(task_t t, int *pid, char *name,
    * `top' does it, because it is a lot of work and only used when
    * debugging. -octo */
 
-  return (0);
+  return 0;
 }
 #endif /* HAVE_THREAD_INFO */
 /* ------- end of additional functions for KERNEL_LINUX/HAVE_THREAD_INFO -------
@@ -1760,7 +1760,7 @@ static int ps_read(void) {
   if ((proc = opendir("/proc")) == NULL) {
     char errbuf[1024];
     ERROR("Cannot open `/proc': %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while ((ent = readdir(proc)) != NULL) {
@@ -1842,7 +1842,7 @@ static int ps_read(void) {
   kd = kvm_openfiles(NULL, "/dev/null", NULL, 0, errbuf);
   if (kd == NULL) {
     ERROR("processes plugin: Cannot open kvm interface: %s", errbuf);
-    return (0);
+    return 0;
   }
 
   /* Get the list of processes. */
@@ -1851,7 +1851,7 @@ static int ps_read(void) {
     ERROR("processes plugin: Cannot get kvm processes list: %s",
           kvm_geterr(kd));
     kvm_close(kd);
-    return (0);
+    return 0;
   }
 
   /* Iterate through the processes in kinfo_proc */
@@ -1992,7 +1992,7 @@ static int ps_read(void) {
   kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
   if (kd == NULL) {
     ERROR("processes plugin: Cannot open kvm interface: %s", errbuf);
-    return (0);
+    return 0;
   }
 
   /* Get the list of processes. */
@@ -2001,7 +2001,7 @@ static int ps_read(void) {
     ERROR("processes plugin: Cannot get kvm processes list: %s",
           kvm_geterr(kd));
     kvm_close(kd);
-    return (0);
+    return 0;
   }
 
   /* Iterate through the processes in kinfo_proc */
@@ -2272,7 +2272,7 @@ static int ps_read(void) {
 
   proc = opendir("/proc");
   if (proc == NULL)
-    return (-1);
+    return -1;
 
   while ((ent = readdir(proc)) != NULL) {
     long pid;
@@ -2344,7 +2344,7 @@ static int ps_read(void) {
 
   want_init = 0;
 
-  return (0);
+  return 0;
 } /* int ps_read */
 
 void module_register(void) {

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -89,7 +89,7 @@ static int read_file(const char *path) {
   if (fh == NULL) {
     ERROR("protocols plugin: fopen (%s) failed: %s.", path,
           sstrerror(errno, key_buffer, sizeof(key_buffer)));
-    return (-1);
+    return -1;
   }
 
   status = -1;
@@ -169,7 +169,7 @@ static int read_file(const char *path) {
 
   fclose(fh);
 
-  return (status);
+  return status;
 } /* int read_file */
 
 static int protocols_read(void) {
@@ -185,9 +185,9 @@ static int protocols_read(void) {
     success++;
 
   if (success == 0)
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 } /* int protocols_read */
 
 static int protocols_config(const char *key, const char *value) {
@@ -202,10 +202,10 @@ static int protocols_config(const char *key, const char *value) {
       invert = 0;
     ignorelist_set_invert(values_list, invert);
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int protocols_config */
 
 void module_register(void) {

--- a/src/python.c
+++ b/src/python.c
@@ -784,8 +784,8 @@ static PyObject *cpy_register_write(PyObject *self, PyObject *args,
 static PyObject *cpy_register_notification(PyObject *self, PyObject *args,
                                            PyObject *kwds) {
   return cpy_register_generic_userdata((void *)plugin_register_notification,
-                                       (void *)cpy_notification_callback, args,
-                                       kwds);
+                                       (void *)cpy_notification_callback,
+                                       args, kwds);
 }
 
 static PyObject *cpy_register_flush(PyObject *self, PyObject *args,
@@ -944,7 +944,8 @@ static PyObject *cpy_unregister_read(PyObject *self, PyObject *arg) {
 }
 
 static PyObject *cpy_unregister_write(PyObject *self, PyObject *arg) {
-  return cpy_unregister_generic_userdata(plugin_unregister_write, arg, "write");
+  return cpy_unregister_generic_userdata(plugin_unregister_write, arg,
+                                         "write");
 }
 
 static PyObject *cpy_unregister_notification(PyObject *self, PyObject *arg) {
@@ -953,7 +954,8 @@ static PyObject *cpy_unregister_notification(PyObject *self, PyObject *arg) {
 }
 
 static PyObject *cpy_unregister_flush(PyObject *self, PyObject *arg) {
-  return cpy_unregister_generic_userdata(plugin_unregister_flush, arg, "flush");
+  return cpy_unregister_generic_userdata(plugin_unregister_flush, arg,
+                                         "flush");
 }
 
 static PyObject *cpy_unregister_shutdown(PyObject *self, PyObject *arg) {
@@ -1397,7 +1399,7 @@ static int cpy_config(oconfig_item_t *ci) {
       status = 1;
     }
   }
-  return (status);
+  return status;
 }
 
 void module_register(void) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -90,13 +90,13 @@ static int redis_node_add(const redis_node_t *rn) /* {{{ */
 
   if (rn_ptr != NULL) {
     ERROR("redis plugin: A node with the name `%s' already exists.", rn->name);
-    return (-1);
+    return -1;
   }
 
   rn_copy = malloc(sizeof(*rn_copy));
   if (rn_copy == NULL) {
     ERROR("redis plugin: malloc failed adding redis_node to the tree.");
-    return (-1);
+    return -1;
   }
 
   memcpy(rn_copy, rn, sizeof(*rn_copy));
@@ -113,7 +113,7 @@ static int redis_node_add(const redis_node_t *rn) /* {{{ */
     rn_ptr->next = rn_copy;
   }
 
-  return (0);
+  return 0;
 } /* }}} */
 
 static redis_query_t *redis_config_query(oconfig_item_t *ci) /* {{{ */
@@ -171,7 +171,7 @@ static int redis_config_node(oconfig_item_t *ci) /* {{{ */
 
   status = cf_util_get_string_buffer(ci, rn.name, sizeof(rn.name));
   if (status != 0)
-    return (status);
+    return status;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *option = ci->children + i;
@@ -208,9 +208,9 @@ static int redis_config_node(oconfig_item_t *ci) /* {{{ */
   }
 
   if (status != 0)
-    return (status);
+    return status;
 
-  return (redis_node_add(&rn));
+  return redis_node_add(&rn);
 } /* }}} int redis_config_node */
 
 static int redis_config(oconfig_item_t *ci) /* {{{ */
@@ -228,10 +228,10 @@ static int redis_config(oconfig_item_t *ci) /* {{{ */
 
   if (nodes_head == NULL) {
     ERROR("redis plugin: No valid node configuration could be found.");
-    return (ENOENT);
+    return ENOENT;
   }
 
-  return (0);
+  return 0;
 } /* }}} */
 
 __attribute__((nonnull(2))) static void
@@ -264,7 +264,7 @@ static int redis_init(void) /* {{{ */
   if (nodes_head == NULL)
     redis_node_add(&rn);
 
-  return (0);
+  return 0;
 } /* }}} int redis_init */
 
 static int redis_handle_info(char *node, char const *info_line,
@@ -285,13 +285,13 @@ static int redis_handle_info(char *node, char const *info_line,
 
     if (parse_value(buf, &val, ds_type) == -1) {
       WARNING("redis plugin: Unable to parse field `%s'.", field_name);
-      return (-1);
+      return -1;
     }
 
     redis_submit(node, type, type_instance, val);
-    return (0);
+    return 0;
   }
-  return (-1);
+  return -1;
 
 } /* }}} int redis_handle_info */
 
@@ -305,17 +305,17 @@ static int redis_handle_query(redisContext *rh, redis_node_t *rn,
   ds = plugin_get_ds(rq->type);
   if (!ds) {
     ERROR("redis plugin: DataSet `%s' not defined.", rq->type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num != 1) {
     ERROR("redis plugin: DS `%s' has too many types.", rq->type);
-    return (-1);
+    return -1;
   }
 
   if ((rr = redisCommand(rh, rq->query)) == NULL) {
     WARNING("redis plugin: unable to carry out query `%s'.", rq->query);
-    return (-1);
+    return -1;
   }
 
   switch (rr->type) {
@@ -339,13 +339,13 @@ static int redis_handle_query(redisContext *rh, redis_node_t *rn,
     if (parse_value(rr->str, &val, ds->ds[0].type) == -1) {
       WARNING("redis plugin: Unable to parse field `%s'.", rq->type);
       freeReplyObject(rr);
-      return (-1);
+      return -1;
     }
     break;
   default:
     WARNING("redis plugin: Cannot coerce redis type.");
     freeReplyObject(rr);
-    return (-1);
+    return -1;
   }
 
   redis_submit(rn->name, rq->type,
@@ -383,13 +383,13 @@ static int redis_db_stats(char *node, char const *info_line) /* {{{ */
 
     if (parse_value(buf, &val, DS_TYPE_GAUGE) != 0) {
       WARNING("redis plugin: Unable to parse field `%s'.", field_name);
-      return (-1);
+      return -1;
     }
 
     ssnprintf(db_id, sizeof(db_id), "%d", db);
     redis_submit(node, "records", db_id, val);
   }
-  return (0);
+  return 0;
 
 } /* }}} int redis_db_stats */
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -92,10 +92,10 @@ static int handle_interface(__attribute__((unused))
                             const ros_interface_t *i,
                             void *user_data) {
   if ((i == NULL) || (user_data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   submit_interface(user_data, i);
-  return (0);
+  return 0;
 } /* }}} int handle_interface */
 
 static void cr_submit_gauge(cr_data_t *rd, const char *type, /* {{{ */
@@ -174,10 +174,10 @@ static int handle_regtable(__attribute__((unused))
                            const ros_registration_table_t *r,
                            void *user_data) {
   if ((r == NULL) || (user_data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   submit_regtable(user_data, r);
-  return (0);
+  return 0;
 } /* }}} int handle_regtable */
 
 #if ROS_VERSION >= ROS_VERSION_ENCODE(1, 1, 0)
@@ -188,7 +188,7 @@ static int handle_system_resource(__attribute__((unused))
   cr_data_t *rd;
 
   if ((r == NULL) || (user_data == NULL))
-    return (EINVAL);
+    return EINVAL;
   rd = user_data;
 
   if (rd->collect_cpu_load)
@@ -212,7 +212,7 @@ static int handle_system_resource(__attribute__((unused))
     cr_submit_gauge(rd, "gauge", "bad_blocks", (gauge_t)r->bad_blocks);
   }
 
-  return (0);
+  return 0;
 } /* }}} int handle_system_resource */
 #endif
 
@@ -222,11 +222,11 @@ static int cr_read(user_data_t *user_data) /* {{{ */
   cr_data_t *rd;
 
   if (user_data == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   rd = user_data->data;
   if (rd == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (rd->connection == NULL) {
     rd->connection =
@@ -235,7 +235,7 @@ static int cr_read(user_data_t *user_data) /* {{{ */
       char errbuf[128];
       ERROR("routeros plugin: ros_connect failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   }
   assert(rd->connection != NULL);
@@ -249,7 +249,7 @@ static int cr_read(user_data_t *user_data) /* {{{ */
             sstrerror(status, errbuf, sizeof(errbuf)));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
-      return (-1);
+      return -1;
     }
   }
 
@@ -262,7 +262,7 @@ static int cr_read(user_data_t *user_data) /* {{{ */
             sstrerror(status, errbuf, sizeof(errbuf)));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
-      return (-1);
+      return -1;
     }
   }
 
@@ -277,12 +277,12 @@ static int cr_read(user_data_t *user_data) /* {{{ */
             sstrerror(status, errbuf, sizeof(errbuf)));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
-      return (-1);
+      return -1;
     }
   }
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int cr_read */
 
 static void cr_free_data(cr_data_t *ptr) /* {{{ */
@@ -309,7 +309,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
 
   router_data = calloc(1, sizeof(*router_data));
   if (router_data == NULL)
-    return (-1);
+    return -1;
   router_data->connection = NULL;
   router_data->node = NULL;
   router_data->service = NULL;
@@ -389,7 +389,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
   if (status != 0)
     cr_free_data(router_data);
 
-  return (status);
+  return status;
 } /* }}} int cr_config_router */
 
 static int cr_config(oconfig_item_t *ci) {
@@ -403,7 +403,7 @@ static int cr_config(oconfig_item_t *ci) {
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int cr_config */
 
 void module_register(void) {

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -77,7 +77,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
   t = CDTIME_T_TO_TIME_T(vl->time);
   status = ssnprintf(buffer, buffer_len, "%lu", (unsigned long)t);
   if ((status < 1) || (status >= buffer_len))
-    return (-1);
+    return -1;
   offset = status;
 
   for (size_t i = 0; i < ds->ds_num; i++) {
@@ -85,7 +85,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
         (ds->ds[i].type != DS_TYPE_GAUGE) &&
         (ds->ds[i].type != DS_TYPE_DERIVE) &&
         (ds->ds[i].type != DS_TYPE_ABSOLUTE))
-      return (-1);
+      return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%llu",
@@ -102,12 +102,12 @@ static int value_list_to_string(char *buffer, int buffer_len,
     }
 
     if ((status < 1) || (status >= (buffer_len - offset)))
-      return (-1);
+      return -1;
 
     offset += status;
   } /* for ds->ds_num */
 
-  return (0);
+  return 0;
 } /* int value_list_to_string */
 
 static int value_list_to_filename(char *buffer, size_t buffer_size,
@@ -120,7 +120,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
     size_t datadir_len = strlen(datadir) + 1;
 
     if (datadir_len >= buffer_size)
-      return (ENOMEM);
+      return ENOMEM;
 
     sstrncpy(buffer, datadir, buffer_size);
     buffer[datadir_len - 1] = '/';
@@ -132,7 +132,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
 
   status = FORMAT_VL(buffer, buffer_size, vl);
   if (status != 0)
-    return (status);
+    return status;
 
   len = strlen(buffer);
   assert(len < buffer_size);
@@ -140,10 +140,10 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
   buffer_size -= len;
 
   if (buffer_size <= sizeof(suffix))
-    return (ENOMEM);
+    return ENOMEM;
 
   memcpy(buffer, suffix, sizeof(suffix));
-  return (0);
+  return 0;
 } /* int value_list_to_filename */
 
 static int rc_config_get_int_positive(oconfig_item_t const *ci, int *ret) {
@@ -152,12 +152,12 @@ static int rc_config_get_int_positive(oconfig_item_t const *ci, int *ret) {
 
   status = cf_util_get_int(ci, &tmp);
   if (status != 0)
-    return (status);
+    return status;
   if (tmp < 0)
-    return (EINVAL);
+    return EINVAL;
 
   *ret = tmp;
-  return (0);
+  return 0;
 } /* int rc_config_get_int_positive */
 
 static int rc_config_get_xff(oconfig_item_t const *ci, double *ret) {
@@ -167,38 +167,38 @@ static int rc_config_get_xff(oconfig_item_t const *ci, double *ret) {
     ERROR("rrdcached plugin: The \"%s\" needs exactly one numeric argument "
           "in the range [0.0, 1.0)",
           ci->key);
-    return (EINVAL);
+    return EINVAL;
   }
 
   value = ci->values[0].value.number;
   if ((value >= 0.0) && (value < 1.0)) {
     *ret = value;
-    return (0);
+    return 0;
   }
 
   ERROR("rrdcached plugin: The \"%s\" needs exactly one numeric argument "
         "in the range [0.0, 1.0)",
         ci->key);
-  return (EINVAL);
+  return EINVAL;
 } /* int rc_config_get_xff */
 
 static int rc_config_add_timespan(int timespan) {
   int *tmp;
 
   if (timespan <= 0)
-    return (EINVAL);
+    return EINVAL;
 
   tmp = realloc(rrdcreate_config.timespans,
                 sizeof(*rrdcreate_config.timespans) *
                     (rrdcreate_config.timespans_num + 1));
   if (tmp == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   rrdcreate_config.timespans = tmp;
 
   rrdcreate_config.timespans[rrdcreate_config.timespans_num] = timespan;
   rrdcreate_config.timespans_num++;
 
-  return (0);
+  return 0;
 } /* int rc_config_add_timespan */
 
 static int rc_config(oconfig_item_t *ci) {
@@ -258,7 +258,7 @@ static int rc_config(oconfig_item_t *ci) {
     plugin_register_write("rrdcached", rc_write, /* user_data = */ NULL);
     plugin_register_flush("rrdcached", rc_flush, /* user_data = */ NULL);
   }
-  return (0);
+  return 0;
 } /* int rc_config */
 
 static int try_reconnect(void) {
@@ -272,13 +272,13 @@ static int try_reconnect(void) {
     ERROR("rrdcached plugin: Failed to reconnect to RRDCacheD "
           "at %s: %s (status=%d)",
           daemon_address, rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
   INFO("rrdcached plugin: Successfully reconnected to RRDCacheD "
        "at %s",
        daemon_address);
-  return (0);
+  return 0;
 } /* int try_reconnect */
 
 static int rc_read(void) {
@@ -291,10 +291,10 @@ static int rc_read(void) {
   vl.values_len = 1;
 
   if (daemon_address == NULL)
-    return (-1);
+    return -1;
 
   if (!config_collect_stats)
-    return (-1);
+    return -1;
 
   if ((strncmp("unix:", daemon_address, strlen("unix:")) != 0) &&
       (daemon_address[0] != '/'))
@@ -307,7 +307,7 @@ static int rc_read(void) {
     ERROR("rrdcached plugin: Failed to connect to RRDCacheD "
           "at %s: %s (status=%d)",
           daemon_address, rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -328,7 +328,7 @@ static int rc_read(void) {
 
     ERROR("rrdcached plugin: rrdc_stats_get failed: %s (status=%i).",
           rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
   for (rrdc_stats_t *ptr = head; ptr != NULL; ptr = ptr->next) {
@@ -376,14 +376,14 @@ static int rc_read(void) {
 
   rrdc_stats_free(head);
 
-  return (0);
+  return 0;
 } /* int rc_read */
 
 static int rc_init(void) {
   if (config_collect_stats)
     plugin_register_read("rrdcached", rc_read);
 
-  return (0);
+  return 0;
 } /* int rc_init */
 
 static int rc_write(const data_set_t *ds, const value_list_t *vl,
@@ -397,22 +397,22 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
   if (daemon_address == NULL) {
     ERROR("rrdcached plugin: daemon_address == NULL.");
     plugin_unregister_write("rrdcached");
-    return (-1);
+    return -1;
   }
 
   if (strcmp(ds->type, vl->type) != 0) {
     ERROR("rrdcached plugin: DS type does not match value list type");
-    return (-1);
+    return -1;
   }
 
   if (value_list_to_filename(filename, sizeof(filename), vl) != 0) {
     ERROR("rrdcached plugin: value_list_to_filename failed.");
-    return (-1);
+    return -1;
   }
 
   if (value_list_to_string(values, sizeof(values), ds, vl) != 0) {
     ERROR("rrdcached plugin: value_list_to_string failed.");
-    return (-1);
+    return -1;
   }
 
   values_array[0] = values;
@@ -427,15 +427,15 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
         char errbuf[1024];
         ERROR("rrdcached plugin: stat (%s) failed: %s", filename,
               sstrerror(errno, errbuf, sizeof(errbuf)));
-        return (-1);
+        return -1;
       }
 
       status = cu_rrd_create_file(filename, ds, vl, &rrdcreate_config);
       if (status != 0) {
         ERROR("rrdcached plugin: cu_rrd_create_file (%s) failed.", filename);
-        return (-1);
+        return -1;
       } else if (rrdcreate_config.async)
-        return (0);
+        return 0;
     }
   }
 
@@ -445,7 +445,7 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
     ERROR("rrdcached plugin: Failed to connect to RRDCacheD "
           "at %s: %s (status=%d)",
           daemon_address, rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -465,10 +465,10 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
 
     ERROR("rrdcached plugin: rrdc_update (%s, [%s], 1) failed: %s (status=%i)",
           filename, values_array[0], rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int rc_write */
 
 static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
@@ -479,7 +479,7 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
   _Bool retried = 0;
 
   if (identifier == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   if (datadir != NULL)
     ssnprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
@@ -492,7 +492,7 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
     ERROR("rrdcached plugin: Failed to connect to RRDCacheD "
           "at %s: %s (status=%d)",
           daemon_address, rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -512,16 +512,16 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
 
     ERROR("rrdcached plugin: rrdc_flush (%s) failed: %s (status=%i).", filename,
           rrd_get_error(), status);
-    return (-1);
+    return -1;
   }
   DEBUG("rrdcached plugin: rrdc_flush (%s): Success.", filename);
 
-  return (0);
+  return 0;
 } /* }}} int rc_flush */
 
 static int rc_shutdown(void) {
   rrdc_disconnect();
-  return (0);
+  return 0;
 } /* int rc_shutdown */
 
 void module_register(void) {

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -122,7 +122,7 @@ static int srrd_update(char *filename, char *template, int argc,
             rrd_get_error());
   }
 
-  return (status);
+  return status;
 } /* int srrd_update */
 /* #endif HAVE_THREADSAFE_LIBRRD */
 
@@ -140,7 +140,7 @@ static int srrd_update(char *filename, char *template, int argc,
   new_argv = malloc((new_argc + 1) * sizeof(*new_argv));
   if (new_argv == NULL) {
     ERROR("rrdtool plugin: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   new_argv[0] = "update";
@@ -163,7 +163,7 @@ static int srrd_update(char *filename, char *template, int argc,
 
   sfree(new_argv);
 
-  return (status);
+  return status;
 } /* int srrd_update */
 #endif /* !HAVE_THREADSAFE_LIBRRD */
 
@@ -179,7 +179,7 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
   tt = CDTIME_T_TO_TIME_T(vl->time);
   status = ssnprintf(buffer, buffer_len, "%u", (unsigned int)tt);
   if ((status < 1) || (status >= buffer_len))
-    return (-1);
+    return -1;
   offset = status;
 
   for (size_t i = 0; i < ds->ds_num; i++) {
@@ -187,7 +187,7 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
         (ds->ds[i].type != DS_TYPE_GAUGE) &&
         (ds->ds[i].type != DS_TYPE_DERIVE) &&
         (ds->ds[i].type != DS_TYPE_ABSOLUTE))
-      return (-1);
+      return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%llu",
@@ -203,12 +203,12 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
                          vl->values[i].absolute);
 
     if ((status < 1) || (status >= (buffer_len - offset)))
-      return (-1);
+      return -1;
 
     offset += status;
   } /* for ds->ds_num */
 
-  return (0);
+  return 0;
 } /* int value_list_to_string_multiple */
 
 static int value_list_to_string(char *buffer, int buffer_len,
@@ -217,7 +217,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
   time_t tt;
 
   if (ds->ds_num != 1)
-    return (value_list_to_string_multiple(buffer, buffer_len, ds, vl));
+    return value_list_to_string_multiple(buffer, buffer_len, ds, vl);
 
   tt = CDTIME_T_TO_TIME_T(vl->time);
   switch (ds->ds[0].type) {
@@ -238,13 +238,13 @@ static int value_list_to_string(char *buffer, int buffer_len,
                        vl->values[0].absolute);
     break;
   default:
-    return (EINVAL);
+    return EINVAL;
   }
 
   if ((status < 1) || (status >= buffer_len))
-    return (ENOMEM);
+    return ENOMEM;
 
-  return (0);
+  return 0;
 } /* int value_list_to_string */
 
 static int value_list_to_filename(char *buffer, size_t buffer_size,
@@ -257,7 +257,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
     size_t datadir_len = strlen(datadir) + 1;
 
     if (datadir_len >= buffer_size)
-      return (ENOMEM);
+      return ENOMEM;
 
     sstrncpy(buffer, datadir, buffer_size);
     buffer[datadir_len - 1] = '/';
@@ -269,7 +269,7 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
 
   status = FORMAT_VL(buffer, buffer_size, vl);
   if (status != 0)
-    return (status);
+    return status;
 
   len = strlen(buffer);
   assert(len < buffer_size);
@@ -277,10 +277,10 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
   buffer_size -= len;
 
   if (buffer_size <= sizeof(suffix))
-    return (ENOMEM);
+    return ENOMEM;
 
   memcpy(buffer, suffix, sizeof(suffix));
-  return (0);
+  return 0;
 } /* int value_list_to_filename */
 
 static void *rrd_queue_thread(void __attribute__((unused)) * data) {
@@ -418,7 +418,7 @@ static void *rrd_queue_thread(void __attribute__((unused)) * data) {
   } /* while (42) */
 
   pthread_exit((void *)0);
-  return ((void *)0);
+  return (void *)0;
 } /* void *rrd_queue_thread */
 
 static int rrd_queue_enqueue(const char *filename, rrd_queue_t **head,
@@ -427,12 +427,12 @@ static int rrd_queue_enqueue(const char *filename, rrd_queue_t **head,
 
   queue_entry = malloc(sizeof(*queue_entry));
   if (queue_entry == NULL)
-    return (-1);
+    return -1;
 
   queue_entry->filename = strdup(filename);
   if (queue_entry->filename == NULL) {
     free(queue_entry);
-    return (-1);
+    return -1;
   }
 
   queue_entry->next = NULL;
@@ -448,7 +448,7 @@ static int rrd_queue_enqueue(const char *filename, rrd_queue_t **head,
   pthread_cond_signal(&queue_cond);
   pthread_mutex_unlock(&queue_lock);
 
-  return (0);
+  return 0;
 } /* int rrd_queue_enqueue */
 
 static int rrd_queue_dequeue(const char *filename, rrd_queue_t **head,
@@ -471,7 +471,7 @@ static int rrd_queue_dequeue(const char *filename, rrd_queue_t **head,
 
   if (this == NULL) {
     pthread_mutex_unlock(&queue_lock);
-    return (-1);
+    return -1;
   }
 
   if (prev == NULL)
@@ -487,7 +487,7 @@ static int rrd_queue_dequeue(const char *filename, rrd_queue_t **head,
   sfree(this->filename);
   sfree(this);
 
-  return (0);
+  return 0;
 } /* int rrd_queue_dequeue */
 
 /* XXX: You must hold "cache_lock" when calling this function! */
@@ -568,7 +568,7 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
 
   if (identifier == NULL) {
     rrd_cache_flush(timeout);
-    return (0);
+    return 0;
   }
 
   now = cdtime();
@@ -584,7 +584,7 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
     INFO("rrdtool plugin: rrd_cache_flush_identifier: "
          "c_avl_get (%s) failed. Does that file really exist?",
          key);
-    return (status);
+    return status;
   }
 
   if (rc->flags == FLAG_FLUSHQ) {
@@ -602,7 +602,7 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
       rc->flags = FLAG_FLUSHQ;
   }
 
-  return (status);
+  return status;
 } /* int rrd_cache_flush_identifier */
 
 static int64_t rrd_get_random_variation(void) {
@@ -610,7 +610,7 @@ static int64_t rrd_get_random_variation(void) {
   long max;
 
   if (random_timeout == 0)
-    return (0);
+    return 0;
 
   /* Assure that "cache_timeout + random_variation" is never negative. */
   if (random_timeout > cache_timeout) {
@@ -622,7 +622,7 @@ static int64_t rrd_get_random_variation(void) {
   max = (long)(random_timeout / 2);
   min = max - ((long)random_timeout);
 
-  return ((int64_t)cdrand_range(min, max));
+  return (int64_t)cdrand_range(min, max);
 } /* int64_t rrd_get_random_variation */
 
 static int rrd_cache_insert(const char *filename, const char *value,
@@ -638,7 +638,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
   if (cache == NULL) {
     pthread_mutex_unlock(&cache_lock);
     WARNING("rrdtool plugin: cache == NULL.");
-    return (-1);
+    return -1;
   }
 
   c_avl_get(cache, filename, (void *)&rc);
@@ -647,7 +647,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
     rc = malloc(sizeof(*rc));
     if (rc == NULL) {
       pthread_mutex_unlock(&cache_lock);
-      return (-1);
+      return -1;
     }
     rc->values_num = 0;
     rc->values = NULL;
@@ -664,7 +664,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
     DEBUG("rrdtool plugin: (rc->last_value = %" PRIu64 ") "
           ">= (value_time = %" PRIu64 ")",
           rc->last_value, value_time);
-    return (-1);
+    return -1;
   }
 
   values_new =
@@ -683,7 +683,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
     sfree(cache_key);
     sfree(rc->values);
     sfree(rc);
-    return (-1);
+    return -1;
   }
   rc->values = values_new;
 
@@ -710,7 +710,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
       sfree(rc->values[0]);
       sfree(rc->values);
       sfree(rc);
-      return (-1);
+      return -1;
     }
 
     c_avl_insert(cache, cache_key, rc);
@@ -744,7 +744,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
 
   pthread_mutex_unlock(&cache_lock);
 
-  return (0);
+  return 0;
 } /* int rrd_cache_insert */
 
 static int rrd_cache_destroy(void) /* {{{ */
@@ -758,7 +758,7 @@ static int rrd_cache_destroy(void) /* {{{ */
 
   if (cache == NULL) {
     pthread_mutex_unlock(&cache_lock);
-    return (0);
+    return 0;
   }
 
   while (c_avl_pick(cache, &key, &value) == 0) {
@@ -791,7 +791,7 @@ static int rrd_cache_destroy(void) /* {{{ */
   }
 
   pthread_mutex_unlock(&cache_lock);
-  return (0);
+  return 0;
 } /* }}} int rrd_cache_destroy */
 
 static int rrd_compare_numeric(const void *a_ptr, const void *b_ptr) {
@@ -799,11 +799,11 @@ static int rrd_compare_numeric(const void *a_ptr, const void *b_ptr) {
   int b = *((int *)b_ptr);
 
   if (a < b)
-    return (-1);
+    return -1;
   else if (a > b)
-    return (1);
+    return 1;
   else
-    return (0);
+    return 0;
 } /* int rrd_compare_numeric */
 
 static int rrd_write(const data_set_t *ds, const value_list_t *vl,
@@ -814,7 +814,7 @@ static int rrd_write(const data_set_t *ds, const value_list_t *vl,
   int status;
 
   if (do_shutdown)
-    return (0);
+    return 0;
 
   if (0 != strcmp(ds->type, vl->type)) {
     ERROR("rrdtool plugin: DS type does not match value list type");
@@ -822,32 +822,32 @@ static int rrd_write(const data_set_t *ds, const value_list_t *vl,
   }
 
   if (value_list_to_filename(filename, sizeof(filename), vl) != 0)
-    return (-1);
+    return -1;
 
   if (value_list_to_string(values, sizeof(values), ds, vl) != 0)
-    return (-1);
+    return -1;
 
   if (stat(filename, &statbuf) == -1) {
     if (errno == ENOENT) {
       status = cu_rrd_create_file(filename, ds, vl, &rrdcreate_config);
       if (status != 0)
-        return (-1);
+        return -1;
       else if (rrdcreate_config.async)
-        return (0);
+        return 0;
     } else {
       char errbuf[1024];
       ERROR("stat(%s) failed: %s", filename,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   } else if (!S_ISREG(statbuf.st_mode)) {
     ERROR("stat(%s): Not a regular file!", filename);
-    return (-1);
+    return -1;
   }
 
   status = rrd_cache_insert(filename, values, vl->time);
 
-  return (status);
+  return status;
 } /* int rrd_write */
 
 static int rrd_flush(cdtime_t timeout, const char *identifier,
@@ -856,13 +856,13 @@ static int rrd_flush(cdtime_t timeout, const char *identifier,
 
   if (cache == NULL) {
     pthread_mutex_unlock(&cache_lock);
-    return (0);
+    return 0;
   }
 
   rrd_cache_flush_identifier(timeout, identifier);
 
   pthread_mutex_unlock(&cache_lock);
-  return (0);
+  return 0;
 } /* int rrd_flush */
 
 static int rrd_config(const char *key, const char *value) {
@@ -873,7 +873,7 @@ static int rrd_config(const char *key, const char *value) {
                       "be greater than 0.\n");
       ERROR("rrdtool: `CacheTimeout' must "
             "be greater than 0.\n");
-      return (1);
+      return 1;
     }
     cache_timeout = DOUBLE_TO_CDTIME_T(tmp);
   } else if (strcasecmp("CacheFlush", key) == 0) {
@@ -883,7 +883,7 @@ static int rrd_config(const char *key, const char *value) {
                       "be greater than 0.\n");
       ERROR("rrdtool: `CacheFlush' must "
             "be greater than 0.\n");
-      return (1);
+      return 1;
     }
     cache_flush_timeout = tmp;
   } else if (strcasecmp("DataDir", key) == 0) {
@@ -893,7 +893,7 @@ static int rrd_config(const char *key, const char *value) {
     tmp = strdup(value);
     if (tmp == NULL) {
       ERROR("rrdtool plugin: strdup failed.");
-      return (1);
+      return 1;
     }
 
     len = strlen(tmp);
@@ -905,7 +905,7 @@ static int rrd_config(const char *key, const char *value) {
     if (len == 0) {
       ERROR("rrdtool plugin: Invalid \"DataDir\" option.");
       sfree(tmp);
-      return (1);
+      return 1;
     }
 
     if (datadir != NULL) {
@@ -933,7 +933,7 @@ static int rrd_config(const char *key, const char *value) {
                       "be greater than 0.\n");
       ERROR("rrdtool: `RRARows' must "
             "be greater than 0.\n");
-      return (1);
+      return 1;
     }
     rrdcreate_config.rrarows = tmp;
   } else if (strcasecmp("RRATimespan", key) == 0) {
@@ -945,7 +945,7 @@ static int rrd_config(const char *key, const char *value) {
 
     value_copy = strdup(value);
     if (value_copy == NULL)
-      return (1);
+      return 1;
 
     dummy = value_copy;
     while ((ptr = strtok_r(dummy, ", \t", &saveptr)) != NULL) {
@@ -957,7 +957,7 @@ static int rrd_config(const char *key, const char *value) {
         fprintf(stderr, "rrdtool: realloc failed.\n");
         ERROR("rrdtool: realloc failed.\n");
         free(value_copy);
-        return (1);
+        return 1;
       }
       rrdcreate_config.timespans = tmp_alloc;
       rrdcreate_config.timespans[rrdcreate_config.timespans_num] = atoi(ptr);
@@ -978,7 +978,7 @@ static int rrd_config(const char *key, const char *value) {
                       "be in the range 0 to 1 (exclusive).");
       ERROR("rrdtool: `XFF' must "
             "be in the range 0 to 1 (exclusive).");
-      return (1);
+      return 1;
     }
     rrdcreate_config.xff = tmp;
   } else if (strcasecmp("WritesPerSecond", key) == 0) {
@@ -987,7 +987,7 @@ static int rrd_config(const char *key, const char *value) {
     if (wps < 0.0) {
       fprintf(stderr, "rrdtool: `WritesPerSecond' must be "
                       "greater than or equal to zero.");
-      return (1);
+      return 1;
     } else if (wps == 0.0) {
       write_rate = 0.0;
     } else {
@@ -1006,9 +1006,9 @@ static int rrd_config(const char *key, const char *value) {
       random_timeout = DOUBLE_TO_CDTIME_T(tmp);
     }
   } else {
-    return (-1);
+    return -1;
   }
-  return (0);
+  return 0;
 } /* int rrd_config */
 
 static int rrd_shutdown(void) {
@@ -1039,7 +1039,7 @@ static int rrd_shutdown(void) {
 
   rrd_cache_destroy();
 
-  return (0);
+  return 0;
 } /* int rrd_shutdown */
 
 static int rrd_init(void) {
@@ -1047,7 +1047,7 @@ static int rrd_init(void) {
   int status;
 
   if (init_once != 0)
-    return (0);
+    return 0;
   init_once = 1;
 
   if (rrdcreate_config.heartbeat <= 0)
@@ -1060,7 +1060,7 @@ static int rrd_init(void) {
   if (cache == NULL) {
     pthread_mutex_unlock(&cache_lock);
     ERROR("rrdtool plugin: c_avl_create failed.");
-    return (-1);
+    return -1;
   }
 
   cache_flush_last = cdtime();
@@ -1076,7 +1076,7 @@ static int rrd_init(void) {
                            /* args = */ NULL, "rrdtool queue");
   if (status != 0) {
     ERROR("rrdtool plugin: Cannot create queue-thread.");
-    return (-1);
+    return -1;
   }
   queue_thread_running = 1;
 
@@ -1086,7 +1086,7 @@ static int rrd_init(void) {
         rrdcreate_config.heartbeat, rrdcreate_config.rrarows,
         rrdcreate_config.xff);
 
-  return (0);
+  return 0;
 } /* int rrd_init */
 
 void module_register(void) {

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -185,7 +185,7 @@ static int sensors_snprintf_chip_name(char *buf, size_t buf_size,
                       chip->addr);
   }
 
-  return (status);
+  return status;
 } /* int sensors_snprintf_chip_name */
 
 static int sensors_feature_name_to_type(const char *name) {
@@ -193,9 +193,9 @@ static int sensors_feature_name_to_type(const char *name) {
    * it's a one time cost.. */
   for (int i = 0; i < known_features_num; i++)
     if (strcasecmp(known_features[i].label, name) == 0)
-      return (known_features[i].type);
+      return known_features[i].type;
 
-  return (SENSOR_TYPE_UNKNOWN);
+  return SENSOR_TYPE_UNKNOWN;
 } /* int sensors_feature_name_to_type */
 #endif
 
@@ -216,7 +216,7 @@ static int sensors_config(const char *key, const char *value) {
     if (ignorelist_add(sensor_list, value)) {
       ERROR("sensors plugin: "
             "Cannot add value to ignorelist.");
-      return (1);
+      return 1;
     }
   } else if (strcasecmp(key, "IgnoreSelected") == 0) {
     ignorelist_set_invert(sensor_list, 1);
@@ -229,10 +229,10 @@ static int sensors_config(const char *key, const char *value) {
   }
 #endif
   else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void sensors_free_features(void) {
@@ -272,7 +272,7 @@ static int sensors_load_conf(void) {
       char errbuf[1024];
       ERROR("sensors plugin: fopen(%s) failed: %s", conffile,
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
   }
 
@@ -283,7 +283,7 @@ static int sensors_load_conf(void) {
   if (status != 0) {
     ERROR("sensors plugin: Cannot initialize sensors. "
           "Data will not be collected.");
-    return (-1);
+    return -1;
   }
 
 #if SENSORS_API_VERSION < 0x400
@@ -416,17 +416,17 @@ static int sensors_load_conf(void) {
     sensors_cleanup();
     INFO("sensors plugin: lm_sensors reports no "
          "features. Data will not be collected.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int sensors_load_conf */
 
 static int sensors_shutdown(void) {
   sensors_free_features();
   ignorelist_free(sensor_list);
 
-  return (0);
+  return 0;
 } /* int sensors_shutdown */
 
 static void sensors_submit(const char *plugin_instance, const char *type,
@@ -460,7 +460,7 @@ static void sensors_submit(const char *plugin_instance, const char *type,
 
 static int sensors_read(void) {
   if (sensors_load_conf() != 0)
-    return (-1);
+    return -1;
 
 #if SENSORS_API_VERSION < 0x400
   for (featurelist_t *fl = first_feature; fl != NULL; fl = fl->next) {
@@ -530,7 +530,7 @@ static int sensors_read(void) {
   } /* for fl = first_feature .. NULL */
 #endif /* (SENSORS_API_VERSION >= 0x400) && (SENSORS_API_VERSION < 0x500) */
 
-  return (0);
+  return 0;
 } /* int sensors_read */
 
 void module_register(void) {

--- a/src/serial.c
+++ b/src/serial.c
@@ -54,7 +54,7 @@ static int serial_read(void) {
       (fh = fopen("/proc/tty/driver/ttyS", "r")) == NULL) {
     char errbuf[1024];
     WARNING("serial: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -100,7 +100,7 @@ static int serial_read(void) {
   }
 
   fclose(fh);
-  return (0);
+  return 0;
 } /* int serial_read */
 
 void module_register(void) {

--- a/src/smart.c
+++ b/src/smart.c
@@ -50,7 +50,7 @@ static int smart_config(const char *key, const char *value) {
   if (ignorelist == NULL)
     ignorelist = ignorelist_create(/* invert = */ 1);
   if (ignorelist == NULL)
-    return (1);
+    return 1;
 
   if (strcasecmp("Disk", key) == 0) {
     ignorelist_add(ignorelist, value);
@@ -66,10 +66,10 @@ static int smart_config(const char *key, const char *value) {
     if (IS_TRUE(value))
       use_serial = 1;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int smart_config */
 
 static void smart_submit(const char *dev, const char *type,
@@ -217,7 +217,7 @@ static int smart_read(void) {
   handle_udev = udev_new();
   if (!handle_udev) {
     ERROR("smart plugin: unable to initialize udev.");
-    return (-1);
+    return -1;
   }
   enumerate = udev_enumerate_new(handle_udev);
   udev_enumerate_add_match_subsystem(enumerate, "block");
@@ -239,7 +239,7 @@ static int smart_read(void) {
   udev_enumerate_unref(enumerate);
   udev_unref(handle_udev);
 
-  return (0);
+  return 0;
 } /* int smart_read */
 
 static int smart_init(void) {
@@ -256,7 +256,7 @@ static int smart_init(void) {
               "running \"setcap cap_sys_rawio=ep\" on the collectd binary.");
   }
 #endif
-  return (0);
+  return 0;
 } /* int smart_init */
 
 void module_register(void) {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -130,23 +130,23 @@ static void csnmp_oid_init(oid_t *dst, oid const *src, size_t n) {
 }
 
 static int csnmp_oid_compare(oid_t const *left, oid_t const *right) {
-  return (
-      snmp_oid_compare(left->oid, left->oid_len, right->oid, right->oid_len));
+  return snmp_oid_compare(left->oid, left->oid_len, right->oid,
+                          right->oid_len);
 }
 
 static int csnmp_oid_suffix(oid_t *dst, oid_t const *src, oid_t const *root) {
   /* Make sure "src" is in "root"s subtree. */
   if (src->oid_len <= root->oid_len)
-    return (EINVAL);
+    return EINVAL;
   if (snmp_oid_ncompare(root->oid, root->oid_len, src->oid, src->oid_len,
                         /* n = */ root->oid_len) != 0)
-    return (EINVAL);
+    return EINVAL;
 
   memset(dst, 0, sizeof(*dst));
   dst->oid_len = src->oid_len - root->oid_len;
   memcpy(dst->oid, &src->oid[root->oid_len],
          dst->oid_len * sizeof(dst->oid[0]));
-  return (0);
+  return 0;
 }
 
 static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
@@ -159,8 +159,7 @@ static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
     oid_str_ptr[i] = oid_str[i];
   }
 
-  return (strjoin(buffer, buffer_size, oid_str_ptr, o->oid_len,
-                  /* separator = */ "."));
+  return strjoin(buffer, buffer_size, oid_str_ptr, o->oid_len, ".");
 }
 
 static void csnmp_host_close_session(host_definition_t *host) /* {{{ */
@@ -241,14 +240,14 @@ static int csnmp_config_add_data_instance(data_definition_t *dd,
 
     if (!read_objid(buffer, dd->instance.oid.oid, &dd->instance.oid.oid_len)) {
       ERROR("snmp plugin: read_objid (%s) failed.", buffer);
-      return (-1);
+      return -1;
     }
   } else {
     /* Instance is a simple string */
     sstrncpy(dd->instance.string, buffer, sizeof(dd->instance.string));
   }
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_data_instance */
 
 static int csnmp_config_add_data_instance_prefix(data_definition_t *dd,
@@ -259,7 +258,7 @@ static int csnmp_config_add_data_instance_prefix(data_definition_t *dd,
     WARNING("snmp plugin: data %s: InstancePrefix is ignored when `Table' "
             "is set to `false'.",
             dd->name);
-    return (-1);
+    return -1;
   }
 
   status = cf_util_get_string(ci, &dd->instance_prefix);
@@ -270,20 +269,20 @@ static int csnmp_config_add_data_values(data_definition_t *dd,
                                         oconfig_item_t *ci) {
   if (ci->values_num < 1) {
     WARNING("snmp plugin: `Values' needs at least one argument.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; i++)
     if (ci->values[i].type != OCONFIG_TYPE_STRING) {
       WARNING("snmp plugin: `Values' needs only string argument.");
-      return (-1);
+      return -1;
     }
 
   sfree(dd->values);
   dd->values_len = 0;
   dd->values = malloc(sizeof(*dd->values) * ci->values_num);
   if (dd->values == NULL)
-    return (-1);
+    return -1;
   dd->values_len = (size_t)ci->values_num;
 
   for (int i = 0; i < ci->values_num; i++) {
@@ -296,22 +295,22 @@ static int csnmp_config_add_data_values(data_definition_t *dd,
       free(dd->values);
       dd->values = NULL;
       dd->values_len = 0;
-      return (-1);
+      return -1;
     }
   }
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_data_instance */
 
 static int csnmp_config_add_data_blacklist(data_definition_t *dd,
                                            oconfig_item_t *ci) {
   if (ci->values_num < 1)
-    return (0);
+    return 0;
 
   for (int i = 0; i < ci->values_num; i++) {
     if (ci->values[i].type != OCONFIG_TYPE_STRING) {
       WARNING("snmp plugin: `Ignore' needs only string argument.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -323,7 +322,7 @@ static int csnmp_config_add_data_blacklist(data_definition_t *dd,
                      ci->values[i].value.string) != 0) {
       ERROR("snmp plugin: Can't allocate memory");
       strarray_free(dd->ignores, dd->ignores_len);
-      return (ENOMEM);
+      return ENOMEM;
     }
   }
   return 0;
@@ -333,12 +332,12 @@ static int csnmp_config_add_data_blacklist_match_inverted(data_definition_t *dd,
                                                           oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_BOOLEAN)) {
     WARNING("snmp plugin: `InvertMatch' needs exactly one boolean argument.");
-    return (-1);
+    return -1;
   }
 
   dd->invert_match = ci->values[0].value.boolean ? 1 : 0;
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_data_blacklist_match_inverted */
 
 static int csnmp_config_add_data(oconfig_item_t *ci) {
@@ -347,12 +346,12 @@ static int csnmp_config_add_data(oconfig_item_t *ci) {
 
   dd = calloc(1, sizeof(*dd));
   if (dd == NULL)
-    return (-1);
+    return -1;
 
   status = cf_util_get_string(ci, &dd->name);
   if (status != 0) {
     free(dd);
-    return (-1);
+    return -1;
   }
 
   dd->scale = 1.0;
@@ -409,7 +408,7 @@ static int csnmp_config_add_data(oconfig_item_t *ci) {
     sfree(dd->values);
     sfree(dd->ignores);
     sfree(dd);
-    return (-1);
+    return -1;
   }
 
   DEBUG("snmp plugin: dd = { name = %s, type = %s, is_table = %s, values_len = "
@@ -427,7 +426,7 @@ static int csnmp_config_add_data(oconfig_item_t *ci) {
     last->next = dd;
   }
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_data */
 
 static int csnmp_config_add_host_version(host_definition_t *hd,
@@ -437,18 +436,18 @@ static int csnmp_config_add_host_version(host_definition_t *hd,
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_NUMBER)) {
     WARNING("snmp plugin: The `Version' config option needs exactly one number "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   version = (int)ci->values[0].value.number;
   if ((version < 1) || (version > 3)) {
     WARNING("snmp plugin: `Version' must either be `1', `2', or `3'.");
-    return (-1);
+    return -1;
   }
 
   hd->version = version;
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host_address */
 
 static int csnmp_config_add_host_collect(host_definition_t *host,
@@ -459,20 +458,20 @@ static int csnmp_config_add_host_collect(host_definition_t *host,
 
   if (ci->values_num < 1) {
     WARNING("snmp plugin: `Collect' needs at least one argument.");
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; i++)
     if (ci->values[i].type != OCONFIG_TYPE_STRING) {
       WARNING("snmp plugin: All arguments to `Collect' must be strings.");
-      return (-1);
+      return -1;
     }
 
   data_list_len = host->data_list_len + ci->values_num;
   data_list =
       realloc(host->data_list, sizeof(data_definition_t *) * data_list_len);
   if (data_list == NULL)
-    return (-1);
+    return -1;
   host->data_list = data_list;
 
   for (int i = 0; i < ci->values_num; i++) {
@@ -493,7 +492,7 @@ static int csnmp_config_add_host_collect(host_definition_t *host,
     host->data_list_len++;
   } /* for (values_num) */
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host_collect */
 
 static int csnmp_config_add_host_auth_protocol(host_definition_t *hd,
@@ -514,13 +513,13 @@ static int csnmp_config_add_host_auth_protocol(host_definition_t *hd,
   } else {
     WARNING("snmp plugin: The `AuthProtocol' config option must be `MD5' or "
             "`SHA'.");
-    return (-1);
+    return -1;
   }
 
   DEBUG("snmp plugin: host = %s; host->auth_protocol = %s;", hd->name,
         hd->auth_protocol == usmHMACMD5AuthProtocol ? "MD5" : "SHA");
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host_auth_protocol */
 
 static int csnmp_config_add_host_priv_protocol(host_definition_t *hd,
@@ -541,13 +540,13 @@ static int csnmp_config_add_host_priv_protocol(host_definition_t *hd,
   } else {
     WARNING("snmp plugin: The `PrivProtocol' config option must be `AES' or "
             "`DES'.");
-    return (-1);
+    return -1;
   }
 
   DEBUG("snmp plugin: host = %s; host->priv_protocol = %s;", hd->name,
         hd->priv_protocol == usmAESPrivProtocol ? "AES" : "DES");
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host_priv_protocol */
 
 static int csnmp_config_add_host_security_level(host_definition_t *hd,
@@ -568,13 +567,13 @@ static int csnmp_config_add_host_security_level(host_definition_t *hd,
   else {
     WARNING("snmp plugin: The `SecurityLevel' config option must be "
             "`noAuthNoPriv', `authNoPriv', or `authPriv'.");
-    return (-1);
+    return -1;
   }
 
   DEBUG("snmp plugin: host = %s; host->security_level = %d;", hd->name,
         hd->security_level);
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host_security_level */
 
 static int csnmp_config_add_host(oconfig_item_t *ci) {
@@ -586,7 +585,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
 
   hd = calloc(1, sizeof(*hd));
   if (hd == NULL)
-    return (-1);
+    return -1;
   hd->version = 2;
   C_COMPLAIN_INIT(&hd->complaint);
 
@@ -697,7 +696,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
 
   if (status != 0) {
     csnmp_host_definition_destroy(hd);
-    return (-1);
+    return -1;
   }
 
   DEBUG("snmp plugin: hd = { name = %s, address = %s, community = %s, version "
@@ -714,10 +713,10 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
   if (status != 0) {
     ERROR("snmp plugin: Registering complex read function failed.");
     csnmp_host_definition_destroy(hd);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int csnmp_config_add_host */
 
 static int csnmp_config(oconfig_item_t *ci) {
@@ -734,7 +733,7 @@ static int csnmp_config(oconfig_item_t *ci) {
     }
   } /* for (ci->children) */
 
-  return (0);
+  return 0;
 } /* int csnmp_config */
 
 /* }}} End of the config stuff. Now the interesting part begins */
@@ -944,7 +943,7 @@ static value_t csnmp_value_list_to_value(struct variable_list *vl, int type,
     ret.gauge = NAN;
   }
 
-  return (ret);
+  return ret;
 } /* value_t csnmp_value_list_to_value */
 
 /* csnmp_strvbcopy_hexstring converts the bit string contained in "vb" to a hex
@@ -1004,7 +1003,7 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
                      (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
   } else {
     dst[0] = 0;
-    return (EINVAL);
+    return EINVAL;
   }
 
   num_chars = dst_size - 1;
@@ -1014,7 +1013,7 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
   for (size_t i = 0; i < num_chars; i++) {
     /* Check for control characters. */
     if ((unsigned char)src[i] < 32)
-      return (csnmp_strvbcopy_hexstring(dst, vb, dst_size));
+      return csnmp_strvbcopy_hexstring(dst, vb, dst_size);
     dst[i] = src[i];
   }
   dst[num_chars] = 0;
@@ -1042,21 +1041,21 @@ static int csnmp_instance_list_add(csnmp_list_instances_t **head,
        vb = vb->next_variable)
     /* do nothing */;
   if (vb == NULL)
-    return (-1);
+    return -1;
 
   csnmp_oid_init(&vb_name, vb->name, vb->name_length);
 
   il = calloc(1, sizeof(*il));
   if (il == NULL) {
     ERROR("snmp plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   il->next = NULL;
 
   status = csnmp_oid_suffix(&il->suffix, &vb_name, &dd->instance.oid);
   if (status != 0) {
     sfree(il);
-    return (status);
+    return status;
   }
 
   /* Get instance name */
@@ -1104,7 +1103,7 @@ static int csnmp_instance_list_add(csnmp_list_instances_t **head,
     (*tail)->next = il;
   *tail = il;
 
-  return (0);
+  return 0;
 } /* int csnmp_instance_list_add */
 
 static int csnmp_dispatch_table(host_definition_t *host,
@@ -1124,7 +1123,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
   ds = plugin_get_ds(data->type);
   if (!ds) {
     ERROR("snmp plugin: DataSet `%s' not defined.", data->type);
-    return (-1);
+    return -1;
   }
   assert(ds->ds_num == data->values_len);
   assert(data->values_len > 0);
@@ -1133,7 +1132,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
 
   value_table_ptr = calloc(data->values_len, sizeof(*value_table_ptr));
   if (value_table_ptr == NULL)
-    return (-1);
+    return -1;
   for (i = 0; i < data->values_len; i++)
     value_table_ptr[i] = value_table[i];
 
@@ -1142,7 +1141,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
   if (vl.values == NULL) {
     ERROR("snmp plugin: malloc failed.");
     sfree(value_table_ptr);
-    return (-1);
+    return -1;
   }
 
   sstrncpy(vl.host, host->name, sizeof(vl.host));
@@ -1257,7 +1256,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
   sfree(vl.values);
   sfree(value_table_ptr);
 
-  return (0);
+  return 0;
 } /* int csnmp_dispatch_table */
 
 static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
@@ -1292,20 +1291,20 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
 
   if (host->sess_handle == NULL) {
     DEBUG("snmp plugin: csnmp_read_table: host->sess_handle == NULL");
-    return (-1);
+    return -1;
   }
 
   ds = plugin_get_ds(data->type);
   if (!ds) {
     ERROR("snmp plugin: DataSet `%s' not defined.", data->type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num != data->values_len) {
     ERROR("snmp plugin: DataSet `%s' requires %zu values, but config talks "
           "about %zu",
           data->type, ds->ds_num, data->values_len);
-    return (-1);
+    return -1;
   }
   assert(data->values_len > 0);
 
@@ -1328,7 +1327,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
     ERROR("snmp plugin: csnmp_read_table: calloc failed.");
     sfree(value_list_head);
     sfree(value_list_tail);
-    return (-1);
+    return -1;
   }
 
   instance_list_head = NULL;
@@ -1517,7 +1516,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   sfree(value_list_head);
   sfree(value_list_tail);
 
-  return (0);
+  return 0;
 } /* int csnmp_read_table */
 
 static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
@@ -1536,26 +1535,26 @@ static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
 
   if (host->sess_handle == NULL) {
     DEBUG("snmp plugin: csnmp_read_value: host->sess_handle == NULL");
-    return (-1);
+    return -1;
   }
 
   ds = plugin_get_ds(data->type);
   if (!ds) {
     ERROR("snmp plugin: DataSet `%s' not defined.", data->type);
-    return (-1);
+    return -1;
   }
 
   if (ds->ds_num != data->values_len) {
     ERROR("snmp plugin: DataSet `%s' requires %zu values, but config talks "
           "about %zu",
           data->type, ds->ds_num, data->values_len);
-    return (-1);
+    return -1;
   }
 
   vl.values_len = ds->ds_num;
   vl.values = malloc(sizeof(*vl.values) * vl.values_len);
   if (vl.values == NULL)
-    return (-1);
+    return -1;
   for (i = 0; i < vl.values_len; i++) {
     if (ds->ds[i].type == DS_TYPE_COUNTER)
       vl.values[i].counter = 0;
@@ -1574,7 +1573,7 @@ static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
   if (req == NULL) {
     ERROR("snmp plugin: snmp_pdu_create failed.");
     sfree(vl.values);
-    return (-1);
+    return -1;
   }
 
   for (i = 0; i < data->values_len; i++)
@@ -1596,7 +1595,7 @@ static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
     sfree(vl.values);
     csnmp_host_close_session(host);
 
-    return (-1);
+    return -1;
   }
 
   for (vb = res->variables; vb != NULL; vb = vb->next_variable) {
@@ -1620,7 +1619,7 @@ static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
   plugin_dispatch_values(&vl);
   sfree(vl.values);
 
-  return (0);
+  return 0;
 } /* int csnmp_read_value */
 
 static int csnmp_read_host(user_data_t *ud) {
@@ -1638,7 +1637,7 @@ static int csnmp_read_host(user_data_t *ud) {
     csnmp_host_open_session(host);
 
   if (host->sess_handle == NULL)
-    return (-1);
+    return -1;
 
   success = 0;
   for (i = 0; i < host->data_list_len; i++) {
@@ -1654,15 +1653,15 @@ static int csnmp_read_host(user_data_t *ud) {
   }
 
   if (success == 0)
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 } /* int csnmp_read_host */
 
 static int csnmp_init(void) {
   call_snmp_init_once();
 
-  return (0);
+  return 0;
 } /* int csnmp_init */
 
 static int csnmp_shutdown(void) {
@@ -1687,7 +1686,7 @@ static int csnmp_shutdown(void) {
     data_this = data_next;
   }
 
-  return (0);
+  return 0;
 } /* int csnmp_shutdown */
 
 void module_register(void) {

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -51,15 +51,15 @@ static int sl_config(const char *key, const char *value) {
     if (log_level < 0) {
       log_level = LOG_INFO;
       ERROR("syslog: invalid loglevel [%s] defaulting to 'info'", value);
-      return (1);
+      return 1;
     }
   } else if (strcasecmp(key, "NotifyLevel") == 0) {
     notif_severity = parse_notif_severity(value);
     if (notif_severity < 0)
-      return (1);
+      return 1;
   }
 
-  return (0);
+  return 0;
 } /* int sl_config */
 
 static void sl_log(int severity, const char *msg,
@@ -73,7 +73,7 @@ static void sl_log(int severity, const char *msg,
 static int sl_shutdown(void) {
   closelog();
 
-  return (0);
+  return 0;
 }
 
 static int sl_notification(const notification_t *n,
@@ -85,7 +85,7 @@ static int sl_notification(const notification_t *n,
   int status;
 
   if (n->severity > notif_severity)
-    return (0);
+    return 0;
 
   switch (n->severity) {
   case NOTIF_FAILURE:
@@ -109,9 +109,9 @@ static int sl_notification(const notification_t *n,
   do {                                                                         \
     status = ssnprintf(&buf[offset], sizeof(buf) - offset, __VA_ARGS__);       \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (sizeof(buf) - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -137,7 +137,7 @@ static int sl_notification(const notification_t *n,
 
   sl_log(log_severity, buf, NULL);
 
-  return (0);
+  return 0;
 } /* int sl_notification */
 
 void module_register(void) {

--- a/src/tail.c
+++ b/src/tail.c
@@ -66,7 +66,7 @@ static int ctail_config_add_match_dstype(ctail_config_match_t *cm,
                                          oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("tail plugin: `DSType' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   char const *ds_type = ci->values[0].value.string;
@@ -93,7 +93,7 @@ static int ctail_config_add_match_dstype(ctail_config_match_t *cm,
 
     int status = latency_config(&cm->latency, ci, "tail");
     if (status != 0)
-      return (status);
+      return status;
   } else if (strncasecmp("Counter", ds_type, strlen("Counter")) == 0) {
     cm->flags = UTILS_MATCH_DS_TYPE_COUNTER;
     if (strcasecmp("CounterSet", ds_type) == 0)
@@ -127,10 +127,10 @@ static int ctail_config_add_match_dstype(ctail_config_match_t *cm,
   if (cm->flags == 0) {
     WARNING("tail plugin: `%s' is not a valid argument to `DSType'.",
             ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int ctail_config_add_match_dstype */
 
 static int ctail_config_add_match(cu_tail_match_t *tm,
@@ -204,7 +204,7 @@ static int ctail_config_add_match(cu_tail_match_t *tm,
   sfree(cm.type_instance);
   latency_config_free(cm.latency);
 
-  return (status);
+  return status;
 } /* int ctail_config_add_match */
 
 static int ctail_config_add_file(oconfig_item_t *ci) {
@@ -215,14 +215,14 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("tail plugin: `File' needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   tm = tail_match_create(ci->values[0].value.string);
   if (tm == NULL) {
     ERROR("tail plugin: tail_match_create (%s) failed.",
           ci->values[0].value.string);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -253,7 +253,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
     ERROR("tail plugin: No (valid) matches found for file `%s'.",
           ci->values[0].value.string);
     tail_match_destroy(tm);
-    return (-1);
+    return -1;
   } else {
     cu_tail_match_t **temp;
 
@@ -262,7 +262,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
     if (temp == NULL) {
       ERROR("tail plugin: realloc failed.");
       tail_match_destroy(tm);
-      return (-1);
+      return -1;
     }
 
     tail_match_list = temp;
@@ -271,7 +271,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
     tail_match_list_num++;
   }
 
-  return (0);
+  return 0;
 } /* int ctail_config_add_file */
 
 static int ctail_config(oconfig_item_t *ci) {
@@ -285,7 +285,7 @@ static int ctail_config(oconfig_item_t *ci) {
     }
   } /* for (i = 0; i < ci->children_num; i++) */
 
-  return (0);
+  return 0;
 } /* int ctail_config */
 
 static int ctail_read(user_data_t *ud) {
@@ -294,10 +294,10 @@ static int ctail_read(user_data_t *ud) {
   status = tail_match_read((cu_tail_match_t *)ud->data);
   if (status != 0) {
     ERROR("tail plugin: tail_match_read failed.");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int ctail_read */
 
 static int ctail_init(void) {
@@ -305,7 +305,7 @@ static int ctail_init(void) {
 
   if (tail_match_list_num == 0) {
     WARNING("tail plugin: File list is empty. Returning an error.");
-    return (-1);
+    return -1;
   }
 
   for (size_t i = 0; i < tail_match_list_num; i++) {
@@ -318,7 +318,7 @@ static int ctail_init(void) {
                                  });
   }
 
-  return (0);
+  return 0;
 } /* int ctail_init */
 
 static int ctail_shutdown(void) {
@@ -329,7 +329,7 @@ static int ctail_shutdown(void) {
   sfree(tail_match_list);
   tail_match_list_num = 0;
 
-  return (0);
+  return 0;
 } /* int ctail_shutdown */
 
 void module_register(void) {

--- a/src/tape.c
+++ b/src/tape.c
@@ -40,7 +40,7 @@ static int tape_init(void) {
   numtape = 0;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   for (numtape = 0, ksp_chain = kc->kc_chain;
        (numtape < MAX_NUMTAPE) && (ksp_chain != NULL);
@@ -52,7 +52,7 @@ static int tape_init(void) {
     ksp[numtape++] = ksp_chain;
   }
 
-  return (0);
+  return 0;
 } /* int tape_init */
 
 static void tape_submit(const char *plugin_instance, const char *type,
@@ -94,10 +94,10 @@ static int tape_read(void) {
   static kstat_io_t kio;
 
   if (kc == NULL)
-    return (-1);
+    return -1;
 
   if (numtape <= 0)
-    return (-1);
+    return -1;
 
   for (int i = 0; i < numtape; i++) {
     if (kstat_read(kc, ksp[i], &kio) == -1)
@@ -112,7 +112,7 @@ static int tape_read(void) {
     }
   }
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -43,7 +43,7 @@ static int tn_config_add_severity(tn_data_t *data, /* {{{ */
     ERROR("Target `notification': The `%s' option requires exactly one string "
           "argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if ((strcasecmp("FAILURE", ci->values[0].value.string) == 0) ||
@@ -61,7 +61,7 @@ static int tn_config_add_severity(tn_data_t *data, /* {{{ */
     data->severity = NOTIF_FAILURE;
   }
 
-  return (0);
+  return 0;
 } /* }}} int tn_config_add_severity */
 
 static int tn_config_add_string(char **dest, /* {{{ */
@@ -69,32 +69,32 @@ static int tn_config_add_string(char **dest, /* {{{ */
   char *temp;
 
   if (dest == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     ERROR("Target `notification': The `%s' option requires exactly one string "
           "argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if (ci->values[0].value.string[0] == 0) {
     ERROR(
         "Target `notification': The `%s' option does not accept empty strings.",
         ci->key);
-    return (-1);
+    return -1;
   }
 
   temp = sstrdup(ci->values[0].value.string);
   if (temp == NULL) {
     ERROR("tn_config_add_string: sstrdup failed.");
-    return (-1);
+    return -1;
   }
 
   free(*dest);
   *dest = temp;
 
-  return (0);
+  return 0;
 } /* }}} int tn_config_add_string */
 
 static int tn_destroy(void **user_data) /* {{{ */
@@ -102,16 +102,16 @@ static int tn_destroy(void **user_data) /* {{{ */
   tn_data_t *data;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL)
-    return (0);
+    return 0;
 
   sfree(data->message);
   sfree(data);
 
-  return (0);
+  return 0;
 } /* }}} int tn_destroy */
 
 static int tn_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -122,7 +122,7 @@ static int tn_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   data = calloc(1, sizeof(*data));
   if (data == NULL) {
     ERROR("tn_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   data->message = NULL;
@@ -168,11 +168,11 @@ static int tn_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     tn_destroy((void *)&data);
-    return (status);
+    return status;
   }
 
   *user_data = data;
-  return (0);
+  return 0;
 } /* }}} int tn_create */
 
 static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -186,12 +186,12 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
   int rates_failed;
 
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL) {
     ERROR("Target `notification': Invoke: `data' is NULL.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   /* Initialize the structure. */
@@ -249,7 +249,7 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   plugin_dispatch_notification(&n);
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int tn_invoke */
 
 void module_register(void) {

--- a/src/target_replace.c
+++ b/src/target_replace.c
@@ -68,16 +68,16 @@ static char *tr_strdup(const char *orig) /* {{{ */
   char *dest;
 
   if (orig == NULL)
-    return (NULL);
+    return NULL;
 
   sz = strlen(orig) + 1;
   dest = malloc(sz);
   if (dest == NULL)
-    return (NULL);
+    return NULL;
 
   memcpy(dest, orig, sz);
 
-  return (dest);
+  return dest;
 } /* }}} char *tr_strdup */
 
 static void tr_action_destroy(tr_action_t *act) /* {{{ */
@@ -115,20 +115,20 @@ static int tr_config_add_action(tr_action_t **dest, /* {{{ */
   int status;
 
   if (dest == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if ((ci->values_num != 2) || (ci->values[0].type != OCONFIG_TYPE_STRING) ||
       (ci->values[1].type != OCONFIG_TYPE_STRING)) {
     ERROR("Target `replace': The `%s' option requires exactly two string "
           "arguments.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   act = calloc(1, sizeof(*act));
   if (act == NULL) {
     ERROR("tr_config_add_action: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   act->replacement = NULL;
@@ -144,14 +144,14 @@ static int tr_config_add_action(tr_action_t **dest, /* {{{ */
           "failed: %s.",
           ci->values[0].value.string, errbuf);
     sfree(act);
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   act->replacement = tr_strdup(ci->values[1].value.string);
   if (act->replacement == NULL) {
     ERROR("tr_config_add_action: tr_strdup failed.");
     tr_action_destroy(act);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   /* Insert action at end of list. */
@@ -167,7 +167,7 @@ static int tr_config_add_action(tr_action_t **dest, /* {{{ */
     prev->next = act;
   }
 
-  return (0);
+  return 0;
 } /* }}} int tr_config_add_action */
 
 static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
@@ -177,7 +177,7 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
   int status;
 
   if (dest == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if (should_delete) {
     if ((ci->values_num != 2) || (ci->values[0].type != OCONFIG_TYPE_STRING) ||
@@ -185,7 +185,7 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
       ERROR("Target `replace': The `%s' option requires exactly two string "
             "arguments.",
             ci->key);
-      return (-1);
+      return -1;
     }
   } else {
     if ((ci->values_num != 3) || (ci->values[0].type != OCONFIG_TYPE_STRING) ||
@@ -194,7 +194,7 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
       ERROR("Target `replace': The `%s' option requires exactly three string "
             "arguments.",
             ci->key);
-      return (-1);
+      return -1;
     }
   }
 
@@ -202,13 +202,13 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
     ERROR("Target `replace': The `%s' option does not accept empty string as "
           "first argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   act = calloc(1, sizeof(*act));
   if (act == NULL) {
     ERROR("tr_config_add_meta_action: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   act->key = NULL;
@@ -225,14 +225,14 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
           ci->values[1].value.string, errbuf);
     sfree(act->key);
     sfree(act);
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   act->key = tr_strdup(ci->values[0].value.string);
   if (act->key == NULL) {
     ERROR("tr_config_add_meta_action: tr_strdup failed.");
     tr_meta_data_action_destroy(act);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   if (!should_delete) {
@@ -240,7 +240,7 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
     if (act->replacement == NULL) {
       ERROR("tr_config_add_meta_action: tr_strdup failed.");
       tr_meta_data_action_destroy(act);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
   }
 
@@ -257,7 +257,7 @@ static int tr_config_add_meta_action(tr_meta_data_action_t **dest, /* {{{ */
     prev->next = act;
   }
 
-  return (0);
+  return 0;
 } /* }}} int tr_config_add_meta_action */
 
 static int tr_action_invoke(tr_action_t *act_head, /* {{{ */
@@ -268,7 +268,7 @@ static int tr_action_invoke(tr_action_t *act_head, /* {{{ */
   regmatch_t matches[8] = {[0] = {0}};
 
   if (act_head == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   sstrncpy(buffer, buffer_in, sizeof(buffer));
 
@@ -308,13 +308,13 @@ static int tr_action_invoke(tr_action_t *act_head, /* {{{ */
   if ((may_be_empty == 0) && (buffer[0] == 0)) {
     WARNING("Target `replace': Replacement resulted in an empty string, "
             "which is not allowed for this buffer (`host' or `plugin').");
-    return (0);
+    return 0;
   }
 
   DEBUG("target_replace plugin: tr_action_invoke: -> buffer = %s;", buffer);
   sstrncpy(buffer_in, buffer, buffer_in_size);
 
-  return (0);
+  return 0;
 } /* }}} int tr_action_invoke */
 
 static int tr_meta_data_action_invoke(/* {{{ */
@@ -324,10 +324,10 @@ static int tr_meta_data_action_invoke(/* {{{ */
   regmatch_t matches[8] = {[0] = {0}};
 
   if (act_head == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if ((*dest) == NULL) /* nothing to do */
-    return (0);
+    return 0;
 
   for (tr_meta_data_action_t *act = act_head; act != NULL; act = act->next) {
     char temp[DATA_MAX_NAME_LEN];
@@ -351,7 +351,7 @@ static int tr_meta_data_action_invoke(/* {{{ */
     if (meta_data_status != 0) {
       ERROR("Target `replace': Unable to retrieve metadata value for `%s'.",
             act->key);
-      return (meta_data_status);
+      return meta_data_status;
     }
 
     DEBUG("target_replace plugin: tr_meta_data_action_invoke: `%s' "
@@ -401,7 +401,7 @@ static int tr_meta_data_action_invoke(/* {{{ */
     if ((result = meta_data_create()) == NULL) {
       ERROR("Target `replace': failed to create metadata for `%s'.", act->key);
       sfree(value);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     meta_data_status = meta_data_add_string(result, act->key, temp);
@@ -410,7 +410,7 @@ static int tr_meta_data_action_invoke(/* {{{ */
             act->key);
       meta_data_destroy(result);
       sfree(value);
-      return (meta_data_status);
+      return meta_data_status;
     }
 
     meta_data_clone_merge(dest, result);
@@ -418,7 +418,7 @@ static int tr_meta_data_action_invoke(/* {{{ */
     sfree(value);
   } /* for (act = act_head; act != NULL; act = act->next) */
 
-  return (0);
+  return 0;
 } /* }}} int tr_meta_data_action_invoke */
 
 static int tr_destroy(void **user_data) /* {{{ */
@@ -426,11 +426,11 @@ static int tr_destroy(void **user_data) /* {{{ */
   tr_data_t *data;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL)
-    return (0);
+    return 0;
 
   tr_action_destroy(data->host);
   tr_action_destroy(data->plugin);
@@ -440,7 +440,7 @@ static int tr_destroy(void **user_data) /* {{{ */
   tr_meta_data_action_destroy(data->meta);
   sfree(data);
 
-  return (0);
+  return 0;
 } /* }}} int tr_destroy */
 
 static int tr_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -451,7 +451,7 @@ static int tr_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   data = calloc(1, sizeof(*data));
   if (data == NULL) {
     ERROR("tr_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   data->host = NULL;
@@ -516,11 +516,11 @@ static int tr_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     tr_destroy((void *)&data);
-    return (status);
+    return status;
   }
 
   *user_data = data;
-  return (0);
+  return 0;
 } /* }}} int tr_create */
 
 static int tr_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -529,12 +529,12 @@ static int tr_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
   tr_data_t *data;
 
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL) {
     ERROR("Target `replace': Invoke: `data' is NULL.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   if (data->meta != NULL) {
@@ -550,7 +550,7 @@ static int tr_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
   /* HANDLE_FIELD (type, 0); */
   HANDLE_FIELD(type_instance, 1);
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int tr_invoke */
 
 void module_register(void) {

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -120,7 +120,7 @@ static int ts_invoke_counter(const data_set_t *ds, value_list_t *vl, /* {{{ */
   uc_meta_data_add_unsigned_int(vl, key_int_counter, int_counter);
   uc_meta_data_add_double(vl, key_int_fraction, int_fraction);
 
-  return (0);
+  return 0;
 } /* }}} int ts_invoke_counter */
 
 static int ts_invoke_gauge(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -130,7 +130,7 @@ static int ts_invoke_gauge(const data_set_t *ds, value_list_t *vl, /* {{{ */
   if (!isnan(data->offset))
     vl->values[dsrc_index].gauge += data->offset;
 
-  return (0);
+  return 0;
 } /* }}} int ts_invoke_gauge */
 
 static int ts_invoke_derive(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -217,7 +217,7 @@ static int ts_invoke_derive(const data_set_t *ds, value_list_t *vl, /* {{{ */
   uc_meta_data_add_signed_int(vl, key_int_derive, int_derive);
   uc_meta_data_add_double(vl, key_int_fraction, int_fraction);
 
-  return (0);
+  return 0;
 } /* }}} int ts_invoke_derive */
 
 static int ts_invoke_absolute(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -260,7 +260,7 @@ static int ts_invoke_absolute(const data_set_t *ds, value_list_t *vl, /* {{{ */
   /* Update to the new absolute value */
   uc_meta_data_add_double(vl, key_int_fraction, int_fraction);
 
-  return (0);
+  return 0;
 } /* }}} int ts_invoke_absolute */
 
 static int ts_config_set_double(double *ret, oconfig_item_t *ci) /* {{{ */
@@ -269,13 +269,13 @@ static int ts_config_set_double(double *ret, oconfig_item_t *ci) /* {{{ */
     WARNING("scale target: The `%s' config option needs "
             "exactly one numeric argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret = ci->values[0].value.number;
   DEBUG("ts_config_set_double: *ret = %g", *ret);
 
-  return (0);
+  return 0;
 } /* }}} int ts_config_set_double */
 
 static int ts_config_add_data_source(ts_data_t *data, /* {{{ */
@@ -286,7 +286,7 @@ static int ts_config_add_data_source(ts_data_t *data, /* {{{ */
   /* Check number of arbuments. */
   if (ci->values_num < 1) {
     ERROR("`value' match: `%s' needs at least one argument.", ci->key);
-    return (-1);
+    return -1;
   }
 
   /* Check type of arguments */
@@ -299,7 +299,7 @@ static int ts_config_add_data_source(ts_data_t *data, /* {{{ */
           ci->key, i + 1,
           (ci->values[i].type == OCONFIG_TYPE_BOOLEAN) ? "truth value"
                                                        : "number");
-    return (-1);
+    return -1;
   }
 
   /* Allocate space for the char pointers */
@@ -307,7 +307,7 @@ static int ts_config_add_data_source(ts_data_t *data, /* {{{ */
   temp = realloc(data->data_sources, new_data_sources_num * sizeof(char *));
   if (temp == NULL) {
     ERROR("`value' match: realloc failed.");
-    return (-1);
+    return -1;
   }
   data->data_sources = temp;
 
@@ -327,7 +327,7 @@ static int ts_config_add_data_source(ts_data_t *data, /* {{{ */
     data->data_sources_num++;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ts_config_add_data_source */
 
 static int ts_destroy(void **user_data) /* {{{ */
@@ -335,7 +335,7 @@ static int ts_destroy(void **user_data) /* {{{ */
   ts_data_t *data;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   data = (ts_data_t *)*user_data;
 
@@ -348,7 +348,7 @@ static int ts_destroy(void **user_data) /* {{{ */
   sfree(data);
   *user_data = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int ts_destroy */
 
 static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -359,7 +359,7 @@ static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   data = calloc(1, sizeof(*data));
   if (data == NULL) {
     ERROR("ts_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   data->factor = NAN;
@@ -399,11 +399,11 @@ static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     ts_destroy((void *)&data);
-    return (status);
+    return status;
   }
 
   *user_data = data;
-  return (0);
+  return 0;
 } /* }}} int ts_create */
 
 static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -412,12 +412,12 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
   ts_data_t *data;
 
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL) {
     ERROR("Target `scale': Invoke: `data' is NULL.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   for (size_t i = 0; i < ds->ds_num; i++) {
@@ -446,7 +446,7 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
             ds->ds[i].type);
   }
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int ts_invoke */
 
 void module_register(void) {

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -70,13 +70,13 @@ static int ts_util_get_key_and_string_wo_strdup(const oconfig_item_t *ci,
     ERROR("ts_util_get_key_and_string_wo_strdup: The %s option requires "
           "exactly two string arguments.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   *ret_key = ci->values[0].value.string;
   *ret_string = ci->values[1].value.string;
 
-  return (0);
+  return 0;
 } /* }}} int ts_util_get_key_and_string_wo_strdup */
 
 static int ts_config_add_string(char **dest, /* {{{ */
@@ -86,17 +86,17 @@ static int ts_config_add_string(char **dest, /* {{{ */
 
   status = cf_util_get_string(ci, &tmp);
   if (status != 0)
-    return (status);
+    return status;
 
   if (!may_be_empty && (strlen(tmp) == 0)) {
     ERROR("Target `set': The `%s' option does not accept empty strings.",
           ci->key);
     sfree(tmp);
-    return (-1);
+    return -1;
   }
 
   *dest = tmp;
-  return (0);
+  return 0;
 } /* }}} int ts_config_add_string */
 
 static int ts_config_add_meta(meta_data_t **dest, /* {{{ */
@@ -107,31 +107,31 @@ static int ts_config_add_meta(meta_data_t **dest, /* {{{ */
 
   status = ts_util_get_key_and_string_wo_strdup(ci, &key, &string);
   if (status != 0)
-    return (status);
+    return status;
 
   if (strlen(key) == 0) {
     ERROR("Target `set': The `%s' option does not accept empty string as "
           "first argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if (!may_be_empty && (strlen(string) == 0)) {
     ERROR("Target `set': The `%s' option does not accept empty string as "
           "second argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
 
   if ((*dest) == NULL) {
     /* Create a new meta_data_t */
     if ((*dest = meta_data_create()) == NULL) {
       ERROR("Target `set': failed to create a meta data for `%s'.", ci->key);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
   }
 
-  return (meta_data_add_string(*dest, key, string));
+  return meta_data_add_string(*dest, key, string);
 } /* }}} int ts_config_add_meta */
 
 static int ts_config_add_meta_delete(ts_key_list_t **dest, /* {{{ */
@@ -141,12 +141,12 @@ static int ts_config_add_meta_delete(ts_key_list_t **dest, /* {{{ */
   entry = calloc(1, sizeof(*entry));
   if (entry == NULL) {
     ERROR("ts_config_add_meta_delete: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   if (cf_util_get_string(ci, &entry->key) != 0) {
     ts_key_list_free(entry);
-    return (-1); /* An error has already been reported. */
+    return -1; /* An error has already been reported. */
   }
 
   if (strlen(entry->key) == 0) {
@@ -154,13 +154,13 @@ static int ts_config_add_meta_delete(ts_key_list_t **dest, /* {{{ */
           "first argument.",
           ci->key);
     ts_key_list_free(entry);
-    return (-1);
+    return -1;
   }
 
   entry->next = *dest;
   *dest = entry;
 
-  return (0);
+  return 0;
 } /* }}} int ts_config_add_meta_delete */
 
 static void ts_subst(char *dest, size_t size, const char *string, /* {{{ */
@@ -210,11 +210,11 @@ static int ts_destroy(void **user_data) /* {{{ */
   ts_data_t *data;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL)
-    return (0);
+    return 0;
 
   free(data->host);
   free(data->plugin);
@@ -225,7 +225,7 @@ static int ts_destroy(void **user_data) /* {{{ */
   ts_key_list_free(data->meta_delete);
   free(data);
 
-  return (0);
+  return 0;
 } /* }}} int ts_destroy */
 
 static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
@@ -236,7 +236,7 @@ static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
   data = calloc(1, sizeof(*data));
   if (data == NULL) {
     ERROR("ts_create: calloc failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   data->host = NULL;
@@ -315,11 +315,11 @@ static int ts_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 
   if (status != 0) {
     ts_destroy((void *)&data);
-    return (status);
+    return status;
   }
 
   *user_data = data;
-  return (0);
+  return 0;
 } /* }}} int ts_create */
 
 static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
@@ -330,12 +330,12 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
   meta_data_t *new_meta = NULL;
 
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   data = *user_data;
   if (data == NULL) {
     ERROR("Target `set': Invoke: `data' is NULL.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   orig = *vl;
@@ -347,7 +347,7 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
     if ((new_meta = meta_data_create()) == NULL) {
       ERROR("Target `set': failed to create replacement metadata.");
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     meta_entries = meta_data_toc(data->meta, &meta_toc);
@@ -362,7 +362,7 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
               key);
         strarray_free(meta_toc, (size_t)meta_entries);
         meta_data_destroy(new_meta);
-        return (status);
+        return status;
       }
 
       ts_subst(temp, sizeof(temp), string, &orig);
@@ -378,7 +378,7 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
         ERROR("Target `set': Unable to set metadata value `%s'.", key);
         strarray_free(meta_toc, (size_t)meta_entries);
         meta_data_destroy(new_meta);
-        return (status);
+        return status;
       }
     }
 
@@ -409,7 +409,7 @@ static int ts_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
     meta_data_delete(vl->meta, l->key);
   }
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int ts_invoke */
 
 void module_register(void) {

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -56,7 +56,7 @@ static int v5_df(const data_set_t *ds, value_list_t *vl) /* {{{ */
 
   /* Can't upgrade if both instances have been set. */
   if ((vl->plugin_instance[0] != 0) && (vl->type_instance[0] != 0))
-    return (FC_TARGET_CONTINUE);
+    return FC_TARGET_CONTINUE;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -83,7 +83,7 @@ static int v5_df(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_df */
 
 /*
@@ -96,10 +96,10 @@ static int v5_df(const data_set_t *ds, value_list_t *vl) /* {{{ */
 static int v5_interface(const data_set_t *ds, value_list_t *vl) /* {{{ */
 {
   if ((vl->plugin_instance[0] != 0) || (vl->type_instance[0] == 0))
-    return (FC_TARGET_CONTINUE);
+    return FC_TARGET_CONTINUE;
 
   v5_swap_instances(vl);
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int v5_interface */
 
 /*
@@ -113,7 +113,7 @@ static int v5_mysql_qcache(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 5)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -153,7 +153,7 @@ static int v5_mysql_qcache(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_mysql_qcache */
 
 /*
@@ -167,7 +167,7 @@ static int v5_mysql_threads(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 4)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -201,7 +201,7 @@ static int v5_mysql_threads(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_mysql_threads */
 
 /*
@@ -216,14 +216,14 @@ static int v5_zfs_arc_counts(const data_set_t *ds, value_list_t *vl) /* {{{ */
   _Bool is_hits;
 
   if (vl->values_len != 4)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   if (strcmp("hits", vl->type_instance) == 0)
     is_hits = 1;
   else if (strcmp("misses", vl->type_instance) == 0)
     is_hits = 0;
   else
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -258,7 +258,7 @@ static int v5_zfs_arc_counts(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_zfs_arc_counts */
 
 /*
@@ -271,7 +271,7 @@ static int v5_zfs_arc_l2_bytes(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 2)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -295,7 +295,7 @@ static int v5_zfs_arc_l2_bytes(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_zfs_arc_l2_bytes */
 
 /*
@@ -309,7 +309,7 @@ static int v5_zfs_arc_l2_size(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 1)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -331,7 +331,7 @@ static int v5_zfs_arc_l2_size(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_zfs_arc_l2_size */
 
 /*
@@ -345,7 +345,7 @@ static int v5_zfs_arc_ratio(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 1)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -368,7 +368,7 @@ static int v5_zfs_arc_ratio(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_zfs_arc_ratio */
 
 /*
@@ -382,7 +382,7 @@ static int v5_zfs_arc_size(const data_set_t *ds, value_list_t *vl) /* {{{ */
   value_list_t new_vl;
 
   if (vl->values_len != 4)
-    return (FC_TARGET_STOP);
+    return FC_TARGET_STOP;
 
   /* Copy everything: Time, interval, host, ... */
   memcpy(&new_vl, vl, sizeof(new_vl));
@@ -401,46 +401,46 @@ static int v5_zfs_arc_size(const data_set_t *ds, value_list_t *vl) /* {{{ */
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */
-  return (FC_TARGET_STOP);
+  return FC_TARGET_STOP;
 } /* }}} int v5_zfs_arc_size */
 
 static int v5_destroy(void **user_data) /* {{{ */
 {
-  return (0);
+  return 0;
 } /* }}} int v5_destroy */
 
 static int v5_create(const oconfig_item_t *ci, void **user_data) /* {{{ */
 {
   *user_data = NULL;
-  return (0);
+  return 0;
 } /* }}} int v5_create */
 
 static int v5_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
                      notification_meta_t __attribute__((unused)) * *meta,
                      void __attribute__((unused)) * *user_data) {
   if ((ds == NULL) || (vl == NULL) || (user_data == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (strcmp("df", vl->type) == 0)
-    return (v5_df(ds, vl));
+    return v5_df(ds, vl);
   else if (strcmp("interface", vl->plugin) == 0)
-    return (v5_interface(ds, vl));
+    return v5_interface(ds, vl);
   else if (strcmp("mysql_qcache", vl->type) == 0)
-    return (v5_mysql_qcache(ds, vl));
+    return v5_mysql_qcache(ds, vl);
   else if (strcmp("mysql_threads", vl->type) == 0)
-    return (v5_mysql_threads(ds, vl));
+    return v5_mysql_threads(ds, vl);
   else if (strcmp("arc_counts", vl->type) == 0)
-    return (v5_zfs_arc_counts(ds, vl));
+    return v5_zfs_arc_counts(ds, vl);
   else if (strcmp("arc_l2_bytes", vl->type) == 0)
-    return (v5_zfs_arc_l2_bytes(ds, vl));
+    return v5_zfs_arc_l2_bytes(ds, vl);
   else if (strcmp("arc_l2_size", vl->type) == 0)
-    return (v5_zfs_arc_l2_size(ds, vl));
+    return v5_zfs_arc_l2_size(ds, vl);
   else if (strcmp("arc_ratio", vl->type) == 0)
-    return (v5_zfs_arc_ratio(ds, vl));
+    return v5_zfs_arc_ratio(ds, vl);
   else if (strcmp("arc_size", vl->type) == 0)
-    return (v5_zfs_arc_size(ds, vl));
+    return v5_zfs_arc_size(ds, vl);
 
-  return (FC_TARGET_CONTINUE);
+  return FC_TARGET_CONTINUE;
 } /* }}} int v5_invoke */
 
 void module_register(void) {

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -71,14 +71,14 @@ static int tss2_add_vserver(int vserver_port) {
   /* Check port range */
   if ((vserver_port <= 0) || (vserver_port > 65535)) {
     ERROR("teamspeak2 plugin: VServer port is invalid: %i", vserver_port);
-    return (-1);
+    return -1;
   }
 
   /* Allocate memory */
   entry = calloc(1, sizeof(*entry));
   if (entry == NULL) {
     ERROR("teamspeak2 plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
 
   /* Save data */
@@ -100,7 +100,7 @@ static int tss2_add_vserver(int vserver_port) {
 
   INFO("teamspeak2 plugin: Registered new vserver: %i", vserver_port);
 
-  return (0);
+  return 0;
 } /* int tss2_add_vserver */
 
 static void tss2_submit_gauge(const char *plugin_instance, const char *type,
@@ -182,7 +182,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
       *ret_read_fh = global_read_fh;
     if (ret_write_fh != NULL)
       *ret_write_fh = global_write_fh;
-    return (0);
+    return 0;
   }
 
   /* Get all addrs for this hostname */
@@ -195,7 +195,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
                        &ai_hints, &ai_head);
   if (status != 0) {
     ERROR("teamspeak2 plugin: getaddrinfo failed: %s", gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   /* Try all given hosts until we can connect to one */
@@ -231,7 +231,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
 
   /* Check if we really got connected */
   if (sd < 0)
-    return (-1);
+    return -1;
 
   /* Create file objects from sockets */
   global_read_fh = fdopen(sd, "r");
@@ -240,7 +240,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
     ERROR("teamspeak2 plugin: fdopen failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(sd);
-    return (-1);
+    return -1;
   }
 
   global_write_fh = fdopen(sd, "w");
@@ -249,7 +249,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
     ERROR("teamspeak2 plugin: fdopen failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     tss2_close_socket();
-    return (-1);
+    return -1;
   }
 
   { /* Check that the server correctly identifies itself. */
@@ -270,7 +270,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
             "to server. Expected ``[TS]'', got ``%s''.",
             buffer);
       tss2_close_socket();
-      return (-1);
+      return -1;
     }
     DEBUG("teamspeak2 plugin: Server send correct banner, connected!");
   }
@@ -280,7 +280,7 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
     *ret_read_fh = global_read_fh;
   if (ret_write_fh != NULL)
     *ret_write_fh = global_write_fh;
-  return (0);
+  return 0;
 } /* int tss2_get_socket */
 
 static int tss2_send_request(FILE *fh, const char *request) {
@@ -293,11 +293,11 @@ static int tss2_send_request(FILE *fh, const char *request) {
   if (status < 0) {
     ERROR("teamspeak2 plugin: fputs failed.");
     tss2_close_socket();
-    return (-1);
+    return -1;
   }
   fflush(fh);
 
-  return (0);
+  return 0;
 } /* int tss2_send_request */
 
 static int tss2_receive_line(FILE *fh, char *buffer, int buffer_size) {
@@ -316,11 +316,11 @@ static int tss2_receive_line(FILE *fh, char *buffer, int buffer_size) {
     ERROR("teamspeak2 plugin: fgets failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     tss2_close_socket();
-    return (-1);
+    return -1;
   }
 
   buffer[buffer_size - 1] = 0;
-  return (0);
+  return 0;
 } /* int tss2_receive_line */
 
 static int tss2_select_vserver(FILE *read_fh, FILE *write_fh,
@@ -338,26 +338,26 @@ static int tss2_select_vserver(FILE *read_fh, FILE *write_fh,
   status = tss2_send_request(write_fh, command);
   if (status != 0) {
     ERROR("teamspeak2 plugin: tss2_send_request (%s) failed.", command);
-    return (-1);
+    return -1;
   }
 
   /* Get answer */
   status = tss2_receive_line(read_fh, response, sizeof(response));
   if (status != 0) {
     ERROR("teamspeak2 plugin: tss2_receive_line failed.");
-    return (-1);
+    return -1;
   }
   response[sizeof(response) - 1] = 0;
 
   /* Check answer */
   if ((strncasecmp("OK", response, 2) == 0) &&
       ((response[2] == 0) || (response[2] == '\n') || (response[2] == '\r')))
-    return (0);
+    return 0;
 
   ERROR("teamspeak2 plugin: Command ``%s'' failed. "
         "Response received from server was: ``%s''.",
         command, response);
-  return (-1);
+  return -1;
 } /* int tss2_select_vserver */
 
 static int tss2_vserver_gapl(FILE *read_fh, FILE *write_fh,
@@ -373,7 +373,7 @@ static int tss2_vserver_gapl(FILE *read_fh, FILE *write_fh,
   status = tss2_send_request(write_fh, "gapl\r\n");
   if (status != 0) {
     ERROR("teamspeak2 plugin: tss2_send_request (gapl) failed.");
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -387,7 +387,7 @@ static int tss2_vserver_gapl(FILE *read_fh, FILE *write_fh,
       read_fh = NULL;
       write_fh = NULL;
       ERROR("teamspeak2 plugin: tss2_receive_line failed.");
-      return (-1);
+      return -1;
     }
     buffer[sizeof(buffer) - 1] = 0;
 
@@ -418,7 +418,7 @@ static int tss2_vserver_gapl(FILE *read_fh, FILE *write_fh,
       break;
     } else if (strncasecmp("ERROR", buffer, 5) == 0) {
       ERROR("teamspeak2 plugin: Server returned an error: %s", buffer);
-      return (-1);
+      return -1;
     } else {
       WARNING("teamspeak2 plugin: Server returned unexpected string: %s",
               buffer);
@@ -426,7 +426,7 @@ static int tss2_vserver_gapl(FILE *read_fh, FILE *write_fh,
   }
 
   *ret_value = packet_loss;
-  return (0);
+  return 0;
 } /* int tss2_vserver_gapl */
 
 static int tss2_read_vserver(vserver_list_t *vserver) {
@@ -455,7 +455,7 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
   status = tss2_get_socket(&read_fh, &write_fh);
   if (status != 0) {
     ERROR("teamspeak2 plugin: tss2_get_socket failed.");
-    return (-1);
+    return -1;
   }
 
   if (vserver == NULL) {
@@ -469,14 +469,14 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
     /* Select the server */
     status = tss2_select_vserver(read_fh, write_fh, vserver);
     if (status != 0)
-      return (status);
+      return status;
 
     status = tss2_send_request(write_fh, "si\r\n");
   }
 
   if (status != 0) {
     ERROR("teamspeak2 plugin: tss2_send_request failed.");
-    return (-1);
+    return -1;
   }
 
   /* Loop until break */
@@ -616,8 +616,8 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
     tss2_submit_gauge(plugin_instance, "gauge", "servers", servers);
 
   if (valid == 0)
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* int tss2_read_vserver */
 
 static int tss2_config(const char *key, const char *value) {
@@ -630,7 +630,7 @@ static int tss2_config(const char *key, const char *value) {
     temp = strdup(value);
     if (temp == NULL) {
       ERROR("teamspeak2 plugin: strdup failed.");
-      return (1);
+      return 1;
     }
     sfree(config_host);
     config_host = temp;
@@ -640,7 +640,7 @@ static int tss2_config(const char *key, const char *value) {
     temp = strdup(value);
     if (temp == NULL) {
       ERROR("teamspeak2 plugin: strdup failed.");
-      return (1);
+      return 1;
     }
     sfree(config_port);
     config_port = temp;
@@ -650,10 +650,10 @@ static int tss2_config(const char *key, const char *value) {
 
     status = tss2_add_vserver(atoi(value));
     if (status != 0)
-      return (1);
+      return 1;
   } else {
     /* Unknown variable found */
-    return (-1);
+    return -1;
   }
 
   return 0;
@@ -690,8 +690,8 @@ static int tss2_read(void) {
   }
 
   if (success == 0)
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* int tss2_read */
 
 static int tss2_shutdown(void) {
@@ -716,7 +716,7 @@ static int tss2_shutdown(void) {
   sfree(config_host);
   sfree(config_port);
 
-  return (0);
+  return 0;
 } /* int tss2_shutdown */
 
 void module_register(void) {

--- a/src/ted.c
+++ b/src/ted.c
@@ -89,7 +89,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
   status = write(fd, pkt_request, sizeof(pkt_request));
   if (status <= 0) {
     ERROR("ted plugin: swrite failed.");
-    return (-1);
+    return -1;
   }
 
   /* Loop until we find the end of the package */
@@ -104,7 +104,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
     {
       WARNING("ted plugin: Timeout while waiting for file descriptor "
               "to become ready.");
-      return (-1);
+      return -1;
     } else if ((status < 0) && ((errno == EAGAIN) || (errno == EINTR))) {
       /* Some signal or something. Start over.. */
       continue;
@@ -112,7 +112,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
       char errbuf[1024];
       ERROR("ted plugin: select failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     }
 
     receive_buffer_length = read(fd, receive_buffer, sizeof(receive_buffer));
@@ -122,15 +122,15 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
         continue;
       ERROR("ted plugin: read(2) failed: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
-      return (-1);
+      return -1;
     } else if (receive_buffer_length == 0) {
       /* Should we close the FD in this case? */
       WARNING("ted plugin: Received EOF from file descriptor.");
-      return (-1);
+      return -1;
     } else if (((size_t)receive_buffer_length) > sizeof(receive_buffer)) {
       ERROR("ted plugin: read(2) returned invalid value %zi.",
             receive_buffer_length);
-      return (-1);
+      return -1;
     }
 
     /*
@@ -175,7 +175,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
 
   /* Check for errors inside the loop. */
   if ((end_flag == 0) || (package_buffer_pos != EXPECTED_PACKAGE_LENGTH))
-    return (-1);
+    return -1;
 
   /*
    * Power is at positions 247 and 248 (LSB first) in [10kW].
@@ -190,7 +190,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
                                 ((int)package_buffer[251]));
 
   /* success */
-  return (0);
+  return 0;
 } /* int ted_read_value */
 
 static int ted_open_device(void) {
@@ -198,7 +198,7 @@ static int ted_open_device(void) {
   struct termios options;
 
   if (fd >= 0)
-    return (0);
+    return 0;
 
   dev = DEFAULT_DEVICE;
   if (conf_device != NULL)
@@ -207,7 +207,7 @@ static int ted_open_device(void) {
   fd = open(dev, O_RDWR | O_NOCTTY | O_NDELAY | O_NONBLOCK);
   if (fd < 0) {
     ERROR("ted plugin: Unable to open device %s.", dev);
-    return (-1);
+    return -1;
   }
 
   /* Get the current options for the port... */
@@ -224,7 +224,7 @@ static int ted_open_device(void) {
   tcsetattr(fd, TCSANOW, &options);
 
   INFO("ted plugin: Successfully opened %s.", dev);
-  return (0);
+  return 0;
 } /* int ted_open_device */
 
 static void ted_submit(const char *type, double value) {
@@ -248,15 +248,15 @@ static int ted_config(const char *key, const char *value) {
     tmp = atoi(value);
     if (tmp < 0) {
       WARNING("ted plugin: Invalid retry count: %i", tmp);
-      return (1);
+      return 1;
     }
     conf_retries = tmp;
   } else {
     ERROR("ted plugin: Unknown config option: %s", key);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int ted_config */
 
 static int ted_read(void) {
@@ -266,7 +266,7 @@ static int ted_read(void) {
 
   status = ted_open_device();
   if (status != 0)
-    return (-1);
+    return -1;
 
   power = NAN;
   voltage = NAN;
@@ -277,12 +277,12 @@ static int ted_read(void) {
   }
 
   if (status != 0)
-    return (-1);
+    return -1;
 
   ted_submit("power", power);
   ted_submit("voltage", voltage);
 
-  return (0);
+  return 0;
 } /* int ted_read */
 
 static int ted_shutdown(void) {
@@ -291,7 +291,7 @@ static int ted_shutdown(void) {
     fd = -1;
   }
 
-  return (0);
+  return 0;
 } /* int ted_shutdown */
 
 void module_register(void) {

--- a/src/testing.h
+++ b/src/testing.h
@@ -71,7 +71,7 @@ static int check_count__ = 0;
     if (strcmp(expect, got__) != 0) {                                          \
       printf("not ok %i - %s = \"%s\", want \"%s\"\n", ++check_count__,        \
              #actual, got__, expect);                                          \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
     printf("ok %i - %s = \"%s\"\n", ++check_count__, #actual, got__);          \
   } while (0)
@@ -83,7 +83,7 @@ static int check_count__ = 0;
     if (got__ != want__) {                                                     \
       printf("not ok %i - %s = %d, want %d\n", ++check_count__, #actual,       \
              got__, want__);                                                   \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
     printf("ok %i - %s = %d\n", ++check_count__, #actual, got__);              \
   } while (0)
@@ -95,7 +95,7 @@ static int check_count__ = 0;
     if (got__ != want__) {                                                     \
       printf("not ok %i - %s = %" PRIu64 ", want %" PRIu64 "\n",               \
              ++check_count__, #actual, got__, want__);                         \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
     printf("ok %i - %s = %" PRIu64 "\n", ++check_count__, #actual, got__);     \
   } while (0)
@@ -107,12 +107,12 @@ static int check_count__ = 0;
     if (isnan(want__) && !isnan(got__)) {                                      \
       printf("not ok %i - %s = %.15g, want %.15g\n", ++check_count__, #actual, \
              got__, want__);                                                   \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else if (!isnan(want__) && (((want__ - got__) < -DBL_PRECISION) ||       \
                                   ((want__ - got__) > DBL_PRECISION))) {       \
       printf("not ok %i - %s = %.15g, want %.15g\n", ++check_count__, #actual, \
              got__, want__);                                                   \
-      return (-1);                                                             \
+      return -1;                                                               \
     }                                                                          \
     printf("ok %i - %s = %.15g\n", ++check_count__, #actual, got__);           \
   } while (0)

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -78,7 +78,7 @@ static int thermal_sysfs_device_read(const char __attribute__((unused)) * dir,
     success = 1;
   }
 
-  return (success ? 0 : -1);
+  return success ? 0 : -1;
 }
 
 static int thermal_procfs_device_read(const char __attribute__((unused)) * dir,
@@ -168,13 +168,11 @@ static int thermal_config(const char *key, const char *value) {
 }
 
 static int thermal_sysfs_read(void) {
-  return walk_directory(dirname_sysfs, thermal_sysfs_device_read,
-                        /* user_data = */ NULL, /* include hidden */ 0);
+  return walk_directory(dirname_sysfs, thermal_sysfs_device_read, NULL, 0);
 }
 
 static int thermal_procfs_read(void) {
-  return walk_directory(dirname_procfs, thermal_procfs_device_read,
-                        /* user_data = */ NULL, /* include hidden */ 0);
+  return walk_directory(dirname_procfs, thermal_procfs_device_read, NULL, 0);
 }
 
 static int thermal_init(void) {

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -55,20 +55,20 @@ static int ut_threshold_add(const threshold_t *th) { /* {{{ */
   if (format_name(name, sizeof(name), th->host, th->plugin, th->plugin_instance,
                   th->type, th->type_instance) != 0) {
     ERROR("ut_threshold_add: format_name failed.");
-    return (-1);
+    return -1;
   }
 
   name_copy = strdup(name);
   if (name_copy == NULL) {
     ERROR("ut_threshold_add: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   th_copy = malloc(sizeof(*th_copy));
   if (th_copy == NULL) {
     sfree(name_copy);
     ERROR("ut_threshold_add: malloc failed.");
-    return (-1);
+    return -1;
   }
   memcpy(th_copy, th, sizeof(threshold_t));
 
@@ -100,7 +100,7 @@ static int ut_threshold_add(const threshold_t *th) { /* {{{ */
     sfree(th_copy);
   }
 
-  return (status);
+  return status;
 } /* }}} int ut_threshold_add */
 
 /*
@@ -113,26 +113,26 @@ static int ut_config_type_datasource(threshold_t *th, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `DataSource' option needs exactly one "
             "string argument.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(th->data_source, ci->values[0].value.string,
            sizeof(th->data_source));
 
-  return (0);
+  return 0;
 } /* int ut_config_type_datasource */
 
 static int ut_config_type_instance(threshold_t *th, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `Instance' option needs exactly one "
             "string argument.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(th->type_instance, ci->values[0].value.string,
            sizeof(th->type_instance));
 
-  return (0);
+  return 0;
 } /* int ut_config_type_instance */
 
 static int ut_config_type_max(threshold_t *th, oconfig_item_t *ci) {
@@ -140,7 +140,7 @@ static int ut_config_type_max(threshold_t *th, oconfig_item_t *ci) {
     WARNING("threshold values: The `%s' option needs exactly one "
             "number argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp(ci->key, "WarningMax") == 0)
@@ -148,7 +148,7 @@ static int ut_config_type_max(threshold_t *th, oconfig_item_t *ci) {
   else
     th->failure_max = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* int ut_config_type_max */
 
 static int ut_config_type_min(threshold_t *th, oconfig_item_t *ci) {
@@ -156,7 +156,7 @@ static int ut_config_type_min(threshold_t *th, oconfig_item_t *ci) {
     WARNING("threshold values: The `%s' option needs exactly one "
             "number argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   if (strcasecmp(ci->key, "WarningMin") == 0)
@@ -164,7 +164,7 @@ static int ut_config_type_min(threshold_t *th, oconfig_item_t *ci) {
   else
     th->failure_min = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* int ut_config_type_min */
 
 static int ut_config_type_hits(threshold_t *th, oconfig_item_t *ci) {
@@ -172,12 +172,12 @@ static int ut_config_type_hits(threshold_t *th, oconfig_item_t *ci) {
     WARNING("threshold values: The `%s' option needs exactly one "
             "number argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   th->hits = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* int ut_config_type_hits */
 
 static int ut_config_type_hysteresis(threshold_t *th, oconfig_item_t *ci) {
@@ -185,12 +185,12 @@ static int ut_config_type_hysteresis(threshold_t *th, oconfig_item_t *ci) {
     WARNING("threshold values: The `%s' option needs exactly one "
             "number argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   th->hysteresis = ci->values[0].value.number;
 
-  return (0);
+  return 0;
 } /* int ut_config_type_hysteresis */
 
 static int ut_config_type(const threshold_t *th_orig, oconfig_item_t *ci) {
@@ -200,12 +200,12 @@ static int ut_config_type(const threshold_t *th_orig, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `Type' block needs exactly one string "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->children_num < 1) {
     WARNING("threshold values: The `Type' block needs at least one option.");
-    return (-1);
+    return -1;
   }
 
   memcpy(&th, th_orig, sizeof(th));
@@ -261,20 +261,20 @@ static int ut_config_type(const threshold_t *th_orig, oconfig_item_t *ci) {
     status = ut_threshold_add(&th);
   }
 
-  return (status);
+  return status;
 } /* int ut_config_type */
 
 static int ut_config_plugin_instance(threshold_t *th, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `Instance' option needs exactly one "
             "string argument.");
-    return (-1);
+    return -1;
   }
 
   sstrncpy(th->plugin_instance, ci->values[0].value.string,
            sizeof(th->plugin_instance));
 
-  return (0);
+  return 0;
 } /* int ut_config_plugin_instance */
 
 static int ut_config_plugin(const threshold_t *th_orig, oconfig_item_t *ci) {
@@ -284,13 +284,13 @@ static int ut_config_plugin(const threshold_t *th_orig, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `Plugin' block needs exactly one string "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->children_num < 1) {
     WARNING("threshold values: The `Plugin' block needs at least one nested "
             "block.");
-    return (-1);
+    return -1;
   }
 
   memcpy(&th, th_orig, sizeof(th));
@@ -314,7 +314,7 @@ static int ut_config_plugin(const threshold_t *th_orig, oconfig_item_t *ci) {
       break;
   }
 
-  return (status);
+  return status;
 } /* int ut_config_plugin */
 
 static int ut_config_host(const threshold_t *th_orig, oconfig_item_t *ci) {
@@ -324,13 +324,13 @@ static int ut_config_host(const threshold_t *th_orig, oconfig_item_t *ci) {
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("threshold values: The `Host' block needs exactly one string "
             "argument.");
-    return (-1);
+    return -1;
   }
 
   if (ci->children_num < 1) {
     WARNING("threshold values: The `Host' block needs at least one nested "
             "block.");
-    return (-1);
+    return -1;
   }
 
   memcpy(&th, th_orig, sizeof(th));
@@ -354,7 +354,7 @@ static int ut_config_host(const threshold_t *th_orig, oconfig_item_t *ci) {
       break;
   }
 
-  return (status);
+  return status;
 } /* int ut_config_host */
   /*
    * End of the functions used to configure threshold values.
@@ -392,7 +392,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
       DEBUG("ut_report_state: th->hits = %d, uc_get_hits = %d", th->hits,
             uc_get_hits(ds, vl));
       (void)uc_inc_hits(ds, vl, 1); /* increase hit counter */
-      return (0);
+      return 0;
     }
   } /* end check hits */
 
@@ -402,9 +402,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
    * state is `okay', then only report if `persist_ok` flag is set. */
   if (state == state_old) {
     if ((th->flags & UT_FLAG_PERSIST) == 0)
-      return (0);
+      return 0;
     else if ((state == STATE_OKAY) && ((th->flags & UT_FLAG_PERSIST_OK) == 0))
-      return (0);
+      return 0;
   }
 
   if (state != state_old)
@@ -522,7 +522,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
   plugin_dispatch_notification(&n);
 
   plugin_notification_meta_free(n.meta);
-  return (0);
+  return 0;
 } /* }}} int ut_report_state */
 
 /*
@@ -547,7 +547,7 @@ static int ut_check_one_data_source(
   if (ds != NULL) {
     ds_name = ds->ds[ds_index].name;
     if ((th->data_source[0] != 0) && (strcmp(ds_name, th->data_source) != 0))
-      return (STATE_OKAY);
+      return STATE_OKAY;
   }
 
   if ((th->flags & UT_FLAG_INVERT) != 0) {
@@ -604,12 +604,12 @@ static int ut_check_one_data_source(
   }
 
   if (is_failure != 0)
-    return (STATE_ERROR);
+    return STATE_ERROR;
 
   if (is_warning != 0)
-    return (STATE_WARNING);
+    return STATE_WARNING;
 
-  return (STATE_OKAY);
+  return STATE_OKAY;
 } /* }}} int ut_check_one_data_source */
 
 /*
@@ -674,7 +674,7 @@ static int ut_check_one_threshold(const data_set_t *ds, const value_list_t *vl,
   if (ret_ds_index != NULL)
     *ret_ds_index = ds_index;
 
-  return (ret);
+  return ret;
 } /* }}} int ut_check_one_threshold */
 
 /*
@@ -698,7 +698,7 @@ static int ut_check_threshold(const data_set_t *ds, const value_list_t *vl,
   int worst_ds_index = -1;
 
   if (threshold_tree == NULL)
-    return (0);
+    return 0;
 
   /* Is this lock really necessary? So far, thresholds are only inserted at
    * startup. -octo */
@@ -706,13 +706,13 @@ static int ut_check_threshold(const data_set_t *ds, const value_list_t *vl,
   th = threshold_search(vl);
   pthread_mutex_unlock(&threshold_lock);
   if (th == NULL)
-    return (0);
+    return 0;
 
   DEBUG("ut_check_threshold: Found matching threshold(s)");
 
   values = uc_get_rate(ds, vl);
   if (values == NULL)
-    return (0);
+    return 0;
 
   while (th != NULL) {
     int ds_index = -1;
@@ -721,7 +721,7 @@ static int ut_check_threshold(const data_set_t *ds, const value_list_t *vl,
     if (status < 0) {
       ERROR("ut_check_threshold: ut_check_one_threshold failed.");
       sfree(values);
-      return (-1);
+      return -1;
     }
 
     if (worst_state < status) {
@@ -738,12 +738,12 @@ static int ut_check_threshold(const data_set_t *ds, const value_list_t *vl,
   if (status != 0) {
     ERROR("ut_check_threshold: ut_report_state failed.");
     sfree(values);
-    return (-1);
+    return -1;
   }
 
   sfree(values);
 
-  return (0);
+  return 0;
 } /* }}} int ut_check_threshold */
 
 /*
@@ -760,12 +760,12 @@ static int ut_missing(const value_list_t *vl,
   cdtime_t now;
 
   if (threshold_tree == NULL)
-    return (0);
+    return 0;
 
   th = threshold_search(vl);
   /* dispatch notifications for "interesting" values only */
   if ((th == NULL) || ((th->flags & UT_FLAG_INTERESTING) == 0))
-    return (0);
+    return 0;
 
   now = cdtime();
   missing_time = now - vl->time;
@@ -779,7 +779,7 @@ static int ut_missing(const value_list_t *vl,
 
   plugin_dispatch_notification(&n);
 
-  return (0);
+  return 0;
 } /* }}} int ut_missing */
 
 static int ut_config(oconfig_item_t *ci) { /* {{{ */
@@ -790,7 +790,7 @@ static int ut_config(oconfig_item_t *ci) { /* {{{ */
     threshold_tree = c_avl_create((int (*)(const void *, const void *))strcmp);
     if (threshold_tree == NULL) {
       ERROR("ut_config: c_avl_create failed.");
-      return (-1);
+      return -1;
     }
   }
 
@@ -828,7 +828,7 @@ static int ut_config(oconfig_item_t *ci) { /* {{{ */
                           /* user data = */ NULL);
   }
 
-  return (status);
+  return status;
 } /* }}} int um_config */
 
 void module_register(void) {

--- a/src/tokyotyrant.c
+++ b/src/tokyotyrant.c
@@ -45,7 +45,7 @@ static int tt_config(const char *key, const char *value) {
     temp = strdup(value);
     if (temp == NULL) {
       ERROR("tokyotyrant plugin: Host strdup failed.");
-      return (1);
+      return 1;
     }
     sfree(config_host);
     config_host = temp;
@@ -55,16 +55,16 @@ static int tt_config(const char *key, const char *value) {
     temp = strdup(value);
     if (temp == NULL) {
       ERROR("tokyotyrant plugin: Port strdup failed.");
-      return (1);
+      return 1;
     }
     sfree(config_port);
     config_port = temp;
   } else {
     ERROR("tokyotyrant plugin: error: unrecognized configuration key %s", key);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 }
 
 static void printerr(void) {
@@ -116,7 +116,7 @@ static int tt_read(void) {
 
   tt_open_db();
   if (rdb == NULL)
-    return (-1);
+    return -1;
 
   rnum = tcrdbrnum(rdb);
   tt_submit(rnum, "records");
@@ -124,7 +124,7 @@ static int tt_read(void) {
   size = tcrdbsize(rdb);
   tt_submit(size, "file_size");
 
-  return (0);
+  return 0;
 }
 
 static int tt_shutdown(void) {
@@ -135,13 +135,13 @@ static int tt_shutdown(void) {
     if (!tcrdbclose(rdb)) {
       printerr();
       tcrdbdel(rdb);
-      return (1);
+      return 1;
     }
     tcrdbdel(rdb);
     rdb = NULL;
   }
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1118,7 +1118,7 @@ for_all_proc_cpus(int(func)(unsigned int)) {
     retval = func(cpu_num);
     if (retval) {
       fclose(fp);
-      return (retval);
+      return retval;
     }
   }
   fclose(fp);

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -78,7 +78,7 @@ static int us_open_socket(void) {
     char errbuf[1024];
     ERROR("unixsock plugin: socket failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   sa.sun_family = AF_UNIX;
@@ -107,7 +107,7 @@ static int us_open_socket(void) {
     ERROR("unixsock plugin: bind failed: %s", errbuf);
     close(sock_fd);
     sock_fd = -1;
-    return (-1);
+    return -1;
   }
 
   status = chmod(sa.sun_path, sock_perms);
@@ -117,7 +117,7 @@ static int us_open_socket(void) {
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(sock_fd);
     sock_fd = -1;
-    return (-1);
+    return -1;
   }
 
   status = listen(sock_fd, 8);
@@ -127,7 +127,7 @@ static int us_open_socket(void) {
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(sock_fd);
     sock_fd = -1;
-    return (-1);
+    return -1;
   }
 
   do {
@@ -160,7 +160,7 @@ static int us_open_socket(void) {
     }
   } while (0);
 
-  return (0);
+  return 0;
 } /* int us_open_socket */
 
 static void *us_handle_client(void *arg) {
@@ -191,7 +191,7 @@ static void *us_handle_client(void *arg) {
     close(fdin);
     close(fdout);
     pthread_exit((void *)1);
-    return ((void *)1);
+    return (void *)1;
   }
 
   fhout = fdopen(fdout, "w");
@@ -202,7 +202,7 @@ static void *us_handle_client(void *arg) {
     fclose(fhin); /* this closes fdin as well */
     close(fdout);
     pthread_exit((void *)1);
-    return ((void *)1);
+    return (void *)1;
   }
 
   /* change output buffer to line buffered mode */
@@ -213,7 +213,7 @@ static void *us_handle_client(void *arg) {
     fclose(fhin);
     fclose(fhout);
     pthread_exit((void *)1);
-    return ((void *)0);
+    return (void *)0;
   }
 
   while (42) {
@@ -253,7 +253,7 @@ static void *us_handle_client(void *arg) {
       fclose(fhin);
       fclose(fhout);
       pthread_exit((void *)1);
-      return ((void *)1);
+      return (void *)1;
     }
 
     if (strcasecmp(fields[0], "getval") == 0) {
@@ -283,7 +283,7 @@ static void *us_handle_client(void *arg) {
   fclose(fhout);
 
   pthread_exit((void *)0);
-  return ((void *)0);
+  return (void *)0;
 } /* void *us_handle_client */
 
 static void *us_server_thread(void __attribute__((unused)) * arg) {
@@ -351,21 +351,21 @@ static void *us_server_thread(void __attribute__((unused)) * arg) {
            sstrerror(errno, errbuf, sizeof(errbuf)));
   }
 
-  return ((void *)0);
+  return (void *)0;
 } /* void *us_server_thread */
 
 static int us_config(const char *key, const char *val) {
   if (strcasecmp(key, "SocketFile") == 0) {
     char *new_sock_file = strdup(val);
     if (new_sock_file == NULL)
-      return (1);
+      return 1;
 
     sfree(sock_file);
     sock_file = new_sock_file;
   } else if (strcasecmp(key, "SocketGroup") == 0) {
     char *new_sock_group = strdup(val);
     if (new_sock_group == NULL)
-      return (1);
+      return 1;
 
     sfree(sock_group);
     sock_group = new_sock_group;
@@ -377,10 +377,10 @@ static int us_config(const char *key, const char *val) {
     else
       delete_socket = 0;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int us_config */
 
 static int us_init(void) {
@@ -390,7 +390,7 @@ static int us_init(void) {
 
   /* Initialize only once. */
   if (have_init != 0)
-    return (0);
+    return 0;
   have_init = 1;
 
   loop = 1;
@@ -401,10 +401,10 @@ static int us_init(void) {
     char errbuf[1024];
     ERROR("unixsock plugin: pthread_create failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int us_init */
 
 static int us_shutdown(void) {
@@ -421,7 +421,7 @@ static int us_shutdown(void) {
   plugin_unregister_init("unixsock");
   plugin_unregister_shutdown("unixsock");
 
-  return (0);
+  return 0;
 } /* int us_shutdown */
 
 void module_register(void) {

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -99,7 +99,7 @@ static int uptime_init(void) /* {{{ */
     char errbuf[1024];
     ERROR("uptime plugin: Cannot open " STAT_FILE ": %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, 1024, fh) != NULL) {
@@ -116,7 +116,7 @@ static int uptime_init(void) /* {{{ */
   /* loop done, check if no value has been found/read */
   if (ret != 1) {
     ERROR("uptime plugin: No value read from " STAT_FILE "");
-    return (-1);
+    return -1;
   }
 
   boottime = (time_t)starttime;
@@ -124,7 +124,7 @@ static int uptime_init(void) /* {{{ */
   if (boottime == 0) {
     ERROR("uptime plugin: btime read from " STAT_FILE ", "
           "but `boottime' is zero!");
-    return (-1);
+    return -1;
   }
 /* #endif KERNEL_LINUX */
 
@@ -139,24 +139,24 @@ static int uptime_init(void) /* {{{ */
    * went fine. */
   if (kc == NULL) {
     ERROR("uptime plugin: kstat chain control structure not available.");
-    return (-1);
+    return -1;
   }
 
   ksp = kstat_lookup(kc, "unix", 0, "system_misc");
   if (ksp == NULL) {
     ERROR("uptime plugin: Cannot find unix:0:system_misc kstat.");
-    return (-1);
+    return -1;
   }
 
   if (kstat_read(kc, ksp, NULL) < 0) {
     ERROR("uptime plugin: kstat_read failed.");
-    return (-1);
+    return -1;
   }
 
   knp = (kstat_named_t *)kstat_data_lookup(ksp, "boot_time");
   if (knp == NULL) {
     ERROR("uptime plugin: kstat_data_lookup (boot_time) failed.");
-    return (-1);
+    return -1;
   }
 
   boottime = (time_t)knp->value.ui32;
@@ -164,7 +164,7 @@ static int uptime_init(void) /* {{{ */
   if (boottime == 0) {
     ERROR("uptime plugin: kstat_data_lookup returned success, "
           "but `boottime' is zero!");
-    return (-1);
+    return -1;
   }
 /* #endif HAVE_LIBKSTAT */
 
@@ -183,7 +183,7 @@ static int uptime_init(void) /* {{{ */
     char errbuf[1024];
     ERROR("uptime plugin: No value read from sysctl interface: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   boottime = boottv.tv_sec;
@@ -191,7 +191,7 @@ static int uptime_init(void) /* {{{ */
   if (boottime == 0) {
     ERROR("uptime plugin: sysctl(3) returned success, "
           "but `boottime' is zero!");
-    return (-1);
+    return -1;
   }
 /* #endif HAVE_SYS_SYSCTL_H */
 
@@ -205,7 +205,7 @@ static int uptime_init(void) /* {{{ */
     char errbuf[1024];
     ERROR("uptime plugin: perfstat_cpu_total: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   hertz = sysconf(_SC_CLK_TCK);
@@ -215,7 +215,7 @@ static int uptime_init(void) /* {{{ */
   boottime = time(NULL) - cputotal.lbolt / hertz;
 #endif /* HAVE_PERFSTAT */
 
-  return (0);
+  return 0;
 } /* }}} int uptime_init */
 
 static int uptime_read(void) {
@@ -229,7 +229,7 @@ static int uptime_read(void) {
 
   uptime_submit(uptime);
 
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/users.c
+++ b/src/users.c
@@ -101,7 +101,7 @@ static int users_read(void) {
   us = sg_get_user_stats();
 #endif
   if (us == NULL)
-    return (-1);
+    return -1;
 
   users_submit((gauge_t)
 #if HAVE_LIBSTATGRAB_0_90
@@ -115,7 +115,7 @@ static int users_read(void) {
 #error "No applicable input method."
 #endif
 
-  return (0);
+  return 0;
 } /* int users_read */
 
 void module_register(void) {

--- a/src/utils_cmd_flush.c
+++ b/src/utils_cmd_flush.c
@@ -39,7 +39,7 @@ cmd_status_t cmd_parse_flush(size_t argc, char **argv, cmd_flush_t *ret_flush,
   if ((ret_flush == NULL) || (opts == NULL)) {
     errno = EINVAL;
     cmd_error(CMD_ERROR, err, "Invalid arguments to cmd_parse_flush.");
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   for (size_t i = 0; i < argc; i++) {
@@ -54,7 +54,7 @@ cmd_status_t cmd_parse_flush(size_t argc, char **argv, cmd_flush_t *ret_flush,
       if (status == CMD_NO_OPTION)
         cmd_error(CMD_PARSE_ERROR, err, "Invalid option string `%s'.", argv[i]);
       cmd_destroy_flush(ret_flush);
-      return (CMD_PARSE_ERROR);
+      return CMD_PARSE_ERROR;
     }
 
     if (strcasecmp("plugin", opt_key) == 0) {
@@ -66,7 +66,7 @@ cmd_status_t cmd_parse_flush(size_t argc, char **argv, cmd_flush_t *ret_flush,
       if (id == NULL) {
         cmd_error(CMD_ERROR, err, "realloc failed.");
         cmd_destroy_flush(ret_flush);
-        return (CMD_ERROR);
+        return CMD_ERROR;
       }
 
       ret_flush->identifiers = id;
@@ -77,7 +77,7 @@ cmd_status_t cmd_parse_flush(size_t argc, char **argv, cmd_flush_t *ret_flush,
                            opts->identifier_default_host) != 0) {
         cmd_error(CMD_PARSE_ERROR, err, "Invalid identifier `%s'.", opt_value);
         cmd_destroy_flush(ret_flush);
-        return (CMD_PARSE_ERROR);
+        return CMD_PARSE_ERROR;
       }
     } else if (strcasecmp("timeout", opt_key) == 0) {
       char *endptr;
@@ -91,18 +91,18 @@ cmd_status_t cmd_parse_flush(size_t argc, char **argv, cmd_flush_t *ret_flush,
         cmd_error(CMD_PARSE_ERROR, err,
                   "Invalid value for option `timeout': %s", opt_value);
         cmd_destroy_flush(ret_flush);
-        return (CMD_PARSE_ERROR);
+        return CMD_PARSE_ERROR;
       } else if (ret_flush->timeout < 0.0) {
         ret_flush->timeout = 0.0;
       }
     } else {
       cmd_error(CMD_PARSE_ERROR, err, "Cannot parse option `%s'.", opt_key);
       cmd_destroy_flush(ret_flush);
-      return (CMD_PARSE_ERROR);
+      return CMD_PARSE_ERROR;
     }
   }
 
-  return (CMD_OK);
+  return CMD_OK;
 } /* cmd_status_t cmd_parse_flush */
 
 cmd_status_t cmd_handle_flush(FILE *fh, char *buffer) {
@@ -114,18 +114,18 @@ cmd_status_t cmd_handle_flush(FILE *fh, char *buffer) {
   int status;
 
   if ((fh == NULL) || (buffer == NULL))
-    return (-1);
+    return -1;
 
   DEBUG("utils_cmd_flush: cmd_handle_flush (fh = %p, buffer = %s);", (void *)fh,
         buffer);
 
   if ((status = cmd_parse(buffer, &cmd, NULL, &err)) != CMD_OK)
-    return (status);
+    return status;
   if (cmd.type != CMD_FLUSH) {
     cmd_error(CMD_UNKNOWN_COMMAND, &err, "Unexpected command: `%s'.",
               CMD_TO_STRING(cmd.type));
     cmd_destroy(&cmd);
-    return (CMD_UNKNOWN_COMMAND);
+    return CMD_UNKNOWN_COMMAND;
   }
 
   for (size_t i = 0; (i == 0) || (i < cmd.cmd.flush.plugins_num); i++) {
@@ -160,7 +160,7 @@ cmd_status_t cmd_handle_flush(FILE *fh, char *buffer) {
   cmd_error(CMD_OK, &err, "Done: %i successful, %i errors", success, error);
 
   cmd_destroy(&cmd);
-  return (0);
+  return 0;
 #undef PRINT_TO_SOCK
 } /* cmd_status_t cmd_handle_flush */
 

--- a/src/utils_cmd_getthreshold.c
+++ b/src/utils_cmd_getthreshold.c
@@ -59,7 +59,7 @@ int handle_getthreshold(FILE *fh, char *buffer) {
   size_t i;
 
   if ((fh == NULL) || (buffer == NULL))
-    return (-1);
+    return -1;
 
   DEBUG("utils_cmd_getthreshold: handle_getthreshold (fh = %p, buffer = %s);",
         (void *)fh, buffer);
@@ -68,26 +68,26 @@ int handle_getthreshold(FILE *fh, char *buffer) {
   status = parse_string(&buffer, &command);
   if (status != 0) {
     print_to_socket(fh, "-1 Cannot parse command.\n");
-    return (-1);
+    return -1;
   }
   assert(command != NULL);
 
   if (strcasecmp("GETTHRESHOLD", command) != 0) {
     print_to_socket(fh, "-1 Unexpected command: `%s'.\n", command);
-    return (-1);
+    return -1;
   }
 
   identifier = NULL;
   status = parse_string(&buffer, &identifier);
   if (status != 0) {
     print_to_socket(fh, "-1 Cannot parse identifier.\n");
-    return (-1);
+    return -1;
   }
   assert(identifier != NULL);
 
   if (*buffer != 0) {
     print_to_socket(fh, "-1 Garbage after end of command: %s\n", buffer);
-    return (-1);
+    return -1;
   }
 
   /* parse_identifier() modifies its first argument,
@@ -101,7 +101,7 @@ int handle_getthreshold(FILE *fh, char *buffer) {
     DEBUG("handle_getthreshold: Cannot parse identifier `%s'.", identifier);
     print_to_socket(fh, "-1 Cannot parse identifier `%s'.\n", identifier);
     sfree(identifier_copy);
-    return (-1);
+    return -1;
   }
 
   value_list_t vl = {.values = NULL};
@@ -118,10 +118,10 @@ int handle_getthreshold(FILE *fh, char *buffer) {
   if (status == ENOENT) {
     print_to_socket(fh, "-1 No threshold found for identifier %s\n",
                     identifier);
-    return (0);
+    return 0;
   } else if (status != 0) {
     print_to_socket(fh, "-1 Error while looking up threshold: %i\n", status);
-    return (-1);
+    return -1;
   }
 
   /* Lets count the number of lines we'll return. */
@@ -179,5 +179,5 @@ int handle_getthreshold(FILE *fh, char *buffer) {
   if (threshold.hits > 1)
     print_to_socket(fh, "Hits: %i\n", threshold.hits);
 
-  return (0);
+  return 0;
 } /* int handle_getthreshold */

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -43,7 +43,7 @@ cmd_status_t cmd_parse_getval(size_t argc, char **argv,
   if ((ret_getval == NULL) || (opts == NULL)) {
     errno = EINVAL;
     cmd_error(CMD_ERROR, err, "Invalid arguments to cmd_parse_getval.");
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   if (argc != 1) {
@@ -52,7 +52,7 @@ cmd_status_t cmd_parse_getval(size_t argc, char **argv,
     else
       cmd_error(CMD_PARSE_ERROR, err, "Garbage after identifier: `%s'.",
                 argv[1]);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   /* parse_identifier() modifies its first argument,
@@ -68,11 +68,11 @@ cmd_status_t cmd_parse_getval(size_t argc, char **argv,
     cmd_error(CMD_PARSE_ERROR, err, "Cannot parse identifier `%s'.",
               identifier_copy);
     sfree(identifier_copy);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   ret_getval->raw_identifier = identifier_copy;
-  return (CMD_OK);
+  return CMD_OK;
 } /* cmd_status_t cmd_parse_getval */
 
 #define print_to_socket(fh, ...)                                               \
@@ -97,18 +97,18 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
   const data_set_t *ds;
 
   if ((fh == NULL) || (buffer == NULL))
-    return (-1);
+    return -1;
 
   DEBUG("utils_cmd_getval: cmd_handle_getval (fh = %p, buffer = %s);",
         (void *)fh, buffer);
 
   if ((status = cmd_parse(buffer, &cmd, NULL, &err)) != CMD_OK)
-    return (status);
+    return status;
   if (cmd.type != CMD_GETVAL) {
     cmd_error(CMD_UNKNOWN_COMMAND, &err, "Unexpected command: `%s'.",
               CMD_TO_STRING(cmd.type));
     cmd_destroy(&cmd);
-    return (CMD_UNKNOWN_COMMAND);
+    return CMD_UNKNOWN_COMMAND;
   }
 
   ds = plugin_get_ds(cmd.cmd.getval.identifier.type);
@@ -118,7 +118,7 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
     cmd_error(CMD_ERROR, &err, "Type `%s' is unknown.\n",
               cmd.cmd.getval.identifier.type);
     cmd_destroy(&cmd);
-    return (-1);
+    return -1;
   }
 
   values = NULL;
@@ -128,7 +128,7 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
   if (status != 0) {
     cmd_error(CMD_ERROR, &err, "No such value.");
     cmd_destroy(&cmd);
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   if (ds->ds_num != values_num) {
@@ -138,7 +138,7 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
     cmd_error(CMD_ERROR, &err, "Error reading value from cache.");
     sfree(values);
     cmd_destroy(&cmd);
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   print_to_socket(fh, "%zu Value%s found\n", values_num,
@@ -155,7 +155,7 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
   sfree(values);
   cmd_destroy(&cmd);
 
-  return (CMD_OK);
+  return CMD_OK;
 } /* cmd_status_t cmd_handle_getval */
 
 void cmd_destroy_getval(cmd_getval_t *getval) {

--- a/src/utils_cmd_listval.c
+++ b/src/utils_cmd_listval.c
@@ -42,10 +42,10 @@ cmd_status_t cmd_parse_listval(size_t argc, char **argv,
   if (argc != 0) {
     cmd_error(CMD_PARSE_ERROR, err, "Garbage after end of command: `%s'.",
               argv[0]);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
-  return (CMD_OK);
+  return CMD_OK;
 } /* cmd_status_t cmd_parse_listval */
 
 #define free_everything_and_return(status)                                     \
@@ -56,7 +56,7 @@ cmd_status_t cmd_parse_listval(size_t argc, char **argv,
     }                                                                          \
     sfree(names);                                                              \
     sfree(times);                                                              \
-    return (status);                                                           \
+    return status;                                                             \
   } while (0)
 
 #define print_to_socket(fh, ...)                                               \
@@ -83,7 +83,7 @@ cmd_status_t cmd_handle_listval(FILE *fh, char *buffer) {
         buffer);
 
   if ((status = cmd_parse(buffer, &cmd, NULL, &err)) != CMD_OK)
-    return (status);
+    return status;
   if (cmd.type != CMD_LISTVAL) {
     cmd_error(CMD_UNKNOWN_COMMAND, &err, "Unexpected command: `%s'.",
               CMD_TO_STRING(cmd.type));

--- a/src/utils_cmd_putnotif.c
+++ b/src/utils_cmd_putnotif.c
@@ -51,9 +51,9 @@ static int set_option_severity(notification_t *n, const char *value) {
   else if (strcasecmp(value, "Okay") == 0)
     n->severity = NOTIF_OKAY;
   else
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 } /* int set_option_severity */
 
 static int set_option_time(notification_t *n, const char *value) {
@@ -66,17 +66,17 @@ static int set_option_time(notification_t *n, const char *value) {
       || (endptr == value) /* Invalid string */
       || (endptr == NULL)  /* This should not happen */
       || (*endptr != 0))   /* Trailing chars */
-    return (-1);
+    return -1;
 
   n->time = DOUBLE_TO_CDTIME_T(tmp);
 
-  return (0);
+  return 0;
 } /* int set_option_time */
 
 static int set_option(notification_t *n, const char *option,
                       const char *value) {
   if ((n == NULL) || (option == NULL) || (value == NULL))
-    return (-1);
+    return -1;
 
   DEBUG("utils_cmd_putnotif: set_option (option = %s, value = %s);", option,
         value);
@@ -85,18 +85,18 @@ static int set_option(notification_t *n, const char *option,
   if (option[0] != '\0' && option[1] == ':') {
     /* Refuse empty key */
     if (option[2] == '\0')
-      return (1);
+      return 1;
 
     if (option[0] == 's')
       return plugin_notification_meta_add_string(n, option + 2, value);
     else
-      return (1);
+      return 1;
   }
 
   if (strcasecmp("severity", option) == 0)
-    return (set_option_severity(n, value));
+    return set_option_severity(n, value);
   else if (strcasecmp("time", option) == 0)
-    return (set_option_time(n, value));
+    return set_option_time(n, value);
   else if (strcasecmp("message", option) == 0)
     sstrncpy(n->message, value, sizeof(n->message));
   else if (strcasecmp("host", option) == 0)
@@ -110,9 +110,9 @@ static int set_option(notification_t *n, const char *option,
   else if (strcasecmp("type_instance", option) == 0)
     sstrncpy(n->type_instance, value, sizeof(n->type_instance));
   else
-    return (1);
+    return 1;
 
-  return (0);
+  return 0;
 } /* int set_option */
 
 int handle_putnotif(FILE *fh, char *buffer) {
@@ -121,7 +121,7 @@ int handle_putnotif(FILE *fh, char *buffer) {
   int status;
 
   if ((fh == NULL) || (buffer == NULL))
-    return (-1);
+    return -1;
 
   DEBUG("utils_cmd_putnotif: handle_putnotif (fh = %p, buffer = %s);",
         (void *)fh, buffer);
@@ -130,13 +130,13 @@ int handle_putnotif(FILE *fh, char *buffer) {
   status = parse_string(&buffer, &command);
   if (status != 0) {
     print_to_socket(fh, "-1 Cannot parse command.\n");
-    return (-1);
+    return -1;
   }
   assert(command != NULL);
 
   if (strcasecmp("PUTNOTIF", command) != 0) {
     print_to_socket(fh, "-1 Unexpected command: `%s'.\n", command);
-    return (-1);
+    return -1;
   }
 
   status = 0;
@@ -178,5 +178,5 @@ int handle_putnotif(FILE *fh, char *buffer) {
     print_to_socket(fh, "0 Success\n");
   }
 
-  return (0);
+  return 0;
 } /* int handle_putnotif */

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -37,7 +37,7 @@
 
 static int set_option(value_list_t *vl, const char *key, const char *value) {
   if ((vl == NULL) || (key == NULL) || (value == NULL))
-    return (-1);
+    return -1;
 
   if (strcasecmp("interval", key) == 0) {
     double tmp;
@@ -50,9 +50,9 @@ static int set_option(value_list_t *vl, const char *key, const char *value) {
     if ((errno == 0) && (endptr != NULL) && (endptr != value) && (tmp > 0.0))
       vl->interval = DOUBLE_TO_CDTIME_T(tmp);
   } else
-    return (1);
+    return 1;
 
-  return (0);
+  return 0;
 } /* int set_option */
 
 /*
@@ -81,12 +81,12 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
   if ((ret_putval == NULL) || (opts == NULL)) {
     errno = EINVAL;
     cmd_error(CMD_ERROR, err, "Invalid arguments to cmd_parse_putval.");
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   if (argc < 2) {
     cmd_error(CMD_PARSE_ERROR, err, "Missing identifier and/or value-list.");
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   identifier = argv[0];
@@ -103,7 +103,7 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
     cmd_error(CMD_PARSE_ERROR, err, "Cannot parse identifier `%s'.",
               identifier_copy);
     sfree(identifier_copy);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   if ((strlen(hostname) >= sizeof(vl.host)) ||
@@ -114,7 +114,7 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
        (strlen(type_instance) >= sizeof(vl.type_instance)))) {
     cmd_error(CMD_PARSE_ERROR, err, "Identifier too long.");
     sfree(identifier_copy);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   sstrncpy(vl.host, hostname, sizeof(vl.host));
@@ -129,7 +129,7 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
   if (ds == NULL) {
     cmd_error(CMD_PARSE_ERROR, err, "1 Type `%s' isn't defined.", type);
     sfree(identifier_copy);
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
   hostname = NULL;
@@ -143,7 +143,7 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
     cmd_error(CMD_ERROR, err, "malloc failed.");
     cmd_destroy_putval(ret_putval);
     sfree(vl.values);
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
   /* All the remaining fields are part of the option list. */
@@ -210,7 +210,7 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
   if (result != CMD_OK)
     cmd_destroy_putval(ret_putval);
 
-  return (result);
+  return result;
 } /* cmd_status_t cmd_parse_putval */
 
 void cmd_destroy_putval(cmd_putval_t *putval) {
@@ -239,12 +239,12 @@ cmd_status_t cmd_handle_putval(FILE *fh, char *buffer) {
         (void *)fh, buffer);
 
   if ((status = cmd_parse(buffer, &cmd, NULL, &err)) != CMD_OK)
-    return (status);
+    return status;
   if (cmd.type != CMD_PUTVAL) {
     cmd_error(CMD_UNKNOWN_COMMAND, &err, "Unexpected command: `%s'.",
               CMD_TO_STRING(cmd.type));
     cmd_destroy(&cmd);
-    return (CMD_UNKNOWN_COMMAND);
+    return CMD_UNKNOWN_COMMAND;
   }
 
   for (size_t i = 0; i < cmd.cmd.putval.vl_num; ++i)
@@ -256,7 +256,7 @@ cmd_status_t cmd_handle_putval(FILE *fh, char *buffer) {
               (cmd.cmd.putval.vl_num == 1) ? "value has" : "values have");
 
   cmd_destroy(&cmd);
-  return (CMD_OK);
+  return CMD_OK;
 } /* int cmd_handle_putval */
 
 int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
@@ -267,13 +267,13 @@ int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
 
   status = FORMAT_VL(buffer_ident, sizeof(buffer_ident), vl);
   if (status != 0)
-    return (status);
+    return status;
   escape_string(buffer_ident, sizeof(buffer_ident));
 
   status = format_values(buffer_values, sizeof(buffer_values), ds, vl,
                          /* store rates = */ 0);
   if (status != 0)
-    return (status);
+    return status;
   escape_string(buffer_values, sizeof(buffer_values));
 
   ssnprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
@@ -281,5 +281,5 @@ int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
                                : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
             buffer_values);
 
-  return (0);
+  return 0;
 } /* }}} int cmd_create_putval */

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -72,7 +72,7 @@ static cmd_status_t cmd_split(char *buffer, size_t *ret_len, char ***ret_fields,
   fields = malloc((estimate + 1) * sizeof(*fields));
   if (fields == NULL) {
     cmd_error(CMD_ERROR, err, "malloc failed.");
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
 
 #define END_FIELD()                                                            \
@@ -130,7 +130,7 @@ static cmd_status_t cmd_split(char *buffer, size_t *ret_len, char ***ret_fields,
       if (string[1] == '\0') {
         free(fields);
         cmd_error(CMD_PARSE_ERROR, err, "Backslash at end of string.");
-        return (CMD_PARSE_ERROR);
+        return CMD_PARSE_ERROR;
       }
 
       /* un-escape the next character; skip backslash */
@@ -148,7 +148,7 @@ static cmd_status_t cmd_split(char *buffer, size_t *ret_len, char ***ret_fields,
   if (in_quotes) {
     free(fields);
     cmd_error(CMD_PARSE_ERROR, err, "Unterminated quoted string.");
-    return (CMD_PARSE_ERROR);
+    return CMD_PARSE_ERROR;
   }
 
 #undef NEW_FIELD
@@ -161,7 +161,7 @@ static cmd_status_t cmd_split(char *buffer, size_t *ret_len, char ***ret_fields,
     *ret_fields = fields;
   else
     free(fields);
-  return (CMD_OK);
+  return CMD_OK;
 } /* int cmd_split */
 
 /*
@@ -215,12 +215,12 @@ cmd_status_t cmd_parsev(size_t argc, char **argv, cmd_t *ret_cmd,
   } else {
     ret_cmd->type = CMD_UNKNOWN;
     cmd_error(CMD_UNKNOWN_COMMAND, err, "Unknown command `%s'.", command);
-    return (CMD_UNKNOWN_COMMAND);
+    return CMD_UNKNOWN_COMMAND;
   }
 
   if (status != CMD_OK)
     ret_cmd->type = CMD_UNKNOWN;
-  return (status);
+  return status;
 } /* cmd_status_t cmd_parsev */
 
 cmd_status_t cmd_parse(char *buffer, cmd_t *ret_cmd, const cmd_options_t *opts,
@@ -234,7 +234,7 @@ cmd_status_t cmd_parse(char *buffer, cmd_t *ret_cmd, const cmd_options_t *opts,
 
   status = cmd_parsev(fields_num, fields, ret_cmd, opts, err);
   free(fields);
-  return (status);
+  return status;
 } /* cmd_status_t cmd_parse */
 
 void cmd_destroy(cmd_t *cmd) {
@@ -267,7 +267,7 @@ cmd_status_t cmd_parse_option(char *field, char **ret_key, char **ret_value,
   if (field == NULL) {
     errno = EINVAL;
     cmd_error(CMD_ERROR, err, "Invalid argument to cmd_parse_option.");
-    return (CMD_ERROR);
+    return CMD_ERROR;
   }
   key = value = field;
 
@@ -276,7 +276,7 @@ cmd_status_t cmd_parse_option(char *field, char **ret_key, char **ret_value,
     value++;
   if ((value[0] != '=') || (value == key)) {
     /* Whether this is a fatal error is up to the caller. */
-    return (CMD_NO_OPTION);
+    return CMD_NO_OPTION;
   }
   *value = '\0';
   value++;
@@ -286,7 +286,7 @@ cmd_status_t cmd_parse_option(char *field, char **ret_key, char **ret_value,
   if (ret_value != NULL)
     *ret_value = value;
 
-  return (CMD_OK);
+  return CMD_OK;
 } /* cmd_status_t cmd_parse_option */
 
 void cmd_error_fh(void *ud, cmd_status_t status, const char *format,

--- a/src/utils_cmds_test.c
+++ b/src/utils_cmds_test.c
@@ -215,7 +215,7 @@ DEF_TEST(parse) {
     free(input);
   }
 
-  return (test_result);
+  return test_result;
 }
 
 int main(int argc, char **argv) {

--- a/src/utils_db_query.c
+++ b/src/utils_db_query.c
@@ -100,20 +100,20 @@ static int udb_config_set_string(char **ret_string, /* {{{ */
     WARNING("db query utils: The `%s' config option "
             "needs exactly one string argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   string = strdup(ci->values[0].value.string);
   if (string == NULL) {
     ERROR("db query utils: strdup failed.");
-    return (-1);
+    return -1;
   }
 
   if (*ret_string != NULL)
     free(*ret_string);
   *ret_string = string;
 
-  return (0);
+  return 0;
 } /* }}} int udb_config_set_string */
 
 static int udb_config_add_string(char ***ret_array, /* {{{ */
@@ -125,7 +125,7 @@ static int udb_config_add_string(char ***ret_array, /* {{{ */
     WARNING("db query utils: The `%s' config option "
             "needs at least one argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   for (int i = 0; i < ci->values_num; i++) {
@@ -133,7 +133,7 @@ static int udb_config_add_string(char ***ret_array, /* {{{ */
       WARNING("db query utils: Argument %i to the `%s' option "
               "is not a string.",
               i + 1, ci->key);
-      return (-1);
+      return -1;
     }
   }
 
@@ -141,7 +141,7 @@ static int udb_config_add_string(char ***ret_array, /* {{{ */
   array = realloc(*ret_array, sizeof(char *) * (array_len + ci->values_num));
   if (array == NULL) {
     ERROR("db query utils: realloc failed.");
-    return (-1);
+    return -1;
   }
   *ret_array = array;
 
@@ -150,13 +150,13 @@ static int udb_config_add_string(char ***ret_array, /* {{{ */
     if (array[array_len] == NULL) {
       ERROR("db query utils: strdup failed.");
       *ret_array_len = array_len;
-      return (-1);
+      return -1;
     }
     array_len++;
   }
 
   *ret_array_len = array_len;
-  return (0);
+  return 0;
 } /* }}} int udb_config_add_string */
 
 static int udb_config_set_uint(unsigned int *ret_value, /* {{{ */
@@ -167,15 +167,15 @@ static int udb_config_set_uint(unsigned int *ret_value, /* {{{ */
     WARNING("db query utils: The `%s' config option "
             "needs exactly one numeric argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   tmp = ci->values[0].value.number;
   if ((tmp < 0.0) || (tmp > ((double)UINT_MAX)))
-    return (-ERANGE);
+    return -ERANGE;
 
   *ret_value = (unsigned int)(tmp + .5);
-  return (0);
+  return 0;
 } /* }}} int udb_config_set_uint */
 
 /*
@@ -195,7 +195,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
   vl.values = calloc(r->values_num, sizeof(*vl.values));
   if (vl.values == NULL) {
     ERROR("db query utils: calloc failed.");
-    return (-1);
+    return -1;
   }
   vl.values_len = r_area->ds->ds_num;
 
@@ -207,7 +207,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
             value_str, DS_TYPE_TO_STRING(r_area->ds->ds[i].type));
       errno = EINVAL;
       free(vl.values);
-      return (-1);
+      return -1;
     }
   }
 
@@ -241,7 +241,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
         ERROR(
             "udb_result_submit: creating type_instance failed with status %d.",
             status);
-        return (status);
+        return status;
       }
     } else {
       char tmp[DATA_MAX_NAME_LEN];
@@ -252,7 +252,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
         ERROR(
             "udb_result_submit: creating type_instance failed with status %d.",
             status);
-        return (status);
+        return status;
       }
       tmp[sizeof(tmp) - 1] = 0;
 
@@ -268,7 +268,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
     vl.meta = meta_data_create();
     if (vl.meta == NULL) {
       ERROR("db query utils:: meta_data_create failed.");
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     for (size_t i = 0; i < r->metadata_num; i++) {
@@ -278,7 +278,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
         ERROR("db query utils:: meta_data_add_string failed.");
         meta_data_destroy(vl.meta);
         vl.meta = NULL;
-        return (status);
+        return status;
       }
     }
   }
@@ -291,7 +291,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
     vl.meta = NULL;
   }
   sfree(vl.values);
-  return (0);
+  return 0;
 } /* }}} void udb_result_submit */
 
 static void udb_result_finish_result(udb_result_t const *r, /* {{{ */
@@ -334,7 +334,7 @@ static int udb_result_prepare_result(udb_result_t const *r, /* {{{ */
                                      udb_result_preparation_area_t *prep_area,
                                      char **column_names, size_t column_num) {
   if ((r == NULL) || (prep_area == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
 #define BAIL_OUT(status)                                                       \
   prep_area->ds = NULL;                                                        \
@@ -472,7 +472,7 @@ static int udb_result_prepare_result(udb_result_t const *r, /* {{{ */
   } /* }}} for (i = 0; i < r->metadata_num; i++) */
 
 #undef BAIL_OUT
-  return (0);
+  return 0;
 } /* }}} int udb_result_prepare_result */
 
 static void udb_result_free(udb_result_t *r) /* {{{ */
@@ -514,7 +514,7 @@ static int udb_result_create(const char *query_name, /* {{{ */
   r = calloc(1, sizeof(*r));
   if (r == NULL) {
     ERROR("db query utils: calloc failed.");
-    return (-1);
+    return -1;
   }
   r->type = NULL;
   r->instance_prefix = NULL;
@@ -568,7 +568,7 @@ static int udb_result_create(const char *query_name, /* {{{ */
 
   if (status != 0) {
     udb_result_free(r);
-    return (-1);
+    return -1;
   }
 
   /* If all went well, add this result to the list of results. */
@@ -584,7 +584,7 @@ static int udb_result_create(const char *query_name, /* {{{ */
     last->next = r;
   }
 
-  return (0);
+  return 0;
 } /* }}} int udb_result_create */
 
 /*
@@ -617,20 +617,20 @@ int udb_query_create(udb_query_t ***ret_query_list, /* {{{ */
   int status;
 
   if ((ret_query_list == NULL) || (ret_query_list_len == NULL))
-    return (-EINVAL);
+    return -EINVAL;
   query_list = *ret_query_list;
   query_list_len = *ret_query_list_len;
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("db query utils: The `Query' block "
             "needs exactly one string argument.");
-    return (-1);
+    return -1;
   }
 
   q = calloc(1, sizeof(*q));
   if (q == NULL) {
     ERROR("db query utils: calloc failed.");
-    return (-1);
+    return -1;
   }
   q->min_version = 0;
   q->max_version = UINT_MAX;
@@ -641,7 +641,7 @@ int udb_query_create(udb_query_t ***ret_query_list, /* {{{ */
   status = udb_config_set_string(&q->name, ci);
   if (status != 0) {
     sfree(q);
-    return (status);
+    return status;
   }
 
   /* Fill the `udb_query_t' structure.. */
@@ -708,13 +708,13 @@ int udb_query_create(udb_query_t ***ret_query_list, /* {{{ */
 
   if (status != 0) {
     udb_query_free_one(q);
-    return (-1);
+    return -1;
   }
 
   *ret_query_list = query_list;
   *ret_query_list_len = query_list_len;
 
-  return (0);
+  return 0;
 } /* }}} int udb_query_create */
 
 void udb_query_free(udb_query_t **query_list, size_t query_list_len) /* {{{ */
@@ -739,7 +739,7 @@ int udb_query_pick_from_list_by_name(const char *name, /* {{{ */
       (dst_list_len == NULL)) {
     ERROR("db query utils: udb_query_pick_from_list_by_name: "
           "Invalid argument.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   num_added = 0;
@@ -754,7 +754,7 @@ int udb_query_pick_from_list_by_name(const char *name, /* {{{ */
     tmp_list = realloc(*dst_list, (tmp_list_len + 1) * sizeof(udb_query_t *));
     if (tmp_list == NULL) {
       ERROR("db query utils: realloc failed.");
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     tmp_list[tmp_list_len] = src_list[i];
@@ -770,12 +770,12 @@ int udb_query_pick_from_list_by_name(const char *name, /* {{{ */
     ERROR("db query utils: Cannot find query `%s'. Make sure the <Query> "
           "block is above the database definition!",
           name);
-    return (-ENOENT);
+    return -ENOENT;
   } else {
     DEBUG("db query utils: Added %i versions of query `%s'.", num_added, name);
   }
 
-  return (0);
+  return 0;
 } /* }}} int udb_query_pick_from_list_by_name */
 
 int udb_query_pick_from_list(oconfig_item_t *ci, /* {{{ */
@@ -787,35 +787,35 @@ int udb_query_pick_from_list(oconfig_item_t *ci, /* {{{ */
       (dst_list_len == NULL)) {
     ERROR("db query utils: udb_query_pick_from_list: "
           "Invalid argument.");
-    return (-EINVAL);
+    return -EINVAL;
   }
 
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     ERROR("db query utils: The `%s' config option "
           "needs exactly one string argument.",
           ci->key);
-    return (-1);
+    return -1;
   }
   name = ci->values[0].value.string;
 
-  return (udb_query_pick_from_list_by_name(name, src_list, src_list_len,
-                                           dst_list, dst_list_len));
+  return udb_query_pick_from_list_by_name(name, src_list, src_list_len,
+                                          dst_list, dst_list_len);
 } /* }}} int udb_query_pick_from_list */
 
 const char *udb_query_get_name(udb_query_t *q) /* {{{ */
 {
   if (q == NULL)
-    return (NULL);
+    return NULL;
 
-  return (q->name);
+  return q->name;
 } /* }}} const char *udb_query_get_name */
 
 const char *udb_query_get_statement(udb_query_t *q) /* {{{ */
 {
   if (q == NULL)
-    return (NULL);
+    return NULL;
 
-  return (q->statement);
+  return q->statement;
 } /* }}} const char *udb_query_get_statement */
 
 void udb_query_set_user_data(udb_query_t *q, void *user_data) /* {{{ */
@@ -829,20 +829,20 @@ void udb_query_set_user_data(udb_query_t *q, void *user_data) /* {{{ */
 void *udb_query_get_user_data(udb_query_t *q) /* {{{ */
 {
   if (q == NULL)
-    return (NULL);
+    return NULL;
 
-  return (q->user_data);
+  return q->user_data;
 } /* }}} void *udb_query_get_user_data */
 
 int udb_query_check_version(udb_query_t *q, unsigned int version) /* {{{ */
 {
   if (q == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   if ((version < q->min_version) || (version > q->max_version))
-    return (0);
+    return 0;
 
-  return (1);
+  return 1;
 } /* }}} int udb_query_check_version */
 
 void udb_query_finish_result(udb_query_t const *q, /* {{{ */
@@ -878,14 +878,14 @@ int udb_query_handle_result(udb_query_t const *q, /* {{{ */
   int status;
 
   if ((q == NULL) || (prep_area == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if ((prep_area->column_num < 1) || (prep_area->host == NULL) ||
       (prep_area->plugin == NULL) || (prep_area->db_name == NULL)) {
     ERROR("db query utils: Query `%s': Query is not prepared; "
           "can't handle result.",
           q->name);
-    return (-EINVAL);
+    return -EINVAL;
   }
 
 #if defined(COLLECT_DEBUG) && COLLECT_DEBUG /* {{{ */
@@ -910,10 +910,10 @@ int udb_query_handle_result(udb_query_t const *q, /* {{{ */
     ERROR("db query utils: udb_query_handle_result (%s, %s): "
           "All results failed.",
           prep_area->db_name, q->name);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int udb_query_handle_result */
 
 int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
@@ -926,7 +926,7 @@ int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
   int status;
 
   if ((q == NULL) || (prep_area == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   udb_query_finish_result(q, prep_area);
 
@@ -942,7 +942,7 @@ int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
     ERROR("db query utils: Query `%s': Prepare failed: Out of memory.",
           q->name);
     udb_query_finish_result(q, prep_area);
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
 #if defined(COLLECT_DEBUG) && COLLECT_DEBUG
@@ -971,7 +971,7 @@ int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
             "Column `%s' from `PluginInstanceFrom' could not be found.",
             q->plugin_instance_from);
       udb_query_finish_result(q, prep_area);
-      return (-ENOENT);
+      return -ENOENT;
     }
   }
   /* }}} */
@@ -983,17 +983,17 @@ int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
             "preparation areas.",
             q->name);
       udb_query_finish_result(q, prep_area);
-      return (-EINVAL);
+      return -EINVAL;
     }
 
     status = udb_result_prepare_result(r, r_area, column_names, column_num);
     if (status != 0) {
       udb_query_finish_result(q, prep_area);
-      return (status);
+      return status;
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int udb_query_prepare_result */
 
 udb_query_preparation_area_t *
@@ -1029,7 +1029,7 @@ udb_query_allocate_preparation_area(udb_query_t *q) /* {{{ */
     next_r_area = &r_area->next;
   }
 
-  return (q_area);
+  return q_area;
 } /* }}} udb_query_preparation_area_t *udb_query_allocate_preparation_area */
 
 void udb_query_delete_preparation_area(

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -185,16 +185,16 @@ static int cmp_in6_addr(const struct in6_addr *a, const struct in6_addr *b) {
       break;
 
   if (i >= 16)
-    return (0);
+    return 0;
 
-  return (a->s6_addr[i] > b->s6_addr[i] ? 1 : -1);
+  return a->s6_addr[i] > b->s6_addr[i] ? 1 : -1;
 } /* int cmp_addrinfo */
 
 static inline int ignore_list_match(const struct in6_addr *addr) {
   for (ip_list_t *ptr = IgnoreList; ptr != NULL; ptr = ptr->next)
     if (cmp_in6_addr(addr, &ptr->addr) == 0)
-      return (1);
-  return (0);
+      return 1;
+  return 0;
 } /* int ignore_list_match */
 
 static void ignore_list_add(const struct in6_addr *addr) {
@@ -416,7 +416,7 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
   uint16_t payload_len;
 
   if (0 > len)
-    return (0);
+    return 0;
 
   offset = sizeof(struct ip6_hdr);
   nexthdr = ipv6->ip6_nxt;
@@ -424,7 +424,7 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
   payload_len = ntohs(ipv6->ip6_plen);
 
   if (ignore_list_match(&c_src_addr))
-    return (0);
+    return 0;
 
   /* Parse extension headers. This only handles the standard headers, as
    * defined in RFC 2460, correctly. Fragments are discarded. */
@@ -440,11 +440,11 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
 
     /* Catch broken packets */
     if ((offset + sizeof(struct ip6_ext)) > (unsigned int)len)
-      return (0);
+      return 0;
 
     /* Cannot handle fragments. */
     if (IPPROTO_FRAGMENT == nexthdr)
-      return (0);
+      return 0;
 
     memcpy(&ext_hdr, (char *)ipv6 + offset, sizeof(struct ip6_ext));
     nexthdr = ext_hdr.ip6e_nxt;
@@ -452,7 +452,7 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
 
     /* This header is longer than the packets payload.. WTF? */
     if (ext_hdr_len > payload_len)
-      return (0);
+      return 0;
 
     offset += ext_hdr_len;
     payload_len -= ext_hdr_len;
@@ -461,23 +461,23 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
   /* Catch broken and empty packets */
   if (((offset + payload_len) > (unsigned int)len) || (payload_len == 0) ||
       (payload_len > PCAP_SNAPLEN))
-    return (0);
+    return 0;
 
   if (IPPROTO_UDP != nexthdr)
-    return (0);
+    return 0;
 
   memcpy(buf, (char *)ipv6 + offset, payload_len);
   if (handle_udp((struct udphdr *)buf, payload_len) == 0)
-    return (0);
+    return 0;
 
-  return (1); /* Success */
+  return 1; /* Success */
 } /* int handle_ipv6 */
 /* #endif HAVE_IPV6 */
 
 #else  /* if !HAVE_IPV6 */
 static int handle_ipv6(__attribute__((unused)) void *pkg,
                        __attribute__((unused)) int len) {
-  return (0);
+  return 0;
 }
 #endif /* !HAVE_IPV6 */
 
@@ -488,14 +488,14 @@ static int handle_ip(const struct ip *ip, int len) {
   struct in6_addr c_dst_addr;
 
   if (ip->ip_v == 6)
-    return (handle_ipv6((void *)ip, len));
+    return handle_ipv6((void *)ip, len);
 
   in6_addr_from_buffer(&c_src_addr, &ip->ip_src.s_addr,
                        sizeof(ip->ip_src.s_addr), AF_INET);
   in6_addr_from_buffer(&c_dst_addr, &ip->ip_dst.s_addr,
                        sizeof(ip->ip_dst.s_addr), AF_INET);
   if (ignore_list_match(&c_src_addr))
-    return (0);
+    return 0;
   if (IPPROTO_UDP != ip->ip_p)
     return 0;
   memcpy(buf, ((char *)ip) + offset, len - offset);
@@ -577,7 +577,7 @@ static int handle_ether(const u_char *pkt, int len) {
     return 0;
   memcpy(buf, pkt, len);
   if (ETHERTYPE_IPV6 == etype)
-    return (handle_ipv6((void *)buf, len));
+    return handle_ipv6((void *)buf, len);
   else
     return handle_ip((struct ip *)buf, len);
 }
@@ -594,7 +594,7 @@ static int handle_linux_sll(const u_char *pkt, int len) {
   uint16_t etype;
 
   if ((0 > len) || ((unsigned int)len < sizeof(struct sll_header)))
-    return (0);
+    return 0;
 
   hdr = (struct sll_header *)pkt;
   pkt = (u_char *)(hdr + 1);
@@ -606,7 +606,7 @@ static int handle_linux_sll(const u_char *pkt, int len) {
     return 0;
 
   if (ETHERTYPE_IPV6 == etype)
-    return (handle_ipv6((void *)pkt, len));
+    return handle_ipv6((void *)pkt, len);
   else
     return handle_ip((struct ip *)pkt, len);
 }
@@ -669,251 +669,251 @@ const char *qtype_str(int t) {
   switch (t) {
 #if (defined(__NAMESER)) && (__NAMESER >= 19991001)
   case ns_t_a:
-    return ("A");
+    return "A";
   case ns_t_ns:
-    return ("NS");
+    return "NS";
   case ns_t_md:
-    return ("MD");
+    return "MD";
   case ns_t_mf:
-    return ("MF");
+    return "MF";
   case ns_t_cname:
-    return ("CNAME");
+    return "CNAME";
   case ns_t_soa:
-    return ("SOA");
+    return "SOA";
   case ns_t_mb:
-    return ("MB");
+    return "MB";
   case ns_t_mg:
-    return ("MG");
+    return "MG";
   case ns_t_mr:
-    return ("MR");
+    return "MR";
   case ns_t_null:
-    return ("NULL");
+    return "NULL";
   case ns_t_wks:
-    return ("WKS");
+    return "WKS";
   case ns_t_ptr:
-    return ("PTR");
+    return "PTR";
   case ns_t_hinfo:
-    return ("HINFO");
+    return "HINFO";
   case ns_t_minfo:
-    return ("MINFO");
+    return "MINFO";
   case ns_t_mx:
-    return ("MX");
+    return "MX";
   case ns_t_txt:
-    return ("TXT");
+    return "TXT";
   case ns_t_rp:
-    return ("RP");
+    return "RP";
   case ns_t_afsdb:
-    return ("AFSDB");
+    return "AFSDB";
   case ns_t_x25:
-    return ("X25");
+    return "X25";
   case ns_t_isdn:
-    return ("ISDN");
+    return "ISDN";
   case ns_t_rt:
-    return ("RT");
+    return "RT";
   case ns_t_nsap:
-    return ("NSAP");
+    return "NSAP";
   case ns_t_nsap_ptr:
-    return ("NSAP-PTR");
+    return "NSAP-PTR";
   case ns_t_sig:
-    return ("SIG");
+    return "SIG";
   case ns_t_key:
-    return ("KEY");
+    return "KEY";
   case ns_t_px:
-    return ("PX");
+    return "PX";
   case ns_t_gpos:
-    return ("GPOS");
+    return "GPOS";
   case ns_t_aaaa:
-    return ("AAAA");
+    return "AAAA";
   case ns_t_loc:
-    return ("LOC");
+    return "LOC";
   case ns_t_nxt:
-    return ("NXT");
+    return "NXT";
   case ns_t_eid:
-    return ("EID");
+    return "EID";
   case ns_t_nimloc:
-    return ("NIMLOC");
+    return "NIMLOC";
   case ns_t_srv:
-    return ("SRV");
+    return "SRV";
   case ns_t_atma:
-    return ("ATMA");
+    return "ATMA";
   case ns_t_naptr:
-    return ("NAPTR");
+    return "NAPTR";
   case ns_t_opt:
-    return ("OPT");
+    return "OPT";
 #if __NAMESER >= 19991006
   case ns_t_kx:
-    return ("KX");
+    return "KX";
   case ns_t_cert:
-    return ("CERT");
+    return "CERT";
   case ns_t_a6:
-    return ("A6");
+    return "A6";
   case ns_t_dname:
-    return ("DNAME");
+    return "DNAME";
   case ns_t_sink:
-    return ("SINK");
+    return "SINK";
   case ns_t_tsig:
-    return ("TSIG");
+    return "TSIG";
 #endif
 #if __NAMESER >= 20090302
   case ns_t_apl:
-    return ("APL");
+    return "APL";
   case ns_t_ds:
-    return ("DS");
+    return "DS";
   case ns_t_sshfp:
-    return ("SSHFP");
+    return "SSHFP";
   case ns_t_ipseckey:
-    return ("IPSECKEY");
+    return "IPSECKEY";
   case ns_t_rrsig:
-    return ("RRSIG");
+    return "RRSIG";
   case ns_t_nsec:
-    return ("NSEC");
+    return "NSEC";
   case ns_t_dnskey:
-    return ("DNSKEY");
+    return "DNSKEY";
   case ns_t_dhcid:
-    return ("DHCID");
+    return "DHCID";
   case ns_t_nsec3:
-    return ("NSEC3");
+    return "NSEC3";
   case ns_t_nsec3param:
-    return ("NSEC3PARAM");
+    return "NSEC3PARAM";
   case ns_t_hip:
-    return ("HIP");
+    return "HIP";
   case ns_t_spf:
-    return ("SPF");
+    return "SPF";
   case ns_t_ixfr:
-    return ("IXFR");
+    return "IXFR";
 #endif
   case ns_t_axfr:
-    return ("AXFR");
+    return "AXFR";
   case ns_t_mailb:
-    return ("MAILB");
+    return "MAILB";
   case ns_t_maila:
-    return ("MAILA");
+    return "MAILA";
   case ns_t_any:
-    return ("ANY");
+    return "ANY";
 #if __NAMESER >= 19991006
   case ns_t_zxfr:
-    return ("ZXFR");
+    return "ZXFR";
 #endif
 #if __NAMESER >= 20090302
   case ns_t_dlv:
-    return ("DLV");
+    return "DLV";
 #endif
 /* #endif __NAMESER >= 19991001 */
 #elif (defined(__BIND)) && (__BIND >= 19950621)
   case T_A:
-    return ("A"); /* 1 ... */
+    return "A"; /* 1 ... */
   case T_NS:
-    return ("NS");
+    return "NS";
   case T_MD:
-    return ("MD");
+    return "MD";
   case T_MF:
-    return ("MF");
+    return "MF";
   case T_CNAME:
-    return ("CNAME");
+    return "CNAME";
   case T_SOA:
-    return ("SOA");
+    return "SOA";
   case T_MB:
-    return ("MB");
+    return "MB";
   case T_MG:
-    return ("MG");
+    return "MG";
   case T_MR:
-    return ("MR");
+    return "MR";
   case T_NULL:
-    return ("NULL");
+    return "NULL";
   case T_WKS:
-    return ("WKS");
+    return "WKS";
   case T_PTR:
-    return ("PTR");
+    return "PTR";
   case T_HINFO:
-    return ("HINFO");
+    return "HINFO";
   case T_MINFO:
-    return ("MINFO");
+    return "MINFO";
   case T_MX:
-    return ("MX");
+    return "MX";
   case T_TXT:
-    return ("TXT");
+    return "TXT";
   case T_RP:
-    return ("RP");
+    return "RP";
   case T_AFSDB:
-    return ("AFSDB");
+    return "AFSDB";
   case T_X25:
-    return ("X25");
+    return "X25";
   case T_ISDN:
-    return ("ISDN");
+    return "ISDN";
   case T_RT:
-    return ("RT");
+    return "RT";
   case T_NSAP:
-    return ("NSAP");
+    return "NSAP";
   case T_NSAP_PTR:
-    return ("NSAP_PTR");
+    return "NSAP_PTR";
   case T_SIG:
-    return ("SIG");
+    return "SIG";
   case T_KEY:
-    return ("KEY");
+    return "KEY";
   case T_PX:
-    return ("PX");
+    return "PX";
   case T_GPOS:
-    return ("GPOS");
+    return "GPOS";
   case T_AAAA:
-    return ("AAAA");
+    return "AAAA";
   case T_LOC:
-    return ("LOC");
+    return "LOC";
   case T_NXT:
-    return ("NXT");
+    return "NXT";
   case T_EID:
-    return ("EID");
+    return "EID";
   case T_NIMLOC:
-    return ("NIMLOC");
+    return "NIMLOC";
   case T_SRV:
-    return ("SRV");
+    return "SRV";
   case T_ATMA:
-    return ("ATMA");
+    return "ATMA";
   case T_NAPTR:
-    return ("NAPTR"); /* ... 35 */
+    return "NAPTR"; /* ... 35 */
 #if (__BIND >= 19960801)
   case T_KX:
-    return ("KX"); /* 36 ... */
+    return "KX"; /* 36 ... */
   case T_CERT:
-    return ("CERT");
+    return "CERT";
   case T_A6:
-    return ("A6");
+    return "A6";
   case T_DNAME:
-    return ("DNAME");
+    return "DNAME";
   case T_SINK:
-    return ("SINK");
+    return "SINK";
   case T_OPT:
-    return ("OPT");
+    return "OPT";
   case T_APL:
-    return ("APL");
+    return "APL";
   case T_DS:
-    return ("DS");
+    return "DS";
   case T_SSHFP:
-    return ("SSHFP");
+    return "SSHFP";
   case T_RRSIG:
-    return ("RRSIG");
+    return "RRSIG";
   case T_NSEC:
-    return ("NSEC");
+    return "NSEC";
   case T_DNSKEY:
-    return ("DNSKEY"); /* ... 48 */
+    return "DNSKEY"; /* ... 48 */
   case T_TKEY:
-    return ("TKEY"); /* 249 */
+    return "TKEY"; /* 249 */
 #endif /* __BIND >= 19960801 */
   case T_TSIG:
-    return ("TSIG"); /* 250 ... */
+    return "TSIG"; /* 250 ... */
   case T_IXFR:
-    return ("IXFR");
+    return "IXFR";
   case T_AXFR:
-    return ("AXFR");
+    return "AXFR";
   case T_MAILB:
-    return ("MAILB");
+    return "MAILB";
   case T_MAILA:
-    return ("MAILA");
+    return "MAILA";
   case T_ANY:
-    return ("ANY"); /* ... 255 */
+    return "ANY"; /* ... 255 */
 #endif /* __BIND >= 19950621 */
   default:
     ssnprintf(buf, sizeof(buf), "#%i", t);
-    return (buf);
+    return buf;
   } /* switch (t) */
 }
 
@@ -941,65 +941,65 @@ const char *rcode_str(int rcode) {
   switch (rcode) {
 #if (defined(__NAMESER)) && (__NAMESER >= 19991006)
   case ns_r_noerror:
-    return ("NOERROR");
+    return "NOERROR";
   case ns_r_formerr:
-    return ("FORMERR");
+    return "FORMERR";
   case ns_r_servfail:
-    return ("SERVFAIL");
+    return "SERVFAIL";
   case ns_r_nxdomain:
-    return ("NXDOMAIN");
+    return "NXDOMAIN";
   case ns_r_notimpl:
-    return ("NOTIMPL");
+    return "NOTIMPL";
   case ns_r_refused:
-    return ("REFUSED");
+    return "REFUSED";
   case ns_r_yxdomain:
-    return ("YXDOMAIN");
+    return "YXDOMAIN";
   case ns_r_yxrrset:
-    return ("YXRRSET");
+    return "YXRRSET";
   case ns_r_nxrrset:
-    return ("NXRRSET");
+    return "NXRRSET";
   case ns_r_notauth:
-    return ("NOTAUTH");
+    return "NOTAUTH";
   case ns_r_notzone:
-    return ("NOTZONE");
+    return "NOTZONE";
   case ns_r_max:
-    return ("MAX");
+    return "MAX";
   case ns_r_badsig:
-    return ("BADSIG");
+    return "BADSIG";
   case ns_r_badkey:
-    return ("BADKEY");
+    return "BADKEY";
   case ns_r_badtime:
-    return ("BADTIME");
+    return "BADTIME";
 /* #endif __NAMESER >= 19991006 */
 #elif (defined(__BIND)) && (__BIND >= 19950621)
   case NOERROR:
-    return ("NOERROR");
+    return "NOERROR";
   case FORMERR:
-    return ("FORMERR");
+    return "FORMERR";
   case SERVFAIL:
-    return ("SERVFAIL");
+    return "SERVFAIL";
   case NXDOMAIN:
-    return ("NXDOMAIN");
+    return "NXDOMAIN";
   case NOTIMP:
-    return ("NOTIMP");
+    return "NOTIMP";
   case REFUSED:
-    return ("REFUSED");
+    return "REFUSED";
 #if defined(YXDOMAIN) && defined(NXRRSET)
   case YXDOMAIN:
-    return ("YXDOMAIN");
+    return "YXDOMAIN";
   case YXRRSET:
-    return ("YXRRSET");
+    return "YXRRSET";
   case NXRRSET:
-    return ("NXRRSET");
+    return "NXRRSET";
   case NOTAUTH:
-    return ("NOTAUTH");
+    return "NOTAUTH";
   case NOTZONE:
-    return ("NOTZONE");
+    return "NOTZONE";
 #endif /* RFC2136 rcodes */
 #endif /* __BIND >= 19950621 */
   default:
     ssnprintf(buf, sizeof(buf), "RCode%i", rcode);
-    return (buf);
+    return buf;
   }
 } /* const char *rcode_str (int rcode) */
 

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -264,7 +264,7 @@ int dpdk_helper_data_size_get(dpdk_helper_ctx_t *phc) {
     return -EINVAL;
   }
 
-  return (phc->shm_size - sizeof(dpdk_helper_ctx_t));
+  return phc->shm_size - sizeof(dpdk_helper_ctx_t);
 }
 
 int dpdk_helper_init(const char *name, size_t data_size,

--- a/src/utils_fbhash.c
+++ b/src/utils_fbhash.c
@@ -74,7 +74,7 @@ static int fbh_read_file(fbhash_t *h) /* {{{ */
 
   fh = fopen(h->filename, "r");
   if (fh == NULL)
-    return (-1);
+    return -1;
 
   fl.l_type = F_RDLCK;
   fl.l_whence = SEEK_SET;
@@ -83,13 +83,13 @@ static int fbh_read_file(fbhash_t *h) /* {{{ */
   status = fcntl(fileno(fh), F_SETLK, &fl);
   if (status != 0) {
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   tree = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (tree == NULL) {
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   /* Read `fh' into `tree' */
@@ -162,7 +162,7 @@ static int fbh_read_file(fbhash_t *h) /* {{{ */
   fbh_free_tree(h->tree);
   h->tree = tree;
 
-  return (0);
+  return 0;
 } /* }}} int fbh_read_file */
 
 static int fbh_check_file(fbhash_t *h) /* {{{ */
@@ -172,16 +172,16 @@ static int fbh_check_file(fbhash_t *h) /* {{{ */
 
   status = stat(h->filename, &statbuf);
   if (status != 0)
-    return (-1);
+    return -1;
 
   if (h->mtime >= statbuf.st_mtime)
-    return (0);
+    return 0;
 
   status = fbh_read_file(h);
   if (status == 0)
     h->mtime = statbuf.st_mtime;
 
-  return (status);
+  return status;
 } /* }}} int fbh_check_file */
 
 /*
@@ -193,16 +193,16 @@ fbhash_t *fbh_create(const char *file) /* {{{ */
   int status;
 
   if (file == NULL)
-    return (NULL);
+    return NULL;
 
   h = calloc(1, sizeof(*h));
   if (h == NULL)
-    return (NULL);
+    return NULL;
 
   h->filename = strdup(file);
   if (h->filename == NULL) {
     free(h);
-    return (NULL);
+    return NULL;
   }
 
   h->mtime = 0;
@@ -212,10 +212,10 @@ fbhash_t *fbh_create(const char *file) /* {{{ */
   if (status != 0) {
     fbh_destroy(h);
     free(h);
-    return (NULL);
+    return NULL;
   }
 
-  return (h);
+  return h;
 } /* }}} fbhash_t *fbh_create */
 
 void fbh_destroy(fbhash_t *h) /* {{{ */
@@ -235,7 +235,7 @@ char *fbh_get(fbhash_t *h, const char *key) /* {{{ */
   int status;
 
   if ((h == NULL) || (key == NULL))
-    return (NULL);
+    return NULL;
 
   value = NULL;
   value_copy = NULL;
@@ -253,5 +253,5 @@ char *fbh_get(fbhash_t *h, const char *key) /* {{{ */
 
   pthread_mutex_unlock(&h->lock);
 
-  return (value_copy);
+  return value_copy;
 } /* }}} char *fbh_get */

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -48,9 +48,9 @@ static int gr_format_values(char *ret, size_t ret_len, int ds_num,
   do {                                                                         \
     status = ssnprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
     if (status < 1) {                                                          \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else if (((size_t)status) >= (ret_len - offset)) {                       \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else                                                                     \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -68,12 +68,12 @@ static int gr_format_values(char *ret, size_t ret_len, int ds_num,
   else {
     ERROR("gr_format_values plugin: Unknown data source type: %i",
           ds->ds[ds_num].type);
-    return (-1);
+    return -1;
   }
 
 #undef BUFFER_ADD
 
-  return (0);
+  return 0;
 }
 
 static void gr_copy_escape_part(char *dst, const char *src, size_t dst_len,
@@ -161,7 +161,7 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
     ssnprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
               tmp_type);
 
-  return (0);
+  return 0;
 }
 
 static void escape_graphite_string(char *buffer, char escape_char) {
@@ -199,7 +199,7 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
     if (status != 0) {
       ERROR("format_graphite: error with gr_format_name");
       sfree(rates);
-      return (status);
+      return status;
     }
 
     escape_graphite_string(key, escape_char);
@@ -209,7 +209,7 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
     if (status != 0) {
       ERROR("format_graphite: error with gr_format_values");
       sfree(rates);
-      return (status);
+      return status;
     }
 
     /* Compute the graphite command */
@@ -221,19 +221,19 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
             "Need %zu bytes.",
             message_len + 1);
       sfree(rates);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
 
     /* Append it in case we got multiple data set */
     if ((buffer_pos + message_len) >= buffer_size) {
       ERROR("format_graphite: target buffer too small");
       sfree(rates);
-      return (-ENOMEM);
+      return -ENOMEM;
     }
     memcpy((void *)(buffer + buffer_pos), message, message_len);
     buffer_pos += message_len;
     buffer[buffer_pos] = '\0';
   }
   sfree(rates);
-  return (status);
+  return status;
 } /* int format_graphite */

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -48,10 +48,10 @@ static int json_escape_string(char *buffer, size_t buffer_size, /* {{{ */
   size_t dst_pos;
 
   if ((buffer == NULL) || (string == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (buffer_size < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   dst_pos = 0;
 
@@ -59,7 +59,7 @@ static int json_escape_string(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     if (dst_pos >= (buffer_size - 1)) {                                        \
       buffer[buffer_size - 1] = 0;                                             \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     }                                                                          \
     buffer[dst_pos] = (c);                                                     \
     dst_pos++;                                                                 \
@@ -81,7 +81,7 @@ static int json_escape_string(char *buffer, size_t buffer_size, /* {{{ */
 
 #undef BUFFER_ADD
 
-  return (0);
+  return 0;
 } /* }}} int json_escape_string */
 
 static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
@@ -98,10 +98,10 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else if (((size_t)status) >= (buffer_size - offset)) {                   \
       sfree(rates);                                                            \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     } else                                                                     \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -122,7 +122,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
       if (rates == NULL) {
         WARNING("utils_format_json: uc_get_rate failed.");
         sfree(rates);
-        return (-1);
+        return -1;
       }
 
       if (isfinite(rates[i]))
@@ -138,7 +138,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
     else {
       ERROR("format_json: Unknown data source type: %i", ds->ds[i].type);
       sfree(rates);
-      return (-1);
+      return -1;
     }
   } /* for ds->ds_num */
   BUFFER_ADD("]");
@@ -147,7 +147,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_json: values_to_json: buffer = %s;", buffer);
   sfree(rates);
-  return (0);
+  return 0;
 } /* }}} int values_to_json */
 
 static int dstypes_to_json(char *buffer, size_t buffer_size, /* {{{ */
@@ -161,9 +161,9 @@ static int dstypes_to_json(char *buffer, size_t buffer_size, /* {{{ */
     int status;                                                                \
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -181,7 +181,7 @@ static int dstypes_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_json: dstypes_to_json: buffer = %s;", buffer);
 
-  return (0);
+  return 0;
 } /* }}} int dstypes_to_json */
 
 static int dsnames_to_json(char *buffer, size_t buffer_size, /* {{{ */
@@ -195,9 +195,9 @@ static int dsnames_to_json(char *buffer, size_t buffer_size, /* {{{ */
     int status;                                                                \
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -215,7 +215,7 @@ static int dsnames_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_json: dsnames_to_json: buffer = %s;", buffer);
 
-  return (0);
+  return 0;
 } /* }}} int dsnames_to_json */
 
 static int meta_data_keys_to_json(char *buffer, size_t buffer_size, /* {{{ */
@@ -230,9 +230,9 @@ static int meta_data_keys_to_json(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -274,14 +274,14 @@ static int meta_data_keys_to_json(char *buffer, size_t buffer_size, /* {{{ */
   } /* for (keys) */
 
   if (offset == 0)
-    return (ENOENT);
+    return ENOENT;
 
   buffer[0] = '{'; /* replace leading ',' */
   BUFFER_ADD("}");
 
 #undef BUFFER_ADD
 
-  return (0);
+  return 0;
 } /* }}} int meta_data_keys_to_json */
 
 static int meta_data_to_json(char *buffer, size_t buffer_size, /* {{{ */
@@ -291,11 +291,11 @@ static int meta_data_to_json(char *buffer, size_t buffer_size, /* {{{ */
   int status;
 
   if ((buffer == NULL) || (buffer_size == 0) || (meta == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   status = meta_data_toc(meta, &keys);
   if (status <= 0)
-    return (status);
+    return status;
   keys_num = (size_t)status;
 
   status = meta_data_keys_to_json(buffer, buffer_size, meta, keys, keys_num);
@@ -320,9 +320,9 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -333,17 +333,17 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
   status = values_to_json(temp, sizeof(temp), ds, vl, store_rates);
   if (status != 0)
-    return (status);
+    return status;
   BUFFER_ADD("\"values\":%s", temp);
 
   status = dstypes_to_json(temp, sizeof(temp), ds);
   if (status != 0)
-    return (status);
+    return status;
   BUFFER_ADD(",\"dstypes\":%s", temp);
 
   status = dsnames_to_json(temp, sizeof(temp), ds);
   if (status != 0)
-    return (status);
+    return status;
   BUFFER_ADD(",\"dsnames\":%s", temp);
 
   BUFFER_ADD(",\"time\":%.3f", CDTIME_T_TO_DOUBLE(vl->time));
@@ -353,7 +353,7 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     status = json_escape_string(temp, sizeof(temp), (value));                  \
     if (status != 0)                                                           \
-      return (status);                                                         \
+      return status;                                                           \
     BUFFER_ADD(",\"%s\":%s", (key), temp);                                     \
   } while (0)
 
@@ -368,7 +368,7 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
     memset(meta_buffer, 0, sizeof(meta_buffer));
     status = meta_data_to_json(meta_buffer, sizeof(meta_buffer), vl->meta);
     if (status != 0)
-      return (status);
+      return status;
 
     BUFFER_ADD(",\"meta\":%s", meta_buffer);
   } /* if (vl->meta != NULL) */
@@ -380,7 +380,7 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_json: value_list_to_json: buffer = %s;", buffer);
 
-  return (0);
+  return 0;
 } /* }}} int value_list_to_json */
 
 static int format_json_value_list_nocheck(char *buffer, /* {{{ */
@@ -394,14 +394,14 @@ static int format_json_value_list_nocheck(char *buffer, /* {{{ */
 
   status = value_list_to_json(temp, sizeof(temp), ds, vl, store_rates);
   if (status != 0)
-    return (status);
+    return status;
   temp_size = strlen(temp);
 
   memcpy(buffer + (*ret_buffer_fill), temp, temp_size + 1);
   (*ret_buffer_fill) += temp_size;
   (*ret_buffer_free) -= temp_size;
 
-  return (0);
+  return 0;
 } /* }}} int format_json_value_list_nocheck */
 
 int format_json_initialize(char *buffer, /* {{{ */
@@ -411,7 +411,7 @@ int format_json_initialize(char *buffer, /* {{{ */
 
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   buffer_fill = *ret_buffer_fill;
   buffer_free = *ret_buffer_free;
@@ -420,13 +420,13 @@ int format_json_initialize(char *buffer, /* {{{ */
   buffer_fill = 0;
 
   if (buffer_free < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   memset(buffer, 0, buffer_free);
   *ret_buffer_fill = buffer_fill;
   *ret_buffer_free = buffer_free;
 
-  return (0);
+  return 0;
 } /* }}} int format_json_initialize */
 
 int format_json_finalize(char *buffer, /* {{{ */
@@ -435,15 +435,15 @@ int format_json_finalize(char *buffer, /* {{{ */
 
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (*ret_buffer_free < 2)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   /* Replace the leading comma added in `value_list_to_json' with a square
    * bracket. */
   if (buffer[0] != ',')
-    return (-EINVAL);
+    return -EINVAL;
   buffer[0] = '[';
 
   pos = *ret_buffer_fill;
@@ -453,7 +453,7 @@ int format_json_finalize(char *buffer, /* {{{ */
   (*ret_buffer_fill)++;
   (*ret_buffer_free)--;
 
-  return (0);
+  return 0;
 } /* }}} int format_json_finalize */
 
 int format_json_value_list(char *buffer, /* {{{ */
@@ -462,14 +462,14 @@ int format_json_value_list(char *buffer, /* {{{ */
                            int store_rates) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (*ret_buffer_free < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
-  return (format_json_value_list_nocheck(buffer, ret_buffer_fill,
-                                         ret_buffer_free, ds, vl, store_rates,
-                                         (*ret_buffer_free) - 2));
+  return format_json_value_list_nocheck(buffer, ret_buffer_fill,
+                                        ret_buffer_free, ds, vl, store_rates,
+                                        (*ret_buffer_free) - 2);
 } /* }}} int format_json_value_list */
 
 #if HAVE_LIBYAJL
@@ -478,7 +478,7 @@ static int json_add_string(yajl_gen g, char const *str) /* {{{ */
   if (str == NULL)
     return (int)yajl_gen_null(g);
 
-  return (int)yajl_gen_string(g, (unsigned char const *)str,
+  return (int)yajl_gen_string(g, (const unsigned char *)str,
                               (unsigned int)strlen(str));
 } /* }}} int json_add_string */
 

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -59,10 +59,10 @@ static int kairosdb_escape_string(char *buffer, size_t buffer_size, /* {{{ */
   size_t dst_pos;
 
   if ((buffer == NULL) || (string == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (buffer_size < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   dst_pos = 0;
 
@@ -70,7 +70,7 @@ static int kairosdb_escape_string(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     if (dst_pos >= (buffer_size - 1)) {                                        \
       buffer[buffer_size - 1] = 0;                                             \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     }                                                                          \
     buffer[dst_pos] = (c);                                                     \
     dst_pos++;                                                                 \
@@ -89,7 +89,7 @@ static int kairosdb_escape_string(char *buffer, size_t buffer_size, /* {{{ */
 
 #undef BUFFER_ADD
 
-  return (0);
+  return 0;
 } /* }}} int kairosdb_escape_string */
 
 static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
@@ -106,10 +106,10 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     } else if (((size_t)status) >= (buffer_size - offset)) {                   \
       sfree(rates);                                                            \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     } else                                                                     \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -125,7 +125,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
             "%s|%s|%s|%s|%s",
             vl->plugin, vl->plugin_instance, vl->type, vl->type_instance,
             ds->ds[ds_idx].name);
-      return (-1);
+      return -1;
     }
   } else if (store_rates) {
     if (rates == NULL)
@@ -135,7 +135,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
               vl->plugin, vl->plugin_instance, vl->type, vl->type_instance,
               ds->ds[ds_idx].name);
 
-      return (-1);
+      return -1;
     }
 
     if (isfinite(rates[ds_idx])) {
@@ -148,7 +148,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
               vl->plugin, vl->plugin_instance, vl->type, vl->type_instance,
               ds->ds[ds_idx].name);
       sfree(rates);
-      return (-1);
+      return -1;
     }
   } else if (ds->ds[ds_idx].type == DS_TYPE_COUNTER) {
     BUFFER_ADD("[[");
@@ -168,7 +168,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
   } else {
     ERROR("format_kairosdb: Unknown data source type: %i", ds->ds[ds_idx].type);
     sfree(rates);
-    return (-1);
+    return -1;
   }
   BUFFER_ADD("]]");
 
@@ -176,7 +176,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_kairosdb: values_to_kairosdb: buffer = %s;", buffer);
   sfree(rates);
-  return (0);
+  return 0;
 } /* }}} int values_to_kairosdb */
 
 static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
@@ -194,9 +194,9 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
-      return (-1);                                                             \
+      return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
-      return (-ENOMEM);                                                        \
+      return -ENOMEM;                                                          \
     else                                                                       \
       offset += ((size_t)status);                                              \
   } while (0)
@@ -205,7 +205,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
   do {                                                                         \
     status = kairosdb_escape_string(temp, sizeof(temp), (value));              \
     if (status != 0)                                                           \
-      return (status);                                                         \
+      return status;                                                           \
     BUFFER_ADD(",\"%s\": %s", (key), temp);                                    \
   } while (0)
 
@@ -220,7 +220,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
     status = values_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates, i);
     if (status != 0)
-      return (status);
+      return status;
 
     BUFFER_ADD("\", \"datapoints\": %s", temp);
 
@@ -256,7 +256,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
   DEBUG("format_kairosdb: value_list_to_kairosdb: buffer = %s;", buffer);
 
-  return (0);
+  return 0;
 } /* }}} int value_list_to_kairosdb */
 
 static int format_kairosdb_value_list_nocheck(
@@ -270,14 +270,14 @@ static int format_kairosdb_value_list_nocheck(
   status = value_list_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates,
                                   http_attrs, http_attrs_num, data_ttl);
   if (status != 0)
-    return (status);
+    return status;
   temp_size = strlen(temp);
 
   memcpy(buffer + (*ret_buffer_fill), temp, temp_size + 1);
   (*ret_buffer_fill) += temp_size;
   (*ret_buffer_free) -= temp_size;
 
-  return (0);
+  return 0;
 } /* }}} int format_kairosdb_value_list_nocheck */
 
 int format_kairosdb_initialize(char *buffer, /* {{{ */
@@ -288,7 +288,7 @@ int format_kairosdb_initialize(char *buffer, /* {{{ */
 
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   buffer_fill = *ret_buffer_fill;
   buffer_free = *ret_buffer_free;
@@ -297,13 +297,13 @@ int format_kairosdb_initialize(char *buffer, /* {{{ */
   buffer_fill = 0;
 
   if (buffer_free < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   memset(buffer, 0, buffer_free);
   *ret_buffer_fill = buffer_fill;
   *ret_buffer_free = buffer_free;
 
-  return (0);
+  return 0;
 } /* }}} int format_kairosdb_initialize */
 
 int format_kairosdb_finalize(char *buffer, /* {{{ */
@@ -312,15 +312,15 @@ int format_kairosdb_finalize(char *buffer, /* {{{ */
 
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (*ret_buffer_free < 2)
-    return (-ENOMEM);
+    return -ENOMEM;
 
   /* Replace the leading comma added in `value_list_to_kairosdb' with a square
    * bracket. */
   if (buffer[0] != ',')
-    return (-EINVAL);
+    return -EINVAL;
   buffer[0] = '[';
 
   pos = *ret_buffer_fill;
@@ -330,7 +330,7 @@ int format_kairosdb_finalize(char *buffer, /* {{{ */
   (*ret_buffer_fill)++;
   (*ret_buffer_free)--;
 
-  return (0);
+  return 0;
 } /* }}} int format_kairosdb_finalize */
 
 int format_kairosdb_value_list(char *buffer, /* {{{ */
@@ -340,14 +340,17 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
                                size_t http_attrs_num, int data_ttl) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   if (*ret_buffer_free < 3)
-    return (-ENOMEM);
+    return -ENOMEM;
 
-  return (format_kairosdb_value_list_nocheck(
-      buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
-      (*ret_buffer_free) - 2, http_attrs, http_attrs_num, data_ttl));
+  return format_kairosdb_value_list_nocheck(buffer, ret_buffer_fill,
+                                            ret_buffer_free, ds, vl,
+                                            store_rates,
+                                            (*ret_buffer_free) - 2,
+                                            http_attrs, http_attrs_num,
+                                            data_ttl);
 } /* }}} int format_kairosdb_value_list */
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_ignorelist.c
+++ b/src/utils_ignorelist.c
@@ -94,7 +94,7 @@ static int ignorelist_append_regex(ignorelist_t *il, const char *re_str) {
   re = calloc(1, sizeof(*re));
   if (re == NULL) {
     ERROR("ignorelist_append_regex: calloc failed.");
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   status = regcomp(re, re_str, REG_EXTENDED);
@@ -106,7 +106,7 @@ static int ignorelist_append_regex(ignorelist_t *il, const char *re_str) {
           "failed: %s",
           re_str, errbuf);
     sfree(re);
-    return (status);
+    return status;
   }
 
   entry = calloc(1, sizeof(*entry));
@@ -114,12 +114,12 @@ static int ignorelist_append_regex(ignorelist_t *il, const char *re_str) {
     ERROR("ignorelist_append_regex: calloc failed.");
     regfree(re);
     sfree(re);
-    return (ENOMEM);
+    return ENOMEM;
   }
   entry->rmatch = re;
 
   ignorelist_append(il, entry);
-  return (0);
+  return 0;
 } /* int ignorelist_append_regex */
 #endif
 
@@ -129,14 +129,14 @@ static int ignorelist_append_string(ignorelist_t *il, const char *entry) {
   /* create new entry */
   if ((new = calloc(1, sizeof(*new))) == NULL) {
     ERROR("cannot allocate new entry");
-    return (1);
+    return 1;
   }
   new->smatch = sstrdup(entry);
 
   /* append new entry */
   ignorelist_append(il, new);
 
-  return (0);
+  return 0;
 } /* int ignorelist_append_string(ignorelist_t *il, const char *entry) */
 
 #if HAVE_REGEX_H
@@ -150,9 +150,9 @@ static int ignorelist_match_regex(ignorelist_item_t *item, const char *entry) {
 
   /* match regex */
   if (regexec(item->rmatch, entry, 0, NULL, 0) == 0)
-    return (1);
+    return 1;
 
-  return (0);
+  return 0;
 } /* int ignorelist_match_regex (ignorelist_item_t *item, const char *entry) */
 #endif
 
@@ -165,9 +165,9 @@ static int ignorelist_match_string(ignorelist_item_t *item, const char *entry) {
          (strlen(entry) > 0));
 
   if (strcmp(entry, item->smatch) == 0)
-    return (1);
+    return 1;
 
-  return (0);
+  return 0;
 } /* int ignorelist_match_string (ignorelist_item_t *item, const char *entry) */
 
 /* *** *** *** ******************************************** *** *** *** */
@@ -191,7 +191,7 @@ ignorelist_t *ignorelist_create(int invert) {
    */
   il->ignore = invert ? 0 : 1;
 
-  return (il);
+  return il;
 } /* ignorelist_t *ignorelist_create (int ignore) */
 
 /*
@@ -244,7 +244,7 @@ int ignorelist_add(ignorelist_t *il, const char *entry) {
 
   if (il == NULL) {
     DEBUG("add called with ignorelist_t == NULL");
-    return (1);
+    return 1;
   }
 
   len = strlen(entry);
@@ -252,7 +252,7 @@ int ignorelist_add(ignorelist_t *il, const char *entry) {
   /* append nothing */
   if (len == 0) {
     DEBUG("not appending: empty entry");
-    return (1);
+    return 1;
   }
 
 #if HAVE_REGEX_H
@@ -285,10 +285,10 @@ int ignorelist_add(ignorelist_t *il, const char *entry) {
 int ignorelist_match(ignorelist_t *il, const char *entry) {
   /* if no entries, collect all */
   if ((il == NULL) || (il->head == NULL))
-    return (0);
+    return 0;
 
   if ((entry == NULL) || (strlen(entry) == 0))
-    return (0);
+    return 0;
 
   /* traverse list and check entries */
   for (ignorelist_item_t *traverse = il->head; traverse != NULL;
@@ -296,14 +296,14 @@ int ignorelist_match(ignorelist_t *il, const char *entry) {
 #if HAVE_REGEX_H
     if (traverse->rmatch != NULL) {
       if (ignorelist_match_regex(traverse, entry))
-        return (il->ignore);
+        return il->ignore;
     } else
 #endif
     {
       if (ignorelist_match_string(traverse, entry))
-        return (il->ignore);
+        return il->ignore;
     }
   } /* for traverse */
 
-  return (1 - il->ignore);
+  return 1 - il->ignore;
 } /* int ignorelist_match (ignorelist_t *il, const char *entry) */

--- a/src/utils_latency.c
+++ b/src/utils_latency.c
@@ -119,11 +119,11 @@ latency_counter_t *latency_counter_create(void) /* {{{ */
 
   lc = calloc(1, sizeof(*lc));
   if (lc == NULL)
-    return (NULL);
+    return NULL;
 
   lc->bin_width = HISTOGRAM_DEFAULT_BIN_WIDTH;
   latency_counter_reset(lc);
-  return (lc);
+  return lc;
 } /* }}} latency_counter_t *latency_counter_create */
 
 void latency_counter_destroy(latency_counter_t *lc) /* {{{ */
@@ -198,29 +198,29 @@ void latency_counter_reset(latency_counter_t *lc) /* {{{ */
 cdtime_t latency_counter_get_min(latency_counter_t *lc) /* {{{ */
 {
   if (lc == NULL)
-    return (0);
-  return (lc->min);
+    return 0;
+  return lc->min;
 } /* }}} cdtime_t latency_counter_get_min */
 
 cdtime_t latency_counter_get_max(latency_counter_t *lc) /* {{{ */
 {
   if (lc == NULL)
-    return (0);
-  return (lc->max);
+    return 0;
+  return lc->max;
 } /* }}} cdtime_t latency_counter_get_max */
 
 cdtime_t latency_counter_get_sum(latency_counter_t *lc) /* {{{ */
 {
   if (lc == NULL)
-    return (0);
-  return (lc->sum);
+    return 0;
+  return lc->sum;
 } /* }}} cdtime_t latency_counter_get_sum */
 
 size_t latency_counter_get_num(latency_counter_t *lc) /* {{{ */
 {
   if (lc == NULL)
-    return (0);
-  return (lc->num);
+    return 0;
+  return lc->num;
 } /* }}} size_t latency_counter_get_num */
 
 cdtime_t latency_counter_get_average(latency_counter_t *lc) /* {{{ */
@@ -228,10 +228,10 @@ cdtime_t latency_counter_get_average(latency_counter_t *lc) /* {{{ */
   double average;
 
   if ((lc == NULL) || (lc->num == 0))
-    return (0);
+    return 0;
 
   average = CDTIME_T_TO_DOUBLE(lc->sum) / ((double)lc->num);
-  return (DOUBLE_TO_CDTIME_T(average));
+  return DOUBLE_TO_CDTIME_T(average);
 } /* }}} cdtime_t latency_counter_get_average */
 
 cdtime_t latency_counter_get_percentile(latency_counter_t *lc, /* {{{ */
@@ -245,7 +245,7 @@ cdtime_t latency_counter_get_percentile(latency_counter_t *lc, /* {{{ */
   size_t i;
 
   if ((lc == NULL) || (lc->num == 0) || !((percent > 0.0) && (percent < 100.0)))
-    return (0);
+    return 0;
 
   /* Find index i so that at least "percent" events are within i+1 ms. */
   percent_upper = 0.0;
@@ -264,13 +264,13 @@ cdtime_t latency_counter_get_percentile(latency_counter_t *lc, /* {{{ */
   }
 
   if (i >= HISTOGRAM_NUM_BINS)
-    return (0);
+    return 0;
 
   assert(percent_upper >= percent);
   assert(percent_lower < percent);
 
   if (i == 0)
-    return (lc->bin_width);
+    return lc->bin_width;
 
   latency_lower = ((cdtime_t)i) * lc->bin_width;
   p = (percent - percent_lower) / (percent_upper - percent_lower);
@@ -280,19 +280,19 @@ cdtime_t latency_counter_get_percentile(latency_counter_t *lc, /* {{{ */
 
   DEBUG("latency_counter_get_percentile: latency_interpolated = %.3f",
         CDTIME_T_TO_DOUBLE(latency_interpolated));
-  return (latency_interpolated);
+  return latency_interpolated;
 } /* }}} cdtime_t latency_counter_get_percentile */
 
 double latency_counter_get_rate(const latency_counter_t *lc, /* {{{ */
                                 cdtime_t lower, cdtime_t upper,
                                 const cdtime_t now) {
   if ((lc == NULL) || (lc->num == 0))
-    return (NAN);
+    return NAN;
 
   if (upper && (upper < lower))
-    return (NAN);
+    return NAN;
   if (lower == upper)
-    return (0);
+    return 0;
 
   /* Buckets have an exclusive lower bound and an inclusive upper bound. That
    * means that the first bucket, index 0, represents (0-bin_width]. That means
@@ -305,7 +305,7 @@ double latency_counter_get_rate(const latency_counter_t *lc, /* {{{ */
 
   /* lower is greater than the longest latency observed => rate is zero. */
   if (lower_bin >= HISTOGRAM_NUM_BINS)
-    return (0);
+    return 0;
 
   cdtime_t upper_bin = HISTOGRAM_NUM_BINS - 1;
   if (upper)

--- a/src/utils_latency_config.c
+++ b/src/utils_latency_config.c
@@ -91,7 +91,7 @@ static int latency_config_add_bucket(latency_config_t *conf, oconfig_item_t *ci,
       DOUBLE_TO_CDTIME_T(ci->values[1].value.number);
   conf->buckets_num++;
 
-  return (0);
+  return 0;
 } /* int latency_config_add_bucket */
 
 int latency_config(latency_config_t *conf, oconfig_item_t *ci,

--- a/src/utils_lua.c
+++ b/src/utils_lua.c
@@ -35,7 +35,7 @@ static int ltoc_values(lua_State *L, /* {{{ */
                        const data_set_t *ds, value_t *ret_values) {
   if (!lua_istable(L, -1)) {
     WARNING("ltoc_values: not a table");
-    return (-1);
+    return -1;
   }
 
   /* Push initial key */
@@ -60,10 +60,10 @@ static int ltoc_values(lua_State *L, /* {{{ */
     WARNING("ltoc_values: invalid size for datasource \"%s\": expected %zu, "
             "got %zu",
             ds->type, ds->ds_num, i);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int ltoc_values */
 
 static int ltoc_table_values(lua_State *L, int idx, /* {{{ */
@@ -78,7 +78,7 @@ static int ltoc_table_values(lua_State *L, int idx, /* {{{ */
             "value, not a table.",
             lua_typename(L, lua_type(L, -1)));
     lua_pop(L, 1);
-    return (-1);
+    return -1;
   }
 
   vl->values_len = ds->ds_num;
@@ -87,7 +87,7 @@ static int ltoc_table_values(lua_State *L, int idx, /* {{{ */
     ERROR("utils_lua: calloc failed.");
     vl->values_len = 0;
     lua_pop(L, 1);
-    return (-1);
+    return -1;
   }
 
   int status = ltoc_values(L, ds, vl->values);
@@ -99,7 +99,7 @@ static int ltoc_table_values(lua_State *L, int idx, /* {{{ */
     sfree(vl->values);
   }
 
-  return (status);
+  return status;
 } /* }}} int ltoc_table_values */
 
 static int luaC_pushvalues(lua_State *L, const data_set_t *ds,
@@ -114,7 +114,7 @@ static int luaC_pushvalues(lua_State *L, const data_set_t *ds,
     lua_settable(L, -3);
   }
 
-  return (0);
+  return 0;
 } /* }}} int luaC_pushvalues */
 
 static int luaC_pushdstypes(lua_State *L, const data_set_t *ds) /* {{{ */
@@ -126,7 +126,7 @@ static int luaC_pushdstypes(lua_State *L, const data_set_t *ds) /* {{{ */
     lua_settable(L, -3);
   }
 
-  return (0);
+  return 0;
 } /* }}} int luaC_pushdstypes */
 
 static int luaC_pushdsnames(lua_State *L, const data_set_t *ds) /* {{{ */
@@ -138,7 +138,7 @@ static int luaC_pushdsnames(lua_State *L, const data_set_t *ds) /* {{{ */
     lua_settable(L, -3);
   }
 
-  return (0);
+  return 0;
 } /* }}} int luaC_pushdsnames */
 
 /*
@@ -147,21 +147,21 @@ static int luaC_pushdsnames(lua_State *L, const data_set_t *ds) /* {{{ */
 cdtime_t luaC_tocdtime(lua_State *L, int idx) /* {{{ */
 {
   if (!lua_isnumber(L, /* stack pos = */ idx))
-    return (0);
+    return 0;
 
   double d = lua_tonumber(L, idx);
 
-  return (DOUBLE_TO_CDTIME_T(d));
+  return DOUBLE_TO_CDTIME_T(d);
 } /* }}} int ltoc_table_cdtime */
 
 int luaC_tostringbuffer(lua_State *L, int idx, /* {{{ */
                         char *buffer, size_t buffer_size) {
   const char *str = lua_tostring(L, idx);
   if (str == NULL)
-    return (-1);
+    return -1;
 
   sstrncpy(buffer, str, buffer_size);
-  return (0);
+  return 0;
 } /* }}} int luaC_tostringbuffer */
 
 value_t luaC_tovalue(lua_State *L, int idx, int ds_type) /* {{{ */
@@ -169,7 +169,7 @@ value_t luaC_tovalue(lua_State *L, int idx, int ds_type) /* {{{ */
   value_t v = {0};
 
   if (!lua_isnumber(L, idx))
-    return (v);
+    return v;
 
   if (ds_type == DS_TYPE_GAUGE)
     v.gauge = (gauge_t)lua_tonumber(L, /* stack pos = */ -1);
@@ -180,7 +180,7 @@ value_t luaC_tovalue(lua_State *L, int idx, int ds_type) /* {{{ */
   else if (ds_type == DS_TYPE_ABSOLUTE)
     v.absolute = (absolute_t)lua_tointeger(L, /* stack pos = */ -1);
 
-  return (v);
+  return v;
 } /* }}} value_t luaC_tovalue */
 
 value_list_t *luaC_tovaluelist(lua_State *L, int idx) /* {{{ */
@@ -197,13 +197,13 @@ value_list_t *luaC_tovaluelist(lua_State *L, int idx) /* {{{ */
   /* Check that idx is in the valid range */
   if ((idx < 1) || (idx > lua_gettop(L))) {
     DEBUG("luaC_tovaluelist: idx(%d), top(%d)", idx, stack_top_before);
-    return (NULL);
+    return NULL;
   }
 
   value_list_t *vl = calloc(1, sizeof(*vl));
   if (vl == NULL) {
     DEBUG("luaC_tovaluelist: calloc failed");
-    return (NULL);
+    return NULL;
   }
 
   /* Push initial key */
@@ -243,20 +243,20 @@ value_list_t *luaC_tovaluelist(lua_State *L, int idx) /* {{{ */
   if (ds == NULL) {
     INFO("utils_lua: Unable to lookup type \"%s\".", vl->type);
     sfree(vl);
-    return (NULL);
+    return NULL;
   }
 
   int status = ltoc_table_values(L, idx, ds, vl);
   if (status != 0) {
     WARNING("utils_lua: ltoc_table_values failed.");
     sfree(vl);
-    return (NULL);
+    return NULL;
   }
 
 #if COLLECT_DEBUG
   assert(stack_top_before == lua_gettop(L));
 #endif
-  return (vl);
+  return vl;
 } /* }}} value_list_t *luaC_tovaluelist */
 
 int luaC_pushcdtime(lua_State *L, cdtime_t t) /* {{{ */
@@ -264,7 +264,7 @@ int luaC_pushcdtime(lua_State *L, cdtime_t t) /* {{{ */
   double d = CDTIME_T_TO_DOUBLE(t);
 
   lua_pushnumber(L, (lua_Number)d);
-  return (0);
+  return 0;
 } /* }}} int luaC_pushcdtime */
 
 int luaC_pushvalue(lua_State *L, value_t v, int ds_type) /* {{{ */
@@ -278,8 +278,8 @@ int luaC_pushvalue(lua_State *L, value_t v, int ds_type) /* {{{ */
   else if (ds_type == DS_TYPE_ABSOLUTE)
     lua_pushinteger(L, (lua_Integer)v.absolute);
   else
-    return (-1);
-  return (0);
+    return -1;
+  return 0;
 } /* }}} int luaC_pushvalue */
 
 int luaC_pushvaluelist(lua_State *L, const data_set_t *ds,
@@ -315,5 +315,5 @@ int luaC_pushvaluelist(lua_State *L, const data_set_t *ds,
   luaC_pushcdtime(L, vl->interval);
   lua_setfield(L, -2, "interval");
 
-  return (0);
+  return 0;
 } /* }}} int luaC_pushvaluelist */

--- a/src/utils_match.c
+++ b/src/utils_match.c
@@ -55,21 +55,21 @@ static char *match_substr(const char *str, int begin, int end) {
   size_t ret_len;
 
   if ((begin < 0) || (end < 0) || (begin >= end))
-    return (NULL);
+    return NULL;
   if ((size_t)end > (strlen(str) + 1)) {
     ERROR("utils_match: match_substr: `end' points after end of string.");
-    return (NULL);
+    return NULL;
   }
 
   ret_len = end - begin;
   ret = malloc(ret_len + 1);
   if (ret == NULL) {
     ERROR("utils_match: match_substr: malloc failed.");
-    return (NULL);
+    return NULL;
   }
 
   sstrncpy(ret, str + begin, ret_len + 1);
-  return (ret);
+  return ret;
 } /* char *match_substr */
 
 static int default_callback(const char __attribute__((unused)) * str,
@@ -84,20 +84,20 @@ static int default_callback(const char __attribute__((unused)) * str,
     if (data->ds_type & UTILS_MATCH_CF_GAUGE_INC) {
       data->value.gauge = isnan(data->value.gauge) ? 1 : data->value.gauge + 1;
       data->values_num++;
-      return (0);
+      return 0;
     }
 
     if (matches_num < 2)
-      return (-1);
+      return -1;
 
     value = (gauge_t)strtod(matches[1], &endptr);
     if (matches[1] == endptr)
-      return (-1);
+      return -1;
 
     if (data->ds_type & UTILS_MATCH_CF_GAUGE_DIST) {
       latency_counter_add(data->latency, DOUBLE_TO_CDTIME_T(value));
       data->values_num++;
-      return (0);
+      return 0;
     }
 
     if ((data->values_num == 0) ||
@@ -117,7 +117,7 @@ static int default_callback(const char __attribute__((unused)) * str,
       data->value.gauge += value;
     } else {
       ERROR("utils_match: default_callback: obj->ds_type is invalid!");
-      return (-1);
+      return -1;
     }
 
     data->values_num++;
@@ -128,15 +128,15 @@ static int default_callback(const char __attribute__((unused)) * str,
     if (data->ds_type & UTILS_MATCH_CF_COUNTER_INC) {
       data->value.counter++;
       data->values_num++;
-      return (0);
+      return 0;
     }
 
     if (matches_num < 2)
-      return (-1);
+      return -1;
 
     value = (counter_t)strtoull(matches[1], &endptr, 0);
     if (matches[1] == endptr)
-      return (-1);
+      return -1;
 
     if (data->ds_type & UTILS_MATCH_CF_COUNTER_SET)
       data->value.counter = value;
@@ -144,7 +144,7 @@ static int default_callback(const char __attribute__((unused)) * str,
       data->value.counter += value;
     else {
       ERROR("utils_match: default_callback: obj->ds_type is invalid!");
-      return (-1);
+      return -1;
     }
 
     data->values_num++;
@@ -155,15 +155,15 @@ static int default_callback(const char __attribute__((unused)) * str,
     if (data->ds_type & UTILS_MATCH_CF_DERIVE_INC) {
       data->value.derive++;
       data->values_num++;
-      return (0);
+      return 0;
     }
 
     if (matches_num < 2)
-      return (-1);
+      return -1;
 
     value = (derive_t)strtoll(matches[1], &endptr, 0);
     if (matches[1] == endptr)
-      return (-1);
+      return -1;
 
     if (data->ds_type & UTILS_MATCH_CF_DERIVE_SET)
       data->value.derive = value;
@@ -171,7 +171,7 @@ static int default_callback(const char __attribute__((unused)) * str,
       data->value.derive += value;
     else {
       ERROR("utils_match: default_callback: obj->ds_type is invalid!");
-      return (-1);
+      return -1;
     }
 
     data->values_num++;
@@ -180,26 +180,26 @@ static int default_callback(const char __attribute__((unused)) * str,
     char *endptr = NULL;
 
     if (matches_num < 2)
-      return (-1);
+      return -1;
 
     value = (absolute_t)strtoull(matches[1], &endptr, 0);
     if (matches[1] == endptr)
-      return (-1);
+      return -1;
 
     if (data->ds_type & UTILS_MATCH_CF_ABSOLUTE_SET)
       data->value.absolute = value;
     else {
       ERROR("utils_match: default_callback: obj->ds_type is invalid!");
-      return (-1);
+      return -1;
     }
 
     data->values_num++;
   } else {
     ERROR("utils_match: default_callback: obj->ds_type is invalid!");
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int default_callback */
 
 static void match_simple_free(void *data) {
@@ -227,13 +227,13 @@ match_create_callback(const char *regex, const char *excluderegex,
 
   obj = calloc(1, sizeof(*obj));
   if (obj == NULL)
-    return (NULL);
+    return NULL;
 
   status = regcomp(&obj->regex, regex, REG_EXTENDED | REG_NEWLINE);
   if (status != 0) {
     ERROR("Compiling the regular expression \"%s\" failed.", regex);
     sfree(obj);
-    return (NULL);
+    return NULL;
   }
   obj->flags |= UTILS_MATCH_FLAGS_REGEX;
 
@@ -243,7 +243,7 @@ match_create_callback(const char *regex, const char *excluderegex,
       ERROR("Compiling the excluding regular expression \"%s\" failed.",
             excluderegex);
       sfree(obj);
-      return (NULL);
+      return NULL;
     }
     obj->flags |= UTILS_MATCH_FLAGS_EXCLUDE_REGEX;
   }
@@ -252,7 +252,7 @@ match_create_callback(const char *regex, const char *excluderegex,
   obj->user_data = user_data;
   obj->free = free_user_data;
 
-  return (obj);
+  return obj;
 } /* cu_match_t *match_create_callback */
 
 cu_match_t *match_create_simple(const char *regex, const char *excluderegex,
@@ -262,7 +262,7 @@ cu_match_t *match_create_simple(const char *regex, const char *excluderegex,
 
   user_data = calloc(1, sizeof(*user_data));
   if (user_data == NULL)
-    return (NULL);
+    return NULL;
   user_data->ds_type = match_ds_type;
 
   if ((match_ds_type & UTILS_MATCH_DS_TYPE_GAUGE) &&
@@ -271,7 +271,7 @@ cu_match_t *match_create_simple(const char *regex, const char *excluderegex,
     if (user_data->latency == NULL) {
       ERROR("match_create_simple(): latency_counter_create() failed.");
       free(user_data);
-      return (NULL);
+      return NULL;
     }
   }
 
@@ -282,9 +282,9 @@ cu_match_t *match_create_simple(const char *regex, const char *excluderegex,
       latency_counter_destroy(user_data->latency);
 
     sfree(user_data);
-    return (NULL);
+    return NULL;
   }
-  return (obj);
+  return obj;
 } /* cu_match_t *match_create_simple */
 
 void match_value_reset(cu_match_value_t *mv) {
@@ -320,7 +320,7 @@ int match_apply(cu_match_t *obj, const char *str) {
   size_t matches_num;
 
   if ((obj == NULL) || (str == NULL))
-    return (-1);
+    return -1;
 
   if (obj->flags & UTILS_MATCH_FLAGS_EXCLUDE_REGEX) {
     status =
@@ -329,7 +329,7 @@ int match_apply(cu_match_t *obj, const char *str) {
     /* Regex did match, so exclude this line */
     if (status == 0) {
       DEBUG("ExludeRegex matched, don't count that line\n");
-      return (0);
+      return 0;
     }
   }
 
@@ -338,7 +338,7 @@ int match_apply(cu_match_t *obj, const char *str) {
 
   /* Regex did not match */
   if (status != 0)
-    return (0);
+    return 0;
 
   for (matches_num = 0; matches_num < STATIC_ARRAY_SIZE(matches);
        matches_num++) {
@@ -366,11 +366,11 @@ int match_apply(cu_match_t *obj, const char *str) {
     sfree(matches[i]);
   }
 
-  return (status);
+  return status;
 } /* int match_apply */
 
 void *match_get_user_data(cu_match_t *obj) {
   if (obj == NULL)
-    return (NULL);
-  return (obj->user_data);
+    return NULL;
+  return obj->user_data;
 } /* void *match_get_user_data */

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -270,11 +270,11 @@ static void uuidcache_init(void) {
 
 static unsigned char fromhex(char c) {
   if (isdigit((int)c)) {
-    return (c - '0');
+    return c - '0';
   } else if (islower((int)c)) {
-    return (c - 'a' + 10);
+    return c - 'a' + 10;
   } else {
-    return (c - 'A' + 10);
+    return c - 'A' + 10;
   }
 }
 
@@ -335,7 +335,7 @@ static char *get_device_name(const char *optstr) {
   char *rc;
 
   if (optstr == NULL) {
-    return (NULL);
+    return NULL;
   } else if (strncmp(optstr, "UUID=", 5) == 0) {
     DEBUG("utils_mount: TODO: check UUID= code!");
     rc = get_spec_by_uuid(optstr + 5);
@@ -401,7 +401,7 @@ static cu_mount_t *cu_mount_listmntent(void) {
     last->next = NULL;
   } /* for(p = mntlist; p; p = p->next) */
 
-  return (last);
+  return last;
 } /* cu_mount_t *cu_mount_listmntent(void) */
 /* #endif HAVE_LISTMNTENT */
 
@@ -435,11 +435,11 @@ static cu_mount_t *cu_mount_getfsstat(void) {
     DEBUG("utils_mount: getv?fsstat failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
 #endif /* COLLECT_DEBUG */
-    return (NULL);
+    return NULL;
   }
 
   if ((buf = calloc(bufsize, sizeof(*buf))) == NULL)
-    return (NULL);
+    return NULL;
 
   /* The bufsize needs to be passed in bytes. Really. This is not in the
    * manpage.. -octo */
@@ -451,7 +451,7 @@ static cu_mount_t *cu_mount_getfsstat(void) {
           sstrerror(errno, errbuf, sizeof(errbuf)));
 #endif /* COLLECT_DEBUG */
     free(buf);
-    return (NULL);
+    return NULL;
   }
 
   for (int i = 0; i < num; i++) {
@@ -478,7 +478,7 @@ static cu_mount_t *cu_mount_getfsstat(void) {
 
   free(buf);
 
-  return (first);
+  return first;
 }
 /* #endif HAVE_GETVFSSTAT || HAVE_GETFSSTAT */
 
@@ -498,7 +498,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
     char errbuf[1024];
     ERROR("fopen (%s): %s", COLLECTD_MNTTAB,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (NULL);
+    return NULL;
   }
 
   while (getmntent(fp, &mt) == 0) {
@@ -525,7 +525,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
 
   fclose(fp);
 
-  return (first);
+  return first;
 } /* static cu_mount_t *cu_mount_gen_getmntent (void) */
 /* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
 
@@ -549,7 +549,7 @@ static cu_mount_t *cu_mount_getmntent(void) {
     char errbuf[1024];
     ERROR("setmntent (%s): %s", COLLECTD_MNTTAB,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (NULL);
+    return NULL;
   }
 
   while (getmntent_r(fp, &me, mntbuf, sizeof(mntbuf))) {
@@ -580,9 +580,9 @@ static cu_mount_t *cu_mount_getmntent(void) {
 
   endmntent(fp);
 
-  DEBUG("utils_mount: return (0x%p)", (void *)first);
+  DEBUG("utils_mount: return 0x%p", (void *)first);
 
-  return (first);
+  return first;
 } /* HAVE_GETMNTENT_R */
 
 #elif HAVE_ONE_GETMNTENT
@@ -600,7 +600,7 @@ static cu_mount_t *cu_mount_getmntent(void) {
     char errbuf[1024];
     ERROR("setmntent (%s): %s", COLLECTD_MNTTAB,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (NULL);
+    return NULL;
   }
 
   while ((me = getmntent(fp)) != NULL) {
@@ -631,9 +631,9 @@ static cu_mount_t *cu_mount_getmntent(void) {
 
   endmntent(fp);
 
-  DEBUG("utils_mount: return (0x%p)", (void *)first);
+  DEBUG("utils_mount: return 0x%p", (void *)first);
 
-  return (first);
+  return first;
 }
 #endif /* HAVE_ONE_GETMNTENT */
 
@@ -647,7 +647,7 @@ cu_mount_t *cu_mount_getlist(cu_mount_t **list) {
   cu_mount_t *last = NULL;
 
   if (list == NULL)
-    return (NULL);
+    return NULL;
 
   if (*list != NULL) {
     first = *list;
@@ -681,7 +681,7 @@ cu_mount_t *cu_mount_getlist(cu_mount_t **list) {
   while ((last != NULL) && (last->next != NULL))
     last = last->next;
 
-  return (last);
+  return last;
 } /* cu_mount_t *cu_mount_getlist(cu_mount_t **list) */
 
 void cu_mount_freelist(cu_mount_t *list) {

--- a/src/utils_mount_test.c
+++ b/src/utils_mount_test.c
@@ -75,7 +75,7 @@ DEF_TEST(cu_mount_checkoption) {
   OK(NULL == cu_mount_checkoption(line_bool, "tw", 1));
   OK(NULL == cu_mount_checkoption(line_bool, "thr", 1));
 
-  return (0);
+  return 0;
 }
 DEF_TEST(cu_mount_getoptionvalue) {
   char line_opts[] = "foo=one,bar=two,qux=three";
@@ -100,7 +100,7 @@ DEF_TEST(cu_mount_getoptionvalue) {
   OK(NULL == (v = cu_mount_getoptionvalue(line_bool, "four")));
   sfree(v);
 
-  return (0);
+  return 0;
 }
 
 int main(void) {

--- a/src/utils_parse_option.c
+++ b/src/utils_parse_option.c
@@ -39,7 +39,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
   while (isspace((int)*string))
     string++;
   if (*string == 0)
-    return (1);
+    return 1;
 
   /* A quoted string */
   if (*string == '"') {
@@ -47,7 +47,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
 
     string++;
     if (*string == 0)
-      return (1);
+      return 1;
 
     dst = string;
     buffer = string;
@@ -57,7 +57,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
         buffer++;
         /* Catch a backslash at the end of buffer */
         if (*buffer == 0)
-          return (-1);
+          return -1;
       }
       *dst = *buffer;
       buffer++;
@@ -65,7 +65,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
     }
     /* No quote sign has been found */
     if (*buffer == 0)
-      return (-1);
+      return -1;
 
     *dst = 0;
     dst++;
@@ -74,7 +74,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
 
     /* Check for trailing spaces. */
     if ((*buffer != 0) && !isspace((int)*buffer))
-      return (-1);
+      return -1;
   } else /* an unquoted string */
   {
     buffer = string;
@@ -93,7 +93,7 @@ int parse_string(char **ret_buffer, char **ret_string) {
   *ret_buffer = buffer;
   *ret_string = string;
 
-  return (0);
+  return 0;
 } /* int parse_string */
 
 /*
@@ -120,23 +120,23 @@ int parse_option(char **ret_buffer, char **ret_key, char **ret_value) {
   while (isspace((int)*key))
     key++;
   if (*key == 0)
-    return (1);
+    return 1;
 
   /* Look for the equal sign */
   buffer = key;
   while (isalnum((int)*buffer) || *buffer == '_' || *buffer == ':')
     buffer++;
   if ((*buffer != '=') || (buffer == key))
-    return (1);
+    return 1;
   *buffer = 0;
   buffer++;
   /* Empty values must be written as "" */
   if (isspace((int)*buffer) || (*buffer == 0))
-    return (-1);
+    return -1;
 
   status = parse_string(&buffer, &value);
   if (status != 0)
-    return (-1);
+    return -1;
 
   /* NB: parse_string will have eaten up all trailing spaces. */
 
@@ -144,5 +144,5 @@ int parse_option(char **ret_buffer, char **ret_key, char **ret_value) {
   *ret_key = key;
   *ret_value = value;
 
-  return (0);
+  return 0;
 } /* int parse_option */

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -97,7 +97,7 @@ static srrd_create_args_t *srrd_create_args_create(const char *filename,
   args = calloc(1, sizeof(*args));
   if (args == NULL) {
     ERROR("srrd_create_args_create: calloc failed.");
-    return (NULL);
+    return NULL;
   }
   args->filename = NULL;
   args->pdp_step = pdp_step;
@@ -108,14 +108,14 @@ static srrd_create_args_t *srrd_create_args_create(const char *filename,
   if (args->filename == NULL) {
     ERROR("srrd_create_args_create: strdup failed.");
     srrd_create_args_destroy(args);
-    return (NULL);
+    return NULL;
   }
 
   args->argv = calloc((size_t)(argc + 1), sizeof(*args->argv));
   if (args->argv == NULL) {
     ERROR("srrd_create_args_create: calloc failed.");
     srrd_create_args_destroy(args);
-    return (NULL);
+    return NULL;
   }
 
   for (args->argc = 0; args->argc < argc; args->argc++) {
@@ -123,13 +123,13 @@ static srrd_create_args_t *srrd_create_args_create(const char *filename,
     if (args->argv[args->argc] == NULL) {
       ERROR("srrd_create_args_create: strdup failed.");
       srrd_create_args_destroy(args);
-      return (NULL);
+      return NULL;
     }
   }
   assert(args->argc == argc);
   args->argv[args->argc] = NULL;
 
-  return (args);
+  return args;
 } /* srrd_create_args_t *srrd_create_args_create */
 
 /* * * * * * * * * *
@@ -154,12 +154,12 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
 
   if (cfg->rrarows <= 0) {
     *ret = NULL;
-    return (-1);
+    return -1;
   }
 
   if ((cfg->xff < 0) || (cfg->xff >= 1.0)) {
     *ret = NULL;
-    return (-1);
+    return -1;
   }
 
   if (cfg->stepsize > 0)
@@ -168,7 +168,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
     ss = (int)CDTIME_T_TO_TIME_T(vl->interval);
   if (ss <= 0) {
     *ret = NULL;
-    return (-1);
+    return -1;
   }
 
   /* Use the configured timespans or fall back to the built-in defaults */
@@ -184,7 +184,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
   assert(rra_max > 0);
 
   if ((rra_def = calloc(rra_max + 1, sizeof(*rra_def))) == NULL)
-    return (-1);
+    return -1;
   rra_num = 0;
 
   cdp_len = 0;
@@ -222,11 +222,11 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
 
   if (rra_num <= 0) {
     sfree(rra_def);
-    return (0);
+    return 0;
   }
 
   *ret = rra_def;
-  return (rra_num);
+  return rra_num;
 } /* }}} int rra_get */
 
 static void ds_free(int ds_num, char **ds_def) /* {{{ */
@@ -254,7 +254,7 @@ static int ds_get(char ***ret, /* {{{ */
     char errbuf[1024];
     ERROR("rrdtool plugin: calloc failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   for (ds_num = 0; ds_num < ds->ds_num; ds_num++) {
@@ -300,16 +300,16 @@ static int ds_get(char ***ret, /* {{{ */
 
   if (ds_num != ds->ds_num) {
     ds_free(ds_num, ds_def);
-    return (-1);
+    return -1;
   }
 
   if (ds_num == 0) {
     sfree(ds_def);
-    return (0);
+    return 0;
   }
 
   *ret = ds_def;
-  return (ds_num);
+  return ds_num;
 } /* }}} int ds_get */
 
 #if HAVE_THREADSAFE_LIBRRD
@@ -320,7 +320,7 @@ static int srrd_create(const char *filename, /* {{{ */
   char *filename_copy;
 
   if ((filename == NULL) || (argv == NULL))
-    return (-EINVAL);
+    return -EINVAL;
 
   /* Some versions of librrd don't have the `const' qualifier for the first
    * argument, so we have to copy the pointer here to avoid warnings. It sucks,
@@ -328,7 +328,7 @@ static int srrd_create(const char *filename, /* {{{ */
   filename_copy = strdup(filename);
   if (filename_copy == NULL) {
     ERROR("srrd_create: strdup failed.");
-    return (-ENOMEM);
+    return -ENOMEM;
   }
 
   optind = 0; /* bug in librrd? */
@@ -343,7 +343,7 @@ static int srrd_create(const char *filename, /* {{{ */
 
   sfree(filename_copy);
 
-  return (status);
+  return status;
 } /* }}} int srrd_create */
 /* #endif HAVE_THREADSAFE_LIBRRD */
 
@@ -363,7 +363,7 @@ static int srrd_create(const char *filename, /* {{{ */
   new_argv = malloc((new_argc + 1) * sizeof(*new_argv));
   if (new_argv == NULL) {
     ERROR("rrdtool plugin: malloc failed.");
-    return (-1);
+    return -1;
   }
 
   if (last_up == 0)
@@ -396,7 +396,7 @@ static int srrd_create(const char *filename, /* {{{ */
 
   sfree(new_argv);
 
-  return (status);
+  return status;
 } /* }}} int srrd_create */
 #endif /* !HAVE_THREADSAFE_LIBRRD */
 
@@ -414,26 +414,26 @@ static int lock_file(char const *filename) /* {{{ */
 
   if (ptr != NULL) {
     pthread_mutex_unlock(&async_creation_lock);
-    return (EEXIST);
+    return EEXIST;
   }
 
   status = stat(filename, &sb);
   if ((status == 0) || (errno != ENOENT)) {
     pthread_mutex_unlock(&async_creation_lock);
-    return (EEXIST);
+    return EEXIST;
   }
 
   ptr = malloc(sizeof(*ptr));
   if (ptr == NULL) {
     pthread_mutex_unlock(&async_creation_lock);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   ptr->filename = strdup(filename);
   if (ptr->filename == NULL) {
     pthread_mutex_unlock(&async_creation_lock);
     sfree(ptr);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   ptr->next = async_creation_list;
@@ -441,7 +441,7 @@ static int lock_file(char const *filename) /* {{{ */
 
   pthread_mutex_unlock(&async_creation_lock);
 
-  return (0);
+  return 0;
 } /* }}} int lock_file */
 
 static int unlock_file(char const *filename) /* {{{ */
@@ -460,7 +460,7 @@ static int unlock_file(char const *filename) /* {{{ */
 
   if (this == NULL) {
     pthread_mutex_unlock(&async_creation_lock);
-    return (ENOENT);
+    return ENOENT;
   }
 
   if (prev == NULL) {
@@ -477,7 +477,7 @@ static int unlock_file(char const *filename) /* {{{ */
   sfree(this->filename);
   sfree(this);
 
-  return (0);
+  return 0;
 } /* }}} int unlock_file */
 
 static void *srrd_create_thread(void *targs) /* {{{ */
@@ -494,7 +494,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     else
       ERROR("srrd_create_thread: Unable to lock file \"%s\".", args->filename);
     srrd_create_args_destroy(args);
-    return (0);
+    return 0;
   }
 
   ssnprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
@@ -507,7 +507,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     unlink(tmpfile);
     unlock_file(args->filename);
     srrd_create_args_destroy(args);
-    return (0);
+    return 0;
   }
 
   status = rename(tmpfile, args->filename);
@@ -518,7 +518,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     unlink(tmpfile);
     unlock_file(args->filename);
     srrd_create_args_destroy(args);
-    return (0);
+    return 0;
   }
 
   DEBUG("srrd_create_thread: Successfully created RRD file \"%s\".",
@@ -527,7 +527,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
   unlock_file(args->filename);
   srrd_create_args_destroy(args);
 
-  return (0);
+  return 0;
 } /* }}} void *srrd_create_thread */
 
 static int srrd_create_async(const char *filename, /* {{{ */
@@ -542,19 +542,19 @@ static int srrd_create_async(const char *filename, /* {{{ */
 
   args = srrd_create_args_create(filename, pdp_step, last_up, argc, argv);
   if (args == NULL)
-    return (-1);
+    return -1;
 
   status = pthread_attr_init(&attr);
   if (status != 0) {
     srrd_create_args_destroy(args);
-    return (-1);
+    return -1;
   }
 
   status = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   if (status != 0) {
     pthread_attr_destroy(&attr);
     srrd_create_args_destroy(args);
-    return (-1);
+    return -1;
   }
 
   status = pthread_create(&thread, &attr, srrd_create_thread, args);
@@ -564,12 +564,12 @@ static int srrd_create_async(const char *filename, /* {{{ */
           sstrerror(status, errbuf, sizeof(errbuf)));
     pthread_attr_destroy(&attr);
     srrd_create_args_destroy(args);
-    return (status);
+    return status;
   }
 
   pthread_attr_destroy(&attr);
   /* args is freed in srrd_create_thread(). */
-  return (0);
+  return 0;
 } /* }}} int srrd_create_async */
 
 /*
@@ -589,17 +589,17 @@ int cu_rrd_create_file(const char *filename, /* {{{ */
   unsigned long stepsize;
 
   if (check_create_dir(filename))
-    return (-1);
+    return -1;
 
   if ((rra_num = rra_get(&rra_def, vl, cfg)) < 1) {
     ERROR("cu_rrd_create_file failed: Could not calculate RRAs");
-    return (-1);
+    return -1;
   }
 
   if ((ds_num = ds_get(&ds_def, ds, vl, cfg)) < 1) {
     ERROR("cu_rrd_create_file failed: Could not calculate DSes");
     rra_free(rra_num, rra_def);
-    return (-1);
+    return -1;
   }
 
   argc = ds_num + rra_num;
@@ -610,7 +610,7 @@ int cu_rrd_create_file(const char *filename, /* {{{ */
           sstrerror(errno, errbuf, sizeof(errbuf)));
     rra_free(rra_num, rra_def);
     ds_free(ds_num, ds_def);
-    return (-1);
+    return -1;
   }
 
   memcpy(argv, ds_def, ds_num * sizeof(char *));
@@ -662,5 +662,5 @@ int cu_rrd_create_file(const char *filename, /* {{{ */
   ds_free(ds_num, ds_def);
   rra_free(rra_num, rra_def);
 
-  return (status);
+  return status;
 } /* }}} int cu_rrd_create_file */

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -76,7 +76,7 @@ static int simple_submit_match(cu_match_t *match, void *user_data) {
 
   match_value = (cu_match_value_t *)match_get_user_data(match);
   if (match_value == NULL)
-    return (-1);
+    return -1;
 
   if ((match_value->ds_type & UTILS_MATCH_DS_TYPE_GAUGE) &&
       (match_value->values_num == 0))
@@ -96,7 +96,7 @@ static int simple_submit_match(cu_match_t *match, void *user_data) {
   plugin_dispatch_values(&vl);
 
   match_value_reset(match_value);
-  return (0);
+  return 0;
 } /* int simple_submit_match */
 
 static int latency_submit_match(cu_match_t *match, void *user_data) {
@@ -106,7 +106,7 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
 
   match_value = (cu_match_value_t *)match_get_user_data(match);
   if (match_value == NULL)
-    return (-1);
+    return -1;
 
   sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, data->plugin, sizeof(vl.plugin));
@@ -167,7 +167,7 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   match_value->values_num = 0;
   latency_counter_reset(match_value->latency);
 
-  return (0);
+  return 0;
 } /* int latency_submit_match */
 
 static int tail_callback(void *data, char *buf,
@@ -177,7 +177,7 @@ static int tail_callback(void *data, char *buf,
   for (size_t i = 0; i < obj->matches_num; i++)
     match_apply(obj->matches[i].match, buf);
 
-  return (0);
+  return 0;
 } /* int tail_callback */
 
 static void tail_match_simple_free(void *data) {
@@ -194,15 +194,15 @@ cu_tail_match_t *tail_match_create(const char *filename) {
 
   obj = calloc(1, sizeof(*obj));
   if (obj == NULL)
-    return (NULL);
+    return NULL;
 
   obj->tail = cu_tail_create(filename);
   if (obj->tail == NULL) {
     sfree(obj);
-    return (NULL);
+    return NULL;
   }
 
-  return (obj);
+  return obj;
 } /* cu_tail_match_t *tail_match_create */
 
 void tail_match_destroy(cu_tail_match_t *obj) {
@@ -240,7 +240,7 @@ int tail_match_add_match(cu_tail_match_t *obj, cu_match_t *match,
   temp = realloc(obj->matches,
                  sizeof(cu_tail_match_match_t) * (obj->matches_num + 1));
   if (temp == NULL)
-    return (-1);
+    return -1;
 
   obj->matches = temp;
   obj->matches_num++;
@@ -254,7 +254,7 @@ int tail_match_add_match(cu_tail_match_t *obj, cu_match_t *match,
   temp->submit = submit_match;
   temp->free = free_user_data;
 
-  return (0);
+  return 0;
 } /* int tail_match_add_match */
 
 int tail_match_add_match_simple(cu_tail_match_t *obj, const char *regex,
@@ -269,12 +269,12 @@ int tail_match_add_match_simple(cu_tail_match_t *obj, const char *regex,
 
   match = match_create_simple(regex, excluderegex, ds_type);
   if (match == NULL)
-    return (-1);
+    return -1;
 
   user_data = calloc(1, sizeof(*user_data));
   if (user_data == NULL) {
     match_destroy(match);
-    return (-1);
+    return -1;
   }
 
   sstrncpy(user_data->plugin, plugin, sizeof(user_data->plugin));
@@ -311,7 +311,7 @@ out:
     match_destroy(match);
   }
 
-  return (status);
+  return status;
 } /* int tail_match_add_match_simple */
 
 int tail_match_read(cu_tail_match_t *obj) {
@@ -322,7 +322,7 @@ int tail_match_read(cu_tail_match_t *obj) {
                         (void *)obj);
   if (status != 0) {
     ERROR("tail_match: cu_tail_read failed.");
-    return (status);
+    return status;
   }
 
   for (size_t i = 0; i < obj->matches_num; i++) {
@@ -334,5 +334,5 @@ int tail_match_read(cu_tail_match_t *obj) {
     (*lt_match->submit)(lt_match->match, lt_match->user_data);
   }
 
-  return (0);
+  return 0;
 } /* int tail_match_read */

--- a/src/utils_vl_lookup_test.c
+++ b/src/utils_vl_lookup_test.c
@@ -53,9 +53,9 @@ static int lookup_obj_callback(data_set_t const *ds, value_list_t const *vl,
   memcpy(&last_obj_ident, obj, sizeof(last_obj_ident));
 
   if (strcmp(obj->plugin_instance, "failure") == 0)
-    return (-1);
+    return -1;
 
-  return (0);
+  return 0;
 }
 
 static void *lookup_class_callback(data_set_t const *ds, value_list_t const *vl,
@@ -77,7 +77,7 @@ static void *lookup_class_callback(data_set_t const *ds, value_list_t const *vl,
 
   have_new_obj = 1;
 
-  return ((void *)obj);
+  return (void *)obj;
 }
 
 static int checked_lookup_add(lookup_t *obj, /* {{{ */
@@ -123,7 +123,7 @@ static int checked_lookup_search(lookup_t *obj, char const *host,
   have_new_obj = 0;
 
   status = lookup_search(obj, ds, &vl);
-  return (status);
+  return status;
 }
 
 DEF_TEST(group_by_specific_host) {
@@ -142,7 +142,7 @@ DEF_TEST(group_by_specific_host) {
                         /* expect new = */ 0);
 
   lookup_destroy(obj);
-  return (0);
+  return 0;
 }
 
 DEF_TEST(group_by_any_host) {
@@ -170,7 +170,7 @@ DEF_TEST(group_by_any_host) {
                         /* expect new = */ 0);
 
   lookup_destroy(obj);
-  return (0);
+  return 0;
 }
 
 DEF_TEST(multiple_lookups) {
@@ -198,7 +198,7 @@ DEF_TEST(multiple_lookups) {
   assert(status == 2);
 
   lookup_destroy(obj);
-  return (0);
+  return 0;
 }
 
 DEF_TEST(regex) {
@@ -228,7 +228,7 @@ DEF_TEST(regex) {
                         /* expect new = */ 1);
 
   lookup_destroy(obj);
-  return (0);
+  return 0;
 }
 
 int main(int argc, char **argv) /* {{{ */

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -45,19 +45,19 @@ static int looks_like_a_uuid(const char *uuid) {
   int len;
 
   if (!uuid)
-    return (0);
+    return 0;
 
   len = strlen(uuid);
 
   if (len < UUID_PRINTABLE_COMPACT_LENGTH)
-    return (0);
+    return 0;
 
   while (*uuid) {
     if (!isxdigit((int)*uuid) && *uuid != '-')
-      return (0);
+      return 0;
     uuid++;
   }
-  return (1);
+  return 1;
 }
 
 static char *uuid_parse_dmidecode(FILE *file) {
@@ -82,9 +82,9 @@ static char *uuid_parse_dmidecode(FILE *file) {
     if (!looks_like_a_uuid(fields[1]))
       continue;
 
-    return (strdup(fields[1]));
+    return strdup(fields[1]);
   }
-  return (NULL);
+  return NULL;
 }
 
 static char *uuid_get_from_dmidecode(void) {
@@ -92,12 +92,12 @@ static char *uuid_get_from_dmidecode(void) {
   char *uuid;
 
   if (!dmidecode)
-    return (NULL);
+    return NULL;
 
   uuid = uuid_parse_dmidecode(dmidecode);
 
   pclose(dmidecode);
-  return (uuid);
+  return uuid;
 }
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
@@ -106,7 +106,7 @@ static char *uuid_get_from_sysctlbyname(const char *name) {
   size_t len = sizeof(uuid);
   if (sysctlbyname(name, &uuid, &len, NULL, 0) == -1)
     return NULL;
-  return (strdup(uuid));
+  return strdup(uuid);
 }
 #elif defined(__OpenBSD__)
 static char *uuid_get_from_sysctl(void) {
@@ -119,7 +119,7 @@ static char *uuid_get_from_sysctl(void) {
 
   if (sysctl(mib, 2, uuid, &len, NULL, 0) == -1)
     return NULL;
-  return (strdup(uuid));
+  return strdup(uuid);
 }
 #endif
 
@@ -129,16 +129,16 @@ static char *uuid_get_from_file(const char *path) {
 
   file = fopen(path, "r");
   if (file == NULL)
-    return (NULL);
+    return NULL;
 
   if (!fgets(uuid, sizeof(uuid), file)) {
     fclose(file);
-    return (NULL);
+    return NULL;
   }
   fclose(file);
   strstripnewline(uuid);
 
-  return (strdup(uuid));
+  return strdup(uuid);
 }
 
 static char *uuid_get_local(void) {
@@ -146,47 +146,47 @@ static char *uuid_get_local(void) {
 
   /* Check /etc/uuid / UUIDFile before any other method. */
   if ((uuid = uuid_get_from_file(uuidfile ? uuidfile : "/etc/uuid")) != NULL)
-    return (uuid);
+    return uuid;
 
 #if defined(__APPLE__)
   if ((uuid = uuid_get_from_sysctlbyname("kern.uuid")) != NULL)
-    return (uuid);
+    return uuid;
 #elif defined(__FreeBSD__)
   if ((uuid = uuid_get_from_sysctlbyname("kern.hostuuid")) != NULL)
-    return (uuid);
+    return uuid;
 #elif defined(__NetBSD__)
   if ((uuid = uuid_get_from_sysctlbyname("machdep.dmi.system-uuid")) != NULL)
-    return (uuid);
+    return uuid;
 #elif defined(__OpenBSD__)
   if ((uuid = uuid_get_from_sysctl()) != NULL)
-    return (uuid);
+    return uuid;
 #elif defined(__linux__)
   if ((uuid = uuid_get_from_file("/sys/class/dmi/id/product_uuid")) != NULL)
-    return (uuid);
+    return uuid;
 #endif
 
   if ((uuid = uuid_get_from_dmidecode()) != NULL)
-    return (uuid);
+    return uuid;
 
 #if defined(__linux__)
   if ((uuid = uuid_get_from_file("/sys/hypervisor/uuid")) != NULL)
-    return (uuid);
+    return uuid;
 #endif
 
-  return (NULL);
+  return NULL;
 }
 
 static int uuid_config(const char *key, const char *value) {
   if (strcasecmp(key, "UUIDFile") == 0) {
     char *tmp = strdup(value);
     if (tmp == NULL)
-      return (-1);
+      return -1;
     sfree(uuidfile);
     uuidfile = tmp;
-    return (0);
+    return 0;
   }
 
-  return (1);
+  return 1;
 }
 
 static int uuid_init(void) {
@@ -195,11 +195,11 @@ static int uuid_init(void) {
   if (uuid) {
     sstrncpy(hostname_g, uuid, DATA_MAX_NAME_LEN);
     sfree(uuid);
-    return (0);
+    return 0;
   }
 
   WARNING("uuid: could not read UUID using any known method");
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -106,23 +106,25 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
   if (type_instance != NULL)
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
-  return (plugin_dispatch_values(&vl));
+  return plugin_dispatch_values(&vl);
 } /* }}} int varnish_submit */
 
 static int varnish_submit_gauge(const char *plugin_instance, /* {{{ */
                                 const char *category, const char *type,
                                 const char *type_instance,
                                 uint64_t gauge_value) {
-  return (varnish_submit(plugin_instance, category, type, type_instance,
-                         (value_t){.gauge = (gauge_t)gauge_value}));
+  return varnish_submit(plugin_instance, category, type, type_instance, (value_t){
+      .gauge=(gauge_t)gauge_value,
+    });
 } /* }}} int varnish_submit_gauge */
 
 static int varnish_submit_derive(const char *plugin_instance, /* {{{ */
                                  const char *category, const char *type,
                                  const char *type_instance,
                                  uint64_t derive_value) {
-  return (varnish_submit(plugin_instance, category, type, type_instance,
-                         (value_t){.derive = (derive_t)derive_value}));
+  return varnish_submit(plugin_instance, category, type, type_instance, (value_t){
+      .derive=(derive_t)derive_value,
+    });
 } /* }}} int varnish_submit_derive */
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
@@ -135,7 +137,7 @@ static int varnish_monitor(void *priv,
   const char *name;
 
   if (pt == NULL)
-    return (0);
+    return 0;
 
   conf = priv;
 
@@ -144,14 +146,14 @@ static int varnish_monitor(void *priv,
   name = pt->desc->name;
 
   if (strcmp(class, "MAIN") != 0)
-    return (0);
+    return 0;
 
 #elif HAVE_VARNISH_V3
   class = pt->class;
   name = pt->name;
 
   if (strcmp(class, "") != 0)
-    return (0);
+    return 0;
 #endif
 
   val = *(const volatile uint64_t *)pt->ptr;
@@ -170,21 +172,21 @@ static int varnish_monitor(void *priv,
 
   if (conf->collect_connections) {
     if (strcmp(name, "client_conn") == 0)
-      return varnish_submit_derive(conf->instance, "connections", "connections",
-                                   "accepted", val);
+      return varnish_submit_derive(conf->instance, "connections",
+                                   "connections", "accepted", val);
     else if (strcmp(name, "client_drop") == 0)
-      return varnish_submit_derive(conf->instance, "connections", "connections",
-                                   "dropped", val);
+      return varnish_submit_derive(conf->instance, "connections",
+                                   "connections", "dropped", val);
     else if (strcmp(name, "client_req") == 0)
-      return varnish_submit_derive(conf->instance, "connections", "connections",
-                                   "received", val);
+      return varnish_submit_derive(conf->instance, "connections",
+                                   "connections", "received", val);
   }
 
 #ifdef HAVE_VARNISH_V3
   if (conf->collect_dirdns) {
     if (strcmp(name, "dir_dns_lookups") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns", "cache_operation",
-                                   "lookups", val);
+      return varnish_submit_derive(conf->instance, "dirdns",
+                                   "cache_operation", "lookups", val);
     else if (strcmp(name, "dir_dns_failed") == 0)
       return varnish_submit_derive(conf->instance, "dirdns", "cache_result",
                                    "failed", val);
@@ -439,26 +441,26 @@ static int varnish_monitor(void *priv,
       return varnish_submit_gauge(conf->instance, "sms", "requests",
                                   "outstanding", val);
     else if (strcmp(name, "sms_nbytes") == 0)
-      return varnish_submit_gauge(conf->instance, "sms", "bytes", "outstanding",
-                                  val);
+      return varnish_submit_gauge(conf->instance, "sms", "bytes",
+                                  "outstanding", val);
     else if (strcmp(name, "sms_balloc") == 0)
       return varnish_submit_derive(conf->instance, "sms", "total_bytes",
                                    "allocated", val);
     else if (strcmp(name, "sms_bfree") == 0)
-      return varnish_submit_derive(conf->instance, "sms", "total_bytes", "free",
-                                   val);
+      return varnish_submit_derive(conf->instance, "sms", "total_bytes",
+                                   "free", val);
   }
 
   if (conf->collect_struct) {
     if (strcmp(name, "n_sess_mem") == 0)
-      return varnish_submit_gauge(conf->instance, "struct", "current_sessions",
-                                  "sess_mem", val);
+      return varnish_submit_gauge(conf->instance, "struct",
+                                  "current_sessions", "sess_mem", val);
     else if (strcmp(name, "n_sess") == 0)
-      return varnish_submit_gauge(conf->instance, "struct", "current_sessions",
-                                  "sess", val);
+      return varnish_submit_gauge(conf->instance, "struct",
+                                  "current_sessions", "sess", val);
     else if (strcmp(name, "n_object") == 0)
-      return varnish_submit_gauge(conf->instance, "struct", "objects", "object",
-                                  val);
+      return varnish_submit_gauge(conf->instance, "struct", "objects",
+                                  "object", val);
     else if (strcmp(name, "n_vampireobject") == 0)
       return varnish_submit_gauge(conf->instance, "struct", "objects",
                                   "vampireobject", val);
@@ -493,14 +495,14 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_requests",
                                    "requests", val);
     else if (strcmp(name, "s_pipe") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "pipe", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "pipe", val);
     else if (strcmp(name, "s_pass") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "pass", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "pass", val);
     else if (strcmp(name, "s_fetch") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "fetches", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "fetches", val);
     else if (strcmp(name, "s_synth") == 0)
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "synth", val);
@@ -526,8 +528,8 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "pipe_out", val);
     else if (strcmp(name, "n_purges") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "purges", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "purges", val);
     else if (strcmp(name, "s_hdrbytes") == 0)
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "header-bytes", val);
@@ -535,11 +537,11 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "body-bytes", val);
     else if (strcmp(name, "n_gzip") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "gzip", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "gzip", val);
     else if (strcmp(name, "n_gunzip") == 0)
-      return varnish_submit_derive(conf->instance, "totals", "total_operations",
-                                   "gunzip", val);
+      return varnish_submit_derive(conf->instance, "totals",
+                                   "total_operations", "gunzip", val);
   }
 
   if (conf->collect_uptime) {
@@ -556,8 +558,8 @@ static int varnish_monitor(void *priv,
       return varnish_submit_gauge(conf->instance, "vcl", "vcl", "avail_vcl",
                                   val);
     else if (strcmp(name, "n_vcl_discard") == 0)
-      return varnish_submit_gauge(conf->instance, "vcl", "vcl", "discarded_vcl",
-                                  val);
+      return varnish_submit_gauge(conf->instance, "vcl", "vcl",
+                                  "discarded_vcl", val);
     else if (strcmp(name, "vmods") == 0)
       return varnish_submit_gauge(conf->instance, "vcl", "objects", "vmod",
                                   val);
@@ -598,17 +600,17 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "workers", "total_threads",
                                    "dropped", val);
     else if (strcmp(name, "n_wrk_queue") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queued", val);
+      return varnish_submit_derive(conf->instance, "workers",
+                                   "total_requests", "queued", val);
     else if (strcmp(name, "n_wrk_overflow") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "overflowed", val);
+      return varnish_submit_derive(conf->instance, "workers",
+                                   "total_requests", "overflowed", val);
     else if (strcmp(name, "n_wrk_queued") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queued", val);
+      return varnish_submit_derive(conf->instance, "workers",
+                                   "total_requests", "queued", val);
     else if (strcmp(name, "n_wrk_lqueue") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queue_length", val);
+      return varnish_submit_derive(conf->instance, "workers",
+                                   "total_requests", "queue_length", val);
   }
 
 #if HAVE_VARNISH_V4
@@ -629,7 +631,7 @@ static int varnish_monitor(void *priv,
   }
 #endif
 
-  return (0);
+  return 0;
 
 } /* }}} static int varnish_monitor */
 #else /* if HAVE_VARNISH_V2 */
@@ -981,7 +983,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   user_config_t *conf;
 
   if ((ud == NULL) || (ud->data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   conf = ud->data;
 
@@ -999,7 +1001,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
       ERROR("varnish plugin: VSM_n_Arg (\"%s\") failed "
             "with status %i.",
             conf->instance, status);
-      return (-1);
+      return -1;
     }
   }
 
@@ -1012,7 +1014,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
     VSM_Delete(vd);
     ERROR("varnish plugin: Unable to open connection.");
 
-    return (-1);
+    return -1;
   }
 
 #if HAVE_VARNISH_V3
@@ -1024,7 +1026,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
     VSM_Delete(vd);
     ERROR("varnish plugin: Unable to get statistics.");
 
-    return (-1);
+    return -1;
   }
 
 #if HAVE_VARNISH_V3
@@ -1034,7 +1036,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #endif
   VSM_Delete(vd);
 
-  return (0);
+  return 0;
 } /* }}} */
 #else /* if HAVE_VARNISH_V2 */
 static int varnish_read(user_data_t *ud) /* {{{ */
@@ -1044,7 +1046,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   user_config_t *conf;
 
   if ((ud == NULL) || (ud->data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   conf = ud->data;
 
@@ -1052,12 +1054,12 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   if (stats == NULL) {
     ERROR("Varnish plugin : unable to load statistics");
 
-    return (-1);
+    return -1;
   }
 
   varnish_monitor(conf, stats);
 
-  return (0);
+  return 0;
 } /* }}} */
 #endif
 
@@ -1075,7 +1077,7 @@ static void varnish_config_free(void *ptr) /* {{{ */
 static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
 {
   if (conf == NULL)
-    return (EINVAL);
+    return EINVAL;
 
   conf->collect_backend = 1;
   conf->collect_cache = 1;
@@ -1110,7 +1112,7 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
   conf->collect_vsm = 0;
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int varnish_config_apply_default */
 
 static int varnish_init(void) /* {{{ */
@@ -1118,11 +1120,11 @@ static int varnish_init(void) /* {{{ */
   user_config_t *conf;
 
   if (have_instance)
-    return (0);
+    return 0;
 
   conf = calloc(1, sizeof(*conf));
   if (conf == NULL)
-    return (ENOMEM);
+    return ENOMEM;
 
   /* Default settings: */
   conf->instance = NULL;
@@ -1137,7 +1139,7 @@ static int varnish_init(void) /* {{{ */
                                .data = conf, .free_func = varnish_config_free,
                            });
 
-  return (0);
+  return 0;
 } /* }}} int varnish_init */
 
 static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
@@ -1147,7 +1149,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 
   conf = calloc(1, sizeof(*conf));
   if (conf == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   conf->instance = NULL;
 
   varnish_config_apply_default(conf);
@@ -1158,7 +1160,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     status = cf_util_get_string(ci, &conf->instance);
     if (status != 0) {
       sfree(conf);
-      return (status);
+      return status;
     }
     assert(conf->instance != NULL);
 
@@ -1170,7 +1172,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     WARNING("Varnish plugin: \"Instance\" blocks accept only "
             "one argument.");
     sfree(conf);
-    return (EINVAL);
+    return EINVAL;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -1290,7 +1292,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);
     sfree(conf);
-    return (EINVAL);
+    return EINVAL;
   }
 
   ssnprintf(callback_name, sizeof(callback_name), "varnish/%s",
@@ -1306,7 +1308,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 
   have_instance = 1;
 
-  return (0);
+  return 0;
 } /* }}} int varnish_config_instance */
 
 static int varnish_config(oconfig_item_t *ci) /* {{{ */
@@ -1323,7 +1325,7 @@ static int varnish_config(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int varnish_config */
 
 void module_register(void) /* {{{ */

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -79,10 +79,10 @@ static int vmem_config(const char *key, const char *value) {
     else
       verbose_output = 0;
   } else {
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* int vmem_config */
 
 static int vmem_read(void) {
@@ -107,7 +107,7 @@ static int vmem_read(void) {
     char errbuf[1024];
     ERROR("vmem plugin: fopen (/proc/vmstat) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -253,7 +253,7 @@ static int vmem_read(void) {
     submit_two(NULL, "vmpage_io", "swap", pswpin, pswpout);
 #endif /* KERNEL_LINUX */
 
-  return (0);
+  return 0;
 } /* int vmem_read */
 
 void module_register(void) {

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -49,7 +49,7 @@ static int vserver_init(void) {
    * What's the right thing to do, if there is no getpagesize ()? */
   pagesize = getpagesize();
 
-  return (0);
+  return 0;
 } /* static void vserver_init(void) */
 
 static void traffic_submit(const char *plugin_instance,
@@ -114,8 +114,8 @@ static derive_t vserver_get_sock_bytes(const char *s) {
 
   status = parse_value(s, &v, DS_TYPE_DERIVE);
   if (status != 0)
-    return (-1);
-  return (v.derive);
+    return -1;
+  return v.derive;
 }
 
 static int vserver_read(void) {
@@ -127,7 +127,7 @@ static int vserver_read(void) {
     char errbuf[1024];
     ERROR("vserver plugin: fopen (%s): %s", PROCDIR,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   while (42) {
@@ -154,7 +154,7 @@ static int vserver_read(void) {
       ERROR("vserver plugin: failed to read directory %s: %s", PROCDIR,
             sstrerror(errno, errbuf, sizeof(errbuf)));
       closedir(proc);
-      return (-1);
+      return -1;
     }
 
     if (dent->d_name[0] == '.')
@@ -314,7 +314,7 @@ static int vserver_read(void) {
 
   closedir(proc);
 
-  return (0);
+  return 0;
 } /* int vserver_read */
 
 void module_register(void) {

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -47,7 +47,7 @@ static double wireless_dbm_to_watt (double dbm)
 
 	watt = pow (10.0, (dbm / 10.0)) / 1000.0;
 
-	return (watt);
+	return watt;
 }
 #endif
 
@@ -69,7 +69,7 @@ static void wireless_submit(const char *plugin_instance, const char *type,
 static double wireless_percent_to_power(double quality) {
   assert((quality >= 0.0) && (quality <= 100.0));
 
-  return ((quality * (POWER_MAX - POWER_MIN)) + POWER_MIN);
+  return (quality * (POWER_MAX - POWER_MIN)) + POWER_MIN;
 } /* double wireless_percent_to_power */
 
 static int wireless_read(void) {
@@ -92,7 +92,7 @@ static int wireless_read(void) {
   if ((fh = fopen(WIRELESS_PROC_FILE, "r")) == NULL) {
     char errbuf[1024];
     WARNING("wireless: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   devices_found = 0;
@@ -151,10 +151,10 @@ static int wireless_read(void) {
   /* If no wireless devices are present return an error, so the plugin
    * code delays our read function. */
   if (devices_found == 0)
-    return (-1);
+    return -1;
 #endif /* KERNEL_LINUX */
 
-  return (0);
+  return 0;
 } /* int wireless_read */
 
 void module_register(void) {

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -129,18 +129,18 @@ static int wh_post_nolock(wh_callback_t *cb, char const *data) /* {{{ */
           "status %i: %s",
           status, cb->curl_errbuf);
   }
-  return (status);
+  return status;
 } /* }}} wh_post_nolock */
 
 static int wh_callback_init(wh_callback_t *cb) /* {{{ */
 {
   if (cb->curl != NULL)
-    return (0);
+    return 0;
 
   cb->curl = curl_easy_init();
   if (cb->curl == NULL) {
     ERROR("curl plugin: curl_easy_init failed.");
-    return (-1);
+    return -1;
   }
 
   if (cb->low_speed_limit > 0 && cb->low_speed_time > 0) {
@@ -187,7 +187,7 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
     cb->credentials = malloc(credentials_size);
     if (cb->credentials == NULL) {
       ERROR("curl plugin: malloc failed.");
-      return (-1);
+      return -1;
     }
 
     ssnprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
@@ -215,7 +215,7 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
 
   wh_reset_buffer(cb);
 
-  return (0);
+  return 0;
 } /* }}} int wh_callback_init */
 
 static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
@@ -232,13 +232,13 @@ static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
 
     now = cdtime();
     if ((cb->send_buffer_init_time + timeout) > now)
-      return (0);
+      return 0;
   }
 
   if (cb->format == WH_FORMAT_COMMAND) {
     if (cb->send_buffer_fill == 0) {
       cb->send_buffer_init_time = cdtime();
-      return (0);
+      return 0;
     }
 
     status = wh_post_nolock(cb, cb->send_buffer);
@@ -246,7 +246,7 @@ static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
   } else if (cb->format == WH_FORMAT_JSON || cb->format == WH_FORMAT_KAIROSDB) {
     if (cb->send_buffer_fill <= 2) {
       cb->send_buffer_init_time = cdtime();
-      return (0);
+      return 0;
     }
 
     status = format_json_finalize(cb->send_buffer, &cb->send_buffer_fill,
@@ -255,7 +255,7 @@ static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
       ERROR("write_http: wh_flush_nolock: "
             "format_json_finalize failed.");
       wh_reset_buffer(cb);
-      return (status);
+      return status;
     }
 
     status = wh_post_nolock(cb, cb->send_buffer);
@@ -264,10 +264,10 @@ static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
     ERROR("write_http: wh_flush_nolock: "
           "Unknown format: %i",
           cb->format);
-    return (-1);
+    return -1;
   }
 
-  return (status);
+  return status;
 } /* }}} wh_flush_nolock */
 
 static int wh_flush(cdtime_t timeout, /* {{{ */
@@ -277,7 +277,7 @@ static int wh_flush(cdtime_t timeout, /* {{{ */
   int status;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   cb = user_data->data;
 
@@ -286,13 +286,13 @@ static int wh_flush(cdtime_t timeout, /* {{{ */
   if (wh_callback_init(cb) != 0) {
     ERROR("write_http plugin: wh_callback_init failed.");
     pthread_mutex_unlock(&cb->send_lock);
-    return (-1);
+    return -1;
   }
 
   status = wh_flush_nolock(timeout, cb);
   pthread_mutex_unlock(&cb->send_lock);
 
-  return (status);
+  return status;
 } /* }}} int wh_flush */
 
 static void wh_callback_free(void *data) /* {{{ */
@@ -356,7 +356,7 @@ static int wh_write_command(const data_set_t *ds,
   status = FORMAT_VL(key, sizeof(key), vl);
   if (status != 0) {
     ERROR("write_http plugin: error with format_name");
-    return (status);
+    return status;
   }
   escape_string(key, sizeof(key));
 
@@ -366,7 +366,7 @@ static int wh_write_command(const data_set_t *ds,
   if (status != 0) {
     ERROR("write_http plugin: error with "
           "wh_value_list_to_string");
-    return (status);
+    return status;
   }
 
   command_len = (size_t)ssnprintf(command, sizeof(command),
@@ -376,21 +376,21 @@ static int wh_write_command(const data_set_t *ds,
     ERROR("write_http plugin: Command buffer too small: "
           "Need %zu bytes.",
           command_len + 1);
-    return (-1);
+    return -1;
   }
 
   pthread_mutex_lock(&cb->send_lock);
   if (wh_callback_init(cb) != 0) {
     ERROR("write_http plugin: wh_callback_init failed.");
     pthread_mutex_unlock(&cb->send_lock);
-    return (-1);
+    return -1;
   }
 
   if (command_len >= cb->send_buffer_free) {
     status = wh_flush_nolock(/* timeout = */ 0, cb);
     if (status != 0) {
       pthread_mutex_unlock(&cb->send_lock);
-      return (status);
+      return status;
     }
   }
   assert(command_len < cb->send_buffer_free);
@@ -412,7 +412,7 @@ static int wh_write_command(const data_set_t *ds,
   /* Check if we have enough space for this command. */
   pthread_mutex_unlock(&cb->send_lock);
 
-  return (0);
+  return 0;
 } /* }}} int wh_write_command */
 
 static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
@@ -423,7 +423,7 @@ static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (wh_callback_init(cb) != 0) {
     ERROR("write_http plugin: wh_callback_init failed.");
     pthread_mutex_unlock(&cb->send_lock);
-    return (-1);
+    return -1;
   }
 
   status =
@@ -434,7 +434,7 @@ static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     if (status != 0) {
       wh_reset_buffer(cb);
       pthread_mutex_unlock(&cb->send_lock);
-      return (status);
+      return status;
     }
 
     status =
@@ -443,7 +443,7 @@ static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   }
   if (status != 0) {
     pthread_mutex_unlock(&cb->send_lock);
-    return (status);
+    return status;
   }
 
   DEBUG("write_http plugin: <%s> buffer %zu/%zu (%g%%)", cb->location,
@@ -454,7 +454,7 @@ static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   /* Check if we have enough space for this command. */
   pthread_mutex_unlock(&cb->send_lock);
 
-  return (0);
+  return 0;
 } /* }}} int wh_write_json */
 
 static int wh_write_kairosdb(const data_set_t *ds,
@@ -469,7 +469,7 @@ static int wh_write_kairosdb(const data_set_t *ds,
     if (status != 0) {
       ERROR("write_http plugin: wh_callback_init failed.");
       pthread_mutex_unlock(&cb->send_lock);
-      return (-1);
+      return -1;
     }
   }
 
@@ -482,7 +482,7 @@ static int wh_write_kairosdb(const data_set_t *ds,
     if (status != 0) {
       wh_reset_buffer(cb);
       pthread_mutex_unlock(&cb->send_lock);
-      return (status);
+      return status;
     }
 
     status = format_kairosdb_value_list(
@@ -492,7 +492,7 @@ static int wh_write_kairosdb(const data_set_t *ds,
   }
   if (status != 0) {
     pthread_mutex_unlock(&cb->send_lock);
-    return (status);
+    return status;
   }
 
   DEBUG("write_http plugin: <%s> buffer %zu/%zu (%g%%)", cb->location,
@@ -503,7 +503,7 @@ static int wh_write_kairosdb(const data_set_t *ds,
   /* Check if we have enough space for this command. */
   pthread_mutex_unlock(&cb->send_lock);
 
-  return (0);
+  return 0;
 } /* }}} int wh_write_kairosdb */
 
 static int wh_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
@@ -512,7 +512,7 @@ static int wh_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   int status;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   cb = user_data->data;
   assert(cb->send_metrics);
@@ -528,7 +528,7 @@ static int wh_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     status = wh_write_command(ds, vl, cb);
     break;
   }
-  return (status);
+  return status;
 } /* }}} int wh_write */
 
 static int wh_notify(notification_t const *n, user_data_t *ud) /* {{{ */
@@ -538,7 +538,7 @@ static int wh_notify(notification_t const *n, user_data_t *ud) /* {{{ */
   int status;
 
   if ((ud == NULL) || (ud->data == NULL))
-    return (EINVAL);
+    return EINVAL;
 
   cb = ud->data;
   assert(cb->send_notifications);
@@ -553,13 +553,13 @@ static int wh_notify(notification_t const *n, user_data_t *ud) /* {{{ */
   if (wh_callback_init(cb) != 0) {
     ERROR("write_http plugin: wh_callback_init failed.");
     pthread_mutex_unlock(&cb->send_lock);
-    return (-1);
+    return -1;
   }
 
   status = wh_post_nolock(cb, alert);
   pthread_mutex_unlock(&cb->send_lock);
 
-  return (status);
+  return status;
 } /* }}} int wh_notify */
 
 static int config_set_format(wh_callback_t *cb, /* {{{ */
@@ -570,7 +570,7 @@ static int config_set_format(wh_callback_t *cb, /* {{{ */
     WARNING("write_http plugin: The `%s' config option "
             "needs exactly one string argument.",
             ci->key);
-    return (-1);
+    return -1;
   }
 
   string = ci->values[0].value.string;
@@ -582,10 +582,10 @@ static int config_set_format(wh_callback_t *cb, /* {{{ */
     cb->format = WH_FORMAT_KAIROSDB;
   else {
     ERROR("write_http plugin: Invalid format string: %s", string);
-    return (-1);
+    return -1;
   }
 
-  return (0);
+  return 0;
 } /* }}} int config_set_format */
 
 static int wh_config_append_string(const char *name,
@@ -594,16 +594,16 @@ static int wh_config_append_string(const char *name,
   struct curl_slist *temp = NULL;
   if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
     WARNING("write_http plugin: `%s' needs exactly one string argument.", name);
-    return (-1);
+    return -1;
   }
 
   temp = curl_slist_append(*dest, ci->values[0].value.string);
   if (temp == NULL)
-    return (-1);
+    return -1;
 
   *dest = temp;
 
-  return (0);
+  return 0;
 } /* }}} int wh_config_append_string */
 
 static int wh_config_node(oconfig_item_t *ci) /* {{{ */
@@ -616,7 +616,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   cb = calloc(1, sizeof(*cb));
   if (cb == NULL) {
     ERROR("write_http plugin: calloc failed.");
-    return (-1);
+    return -1;
   }
   cb->verify_peer = 1;
   cb->verify_host = 1;
@@ -753,13 +753,13 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     wh_callback_free(cb);
-    return (status);
+    return status;
   }
 
   if (cb->location == NULL) {
     ERROR("write_http plugin: no URL defined for instance '%s'", cb->name);
     wh_callback_free(cb);
-    return (-1);
+    return -1;
   }
 
   if (!cb->send_metrics && !cb->send_notifications) {
@@ -767,7 +767,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
           "are enabled for \"%s\".",
           cb->name);
     wh_callback_free(cb);
-    return (-1);
+    return -1;
   }
 
   if (cb->low_speed_limit > 0)
@@ -786,7 +786,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   if (cb->send_buffer == NULL) {
     ERROR("write_http plugin: malloc(%zu) failed.", cb->send_buffer_size);
     wh_callback_free(cb);
-    return (-1);
+    return -1;
   }
   /* Nulls the buffer and sets ..._free and ..._fill. */
   wh_reset_buffer(cb);
@@ -811,7 +811,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
     user_data.free_func = NULL;
   }
 
-  return (0);
+  return 0;
 } /* }}} int wh_config_node */
 
 static int wh_config(oconfig_item_t *ci) /* {{{ */
@@ -833,7 +833,7 @@ static int wh_config(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int wh_config */
 
 static int wh_init(void) /* {{{ */
@@ -841,7 +841,7 @@ static int wh_init(void) /* {{{ */
   /* Call this while collectd is still single-threaded to avoid
    * initialization issues in libgcrypt. */
   curl_global_init(CURL_GLOBAL_SSL);
-  return (0);
+  return 0;
 } /* }}} int wh_init */
 
 void module_register(void) /* {{{ */

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -113,12 +113,12 @@ static int kafka_handle(struct kafka_topic_context *ctx) /* {{{ */
   rd_kafka_topic_conf_t *topic_conf;
 
   if (ctx->kafka != NULL && ctx->topic != NULL)
-    return (0);
+    return 0;
 
   if (ctx->kafka == NULL) {
     if ((conf = rd_kafka_conf_dup(ctx->kafka_conf)) == NULL) {
       ERROR("write_kafka plugin: cannot duplicate kafka config");
-      return (1);
+      return 1;
     }
 
     if ((ctx->kafka = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errbuf,
@@ -158,7 +158,7 @@ static int kafka_handle(struct kafka_topic_context *ctx) /* {{{ */
          rd_kafka_topic_name(ctx->topic));
   }
 
-  return (0);
+  return 0;
 
 } /* }}} int kafka_handle */
 
@@ -481,7 +481,7 @@ static int kafka_config(oconfig_item_t *ci) /* {{{ */
   }
   if (conf != NULL)
     rd_kafka_conf_destroy(conf);
-  return (0);
+  return 0;
 errout:
   if (conf != NULL)
     rd_kafka_conf_destroy(conf);

--- a/src/write_log.c
+++ b/src/write_log.c
@@ -54,11 +54,11 @@ static int wl_write_graphite(const data_set_t *ds, const value_list_t *vl) {
 
   status = format_graphite(buffer, sizeof(buffer), ds, vl, NULL, NULL, '_', 0);
   if (status != 0) /* error message has been printed already. */
-    return (status);
+    return status;
 
   INFO("write_log values:\n%s", buffer);
 
-  return (0);
+  return 0;
 } /* int wl_write_graphite */
 
 static int wl_write_json(const data_set_t *ds, const value_list_t *vl) {
@@ -78,7 +78,7 @@ static int wl_write_json(const data_set_t *ds, const value_list_t *vl) {
 
   INFO("write_log values:\n%s", buffer);
 
-  return (0);
+  return 0;
 } /* int wl_write_json */
 
 static int wl_write(const data_set_t *ds, const value_list_t *vl,
@@ -91,7 +91,7 @@ static int wl_write(const data_set_t *ds, const value_list_t *vl,
     status = wl_write_json(ds, vl);
   }
 
-  return (status);
+  return status;
 }
 
 static int wl_config(oconfig_item_t *ci) /* {{{ */
@@ -119,16 +119,16 @@ static int wl_config(oconfig_item_t *ci) /* {{{ */
       else {
         ERROR("write_log plugin: Unknown format `%s' for option `%s'.", str,
               child->key);
-        return (-EINVAL);
+        return -EINVAL;
       }
     } else {
       ERROR("write_log plugin: Invalid configuration option: `%s'.",
             child->key);
-      return (-EINVAL);
+      return -EINVAL;
     }
   }
 
-  return (0);
+  return 0;
 } /* }}} int wl_config */
 
 void module_register(void) {

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -317,7 +317,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
 
   node = calloc(1, sizeof(*node));
   if (node == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   mongoc_init();
   node->host = NULL;
   node->store_rates = 1;
@@ -327,7 +327,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
 
   if (status != 0) {
     sfree(node);
-    return (status);
+    return status;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -388,7 +388,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
   if (status != 0)
     wm_config_free(node);
 
-  return (status);
+  return status;
 } /* }}} int wm_config_node */
 
 static int wm_config(oconfig_item_t *ci) /* {{{ */
@@ -404,7 +404,7 @@ static int wm_config(oconfig_item_t *ci) /* {{{ */
               child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int wm_config */
 
 void module_register(void) {

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -599,8 +599,8 @@ static int metric_family_update(Io__Prometheus__Client__MetricFamily *fam,
   if (m == NULL)
     return -1;
 
-  return metric_update(m, vl->values[ds_index], ds->ds[ds_index].type, vl->time,
-                       vl->interval);
+  return metric_update(m, vl->values[ds_index], ds->ds[ds_index].type,
+                       vl->time, vl->interval);
 }
 
 /* metric_family_destroy frees the memory used by a metric family. */

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -69,7 +69,7 @@ static int wr_write(const data_set_t *ds, /* {{{ */
 
   status = FORMAT_VL(ident, sizeof(ident), vl);
   if (status != 0)
-    return (status);
+    return status;
   ssnprintf(key, sizeof(key), "%s%s",
             (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX,
             ident);
@@ -79,7 +79,7 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   value_ptr = &value[0];
   status = format_values(value_ptr, value_size, ds, vl, node->store_rates);
   if (status != 0)
-    return (status);
+    return status;
 
   pthread_mutex_lock(&node->lock);
 
@@ -92,14 +92,14 @@ static int wr_write(const data_set_t *ds, /* {{{ */
             (node->host != NULL) ? node->host : "localhost",
             (node->port != 0) ? node->port : 6379);
       pthread_mutex_unlock(&node->lock);
-      return (-1);
+      return -1;
     } else if (node->conn->err) {
       ERROR(
           "write_redis plugin: Connecting to host \"%s\" (port %i) failed: %s",
           (node->host != NULL) ? node->host : "localhost",
           (node->port != 0) ? node->port : 6379, node->conn->errstr);
       pthread_mutex_unlock(&node->lock);
-      return (-1);
+      return -1;
     }
 
     rr = redisCommand(node->conn, "SELECT %d", node->database);
@@ -140,7 +140,7 @@ static int wr_write(const data_set_t *ds, /* {{{ */
 
   pthread_mutex_unlock(&node->lock);
 
-  return (0);
+  return 0;
 } /* }}} int wr_write */
 
 static void wr_config_free(void *ptr) /* {{{ */
@@ -167,7 +167,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
 
   node = calloc(1, sizeof(*node));
   if (node == NULL)
-    return (ENOMEM);
+    return ENOMEM;
   node->host = NULL;
   node->port = 0;
   node->timeout.tv_sec = 0;
@@ -182,7 +182,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   status = cf_util_get_string_buffer(ci, node->name, sizeof(node->name));
   if (status != 0) {
     sfree(node);
-    return (status);
+    return status;
   }
 
   for (int i = 0; i < ci->children_num; i++) {
@@ -230,7 +230,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   if (status != 0)
     wr_config_free(node);
 
-  return (status);
+  return status;
 } /* }}} int wr_config_node */
 
 static int wr_config(oconfig_item_t *ci) /* {{{ */
@@ -246,7 +246,7 @@ static int wr_config(oconfig_item_t *ci) /* {{{ */
               child->key);
   }
 
-  return (0);
+  return 0;
 } /* }}} int wr_config */
 
 void module_register(void) {

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -125,12 +125,12 @@ static int wrr_connect(struct riemann_host *host) /* {{{ */
 static int wrr_disconnect(struct riemann_host *host) /* {{{ */
 {
   if (!host->client)
-    return (0);
+    return 0;
 
   riemann_client_free(host->client);
   host->client = NULL;
 
-  return (0);
+  return 0;
 } /* }}} int wrr_disconnect */
 
 /**
@@ -259,13 +259,13 @@ wrr_notification_to_message(struct riemann_host *host, /* {{{ */
   if (msg == NULL) {
     ERROR("write_riemann plugin: riemann_message_create_with_events() failed.");
     riemann_event_free(event);
-    return (NULL);
+    return NULL;
   }
 
   DEBUG("write_riemann plugin: Successfully created message for notification: "
         "host = \"%s\", service = \"%s\", state = \"%s\"",
         event->host, event->service, event->state);
-  return (msg);
+  return msg;
 } /* }}} riemann_message_t *wrr_notification_to_message */
 
 static riemann_event_t *
@@ -280,7 +280,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   event = riemann_event_new();
   if (event == NULL) {
     ERROR("write_riemann plugin: riemann_event_new() failed.");
-    return (NULL);
+    return NULL;
   }
 
   format_name(name_buffer, sizeof(name_buffer),
@@ -388,7 +388,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   DEBUG("write_riemann plugin: Successfully created message for metric: "
         "host = \"%s\", service = \"%s\"",
         event->host, event->service);
-  return (event);
+  return event;
 } /* }}} riemann_event_t *wrr_value_to_event */
 
 static riemann_message_t *
@@ -403,7 +403,7 @@ wrr_value_list_to_message(struct riemann_host const *host, /* {{{ */
   msg = riemann_message_new();
   if (msg == NULL) {
     ERROR("write_riemann plugin: riemann_message_new failed.");
-    return (NULL);
+    return NULL;
   }
 
   if (host->store_rates) {
@@ -411,7 +411,7 @@ wrr_value_list_to_message(struct riemann_host const *host, /* {{{ */
     if (rates == NULL) {
       ERROR("write_riemann plugin: uc_get_rate failed.");
       riemann_message_free(msg);
-      return (NULL);
+      return NULL;
     }
   }
 
@@ -422,13 +422,13 @@ wrr_value_list_to_message(struct riemann_host const *host, /* {{{ */
     if (event == NULL) {
       riemann_message_free(msg);
       sfree(rates);
-      return (NULL);
+      return NULL;
     }
     riemann_message_append_events(msg, event, NULL);
   }
 
   sfree(rates);
-  return (msg);
+  return msg;
 } /* }}} riemann_message_t *wrr_value_list_to_message */
 
 /*
@@ -459,7 +459,7 @@ static int wrr_batch_flush(cdtime_t timeout,
   int status;
 
   if (user_data == NULL)
-    return (-EINVAL);
+    return -EINVAL;
 
   host = user_data->data;
   pthread_mutex_lock(&host->lock);
@@ -539,7 +539,7 @@ static int wrr_notification(const notification_t *n, user_data_t *ud) /* {{{ */
    */
   msg = wrr_notification_to_message(host, n);
   if (msg == NULL)
-    return (-1);
+    return -1;
 
   status = wrr_send(host, msg);
   if (status != 0)
@@ -552,7 +552,7 @@ static int wrr_notification(const notification_t *n, user_data_t *ud) /* {{{ */
               "write_riemann plugin: riemann_client_send succeeded");
 
   riemann_message_free(msg);
-  return (status);
+  return status;
 } /* }}} int wrr_notification */
 
 static int wrr_write(const data_set_t *ds, /* {{{ */
@@ -575,7 +575,7 @@ static int wrr_write(const data_set_t *ds, /* {{{ */
   } else {
     msg = wrr_value_list_to_message(host, ds, vl, statuses);
     if (msg == NULL)
-      return (-1);
+      return -1;
 
     status = wrr_send(host, msg);
 
@@ -827,7 +827,7 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
      * holding a reference. */
     pthread_mutex_unlock(&host->lock);
     wrr_free(host);
-    return (-1);
+    return -1;
   }
 
   host->reference_count--;
@@ -853,21 +853,21 @@ static int wrr_config(oconfig_item_t *ci) /* {{{ */
 
       if (child->values_num != 2) {
         WARNING("riemann attributes need both a key and a value.");
-        return (-1);
+        return -1;
       }
       if (child->values[0].type != OCONFIG_TYPE_STRING ||
           child->values[1].type != OCONFIG_TYPE_STRING) {
         WARNING("riemann attribute needs string arguments.");
-        return (-1);
+        return -1;
       }
       if ((key = strdup(child->values[0].value.string)) == NULL) {
         WARNING("cannot allocate memory for attribute key.");
-        return (-1);
+        return -1;
       }
       if ((val = strdup(child->values[1].value.string)) == NULL) {
         WARNING("cannot allocate memory for attribute value.");
         sfree(key);
-        return (-1);
+        return -1;
       }
       strarray_add(&riemann_attrs, &riemann_attrs_num, key);
       strarray_add(&riemann_attrs, &riemann_attrs_num, val);
@@ -889,7 +889,7 @@ static int wrr_config(oconfig_item_t *ci) /* {{{ */
               child->key);
     }
   }
-  return (0);
+  return 0;
 } /* }}} int wrr_config */
 
 void module_register(void) {

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -63,7 +63,7 @@ static int ut_check_one_data_source(
   if (ds != NULL) {
     ds_name = ds->ds[ds_index].name;
     if ((th->data_source[0] != 0) && (strcmp(ds_name, th->data_source) != 0))
-      return (STATE_OKAY);
+      return STATE_OKAY;
   }
 
   if ((th->flags & UT_FLAG_INVERT) != 0) {
@@ -81,7 +81,7 @@ static int ut_check_one_data_source(
            ((th->failure_min + th->hysteresis) < values[ds_index])) ||
           (!isnan(th->failure_max) &&
            ((th->failure_max - th->hysteresis) > values[ds_index])))
-        return (STATE_OKAY);
+        return STATE_OKAY;
       else
         is_failure++;
     case STATE_WARNING:
@@ -89,7 +89,7 @@ static int ut_check_one_data_source(
            ((th->warning_min + th->hysteresis) < values[ds_index])) ||
           (!isnan(th->warning_max) &&
            ((th->warning_max - th->hysteresis) > values[ds_index])))
-        return (STATE_OKAY);
+        return STATE_OKAY;
       else
         is_warning++;
     }
@@ -104,12 +104,12 @@ static int ut_check_one_data_source(
   }
 
   if (is_failure != 0)
-    return (STATE_ERROR);
+    return STATE_ERROR;
 
   if (is_warning != 0)
-    return (STATE_WARNING);
+    return STATE_WARNING;
 
-  return (STATE_OKAY);
+  return STATE_OKAY;
 } /* }}} int ut_check_one_data_source */
 
 /*
@@ -170,7 +170,7 @@ static int ut_check_one_threshold(const data_set_t *ds, const value_list_t *vl,
     }
   } /* for (ds->ds_num) */
 
-  return (ret);
+  return ret;
 } /* }}} int ut_check_one_threshold */
 
 /*
@@ -200,20 +200,20 @@ int write_riemann_threshold_check(const data_set_t *ds, const value_list_t *vl,
   th = threshold_search(vl);
   pthread_mutex_unlock(&threshold_lock);
   if (th == NULL)
-    return (0);
+    return 0;
 
   DEBUG("ut_check_threshold: Found matching threshold(s)");
 
   values = uc_get_rate(ds, vl);
   if (values == NULL)
-    return (0);
+    return 0;
 
   while (th != NULL) {
     status = ut_check_one_threshold(ds, vl, th, values, statuses);
     if (status < 0) {
       ERROR("ut_check_threshold: ut_check_one_threshold failed.");
       sfree(values);
-      return (-1);
+      return -1;
     }
 
     th = th->next;
@@ -221,5 +221,5 @@ int write_riemann_threshold_check(const data_set_t *ds, const value_list_t *vl,
 
   sfree(values);
 
-  return (0);
+  return 0;
 } /* }}} int ut_check_threshold */

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -278,7 +278,7 @@ static int sensu_format_name2(char *ret, int ret_len, const char *hostname,
   do {                                                                         \
     size_t l = strlen(str);                                                    \
     if (l >= buffer_size)                                                      \
-      return (ENOBUFS);                                                        \
+      return ENOBUFS;                                                          \
     memcpy(buffer, (str), l);                                                  \
     buffer += l;                                                               \
     buffer_size -= l;                                                          \
@@ -304,7 +304,7 @@ static int sensu_format_name2(char *ret, int ret_len, const char *hostname,
   buffer[0] = 0;
 
 #undef APPEND
-  return (0);
+  return 0;
 } /* int sensu_format_name2 */
 
 static void in_place_replace_sensu_name_reserved(char *orig_name) /* {{{ */

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -197,7 +197,7 @@ static int wt_callback_init(struct wt_callback *cb) {
     if ((cb->ai_last_update + resolve_interval + cb->next_random_ttl) >= now) {
       DEBUG("write_tsdb plugin: too many getaddrinfo(%s, %s) failures", node,
             service);
-      return (-1);
+      return -1;
     }
     cb->ai_last_update = now;
     cb->next_random_ttl = new_random_ttl();

--- a/src/xencpu.c
+++ b/src/xencpu.c
@@ -51,7 +51,7 @@ static int xencpu_init(void) {
   xc_handle = xc_interface_open(XC_INTERFACE_INIT_ARGS);
   if (!xc_handle) {
     ERROR("xencpu: xc_interface_open() failed");
-    return (-1);
+    return -1;
   }
 
   xc_physinfo_t *physinfo;
@@ -60,14 +60,14 @@ static int xencpu_init(void) {
   if (physinfo == NULL) {
     ERROR("xencpu plugin: calloc() for physinfo failed.");
     xc_interface_close(xc_handle);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   if (xc_physinfo(xc_handle, physinfo) < 0) {
     ERROR("xencpu plugin: xc_physinfo() failed");
     xc_interface_close(xc_handle);
     free(physinfo);
-    return (-1);
+    return -1;
   }
 
   num_cpus = physinfo->nr_cpus;
@@ -79,7 +79,7 @@ static int xencpu_init(void) {
   if (cpu_info == NULL) {
     ERROR("xencpu plugin: calloc() for num_cpus failed.");
     xc_interface_close(xc_handle);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
   cpu_states = calloc(num_cpus, sizeof(value_to_rate_state_t));
@@ -87,10 +87,10 @@ static int xencpu_init(void) {
     ERROR("xencpu plugin: calloc() for cpu_states failed.");
     xc_interface_close(xc_handle);
     free(cpu_info);
-    return (ENOMEM);
+    return ENOMEM;
   }
 
-  return (0);
+  return 0;
 } /* static int xencpu_init */
 
 static int xencpu_shutdown(void) {
@@ -126,7 +126,7 @@ static int xencpu_read(void) {
   if (rc < 0) {
     ERROR("xencpu: xc_getcpuinfo() Failed: %d %s\n", rc,
           xc_strerror(xc_handle, errno));
-    return (-1);
+    return -1;
   }
 
   int status;
@@ -140,7 +140,7 @@ static int xencpu_read(void) {
     }
   }
 
-  return (0);
+  return 0;
 } /* static int xencpu_read */
 
 void module_register(void) {

--- a/src/xmms.c
+++ b/src/xmms.c
@@ -50,17 +50,17 @@ static int cxmms_read(void) {
   gint nch;
 
   if (!xmms_remote_is_running(xmms_session))
-    return (0);
+    return 0;
 
   xmms_remote_get_info(xmms_session, &rate, &freq, &nch);
 
   if ((freq == 0) || (nch == 0))
-    return (-1);
+    return -1;
 
   cxmms_submit("bitrate", rate);
   cxmms_submit("frequency", freq);
 
-  return (0);
+  return 0;
 } /* int read */
 
 void module_register(void) {

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -75,11 +75,11 @@ static long long get_zfs_value(kstat_t *ksp, const char *key) {
 
   e = llist_search(ksp, key);
   if (e == NULL) {
-    return (-1);
+    return -1;
   }
 
   v = e->value;
-  return ((long long)v->derive);
+  return (long long)v->derive;
 }
 
 static void free_zfs_values(kstat_t *ksp) {
@@ -99,7 +99,7 @@ extern kstat_ctl_t *kc;
 
 static long long get_zfs_value(kstat_t *ksp, char *name) {
 
-  return (get_kstat_value(ksp, name));
+  return get_kstat_value(ksp, name);
 }
 #elif defined(KERNEL_FREEBSD)
 #include <sys/sysctl.h>
@@ -122,9 +122,9 @@ static long long get_zfs_value(kstat_t *dummy __attribute__((unused)),
   rv = sysctlbyname(buffer, (void *)&value, &valuelen,
                     /* new value = */ NULL, /* new length = */ (size_t)0);
   if (rv == 0)
-    return (value);
+    return value;
 
-  return (-1);
+  return -1;
 }
 #endif
 
@@ -152,12 +152,12 @@ static int za_read_derive(kstat_t *ksp, const char *kstat_value,
   long long tmp = get_zfs_value(ksp, (char *)kstat_value);
   if (tmp == -1LL) {
     DEBUG("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
-    return (-1);
+    return -1;
   }
 
   za_submit(type, type_instance, &(value_t){.derive = (derive_t)tmp},
             /* values_num = */ 1);
-  return (0);
+  return 0;
 }
 
 static int za_read_gauge(kstat_t *ksp, const char *kstat_value,
@@ -165,12 +165,12 @@ static int za_read_gauge(kstat_t *ksp, const char *kstat_value,
   long long tmp = get_zfs_value(ksp, (char *)kstat_value);
   if (tmp == -1LL) {
     DEBUG("zfs_arc plugin: Reading kstat value \"%s\" failed.", kstat_value);
-    return (-1);
+    return -1;
   }
 
   za_submit(type, type_instance, &(value_t){.gauge = (gauge_t)tmp},
             /* values_num = */ 1);
-  return (0);
+  return 0;
 }
 
 static void za_submit_ratio(const char *type_instance, gauge_t hits,
@@ -201,14 +201,14 @@ static int za_read(void) {
     char errbuf[1024];
     ERROR("zfs_arc plugin: Opening \"%s\" failed: %s", ZOL_ARCSTATS_FILE,
           sstrerror(errno, errbuf, sizeof(errbuf)));
-    return (-1);
+    return -1;
   }
 
   ksp = llist_create();
   if (ksp == NULL) {
     ERROR("zfs_arc plugin: `llist_create' failed.");
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   // Ignore the first two lines because they contain information about
@@ -218,12 +218,12 @@ static int za_read(void) {
   if (fgets(buffer, sizeof(buffer), fh) == NULL) {
     ERROR("zfs_arc plugin: \"%s\" does not contain a single line.", ZOL_ARCSTATS_FILE);
     fclose(fh);
-    return (-1);
+    return -1;
   }
   if (fgets(buffer, sizeof(buffer), fh) == NULL) {
     ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.", ZOL_ARCSTATS_FILE);
     fclose(fh);
-    return (-1);
+    return -1;
   }
 
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
@@ -248,7 +248,7 @@ static int za_read(void) {
   get_kstat(&ksp, "zfs", 0, "arcstats");
   if (ksp == NULL) {
     ERROR("zfs_arc plugin: Cannot find zfs:0:arcstats kstat.");
-    return (-1);
+    return -1;
   }
 #endif
 
@@ -331,7 +331,7 @@ static int za_read(void) {
   free_zfs_values(ksp);
 #endif
 
-  return (0);
+  return 0;
 } /* int za_read */
 
 static int za_init(void) /* {{{ */
@@ -341,11 +341,11 @@ static int za_init(void) /* {{{ */
    * went fine. */
   if (kc == NULL) {
     ERROR("zfs_arc plugin: kstat chain control structure not available.");
-    return (-1);
+    return -1;
   }
 #endif
 
-  return (0);
+  return 0;
 } /* }}} int za_init */
 
 void module_register(void) {

--- a/src/zone.c
+++ b/src/zone.c
@@ -51,10 +51,10 @@ typedef struct zone_stats {
 
 static int zone_compare(const void *a, const void *b) {
   if (*(const zoneid_t *)a == *(const zoneid_t *)b)
-    return (0);
+    return 0;
   if (*(const zoneid_t *)a < *(const zoneid_t *)b)
-    return (-1);
-  return (1);
+    return -1;
+  return 1;
 }
 
 static int zone_read_procfile(char const *pidstr, char const *name, void *buf,
@@ -64,7 +64,7 @@ static int zone_read_procfile(char const *pidstr, char const *name, void *buf,
   char procfile[MAX_PROCFS_PATH];
   (void)snprintf(procfile, sizeof(procfile), "/proc/%s/%s", pidstr, name);
   if ((fd = open(procfile, O_RDONLY)) == -1) {
-    return (1);
+    return 1;
   }
 
   if (sread(fd, buf, bufsize) != 0) {
@@ -72,11 +72,11 @@ static int zone_read_procfile(char const *pidstr, char const *name, void *buf,
     ERROR("zone plugin: Reading \"%s\" failed: %s", procfile,
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(fd);
-    return (1);
+    return 1;
   }
 
   close(fd);
-  return (0);
+  return 0;
 }
 
 static int zone_submit_value(char *zone, gauge_t value) {
@@ -91,7 +91,7 @@ static int zone_submit_value(char *zone, gauge_t value) {
   sstrncpy(vl.type, "percent", sizeof(vl.type));
   sstrncpy(vl.type_instance, zone, sizeof(vl.type_instance));
 
-  return (plugin_dispatch_values(&vl));
+  return plugin_dispatch_values(&vl);
 }
 
 static zone_stats_t *zone_find_stats(c_avl_tree_t *tree, zoneid_t zoneid) {
@@ -101,20 +101,20 @@ static zone_stats_t *zone_find_stats(c_avl_tree_t *tree, zoneid_t zoneid) {
   if (c_avl_get(tree, (void **)&zoneid, (void **)&ret)) {
     if (!(ret = malloc(sizeof(*ret)))) {
       WARNING("zone plugin: no memory");
-      return (NULL);
+      return NULL;
     }
     if (!(key = malloc(sizeof(*key)))) {
       WARNING("zone plugin: no memory");
       free(ret);
-      return (NULL);
+      return NULL;
     }
     *key = zoneid;
     if (c_avl_insert(tree, key, ret)) {
       WARNING("zone plugin: error inserting into tree");
-      return (NULL);
+      return NULL;
     }
   }
-  return (ret);
+  return ret;
 }
 
 static void zone_submit_values(c_avl_tree_t *tree) {
@@ -143,7 +143,7 @@ static c_avl_tree_t *zone_scandir(DIR *procdir) {
 
   if (!(tree = c_avl_create(zone_compare))) {
     WARNING("zone plugin: Failed to create tree");
-    return (NULL);
+    return NULL;
   }
 
   rewinddir(procdir);
@@ -165,7 +165,7 @@ static c_avl_tree_t *zone_scandir(DIR *procdir) {
       stats->pctmem += psinfo.pr_pctmem;
     }
   }
-  return (tree);
+  return tree;
 }
 
 static int zone_read(void) {
@@ -174,16 +174,16 @@ static int zone_read(void) {
 
   if ((procdir = opendir("/proc")) == NULL) {
     ERROR("zone plugin: cannot open /proc directory\n");
-    return (-1);
+    return -1;
   }
 
   tree = zone_scandir(procdir);
   closedir(procdir);
   if (tree == NULL) {
-    return (-1);
+    return -1;
   }
   zone_submit_values(tree); /* this also frees tree */
-  return (0);
+  return 0;
 }
 
 void module_register(void) {

--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -103,7 +103,7 @@ static int zookeeper_connect(void) {
     INFO("getaddrinfo failed: %s",
          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
                                 : gai_strerror(status));
-    return (-1);
+    return -1;
   }
 
   for (struct addrinfo *ai = ai_list; ai != NULL; ai = ai->ai_next) {
@@ -129,7 +129,7 @@ static int zookeeper_connect(void) {
   }
 
   freeaddrinfo(ai_list);
-  return (sk);
+  return sk;
 } /* int zookeeper_connect */
 
 static int zookeeper_query(char *buffer, size_t buffer_size) {
@@ -139,7 +139,7 @@ static int zookeeper_query(char *buffer, size_t buffer_size) {
   sk = zookeeper_connect();
   if (sk < 0) {
     ERROR("zookeeper: Could not connect to daemon");
-    return (-1);
+    return -1;
   }
 
   status = (int)swrite(sk, "mntr\r\n", strlen("mntr\r\n"));
@@ -148,7 +148,7 @@ static int zookeeper_query(char *buffer, size_t buffer_size) {
     ERROR("zookeeper: write(2) failed: %s",
           sstrerror(errno, errbuf, sizeof(errbuf)));
     close(sk);
-    return (-1);
+    return -1;
   }
 
   memset(buffer, 0, buffer_size);
@@ -164,7 +164,7 @@ static int zookeeper_query(char *buffer, size_t buffer_size) {
       ERROR("zookeeper: Error reading from socket: %s",
             sstrerror(errno, errbuf, sizeof(errbuf)));
       close(sk);
-      return (-1);
+      return -1;
     }
 
     buffer_fill += (size_t)status;
@@ -177,7 +177,7 @@ static int zookeeper_query(char *buffer, size_t buffer_size) {
   }
 
   close(sk);
-  return (status);
+  return status;
 } /* int zookeeper_query */
 
 static int zookeeper_read(void) {
@@ -188,7 +188,7 @@ static int zookeeper_read(void) {
   char *fields[2];
 
   if (zookeeper_query(buf, sizeof(buf)) < 0) {
-    return (-1);
+    return -1;
   }
 
   ptr = buf;
@@ -238,7 +238,7 @@ static int zookeeper_read(void) {
     }
   }
 
-  return (0);
+  return 0;
 } /* zookeeper_read */
 
 void module_register(void) {


### PR DESCRIPTION
They don't do any harm but they are not really needed either.
Contributors are not used to following this style, and reviewers have to
keep pointing it out in reviews. This takes up valuable time for both
the contributor and the reviewer and distracts from the more important
issues.

I used the following Coccinelle patch:

```diff
@@
expression e;
@@
- return (e);
+ return e;
```

spatch is having trouble with some files so I have cleaned up the rest
with a few regexes.