### PR TITLE
Drop caps after plugin init

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -263,6 +263,7 @@ __attribute__((noreturn)) static void exit_usage(int status) {
 } /* static void exit_usage (int status) */
 
 static int do_init(void) {
+  int ret;
 #if HAVE_SETLOCALE
   if (setlocale(LC_NUMERIC, COLLECTD_LOCALE) == NULL)
     WARNING("setlocale (\"%s\") failed.", COLLECTD_LOCALE);
@@ -287,14 +288,17 @@ static int do_init(void) {
     ERROR("sg_init: %s", sg_str_error(sg_get_error()));
     return -1;
   }
+#endif
+  ret = plugin_init_all();
 
+#if HAVE_LIBSTATGRAB
   if (sg_drop_privileges()) {
     ERROR("sg_drop_privileges: %s", sg_str_error(sg_get_error()));
     return -1;
   }
 #endif
 
-  return plugin_init_all();
+  return ret;
 } /* int do_init () */
 
 static int do_loop(void) {


### PR DESCRIPTION
unixsock and email plugins are unable to chown since capabilities are dropped before plugin initialization is complete.