### PR TITLE
format_graphite: Error if call to uc_get_rate fails to return a value.

### DIFF
--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -180,8 +180,13 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
   int buffer_pos = 0;
 
   gauge_t *rates = NULL;
-  if (flags & GRAPHITE_STORE_RATES)
+  if (flags & GRAPHITE_STORE_RATES) {
     rates = uc_get_rate(ds, vl);
+    if (rates == NULL) {
+      ERROR("format_graphite: error with uc_get_rate");
+      return -1;
+    }
+  }
 
   for (size_t i = 0; i < ds->ds_num; i++) {
     char const *ds_name = NULL;


### PR DESCRIPTION
This prevents a wrong value being sent to graphite for DERIVE types.

Fixes: #2209