### PR TITLE
curl_json plugin: Refactor the way trees/keys are stored.

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -946,9 +946,13 @@ static int cj_read(user_data_t *ud) /* {{{ */
 
   db->depth = 0;
   memset(&db->state, 0, sizeof(db->state));
-  db->state[0].entry = &(cj_tree_entry_t){
-      .type = TREE, .tree = db->tree,
-  };
+
+  /* This is not a compound literal because EPEL6's GCC is not cool enough to
+   * handle anonymous unions within compound literals. */
+  cj_tree_entry_t root = {0};
+  root.type = TREE;
+  root.tree = db->tree;
+  db->state[0].entry = &root;
 
   int status = cj_perform(db);
 

--- a/src/curl_json_test.c
+++ b/src/curl_json_test.c
@@ -47,13 +47,14 @@ static cj_t *test_setup(char *json, char *key_path) {
   db->curl = (void *)cj_avl_create();
 
   cj_key_t *key = calloc(1, sizeof(*key));
-  key->magic = CJ_KEY_MAGIC;
   key->path = strdup(key_path);
   key->type = strdup("MAGIC");
 
   assert(cj_append_key(db, key) == 0);
 
-  db->state[0].tree = db->tree;
+  db->state[0].entry = &(cj_tree_entry_t){
+      .type = TREE, .tree = db->tree,
+  };
 
   cj_curl_callback(json, strlen(json), 1, db);
 #if HAVE_YAJL_V2
@@ -61,6 +62,8 @@ static cj_t *test_setup(char *json, char *key_path) {
 #else
   yajl_parse_complete(db->yajl);
 #endif
+
+  db->state[0].entry = NULL;
 
   return db;
 }

--- a/src/curl_json_test.c
+++ b/src/curl_json_test.c
@@ -52,9 +52,10 @@ static cj_t *test_setup(char *json, char *key_path) {
 
   assert(cj_append_key(db, key) == 0);
 
-  db->state[0].entry = &(cj_tree_entry_t){
-      .type = TREE, .tree = db->tree,
-  };
+  cj_tree_entry_t root = {0};
+  root.type = TREE;
+  root.tree = db->tree;
+  db->state[0].entry = &root;
 
   cj_curl_callback(json, strlen(json), 1, db);
 #if HAVE_YAJL_V2


### PR DESCRIPTION
Previously, keys had a "magic" as their first member which was used to differentiate between the two types when they were returned from the binary search tree.

This patch creates a new struct, cj_tree_entry_t, which includes an enum identifying which union member is valid.

I have to admit I'm a bit on the fence on this one. It feels more "correct" but unfortunately isn't as readable as I'd hope it to be. Thoughts?