### PR TITLE
valgrind.FreeBSD.suppress: parse_value(): Always suppress the strlen(…

### DIFF
--- a/src/valgrind.FreeBSD.suppress
+++ b/src/valgrind.FreeBSD.suppress
@@ -2,7 +2,6 @@
    strlen_bogus_invalid_read_after_strdup
    Memcheck:Addr4
    fun:parse_value
-   fun:parse_values
    ...
    fun:main
 }


### PR DESCRIPTION
…) false positive.

Previously, this was only suppressed when called via parse_values()
(note the plural).

Fixes: #2282