### PR TITLE
Remove close() call from sread()

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -230,10 +230,7 @@ ssize_t sread(int fd, void *buf, size_t count) {
       return status;
 
     if (status == 0) {
-      DEBUG("Received EOF from fd %i. "
-            "Closing fd and returning error.",
-            fd);
-      close(fd);
+      DEBUG("Received EOF from fd %i. ", fd);
       return -1;
     }
 

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -212,7 +212,7 @@ void sfree (void **ptr)
 }
 #endif
 
-ssize_t sread(int fd, void *buf, size_t count) {
+int sread(int fd, void *buf, size_t count) {
   char *ptr;
   size_t nleft;
   ssize_t status;
@@ -243,7 +243,7 @@ ssize_t sread(int fd, void *buf, size_t count) {
   return 0;
 }
 
-ssize_t swrite(int fd, const void *buf, size_t count) {
+int swrite(int fd, const void *buf, size_t count) {
   const char *ptr;
   size_t nleft;
   ssize_t status;

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -79,8 +79,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen);
  *
  * DESCRIPTION
  *   Reads exactly `n' bytes or fails. Syntax and other behavior is analogous
- *   to `read(2)'. If EOF is received the file descriptor is closed and an
- *   error is returned.
+ *   to `read(2)'.
  *
  * PARAMETERS
  *   `fd'          File descriptor to write to.

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -90,7 +90,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen);
  *   Zero upon success or non-zero if an error occurred. `errno' is set in this
  *   case.
  */
-ssize_t sread(int fd, void *buf, size_t count);
+int sread(int fd, void *buf, size_t count);
 
 /*
  * NAME
@@ -109,7 +109,7 @@ ssize_t sread(int fd, void *buf, size_t count);
  *   Zero upon success or non-zero if an error occurred. `errno' is set in this
  *   case.
  */
-ssize_t swrite(int fd, const void *buf, size_t count);
+int swrite(int fd, const void *buf, size_t count);
 
 /*
  * NAME

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -257,7 +257,7 @@ static int socket_write(socket_adapter_t *self, const char *msg,
                         const size_t len) {
   int ret = 0;
   pthread_rwlock_rdlock(&self->lock);
-  if (swrite(self->sock_fd, msg, len) < 0)
+  if (swrite(self->sock_fd, msg, len) != 0)
     ret = -1;
   pthread_rwlock_unlock(&self->lock);
   return ret;

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -62,7 +62,7 @@ static int multimeter_read_value(double *value) {
       struct timeval time_now;
 
       status = swrite(fd, "D", 1);
-      if (status < 0) {
+      if (status != 0) {
         ERROR("multimeter plugin: swrite failed.");
         return -1;
       }

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -669,7 +669,7 @@ static int ntpd_send_request(int req_code, int req_items, int req_size,
         (void *)req_data);
 
   status = swrite(sd, (const char *)&req, REQ_LEN_NOMAC);
-  if (status < 0) {
+  if (status != 0) {
     DEBUG("`swrite' failed. Closing socket #%i", sd);
     close(sd);
     sock_descr = sd = -1;

--- a/src/ted.c
+++ b/src/ted.c
@@ -88,7 +88,7 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
 
   status = write(fd, pkt_request, sizeof(pkt_request));
   if (status <= 0) {
-    ERROR("ted plugin: swrite failed.");
+    ERROR("ted plugin: write failed.");
     return -1;
   }
 

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -111,7 +111,7 @@ static int wt_send_buffer(struct wt_callback *cb) {
   ssize_t status = 0;
 
   status = swrite(cb->sock_fd, cb->send_buf, strlen(cb->send_buf));
-  if (status < 0) {
+  if (status != 0) {
     char errbuf[1024];
     ERROR("write_tsdb plugin: send failed with status %zi (%s)", status,
           sstrerror(errno, errbuf, sizeof(errbuf)));


### PR DESCRIPTION
Function sread() behaves incorrectly and unexpectedly in case of EOF - it closes FD. 
At the same time, in case of socket errors it does not close FD.

Function sread() used in two modules: zone.c and apcups.c.
Both of them do `close(fd)` when sread() return value is not equal to zero - i.e in both cases of socket error and socket EOF. Duplicated `close()` call occurs.

I think *read* function should not close fd in any cases, and other developers expects the same, I think.

This patch is proposed to fix this.

The `swrite()` function is ok, no similar fix needed.

src/apcups.c:

```
if (sread(*sockfd, (void *)&packet_size, sizeof(packet_size)) != 0) {
    close(*sockfd);
    *sockfd = -1;
    return -1;
  }
...

  if (sread(*sockfd, (void *)buf, packet_size) != 0) {
    close(*sockfd);
    *sockfd = -1;
    return -1;
  }
```

src/zone.c

```
  if (sread(fd, buf, bufsize) != 0) {
    char errbuf[1024];
    ERROR("zone plugin: Reading \"%s\" failed: %s", procfile,
          sstrerror(errno, errbuf, sizeof(errbuf)));
    close(fd);
    return 1;
  }
```