### PR TITLE
Ipvs ipv6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -611,6 +611,24 @@ else
 fi
 
 AM_CONDITIONAL([IP_VS_H_NEEDS_KERNEL_CFLAGS], [test "x$ip_vs_h_needs_kernel_cflags" = "xyes"])
+PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
+PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes],
+    [PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
+	    [PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
+        ])
+	])
+
+if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
+        CFLAGS+=" $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS -DLIBIPVS_USE_NL"
+        LIBS+=" $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+#LIBS+=" $"
+elif (test "${have_libnl2}" = "yes"); then
+    CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+	LIBS+="$LIBNL2_LIBS"
+elif  (test "${have_libnl1}" = "yes"); then
+    CFLAGS+="$LIBNL1_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+    LIBS+="$LIBNL1_LIBS"
+fi
 AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
 
 # For the swap module

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -42,7 +42,6 @@
 #include <netinet/in.h>
 #endif /* HAVE_NETINET_IN_H */
 
-
 #ifdef LIBIPVS_USE_NL
 /* Include our own structures as the IPV6 structuress required are
   not included in the standard kernel source */
@@ -58,22 +57,21 @@
 #endif /* HAVE_IP_VS_H */
 #endif
 
-
 #ifdef LIBIPVS_USE_NL
-# include <netlink/netlink.h>
-# include <netlink/genl/genl.h>
-# include <netlink/genl/ctrl.h>
-# include <netlink/msg.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/genl.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
 #endif
 
 #ifdef LIBIPVS_USE_NL
 #ifdef FALLBACK_LIBNL1
-#define nl_sock         nl_handle
+#define nl_sock nl_handle
 #define nl_socket_alloc nl_handle_alloc
-#define nl_socket_free  nl_handle_destroy
+#define nl_socket_free nl_handle_destroy
 #endif
-static  struct nl_sock *sock = NULL;
-static  int family;
+static struct nl_sock *sock = NULL;
+static int family;
 #endif
 
 static int try_nl = 1;
@@ -91,23 +89,21 @@ struct ip_vs_getinfo ipvs_info;
 /*
  * libipvs API
  */
-struct nl_msg *ipvs_nl_message(int cmd, int flags)
-{
+struct nl_msg *ipvs_nl_message(int cmd, int flags) {
   struct nl_msg *msg;
 
   msg = nlmsg_alloc();
   if (!msg)
     return NULL;
 
-  genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, family, 0, flags,
-              cmd, IPVS_GENL_VERSION);
+  genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, family, 0, flags, cmd,
+              IPVS_GENL_VERSION);
 
   return msg;
 }
 
-
-static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, void *arg)
-{
+static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func,
+                                void *arg) {
   int err = EINVAL;
 
   sock = nl_socket_alloc();
@@ -123,7 +119,7 @@ static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, vo
   if (family < 0)
     goto fail_genl;
 
-// To test connections and set the family
+  // To test connections and set the family
   if (msg == NULL) {
     nl_socket_free(sock);
     sock = NULL;
@@ -145,7 +141,7 @@ static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, vo
 
   return 0;
 
-    fail_genl:
+fail_genl:
   nl_socket_free(sock);
   sock = NULL;
   nlmsg_free(msg);
@@ -153,16 +149,14 @@ static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, vo
   return -1;
 }
 
-static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg)
-{
+static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg) {
   struct nlmsghdr *nlh = nlmsg_hdr(msg);
   struct nlattr *attrs[IPVS_INFO_ATTR_MAX + 1];
 
   if (genlmsg_parse(nlh, 0, attrs, IPVS_INFO_ATTR_MAX, ipvs_info_policy) != 0)
     return -1;
 
-  if (!(attrs[IPVS_INFO_ATTR_VERSION] &&
-        attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]))
+  if (!(attrs[IPVS_INFO_ATTR_VERSION] && attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]))
     return -1;
 
   ipvs_info.version = nla_get_u32(attrs[IPVS_INFO_ATTR_VERSION]);
@@ -175,151 +169,136 @@ static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg)
 
 #ifdef LIBIPVS_USE_NL
 
-static int ipvs_parse_stats(struct ip_vs_stats64 *stats, struct nlattr *nla)
-{
-	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+static int ipvs_parse_stats(struct ip_vs_stats64 *stats, struct nlattr *nla) {
+  struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
 
-	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
-		return -1;
+  if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
+    return -1;
 
-	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
-			attrs[IPVS_STATS_ATTR_INPKTS] &&
-			attrs[IPVS_STATS_ATTR_OUTPKTS] &&
-			attrs[IPVS_STATS_ATTR_INBYTES] &&
-			attrs[IPVS_STATS_ATTR_OUTBYTES] &&
-			attrs[IPVS_STATS_ATTR_CPS] &&
-			attrs[IPVS_STATS_ATTR_INPPS] &&
-			attrs[IPVS_STATS_ATTR_OUTPPS] &&
-			attrs[IPVS_STATS_ATTR_INBPS] &&
-			attrs[IPVS_STATS_ATTR_OUTBPS]))
-		return -1;
+  if (!(attrs[IPVS_STATS_ATTR_CONNS] && attrs[IPVS_STATS_ATTR_INPKTS] &&
+        attrs[IPVS_STATS_ATTR_OUTPKTS] && attrs[IPVS_STATS_ATTR_INBYTES] &&
+        attrs[IPVS_STATS_ATTR_OUTBYTES] && attrs[IPVS_STATS_ATTR_CPS] &&
+        attrs[IPVS_STATS_ATTR_INPPS] && attrs[IPVS_STATS_ATTR_OUTPPS] &&
+        attrs[IPVS_STATS_ATTR_INBPS] && attrs[IPVS_STATS_ATTR_OUTBPS]))
+    return -1;
 
-	stats->conns = nla_get_u32(attrs[IPVS_STATS_ATTR_CONNS]);
-	stats->inpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_INPKTS]);
-	stats->outpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPKTS]);
-	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
-	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
-	stats->cps = nla_get_u32(attrs[IPVS_STATS_ATTR_CPS]);
-	stats->inpps = nla_get_u32(attrs[IPVS_STATS_ATTR_INPPS]);
-	stats->outpps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPPS]);
-	stats->inbps = nla_get_u32(attrs[IPVS_STATS_ATTR_INBPS]);
-	stats->outbps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTBPS]);
+  stats->conns = nla_get_u32(attrs[IPVS_STATS_ATTR_CONNS]);
+  stats->inpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_INPKTS]);
+  stats->outpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+  stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+  stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+  stats->cps = nla_get_u32(attrs[IPVS_STATS_ATTR_CPS]);
+  stats->inpps = nla_get_u32(attrs[IPVS_STATS_ATTR_INPPS]);
+  stats->outpps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPPS]);
+  stats->inbps = nla_get_u32(attrs[IPVS_STATS_ATTR_INBPS]);
+  stats->outbps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTBPS]);
 
-	return 0;
-
+  return 0;
 }
 
-static int ipvs_parse_stats64(struct ip_vs_stats64 *stats, struct nlattr *nla)
-{
-	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+static int ipvs_parse_stats64(struct ip_vs_stats64 *stats, struct nlattr *nla) {
+  struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
 
-	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla,
-			ipvs_stats_policy))
-		return -1;
+  if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
+    return -1;
 
-	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
-		attrs[IPVS_STATS_ATTR_INPKTS] &&
-		attrs[IPVS_STATS_ATTR_OUTPKTS] &&
-		attrs[IPVS_STATS_ATTR_INBYTES] &&
-		attrs[IPVS_STATS_ATTR_OUTBYTES] &&
-		attrs[IPVS_STATS_ATTR_CPS] &&
-		attrs[IPVS_STATS_ATTR_INPPS] &&
-		attrs[IPVS_STATS_ATTR_OUTPPS] &&
-		attrs[IPVS_STATS_ATTR_INBPS] &&
-		attrs[IPVS_STATS_ATTR_OUTBPS]))
-	return -1;
+  if (!(attrs[IPVS_STATS_ATTR_CONNS] && attrs[IPVS_STATS_ATTR_INPKTS] &&
+        attrs[IPVS_STATS_ATTR_OUTPKTS] && attrs[IPVS_STATS_ATTR_INBYTES] &&
+        attrs[IPVS_STATS_ATTR_OUTBYTES] && attrs[IPVS_STATS_ATTR_CPS] &&
+        attrs[IPVS_STATS_ATTR_INPPS] && attrs[IPVS_STATS_ATTR_OUTPPS] &&
+        attrs[IPVS_STATS_ATTR_INBPS] && attrs[IPVS_STATS_ATTR_OUTBPS]))
+    return -1;
 
-	stats->conns = nla_get_u64(attrs[IPVS_STATS_ATTR_CONNS]);
-	stats->inpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_INPKTS]);
-	stats->outpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPKTS]);
-	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
-	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
-	stats->cps = nla_get_u64(attrs[IPVS_STATS_ATTR_CPS]);
-	stats->inpps = nla_get_u64(attrs[IPVS_STATS_ATTR_INPPS]);
-	stats->outpps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPPS]);
-	stats->inbps = nla_get_u64(attrs[IPVS_STATS_ATTR_INBPS]);
-	stats->outbps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBPS]);
+  stats->conns = nla_get_u64(attrs[IPVS_STATS_ATTR_CONNS]);
+  stats->inpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_INPKTS]);
+  stats->outpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+  stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+  stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+  stats->cps = nla_get_u64(attrs[IPVS_STATS_ATTR_CPS]);
+  stats->inpps = nla_get_u64(attrs[IPVS_STATS_ATTR_INPPS]);
+  stats->outpps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPPS]);
+  stats->inbps = nla_get_u64(attrs[IPVS_STATS_ATTR_INBPS]);
+  stats->outbps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBPS]);
 
-	return 0;
+  return 0;
 }
 
+static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
+  struct nlmsghdr *nlh = nlmsg_hdr(msg);
+  struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+  struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
+  struct ip_vs_get_services **getp = (struct ip_vs_get_services **)arg;
+  struct ip_vs_get_services *get = (struct ip_vs_get_services *)*getp;
+  struct ip_vs_flags flags;
+  int i = get->num_services;
 
-static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
-{
-	struct nlmsghdr *nlh = nlmsg_hdr(msg);
-	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
-	struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
-	struct ip_vs_get_services **getp = (struct ip_vs_get_services **)arg;
-	struct ip_vs_get_services *get = (struct ip_vs_get_services *)*getp;
-	struct ip_vs_flags flags;
-	int i = get->num_services;
+  if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+    return -1;
 
-	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
-		return -1;
+  if (!attrs[IPVS_CMD_ATTR_SERVICE])
+    return -1;
 
-	if (!attrs[IPVS_CMD_ATTR_SERVICE])
-		return -1;
+  if (nla_parse_nested(svc_attrs, IPVS_SVC_ATTR_MAX,
+                       attrs[IPVS_CMD_ATTR_SERVICE], ipvs_service_policy))
+    return -1;
 
-	if (nla_parse_nested(svc_attrs, IPVS_SVC_ATTR_MAX, attrs[IPVS_CMD_ATTR_SERVICE], ipvs_service_policy))
-		return -1;
+  memset(&(get->entrytable[i]), 0, sizeof(get->entrytable[i]));
 
-	memset(&(get->entrytable[i]), 0, sizeof(get->entrytable[i]));
+  if (!(svc_attrs[IPVS_SVC_ATTR_AF] &&
+        (svc_attrs[IPVS_SVC_ATTR_FWMARK] ||
+         (svc_attrs[IPVS_SVC_ATTR_PROTOCOL] && svc_attrs[IPVS_SVC_ATTR_ADDR] &&
+          svc_attrs[IPVS_SVC_ATTR_PORT])) &&
+        svc_attrs[IPVS_SVC_ATTR_SCHED_NAME] &&
+        svc_attrs[IPVS_SVC_ATTR_NETMASK] && svc_attrs[IPVS_SVC_ATTR_TIMEOUT] &&
+        svc_attrs[IPVS_SVC_ATTR_FLAGS]))
+    return -1;
 
-	if (!(svc_attrs[IPVS_SVC_ATTR_AF] &&
-		(svc_attrs[IPVS_SVC_ATTR_FWMARK] ||
-		(svc_attrs[IPVS_SVC_ATTR_PROTOCOL] &&
-		svc_attrs[IPVS_SVC_ATTR_ADDR] &&
-		svc_attrs[IPVS_SVC_ATTR_PORT])) &&
-		svc_attrs[IPVS_SVC_ATTR_SCHED_NAME] &&
-		svc_attrs[IPVS_SVC_ATTR_NETMASK] &&
-		svc_attrs[IPVS_SVC_ATTR_TIMEOUT] &&
-		svc_attrs[IPVS_SVC_ATTR_FLAGS]))
-		return -1;
+  get->entrytable[i].af = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_AF]);
 
-	get->entrytable[i].af = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_AF]);
+  if (svc_attrs[IPVS_SVC_ATTR_FWMARK])
+    get->entrytable[i].fwmark = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_FWMARK]);
+  else {
+    get->entrytable[i].protocol =
+        nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PROTOCOL]);
+    memcpy(&(get->entrytable[i].addr), nla_data(svc_attrs[IPVS_SVC_ATTR_ADDR]),
+           sizeof(get->entrytable[i].addr));
+    get->entrytable[i].port = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PORT]);
+  }
 
-	if (svc_attrs[IPVS_SVC_ATTR_FWMARK])
-		get->entrytable[i].fwmark = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_FWMARK]);
-	else {
-		get->entrytable[i].protocol = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PROTOCOL]);
-		memcpy(&(get->entrytable[i].addr), nla_data(svc_attrs[IPVS_SVC_ATTR_ADDR]),
-			sizeof(get->entrytable[i].addr));
-		get->entrytable[i].port = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PORT]);
-	}
+  strncpy(get->entrytable[i].sched_name,
+          nla_get_string(svc_attrs[IPVS_SVC_ATTR_SCHED_NAME]),
+          IP_VS_SCHEDNAME_MAXLEN);
 
-	strncpy(get->entrytable[i].sched_name,
-		nla_get_string(svc_attrs[IPVS_SVC_ATTR_SCHED_NAME]),
-	IP_VS_SCHEDNAME_MAXLEN);
+  if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
+    strncpy(get->entrytable[i].pe_name,
+            nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
+            IP_VS_PENAME_MAXLEN);
 
-	if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
-		strncpy(get->entrytable[i].pe_name,
-			nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
-		IP_VS_PENAME_MAXLEN);
+  get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
+  get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
+  nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
+  get->entrytable[i].flags = flags.flags & flags.mask;
 
-	get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
-	get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
-	nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
-	get->entrytable[i].flags = flags.flags & flags.mask;
+  if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
+    if (ipvs_parse_stats64(&get->entrytable[i].stats64,
+                           svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
+      return -1;
+  } else if (svc_attrs[IPVS_SVC_ATTR_STATS]) {
+    if (ipvs_parse_stats(&get->entrytable[i].stats64,
+                         svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
+      return -1;
+  }
 
-	if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
-		if (ipvs_parse_stats64(&get->entrytable[i].stats64,
-				svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
-			return -1;
-	} else if (svc_attrs[IPVS_SVC_ATTR_STATS]) {
-		if (ipvs_parse_stats(&get->entrytable[i].stats64,
-			svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
-			return -1;
-	}
+  get->entrytable[i].num_dests = 0;
 
-	get->entrytable[i].num_dests = 0;
+  i++;
 
-	i++;
-
-	get->num_services = i;
-	get = realloc(get, sizeof(*get)
-			+ sizeof(struct ip_vs_service_entry) * (get->num_services + 1));
-	*getp = get;
-	return 0;
+  get->num_services = i;
+  get = realloc(get, sizeof(*get) +
+                         sizeof(struct ip_vs_service_entry) *
+                             (get->num_services + 1));
+  *getp = get;
+  return 0;
 }
 
 #endif
@@ -335,22 +314,21 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
 
 #ifdef LIBIPVS_USE_NL
   if (try_nl) {
-		struct nl_msg *msg;
-		len = sizeof(*ret) +
-				sizeof(struct ip_vs_service_entry);
-		if (!(ret = malloc(len)))
-			return NULL;
+    struct nl_msg *msg;
+    len = sizeof(*ret) + sizeof(struct ip_vs_service_entry);
+    if (!(ret = malloc(len)))
+      return NULL;
 
-		ret->num_services = 0;
+    ret->num_services = 0;
 
-		msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
+    msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
 
-		if (msg && (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &ret) == 0)) {
-			return ret;
-		}
-		free(ret);
-		return NULL;
-	}
+    if (msg && (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &ret) == 0)) {
+      return ret;
+    }
+    free(ret);
+    return NULL;
+  }
 #endif
 
   len = sizeof(ipvs_info);
@@ -385,73 +363,77 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
   return ret;
 } /* ipvs_get_services */
 
-
 #ifdef LIBIPVS_USE_NL
-static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg)
-{
-	struct nlmsghdr *nlh = nlmsg_hdr(msg);
-	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
-	struct nlattr *dest_attrs[IPVS_DEST_ATTR_MAX + 1];
-	struct nlattr *attr_addr_family = NULL;
-	struct ip_vs_get_dests **dp = (struct ip_vs_get_dests **)arg;
-	struct ip_vs_get_dests *d = (struct ip_vs_get_dests *)*dp;
-	int i = d->num_dests;
+static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
+  struct nlmsghdr *nlh = nlmsg_hdr(msg);
+  struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+  struct nlattr *dest_attrs[IPVS_DEST_ATTR_MAX + 1];
+  struct nlattr *attr_addr_family = NULL;
+  struct ip_vs_get_dests **dp = (struct ip_vs_get_dests **)arg;
+  struct ip_vs_get_dests *d = (struct ip_vs_get_dests *)*dp;
+  int i = d->num_dests;
 
-	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
-		return -1;
+  if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+    return -1;
 
-	if (!attrs[IPVS_CMD_ATTR_DEST])
-		return -1;
+  if (!attrs[IPVS_CMD_ATTR_DEST])
+    return -1;
 
-	if (nla_parse_nested(dest_attrs, IPVS_DEST_ATTR_MAX, attrs[IPVS_CMD_ATTR_DEST], ipvs_dest_policy))
-		return -1;
+  if (nla_parse_nested(dest_attrs, IPVS_DEST_ATTR_MAX,
+                       attrs[IPVS_CMD_ATTR_DEST], ipvs_dest_policy))
+    return -1;
 
-	memset(&(d->entrytable[i]), 0, sizeof(d->entrytable[i]));
+  memset(&(d->entrytable[i]), 0, sizeof(d->entrytable[i]));
 
-	if (!(dest_attrs[IPVS_DEST_ATTR_ADDR] &&
-			dest_attrs[IPVS_DEST_ATTR_PORT] &&
-			dest_attrs[IPVS_DEST_ATTR_FWD_METHOD] &&
-			dest_attrs[IPVS_DEST_ATTR_WEIGHT] &&
-			dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
-			dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
-			dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS] &&
-			dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
-			dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
-		return -1;
+  if (!(dest_attrs[IPVS_DEST_ATTR_ADDR] && dest_attrs[IPVS_DEST_ATTR_PORT] &&
+        dest_attrs[IPVS_DEST_ATTR_FWD_METHOD] &&
+        dest_attrs[IPVS_DEST_ATTR_WEIGHT] &&
+        dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
+        dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
+        dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS] &&
+        dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
+        dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
+    return -1;
 
-	memcpy(&(d->entrytable[i].addr),
-		nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
-		sizeof(d->entrytable[i].addr));
-	d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
-	d->entrytable[i].conn_flags = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
-	d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
-	d->entrytable[i].u_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
-	d->entrytable[i].l_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
-	d->entrytable[i].activeconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
-	d->entrytable[i].inactconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
-	d->entrytable[i].persistconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
-	attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
-	if (attr_addr_family)
-		d->entrytable[i].af = nla_get_u16(attr_addr_family);
-	else
-		d->entrytable[i].af = d->af;
+  memcpy(&(d->entrytable[i].addr), nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
+         sizeof(d->entrytable[i].addr));
+  d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
+  d->entrytable[i].conn_flags =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
+  d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
+  d->entrytable[i].u_threshold =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
+  d->entrytable[i].l_threshold =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
+  d->entrytable[i].activeconns =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
+  d->entrytable[i].inactconns =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
+  d->entrytable[i].persistconns =
+      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
+  attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
+  if (attr_addr_family)
+    d->entrytable[i].af = nla_get_u16(attr_addr_family);
+  else
+    d->entrytable[i].af = d->af;
 
-	if (dest_attrs[IPVS_DEST_ATTR_STATS64]) {
-		if (ipvs_parse_stats(&d->entrytable[i].stats64,
-				dest_attrs[IPVS_DEST_ATTR_STATS64]) != 0)
-			return -1;
-	} else if (dest_attrs[IPVS_DEST_ATTR_STATS]) {
-		if (ipvs_parse_stats(&d->entrytable[i].stats64,
-				dest_attrs[IPVS_DEST_ATTR_STATS]) != 0)
-			return -1;
-	}
+  if (dest_attrs[IPVS_DEST_ATTR_STATS64]) {
+    if (ipvs_parse_stats(&d->entrytable[i].stats64,
+                         dest_attrs[IPVS_DEST_ATTR_STATS64]) != 0)
+      return -1;
+  } else if (dest_attrs[IPVS_DEST_ATTR_STATS]) {
+    if (ipvs_parse_stats(&d->entrytable[i].stats64,
+                         dest_attrs[IPVS_DEST_ATTR_STATS]) != 0)
+      return -1;
+  }
 
-	i++;
+  i++;
 
-	d->num_dests = i;
-	d = realloc(d, sizeof(*d) + sizeof(struct ip_vs_dest_entry) * (d->num_dests + 1));
-	*dp = d;
-	return 0;
+  d->num_dests = i;
+  d = realloc(d, sizeof(*d) +
+                     sizeof(struct ip_vs_dest_entry) * (d->num_dests + 1));
+  *dp = d;
+  return 0;
 }
 #endif
 
@@ -459,72 +441,71 @@ static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
   struct ip_vs_get_dests *ret;
   socklen_t len;
 
-  len = sizeof (*ret) + sizeof (struct ip_vs_dest_entry) * se->num_dests;
+  len = sizeof(*ret) + sizeof(struct ip_vs_dest_entry) * se->num_dests;
 
-  if (NULL == (ret = malloc (len))) {
-    log_err ("ipvs_get_dests: Out of memory.");
-    exit (3);
+  if (NULL == (ret = malloc(len))) {
+    log_err("ipvs_get_dests: Out of memory.");
+    exit(3);
   }
 
 #ifdef LIBIPVS_USE_NL
   if (try_nl) {
-		struct nl_msg *msg;
-		struct nlattr *nl_service;
-		if (se->num_dests == 0)
-				ret  = realloc(ret,sizeof(*ret) + sizeof(struct ip_vs_dest_entry));
+    struct nl_msg *msg;
+    struct nlattr *nl_service;
+    if (se->num_dests == 0)
+      ret = realloc(ret, sizeof(*ret) + sizeof(struct ip_vs_dest_entry));
 
-		ret->fwmark = se->fwmark;
-		ret->protocol = se->protocol;
-		ret->addr = se->addr;
-		ret->port = se->port;
-		ret->num_dests = se->num_dests;
-		ret->af = se->af;
+    ret->fwmark = se->fwmark;
+    ret->protocol = se->protocol;
+    ret->addr = se->addr;
+    ret->port = se->port;
+    ret->num_dests = se->num_dests;
+    ret->af = se->af;
 
-		msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
-		if (!msg)
-			goto ipvs_nl_dest_failure;
+    msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
+    if (!msg)
+      goto ipvs_nl_dest_failure;
 
-		nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
-		if (!nl_service)
-			goto nla_put_failure;
+    nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
+    if (!nl_service)
+      goto nla_put_failure;
 
-		NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
+    NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
 
-		if (se->fwmark) {
-			NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
-		} else {
-			NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
-			NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr),
-				&se->addr);
-			NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
-		}
+    if (se->fwmark) {
+      NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
+    } else {
+      NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
+      NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr), &se->addr);
+      NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
+    }
 
-		nla_nest_end(msg, nl_service);
-		if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
-			goto ipvs_nl_dest_failure;
+    nla_nest_end(msg, nl_service);
+    if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
+      goto ipvs_nl_dest_failure;
 
-		return ret;
+    return ret;
 
-nla_put_failure:
-		nlmsg_free(msg);
-ipvs_nl_dest_failure:
-		free(ret);
-		return NULL;
-	}
+  nla_put_failure:
+    nlmsg_free(msg);
+  ipvs_nl_dest_failure:
+    free(ret);
+    return NULL;
+  }
 #endif
 
-  ret->fwmark    = se->fwmark;
-  ret->protocol  = se->protocol;
-  ret->addr      = se->addr;
-  ret->port      = se->port;
+  ret->fwmark = se->fwmark;
+  ret->protocol = se->protocol;
+  ret->addr = se->addr;
+  ret->port = se->port;
   ret->num_dests = se->num_dests;
 
-  if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS,
-                       (void *)ret, &len)) {
+  if (0 !=
+      getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS, (void *)ret, &len)) {
     char errbuf[1024];
-    log_err ("ipvs_get_dests: getsockopt() failed: %s",
-             sstrerror (errno, errbuf, sizeof (errbuf)));
-    free (ret);
+    log_err("ipvs_get_dests: getsockopt() failed: %s",
+            sstrerror(errno, errbuf, sizeof(errbuf)));
+    free(ret);
     return NULL;
   }
   return ret;
@@ -548,7 +529,7 @@ static int cipvs_init(void) {
     struct nl_msg *msg;
     msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
     if (msg) {
-      ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb,NULL);
+      ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb, NULL);
     } else {
       return -1;
     }
@@ -557,21 +538,21 @@ static int cipvs_init(void) {
 
   socklen_t len;
 
-  if (-1 == (sockfd = socket (AF_INET, SOCK_RAW, IPPROTO_RAW))) {
+  if (-1 == (sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW))) {
     char errbuf[1024];
-    log_err ("cipvs_init: socket() failed: %s",
-             sstrerror (errno, errbuf, sizeof (errbuf)));
+    log_err("cipvs_init: socket() failed: %s",
+            sstrerror(errno, errbuf, sizeof(errbuf)));
     return -1;
   }
 
-  len = sizeof (ipvs_info);
+  len = sizeof(ipvs_info);
 
-  if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,
-                       (void *)&ipvs_info, &len)) {
+  if (0 != getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, (void *)&ipvs_info,
+                      &len)) {
     char errbuf[1024];
-    log_err ("cipvs_init: getsockopt() failed: %s",
-             sstrerror (errno, errbuf, sizeof (errbuf)));
-    close (sockfd);
+    log_err("cipvs_init: getsockopt() failed: %s",
+            sstrerror(errno, errbuf, sizeof(errbuf)));
+    close(sockfd);
     sockfd = -1;
     return -1;
   }
@@ -610,24 +591,25 @@ static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
   if ((NULL == se) || (NULL == pi))
     return 0;
 
-  /* inet_ntoa() returns a pointer to a statically allocated buffer
-   * I hope non-glibc systems behave the same */
+/* inet_ntoa() returns a pointer to a statically allocated buffer
+ * I hope non-glibc systems behave the same */
 #ifdef LIBIPVS_USE_NL
   addr = se->addr;
-  if ( se->af == AF_INET6) {
-    len = ssnprintf (pi, size, "%s_%s%u", inet_ntop(AF_INET6, &addr,
-      straddr, sizeof(straddr)), (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-     ntohs (se->port));
-   }else {
-    len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr.in),
-    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-    ntohs (se->port));
-   }
+  if (se->af == AF_INET6) {
+    len = ssnprintf(pi, size, "%s_%s%u",
+                    inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
+                    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+                    ntohs(se->port));
+  } else {
+    len = ssnprintf(pi, size, "%s_%s%u", inet_ntoa(addr.in),
+                    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+                    ntohs(se->port));
+  }
 #else
   addr.s_addr = se->addr;
-  len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr),
-                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-       			ntohs (se->port));
+  len =
+      ssnprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
+                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
 #endif
   if ((0 > len) || (size <= ((size_t)len))) {
     log_err("plugin instance truncated: %s", pi);
@@ -653,19 +635,18 @@ static int get_ti(struct ip_vs_dest_entry *de, char *ti, size_t size) {
   addr = de->addr;
   /* inet_ntoa() returns a pointer to a statically allocated buffer
     I hope non-glibc systems behave the same */
-  if ( de->af == AF_INET6) {
-    len = ssnprintf (ti, size, "%s_%u", inet_ntop(AF_INET6, &addr,
-    straddr, sizeof(straddr)),
-    ntohs (de->port));
-  }else {
-    len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr.in),
-     ntohs (de->port));
+  if (de->af == AF_INET6) {
+    len = ssnprintf(ti, size, "%s_%u",
+                    inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
+                    ntohs(de->port));
+  } else {
+    len = ssnprintf(ti, size, "%s_%u", inet_ntoa(addr.in), ntohs(de->port));
   }
 #else
   addr.s_addr = de->addr;
-  len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr),
+  len = ssnprintf(ti, size, "%s_%u", inet_ntoa(addr),
 
-  ntohs (de->port));
+                  ntohs(de->port));
 #endif
 
   if ((0 > len) || (size <= ((size_t)len))) {
@@ -714,9 +695,9 @@ static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
 
 static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
 #ifdef LIBIPVS_USE_NL
-  struct ip_vs_stats64  stats = de->stats64;
+  struct ip_vs_stats64 stats = de->stats64;
 #else
-  	struct ip_vs_stats_user stats = de->stats;
+  struct ip_vs_stats_user stats = de->stats;
 #endif
 
   char ti[DATA_MAX_NAME_LEN];
@@ -732,7 +713,7 @@ static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
 
 static void cipvs_submit_service(struct ip_vs_service_entry *se) {
 #ifdef LIBIPVS_USE_NL
-  struct ip_vs_stats64  stats = se->stats64;
+  struct ip_vs_stats64 stats = se->stats64;
 #else
   struct ip_vs_stats_user stats = se->stats;
 #endif

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -43,6 +43,10 @@
 #endif /* HAVE_NETINET_IN_H */
 
 /* this can probably only be found in the kernel sources */
+#ifdef LIBIPVS_USE_NL
+//Include our own version of ip_vs.h
+#include <ipvs.h>
+#else
 #if HAVE_LINUX_IP_VS_H
 #include <linux/ip_vs.h>
 #elif HAVE_NET_IP_VS_H
@@ -50,6 +54,28 @@
 #elif HAVE_IP_VS_H
 #include <ip_vs.h>
 #endif /* HAVE_IP_VS_H */
+#endif
+
+
+#ifdef LIBIPVS_USE_NL
+# include <netlink/netlink.h>
+# include <netlink/genl/genl.h>
+# include <netlink/genl/ctrl.h>
+# include <netlink/msg.h>
+//#define ip_vs_service_entry ip_vs_service_entry_kern
+#endif
+
+#ifdef LIBIPVS_USE_NL
+#ifdef FALLBACK_LIBNL1
+#define nl_sock         nl_handle
+#define nl_socket_alloc nl_handle_alloc
+#define nl_socket_free  nl_handle_destroy
+#endif
+static  struct nl_sock *sock = NULL;
+static  int family;
+#endif
+
+static int try_nl = 1;
 
 #define log_err(...) ERROR("ipvs: " __VA_ARGS__)
 #define log_info(...) INFO("ipvs: " __VA_ARGS__)
@@ -58,6 +84,244 @@
  * private variables
  */
 static int sockfd = -1;
+struct ip_vs_getinfo ipvs_info;
+
+#ifdef LIBIPVS_USE_NL
+/*
+ * libipvs API
+ */
+struct nl_msg *ipvs_nl_message(int cmd, int flags)
+{
+  struct nl_msg *msg;
+
+  msg = nlmsg_alloc();
+  if (!msg)
+    return NULL;
+
+  genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, family, 0, flags,
+              cmd, IPVS_GENL_VERSION);
+
+  return msg;
+}
+
+
+static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func, void *arg)
+{
+  int err = EINVAL;
+
+  sock = nl_socket_alloc();
+  if (!sock) {
+    nlmsg_free(msg);
+    return -1;
+  }
+
+  if (genl_connect(sock) < 0)
+    goto fail_genl;
+
+  family = genl_ctrl_resolve(sock, IPVS_GENL_NAME);
+  if (family < 0)
+    goto fail_genl;
+
+// To test connections and set the family
+  if (msg == NULL) {
+    nl_socket_free(sock);
+    sock = NULL;
+    return 0;
+  }
+
+  if (nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, func, arg) != 0)
+    goto fail_genl;
+
+  if (nl_send_auto_complete(sock, msg) < 0)
+    goto fail_genl;
+
+  if ((err = -nl_recvmsgs_default(sock)) > 0)
+    goto fail_genl;
+
+  nlmsg_free(msg);
+
+  nl_socket_free(sock);
+
+  return 0;
+
+    fail_genl:
+  nl_socket_free(sock);
+  sock = NULL;
+  nlmsg_free(msg);
+  errno = err;
+  return -1;
+}
+
+static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg)
+{
+  struct nlmsghdr *nlh = nlmsg_hdr(msg);
+  struct nlattr *attrs[IPVS_INFO_ATTR_MAX + 1];
+
+  if (genlmsg_parse(nlh, 0, attrs, IPVS_INFO_ATTR_MAX, ipvs_info_policy) != 0)
+    return -1;
+
+  if (!(attrs[IPVS_INFO_ATTR_VERSION] &&
+        attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]))
+    return -1;
+
+  ipvs_info.version = nla_get_u32(attrs[IPVS_INFO_ATTR_VERSION]);
+  ipvs_info.size = nla_get_u32(attrs[IPVS_INFO_ATTR_CONN_TAB_SIZE]);
+
+  return NL_OK;
+}
+
+#endif
+
+#ifdef LIBIPVS_USE_NL
+
+static int ipvs_parse_stats(struct ip_vs_stats64 *stats, struct nlattr *nla)
+{
+	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+
+	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
+		return -1;
+
+	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
+			attrs[IPVS_STATS_ATTR_INPKTS] &&
+			attrs[IPVS_STATS_ATTR_OUTPKTS] &&
+			attrs[IPVS_STATS_ATTR_INBYTES] &&
+			attrs[IPVS_STATS_ATTR_OUTBYTES] &&
+			attrs[IPVS_STATS_ATTR_CPS] &&
+			attrs[IPVS_STATS_ATTR_INPPS] &&
+			attrs[IPVS_STATS_ATTR_OUTPPS] &&
+			attrs[IPVS_STATS_ATTR_INBPS] &&
+			attrs[IPVS_STATS_ATTR_OUTBPS]))
+		return -1;
+
+	stats->conns = nla_get_u32(attrs[IPVS_STATS_ATTR_CONNS]);
+	stats->inpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_INPKTS]);
+	stats->outpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+	stats->cps = nla_get_u32(attrs[IPVS_STATS_ATTR_CPS]);
+	stats->inpps = nla_get_u32(attrs[IPVS_STATS_ATTR_INPPS]);
+	stats->outpps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPPS]);
+	stats->inbps = nla_get_u32(attrs[IPVS_STATS_ATTR_INBPS]);
+	stats->outbps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTBPS]);
+
+	return 0;
+
+}
+
+static int ipvs_parse_stats64(struct ip_vs_stats64 *stats, struct nlattr *nla)
+{
+	struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
+
+	if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla,
+			ipvs_stats_policy))
+		return -1;
+
+	if (!(attrs[IPVS_STATS_ATTR_CONNS] &&
+		attrs[IPVS_STATS_ATTR_INPKTS] &&
+		attrs[IPVS_STATS_ATTR_OUTPKTS] &&
+		attrs[IPVS_STATS_ATTR_INBYTES] &&
+		attrs[IPVS_STATS_ATTR_OUTBYTES] &&
+		attrs[IPVS_STATS_ATTR_CPS] &&
+		attrs[IPVS_STATS_ATTR_INPPS] &&
+		attrs[IPVS_STATS_ATTR_OUTPPS] &&
+		attrs[IPVS_STATS_ATTR_INBPS] &&
+		attrs[IPVS_STATS_ATTR_OUTBPS]))
+	return -1;
+
+	stats->conns = nla_get_u64(attrs[IPVS_STATS_ATTR_CONNS]);
+	stats->inpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_INPKTS]);
+	stats->outpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPKTS]);
+	stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
+	stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
+	stats->cps = nla_get_u64(attrs[IPVS_STATS_ATTR_CPS]);
+	stats->inpps = nla_get_u64(attrs[IPVS_STATS_ATTR_INPPS]);
+	stats->outpps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPPS]);
+	stats->inbps = nla_get_u64(attrs[IPVS_STATS_ATTR_INBPS]);
+	stats->outbps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBPS]);
+
+	return 0;
+}
+
+
+static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
+{
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+	struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
+	struct ip_vs_get_services **getp = (struct ip_vs_get_services **)arg;
+	struct ip_vs_get_services *get = (struct ip_vs_get_services *)*getp;
+	struct ip_vs_flags flags;
+	int i = get->num_services;
+
+	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+		return -1;
+
+	if (!attrs[IPVS_CMD_ATTR_SERVICE])
+		return -1;
+
+	if (nla_parse_nested(svc_attrs, IPVS_SVC_ATTR_MAX, attrs[IPVS_CMD_ATTR_SERVICE], ipvs_service_policy))
+		return -1;
+
+	memset(&(get->entrytable[i]), 0, sizeof(get->entrytable[i]));
+
+	if (!(svc_attrs[IPVS_SVC_ATTR_AF] &&
+		(svc_attrs[IPVS_SVC_ATTR_FWMARK] ||
+		(svc_attrs[IPVS_SVC_ATTR_PROTOCOL] &&
+		svc_attrs[IPVS_SVC_ATTR_ADDR] &&
+		svc_attrs[IPVS_SVC_ATTR_PORT])) &&
+		svc_attrs[IPVS_SVC_ATTR_SCHED_NAME] &&
+		svc_attrs[IPVS_SVC_ATTR_NETMASK] &&
+		svc_attrs[IPVS_SVC_ATTR_TIMEOUT] &&
+		svc_attrs[IPVS_SVC_ATTR_FLAGS]))
+		return -1;
+
+	get->entrytable[i].af = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_AF]);
+
+	if (svc_attrs[IPVS_SVC_ATTR_FWMARK])
+		get->entrytable[i].fwmark = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_FWMARK]);
+	else {
+		get->entrytable[i].protocol = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PROTOCOL]);
+		memcpy(&(get->entrytable[i].addr), nla_data(svc_attrs[IPVS_SVC_ATTR_ADDR]),
+			sizeof(get->entrytable[i].addr));
+		get->entrytable[i].port = nla_get_u16(svc_attrs[IPVS_SVC_ATTR_PORT]);
+	}
+
+	strncpy(get->entrytable[i].sched_name,
+		nla_get_string(svc_attrs[IPVS_SVC_ATTR_SCHED_NAME]),
+	IP_VS_SCHEDNAME_MAXLEN);
+
+	if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
+		strncpy(get->entrytable[i].pe_name,
+			nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
+		IP_VS_PENAME_MAXLEN);
+
+	get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
+	get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
+	nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
+	get->entrytable[i].flags = flags.flags & flags.mask;
+
+	if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
+		if (ipvs_parse_stats64(&get->entrytable[i].stats64,
+				svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
+			return -1;
+	} else if (svc_attrs[IPVS_SVC_ATTR_STATS]) {
+		if (ipvs_parse_stats(&get->entrytable[i].stats64,
+			svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
+			return -1;
+	}
+
+	get->entrytable[i].num_dests = 0;
+
+	i++;
+
+	get->num_services = i;
+	get = realloc(get, sizeof(*get)
+			+ sizeof(struct ip_vs_service_entry) * (get->num_services + 1));
+	*getp = get;
+	return 0;
+}
+
+#endif
 
 /*
  * libipvs API
@@ -67,6 +331,26 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
   struct ip_vs_get_services *ret;
 
   socklen_t len;
+
+#ifdef LIBIPVS_USE_NL
+  if (try_nl) {
+		struct nl_msg *msg;
+		len = sizeof(*ret) +
+				sizeof(struct ip_vs_service_entry);
+		if (!(ret = malloc(len)))
+			return NULL;
+
+		ret->num_services = 0;
+
+		msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
+
+		if (msg && (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &ret) == 0)) {
+			return ret;
+		}
+		free(ret);
+		return NULL;
+	}
+#endif
 
   len = sizeof(ipvs_info);
 
@@ -100,29 +384,146 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
   return ret;
 } /* ipvs_get_services */
 
+
+#ifdef LIBIPVS_USE_NL
+static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg)
+{
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
+	struct nlattr *dest_attrs[IPVS_DEST_ATTR_MAX + 1];
+	struct nlattr *attr_addr_family = NULL;
+	struct ip_vs_get_dests **dp = (struct ip_vs_get_dests **)arg;
+	struct ip_vs_get_dests *d = (struct ip_vs_get_dests *)*dp;
+	int i = d->num_dests;
+
+	if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
+		return -1;
+
+	if (!attrs[IPVS_CMD_ATTR_DEST])
+		return -1;
+
+	if (nla_parse_nested(dest_attrs, IPVS_DEST_ATTR_MAX, attrs[IPVS_CMD_ATTR_DEST], ipvs_dest_policy))
+		return -1;
+
+	memset(&(d->entrytable[i]), 0, sizeof(d->entrytable[i]));
+
+	if (!(dest_attrs[IPVS_DEST_ATTR_ADDR] &&
+			dest_attrs[IPVS_DEST_ATTR_PORT] &&
+			dest_attrs[IPVS_DEST_ATTR_FWD_METHOD] &&
+			dest_attrs[IPVS_DEST_ATTR_WEIGHT] &&
+			dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
+			dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
+			dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS] &&
+			dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
+			dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
+		return -1;
+
+	memcpy(&(d->entrytable[i].addr),
+		nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
+		sizeof(d->entrytable[i].addr));
+	d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
+	d->entrytable[i].conn_flags = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
+	d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
+	d->entrytable[i].u_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
+	d->entrytable[i].l_threshold = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
+	d->entrytable[i].activeconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
+	d->entrytable[i].inactconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
+	d->entrytable[i].persistconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
+	attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
+	if (attr_addr_family)
+		d->entrytable[i].af = nla_get_u16(attr_addr_family);
+	else
+		d->entrytable[i].af = d->af;
+
+	if (dest_attrs[IPVS_DEST_ATTR_STATS64]) {
+		if (ipvs_parse_stats(&d->entrytable[i].stats64,
+				dest_attrs[IPVS_DEST_ATTR_STATS64]) != 0)
+			return -1;
+	} else if (dest_attrs[IPVS_DEST_ATTR_STATS]) {
+		if (ipvs_parse_stats(&d->entrytable[i].stats64,
+				dest_attrs[IPVS_DEST_ATTR_STATS]) != 0)
+			return -1;
+	}
+
+	i++;
+
+	d->num_dests = i;
+	d = realloc(d, sizeof(*d) + sizeof(struct ip_vs_dest_entry) * (d->num_dests + 1));
+	*dp = d;
+	return 0;
+}
+#endif
+
 static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
   struct ip_vs_get_dests *ret;
   socklen_t len;
 
-  len = sizeof(*ret) + sizeof(struct ip_vs_dest_entry) * se->num_dests;
+  len = sizeof (*ret) + sizeof (struct ip_vs_dest_entry) * se->num_dests;
 
-  if (NULL == (ret = malloc(len))) {
-    log_err("ipvs_get_dests: Out of memory.");
-    exit(3);
+  if (NULL == (ret = malloc (len))) {
+    log_err ("ipvs_get_dests: Out of memory.");
+    exit (3);
   }
 
-  ret->fwmark = se->fwmark;
-  ret->protocol = se->protocol;
-  ret->addr = se->addr;
-  ret->port = se->port;
+#ifdef LIBIPVS_USE_NL
+  if (try_nl) {
+		struct nl_msg *msg;
+		struct nlattr *nl_service;
+		if (se->num_dests == 0)
+				ret  = realloc(ret,sizeof(*ret) + sizeof(struct ip_vs_dest_entry));
+
+		ret->fwmark = se->fwmark;
+		ret->protocol = se->protocol;
+		ret->addr = se->addr;
+		ret->port = se->port;
+		ret->num_dests = se->num_dests;
+		ret->af = se->af;
+
+		msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
+		if (!msg)
+			goto ipvs_nl_dest_failure;
+
+		nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
+		if (!nl_service)
+			goto nla_put_failure;
+
+		NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
+
+		if (se->fwmark) {
+			NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
+		} else {
+			NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
+			NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr),
+				&se->addr);
+			NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
+		}
+
+		nla_nest_end(msg, nl_service);
+		if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
+			goto ipvs_nl_dest_failure;
+
+		return ret;
+
+nla_put_failure:
+		nlmsg_free(msg);
+ipvs_nl_dest_failure:
+		free(ret);
+		return NULL;
+	}
+#endif
+
+  ret->fwmark    = se->fwmark;
+  ret->protocol  = se->protocol;
+  ret->addr      = se->addr;
+  ret->port      = se->port;
   ret->num_dests = se->num_dests;
 
-  if (0 !=
-      getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS, (void *)ret, &len)) {
+  if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS,
+                       (void *)ret, &len)) {
     char errbuf[1024];
-    log_err("ipvs_get_dests: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    free(ret);
+    log_err ("ipvs_get_dests: getsockopt() failed: %s",
+             sstrerror (errno, errbuf, sizeof (errbuf)));
+    free (ret);
     return NULL;
   }
   return ret;
@@ -132,28 +533,49 @@ static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
  * collectd plugin API and helper functions
  */
 static int cipvs_init(void) {
-  struct ip_vs_getinfo ipvs_info;
+#ifdef LIBIPVS_USE_NL
+  try_nl = 1;
+
+  /*Test we can use netlink*/
+  if (ipvs_nl_send_message(NULL, NULL, NULL) == 0)
+    try_nl = 1;
+  else
+    try_nl = 0;
+
+  if (try_nl) {
+
+    struct nl_msg *msg;
+    msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
+    if (msg) {
+      ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb,NULL);
+    } else {
+      return -1;
+    }
+  }
+#else
 
   socklen_t len;
 
-  if (-1 == (sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW))) {
+  if (-1 == (sockfd = socket (AF_INET, SOCK_RAW, IPPROTO_RAW))) {
     char errbuf[1024];
-    log_err("cipvs_init: socket() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err ("cipvs_init: socket() failed: %s",
+             sstrerror (errno, errbuf, sizeof (errbuf)));
     return -1;
   }
 
-  len = sizeof(ipvs_info);
+  len = sizeof (ipvs_info);
 
-  if (0 != getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, (void *)&ipvs_info,
-                      &len)) {
+  if (0 != getsockopt (sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,
+                       (void *)&ipvs_info, &len)) {
     char errbuf[1024];
-    log_err("cipvs_init: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    close(sockfd);
+    log_err ("cipvs_init: getsockopt() failed: %s",
+             sstrerror (errno, errbuf, sizeof (errbuf)));
+    close (sockfd);
     sockfd = -1;
     return -1;
   }
+
+#endif
 
   /* we need IPVS >= 1.1.4 */
   if (ipvs_info.version < ((1 << 16) + (1 << 8) + 4)) {
@@ -176,20 +598,36 @@ static int cipvs_init(void) {
 
 /* plugin instance */
 static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
+#ifdef LIBIPVS_USE_NL
+  union nf_inet_addr addr;
+  char straddr[INET6_ADDRSTRLEN];
+#else
   struct in_addr addr;
+#endif
   int len = 0;
 
   if ((NULL == se) || (NULL == pi))
     return 0;
 
-  addr.s_addr = se->addr;
-
   /* inet_ntoa() returns a pointer to a statically allocated buffer
    * I hope non-glibc systems behave the same */
-  len =
-      ssnprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
-                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
-
+#ifdef LIBIPVS_USE_NL
+  addr = se->addr;
+  if ( se->af == AF_INET6) {
+    len = ssnprintf (pi, size, "%s_%s%u", inet_ntop(AF_INET6, &addr,
+      straddr, sizeof(straddr)), (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+     ntohs (se->port));
+   }else {
+    len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr.in),
+    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+    ntohs (se->port));
+   }
+#else
+  addr.s_addr = se->addr;
+  len = ssnprintf (pi, size, "%s_%s%u", inet_ntoa (addr),
+                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+       			ntohs (se->port));
+#endif
   if ((0 > len) || (size <= ((size_t)len))) {
     log_err("plugin instance truncated: %s", pi);
     return -1;
@@ -199,17 +637,35 @@ static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
 
 /* type instance */
 static int get_ti(struct ip_vs_dest_entry *de, char *ti, size_t size) {
+#ifdef LIBIPVS_USE_NL
+  union nf_inet_addr addr;
+  char straddr[INET6_ADDRSTRLEN];
+#else
   struct in_addr addr;
+#endif
   int len = 0;
 
   if ((NULL == de) || (NULL == ti))
     return 0;
 
-  addr.s_addr = de->addr;
-
+#ifdef LIBIPVS_USE_NL
+  addr = de->addr;
   /* inet_ntoa() returns a pointer to a statically allocated buffer
-   * I hope non-glibc systems behave the same */
-  len = ssnprintf(ti, size, "%s_%u", inet_ntoa(addr), ntohs(de->port));
+    I hope non-glibc systems behave the same */
+  if ( de->af == AF_INET6) {
+    len = ssnprintf (ti, size, "%s_%u", inet_ntop(AF_INET6, &addr,
+    straddr, sizeof(straddr)),
+    ntohs (de->port));
+  }else {
+    len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr.in),
+     ntohs (de->port));
+  }
+#else
+  addr.s_addr = de->addr;
+  len = ssnprintf (ti, size, "%s_%u", inet_ntoa (addr),
+
+  ntohs (de->port));
+#endif
 
   if ((0 > len) || (size <= ((size_t)len))) {
     log_err("type instance truncated: %s", ti);
@@ -256,7 +712,11 @@ static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
 } /* cipvs_submit_if */
 
 static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
-  struct ip_vs_stats_user stats = de->stats;
+#ifdef LIBIPVS_USE_NL
+  struct ip_vs_stats64  stats = de->stats64;
+#else
+  	struct ip_vs_stats_user stats = de->stats;
+#endif
 
   char ti[DATA_MAX_NAME_LEN];
 
@@ -270,7 +730,11 @@ static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
 } /* cipvs_submit_dest */
 
 static void cipvs_submit_service(struct ip_vs_service_entry *se) {
+#ifdef LIBIPVS_USE_NL
+  struct ip_vs_stats64  stats = se->stats64;
+#else
   struct ip_vs_stats_user stats = se->stats;
+#endif
   struct ip_vs_get_dests *dests = ipvs_get_dests(se);
 
   char pi[DATA_MAX_NAME_LEN];
@@ -294,13 +758,14 @@ static void cipvs_submit_service(struct ip_vs_service_entry *se) {
 static int cipvs_read(void) {
   struct ip_vs_get_services *services = NULL;
 
-  if (sockfd < 0)
+  /* socket only available when not using netlink*/
+  if (!try_nl && sockfd < 0)
     return -1;
 
   if (NULL == (services = ipvs_get_services()))
     return -1;
 
-  for (size_t i = 0; i < services->num_services; ++i)
+  for (unsigned int i = 0; i < services->num_services; ++i)
     cipvs_submit_service(&services->entrytable[i]);
 
   free(services);

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -42,11 +42,13 @@
 #include <netinet/in.h>
 #endif /* HAVE_NETINET_IN_H */
 
-/* this can probably only be found in the kernel sources */
+
 #ifdef LIBIPVS_USE_NL
-//Include our own version of ip_vs.h
+/* Include our own structures as the IPV6 structuress required are
+  not included in the standard kernel source */
 #include <ipvs.h>
 #else
+/* this can probably only be found in the kernel sources */
 #if HAVE_LINUX_IP_VS_H
 #include <linux/ip_vs.h>
 #elif HAVE_NET_IP_VS_H
@@ -62,7 +64,6 @@
 # include <netlink/genl/genl.h>
 # include <netlink/genl/ctrl.h>
 # include <netlink/msg.h>
-//#define ip_vs_service_entry ip_vs_service_entry_kern
 #endif
 
 #ifdef LIBIPVS_USE_NL

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -3,9 +3,6 @@
  *      data structure and functionality definitions
  */
 
-#ifndef _IP_VS_H
-#define _IP_VS_H
-
 #include <arpa/inet.h>
 #include <linux/types.h> /* For __beXX types in userland */
 #include <netinet/in.h>
@@ -26,47 +23,9 @@
   (version >> 16) & 0xFF, (version >> 8) & 0xFF, version & 0xFF
 
 /*
- *      Virtual Service Flags
- */
-#define IP_VS_SVC_F_PERSISTENT 0x0001 /* persistent port */
-#define IP_VS_SVC_F_HASHED 0x0002     /* hashed entry */
-#define IP_VS_SVC_F_ONEPACKET 0x0004  /* one-packet scheduling */
-#define IP_VS_SVC_F_SCHED1 0x0008     /* scheduler flag 1 */
-#define IP_VS_SVC_F_SCHED2 0x0010     /* scheduler flag 2 */
-#define IP_VS_SVC_F_SCHED3 0x0020     /* scheduler flag 3 */
-
-#define IP_VS_SVC_F_SCHED_SH_FALLBACK IP_VS_SVC_F_SCHED1 /* SH fallback */
-#define IP_VS_SVC_F_SCHED_SH_PORT IP_VS_SVC_F_SCHED2     /* SH use port */
-
-/*
- *      IPVS sync daemon states
- */
-#define IP_VS_STATE_NONE 0x0000   /* daemon is stopped */
-#define IP_VS_STATE_MASTER 0x0001 /* started as master */
-#define IP_VS_STATE_BACKUP 0x0002 /* started as backup */
-
-/*
  *      IPVS socket options
  */
 #define IP_VS_BASE_CTL (64 + 1024 + 64) /* base */
-
-#define IP_VS_SO_SET_NONE IP_VS_BASE_CTL /* just peek */
-#define IP_VS_SO_SET_INSERT (IP_VS_BASE_CTL + 1)
-#define IP_VS_SO_SET_ADD (IP_VS_BASE_CTL + 2)
-#define IP_VS_SO_SET_EDIT (IP_VS_BASE_CTL + 3)
-#define IP_VS_SO_SET_DEL (IP_VS_BASE_CTL + 4)
-#define IP_VS_SO_SET_FLUSH (IP_VS_BASE_CTL + 5)
-#define IP_VS_SO_SET_LIST (IP_VS_BASE_CTL + 6)
-#define IP_VS_SO_SET_ADDDEST (IP_VS_BASE_CTL + 7)
-#define IP_VS_SO_SET_DELDEST (IP_VS_BASE_CTL + 8)
-#define IP_VS_SO_SET_EDITDEST (IP_VS_BASE_CTL + 9)
-#define IP_VS_SO_SET_TIMEOUT (IP_VS_BASE_CTL + 10)
-#define IP_VS_SO_SET_STARTDAEMON (IP_VS_BASE_CTL + 11)
-#define IP_VS_SO_SET_STOPDAEMON (IP_VS_BASE_CTL + 12)
-#define IP_VS_SO_SET_RESTORE (IP_VS_BASE_CTL + 13)
-#define IP_VS_SO_SET_SAVE (IP_VS_BASE_CTL + 14)
-#define IP_VS_SO_SET_ZERO (IP_VS_BASE_CTL + 15)
-#define IP_VS_SO_SET_MAX IP_VS_SO_SET_ZERO
 
 #define IP_VS_SO_GET_VERSION IP_VS_BASE_CTL
 #define IP_VS_SO_GET_INFO (IP_VS_BASE_CTL + 1)
@@ -77,26 +36,6 @@
 #define IP_VS_SO_GET_TIMEOUT (IP_VS_BASE_CTL + 6)
 #define IP_VS_SO_GET_DAEMON (IP_VS_BASE_CTL + 7)
 #define IP_VS_SO_GET_MAX IP_VS_SO_GET_DAEMON
-
-/*
- *      IPVS Connection Flags
- */
-#define IP_VS_CONN_F_FWD_MASK 0x0007   /* mask for the fwd methods */
-#define IP_VS_CONN_F_MASQ 0x0000       /* masquerading/NAT */
-#define IP_VS_CONN_F_LOCALNODE 0x0001  /* local node */
-#define IP_VS_CONN_F_TUNNEL 0x0002     /* tunneling */
-#define IP_VS_CONN_F_DROUTE 0x0003     /* direct routing */
-#define IP_VS_CONN_F_BYPASS 0x0004     /* cache bypass */
-#define IP_VS_CONN_F_SYNC 0x0020       /* entry created by sync */
-#define IP_VS_CONN_F_HASHED 0x0040     /* hashed entry */
-#define IP_VS_CONN_F_NOOUTPUT 0x0080   /* no output packets */
-#define IP_VS_CONN_F_INACTIVE 0x0100   /* not established */
-#define IP_VS_CONN_F_OUT_SEQ 0x0200    /* must do output seq adjust */
-#define IP_VS_CONN_F_IN_SEQ 0x0400     /* must do input seq adjust */
-#define IP_VS_CONN_F_SEQ_MASK 0x0600   /* in/out sequence mask */
-#define IP_VS_CONN_F_NO_CPORT 0x0800   /* no client port set yet */
-#define IP_VS_CONN_F_TEMPLATE 0x1000   /* template, not connection */
-#define IP_VS_CONN_F_ONE_PACKET 0x2000 /* forward only one packet */
 
 #define IP_VS_SCHEDNAME_MAXLEN 16
 #define IP_VS_PENAME_MAXLEN 16
@@ -365,44 +304,6 @@ struct ip_vs_timeout_user {
   int udp_timeout;
 };
 
-/* The argument to IP_VS_SO_GET_DAEMON */
-// struct ip_vs_daemon_kern {
-/* sync daemon state (master/backup) */
-//  int			state;
-
-/* multicast interface name */
-// char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
-
-/* SyncID we belong to */
-// int			syncid;
-//};
-
-// struct ip_vs_daemon_user {
-/* sync daemon state (master/backup) */
-//  int			state;
-
-/* multicast interface name */
-// char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
-
-/* SyncID we belong to */
-// int			syncid;
-
-/* UDP Payload Size */
-// int			sync_maxlen;
-
-/* Multicast Port (base) */
-// u_int16_t		mcast_port;
-
-/* Multicast TTL */
-// u_int16_t		mcast_ttl;
-
-/* Multicast Address Family */
-// u_int16_t		mcast_af;
-
-/* Multicast Address */
-// union nf_inet_addr	mcast_group;
-//};
-
 /*
  *
  * IPVS Generic Netlink interface definitions
@@ -526,26 +427,6 @@ enum {
 #define IPVS_DEST_ATTR_MAX (__IPVS_DEST_ATTR_MAX - 1)
 
 /*
- * Attributes describing a sync daemon
- *
- * Used inside nested attribute IPVS_CMD_ATTR_DAEMON
- */
-enum {
-  IPVS_DAEMON_ATTR_UNSPEC = 0,
-  IPVS_DAEMON_ATTR_STATE,        /* sync daemon state (master/backup) */
-  IPVS_DAEMON_ATTR_MCAST_IFN,    /* multicast interface name */
-  IPVS_DAEMON_ATTR_SYNC_ID,      /* SyncID we belong to */
-  IPVS_DAEMON_ATTR_SYNC_MAXLEN,  /* UDP Payload Size */
-  IPVS_DAEMON_ATTR_MCAST_GROUP,  /* IPv4 Multicast Address */
-  IPVS_DAEMON_ATTR_MCAST_GROUP6, /* IPv6 Multicast Address */
-  IPVS_DAEMON_ATTR_MCAST_PORT,   /* Multicast Port (base) */
-  IPVS_DAEMON_ATTR_MCAST_TTL,    /* Multicast TTL */
-  __IPVS_DAEMON_ATTR_MAX,
-};
-
-#define IPVS_DAEMON_ATTR_MAX (__IPVS_DAEMON_ATTR_MAX - 1)
-
-/*
  * Attributes used to describe service or destination entry statistics
  *
  * Used inside nested attributes IPVS_SVC_ATTR_STATS, IPVS_DEST_ATTR_STATS,
@@ -650,4 +531,4 @@ struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
 #endif
 /* End of Generic Netlink interface definitions */
 
-#endif /* _IP_VS_H */
+//#endif /* _IP_VS_H */

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -1,0 +1,653 @@
+/*
+ *      IP Virtual Server
+ *      data structure and functionality definitions
+ */
+
+#ifndef _IP_VS_H
+#define _IP_VS_H
+
+#include <arpa/inet.h>
+#include <linux/types.h> /* For __beXX types in userland */
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#ifdef LIBIPVS_USE_NL
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/genl.h>
+#include <netlink/netlink.h>
+//#include <libnl3/netlink/netlink.h>
+//#include <libnl3/netlink/genl/genl.h>
+//#include <libnl3/netlink/genl/ctrl.h>
+
+#endif
+
+#define IP_VS_VERSION_CODE 0x010201
+#define NVERSION(version)                                                      \
+  (version >> 16) & 0xFF, (version >> 8) & 0xFF, version & 0xFF
+
+/*
+ *      Virtual Service Flags
+ */
+#define IP_VS_SVC_F_PERSISTENT 0x0001 /* persistent port */
+#define IP_VS_SVC_F_HASHED 0x0002     /* hashed entry */
+#define IP_VS_SVC_F_ONEPACKET 0x0004  /* one-packet scheduling */
+#define IP_VS_SVC_F_SCHED1 0x0008     /* scheduler flag 1 */
+#define IP_VS_SVC_F_SCHED2 0x0010     /* scheduler flag 2 */
+#define IP_VS_SVC_F_SCHED3 0x0020     /* scheduler flag 3 */
+
+#define IP_VS_SVC_F_SCHED_SH_FALLBACK IP_VS_SVC_F_SCHED1 /* SH fallback */
+#define IP_VS_SVC_F_SCHED_SH_PORT IP_VS_SVC_F_SCHED2     /* SH use port */
+
+/*
+ *      IPVS sync daemon states
+ */
+#define IP_VS_STATE_NONE 0x0000   /* daemon is stopped */
+#define IP_VS_STATE_MASTER 0x0001 /* started as master */
+#define IP_VS_STATE_BACKUP 0x0002 /* started as backup */
+
+/*
+ *      IPVS socket options
+ */
+#define IP_VS_BASE_CTL (64 + 1024 + 64) /* base */
+
+#define IP_VS_SO_SET_NONE IP_VS_BASE_CTL /* just peek */
+#define IP_VS_SO_SET_INSERT (IP_VS_BASE_CTL + 1)
+#define IP_VS_SO_SET_ADD (IP_VS_BASE_CTL + 2)
+#define IP_VS_SO_SET_EDIT (IP_VS_BASE_CTL + 3)
+#define IP_VS_SO_SET_DEL (IP_VS_BASE_CTL + 4)
+#define IP_VS_SO_SET_FLUSH (IP_VS_BASE_CTL + 5)
+#define IP_VS_SO_SET_LIST (IP_VS_BASE_CTL + 6)
+#define IP_VS_SO_SET_ADDDEST (IP_VS_BASE_CTL + 7)
+#define IP_VS_SO_SET_DELDEST (IP_VS_BASE_CTL + 8)
+#define IP_VS_SO_SET_EDITDEST (IP_VS_BASE_CTL + 9)
+#define IP_VS_SO_SET_TIMEOUT (IP_VS_BASE_CTL + 10)
+#define IP_VS_SO_SET_STARTDAEMON (IP_VS_BASE_CTL + 11)
+#define IP_VS_SO_SET_STOPDAEMON (IP_VS_BASE_CTL + 12)
+#define IP_VS_SO_SET_RESTORE (IP_VS_BASE_CTL + 13)
+#define IP_VS_SO_SET_SAVE (IP_VS_BASE_CTL + 14)
+#define IP_VS_SO_SET_ZERO (IP_VS_BASE_CTL + 15)
+#define IP_VS_SO_SET_MAX IP_VS_SO_SET_ZERO
+
+#define IP_VS_SO_GET_VERSION IP_VS_BASE_CTL
+#define IP_VS_SO_GET_INFO (IP_VS_BASE_CTL + 1)
+#define IP_VS_SO_GET_SERVICES (IP_VS_BASE_CTL + 2)
+#define IP_VS_SO_GET_SERVICE (IP_VS_BASE_CTL + 3)
+#define IP_VS_SO_GET_DESTS (IP_VS_BASE_CTL + 4)
+#define IP_VS_SO_GET_DEST (IP_VS_BASE_CTL + 5) /* not used now */
+#define IP_VS_SO_GET_TIMEOUT (IP_VS_BASE_CTL + 6)
+#define IP_VS_SO_GET_DAEMON (IP_VS_BASE_CTL + 7)
+#define IP_VS_SO_GET_MAX IP_VS_SO_GET_DAEMON
+
+/*
+ *      IPVS Connection Flags
+ */
+#define IP_VS_CONN_F_FWD_MASK 0x0007   /* mask for the fwd methods */
+#define IP_VS_CONN_F_MASQ 0x0000       /* masquerading/NAT */
+#define IP_VS_CONN_F_LOCALNODE 0x0001  /* local node */
+#define IP_VS_CONN_F_TUNNEL 0x0002     /* tunneling */
+#define IP_VS_CONN_F_DROUTE 0x0003     /* direct routing */
+#define IP_VS_CONN_F_BYPASS 0x0004     /* cache bypass */
+#define IP_VS_CONN_F_SYNC 0x0020       /* entry created by sync */
+#define IP_VS_CONN_F_HASHED 0x0040     /* hashed entry */
+#define IP_VS_CONN_F_NOOUTPUT 0x0080   /* no output packets */
+#define IP_VS_CONN_F_INACTIVE 0x0100   /* not established */
+#define IP_VS_CONN_F_OUT_SEQ 0x0200    /* must do output seq adjust */
+#define IP_VS_CONN_F_IN_SEQ 0x0400     /* must do input seq adjust */
+#define IP_VS_CONN_F_SEQ_MASK 0x0600   /* in/out sequence mask */
+#define IP_VS_CONN_F_NO_CPORT 0x0800   /* no client port set yet */
+#define IP_VS_CONN_F_TEMPLATE 0x1000   /* template, not connection */
+#define IP_VS_CONN_F_ONE_PACKET 0x2000 /* forward only one packet */
+
+#define IP_VS_SCHEDNAME_MAXLEN 16
+#define IP_VS_PENAME_MAXLEN 16
+#define IP_VS_IFNAME_MAXLEN 16
+
+#define IP_VS_PEDATA_MAXLEN 255
+
+union nf_inet_addr {
+  __u32 all[4];
+  __be32 ip;
+  __be32 ip6[4];
+  struct in_addr in;
+  struct in6_addr in6;
+};
+
+/*
+ *	The struct ip_vs_service_user and struct ip_vs_dest_user are
+ *	used to set IPVS rules through setsockopt.
+ */
+struct ip_vs_service_kern {
+  /* virtual service addresses */
+  u_int16_t protocol;
+  __be32 addr; /* virtual ip address */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* virtual service options */
+  char sched_name[IP_VS_SCHEDNAME_MAXLEN];
+  unsigned flags;   /* virtual service flags */
+  unsigned timeout; /* persistent timeout in sec */
+  __be32 netmask;   /* persistent netmask */
+};
+
+struct ip_vs_service_user {
+  /* virtual service addresses */
+  u_int16_t protocol;
+  __be32 __addr_v4; /* virtual ip address - internal use only */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* virtual service options */
+  char sched_name[IP_VS_SCHEDNAME_MAXLEN];
+  unsigned flags;   /* virtual service flags */
+  unsigned timeout; /* persistent timeout in sec */
+  __be32 netmask;   /* persistent netmask */
+  u_int16_t af;
+  union nf_inet_addr addr;
+  char pe_name[IP_VS_PENAME_MAXLEN];
+};
+
+struct ip_vs_dest_kern {
+  /* destination server address */
+  __be32 addr;
+  __be16 port;
+
+  /* real server options */
+  unsigned conn_flags; /* connection flags */
+  int weight;          /* destination weight */
+
+  /* thresholds for active connections */
+  u_int32_t u_threshold; /* upper threshold */
+  u_int32_t l_threshold; /* lower threshold */
+};
+
+struct ip_vs_dest_user {
+  /* destination server address */
+  __be32 __addr_v4; /* internal use only */
+  __be16 port;
+
+  /* real server options */
+  unsigned conn_flags; /* connection flags */
+  int weight;          /* destination weight */
+
+  /* thresholds for active connections */
+  u_int32_t u_threshold; /* upper threshold */
+  u_int32_t l_threshold; /* lower threshold */
+  u_int16_t af;
+  union nf_inet_addr addr;
+};
+
+/*
+ *	IPVS statistics object (for user space)
+ */
+struct ip_vs_stats_user {
+  __u32 conns;    /* connections scheduled */
+  __u32 inpkts;   /* incoming packets */
+  __u32 outpkts;  /* outgoing packets */
+  __u64 inbytes;  /* incoming bytes */
+  __u64 outbytes; /* outgoing bytes */
+
+  __u32 cps;    /* current connection rate */
+  __u32 inpps;  /* current in packet rate */
+  __u32 outpps; /* current out packet rate */
+  __u32 inbps;  /* current in byte rate */
+  __u32 outbps; /* current out byte rate */
+};
+
+/*
+ *	IPVS statistics object (for user space), 64-bit
+ */
+struct ip_vs_stats64 {
+  __u64 conns;    /* connections scheduled */
+  __u64 inpkts;   /* incoming packets */
+  __u64 outpkts;  /* outgoing packets */
+  __u64 inbytes;  /* incoming bytes */
+  __u64 outbytes; /* outgoing bytes */
+
+  __u64 cps;    /* current connection rate */
+  __u64 inpps;  /* current in packet rate */
+  __u64 outpps; /* current out packet rate */
+  __u64 inbps;  /* current in byte rate */
+  __u64 outbps; /* current out byte rate */
+};
+
+/* The argument to IP_VS_SO_GET_INFO */
+struct ip_vs_getinfo {
+  /* version number */
+  unsigned int version;
+
+  /* size of connection hash table */
+  unsigned int size;
+
+  /* number of virtual services */
+  unsigned int num_services;
+};
+
+/* The argument to IP_VS_SO_GET_SERVICE */
+struct ip_vs_service_entry_kern {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 addr; /* virtual address */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* service options */
+  char sched_name[IP_VS_SCHEDNAME_MAXLEN];
+  unsigned flags;   /* virtual service flags */
+  unsigned timeout; /* persistent timeout */
+  __be32 netmask;   /* persistent netmask */
+
+  /* number of real servers */
+  unsigned int num_dests;
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+};
+
+struct ip_vs_service_entry {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 __addr_v4; /* virtual address - internal use only*/
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* service options */
+  char sched_name[IP_VS_SCHEDNAME_MAXLEN];
+  unsigned flags;   /* virtual service flags */
+  unsigned timeout; /* persistent timeout */
+  __be32 netmask;   /* persistent netmask */
+
+  /* number of real servers */
+  unsigned int num_dests;
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+
+  u_int16_t af;
+  union nf_inet_addr addr;
+  char pe_name[IP_VS_PENAME_MAXLEN];
+
+  /* statistics, 64-bit */
+  struct ip_vs_stats64 stats64;
+};
+
+struct ip_vs_dest_entry_kern {
+  __be32 addr; /* destination address */
+  __be16 port;
+  unsigned conn_flags; /* connection flags */
+  int weight;          /* destination weight */
+
+  u_int32_t u_threshold; /* upper threshold */
+  u_int32_t l_threshold; /* lower threshold */
+
+  u_int32_t activeconns;  /* active connections */
+  u_int32_t inactconns;   /* inactive connections */
+  u_int32_t persistconns; /* persistent connections */
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+};
+
+struct ip_vs_dest_entry {
+  __be32 __addr_v4; /* destination address - internal use only */
+  __be16 port;
+  unsigned conn_flags; /* connection flags */
+  int weight;          /* destination weight */
+
+  u_int32_t u_threshold; /* upper threshold */
+  u_int32_t l_threshold; /* lower threshold */
+
+  u_int32_t activeconns;  /* active connections */
+  u_int32_t inactconns;   /* inactive connections */
+  u_int32_t persistconns; /* persistent connections */
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+  u_int16_t af;
+  union nf_inet_addr addr;
+
+  /* statistics, 64-bit */
+  struct ip_vs_stats64 stats64;
+};
+
+/* The argument to IP_VS_SO_GET_DESTS */
+struct ip_vs_get_dests_kern {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 addr; /* virtual address - internal use only */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* number of real servers */
+  unsigned int num_dests;
+
+  /* the real servers */
+  struct ip_vs_dest_entry_kern entrytable[0];
+};
+
+struct ip_vs_get_dests {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 __addr_v4; /* virtual address - internal use only */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* number of real servers */
+  unsigned int num_dests;
+  u_int16_t af;
+  union nf_inet_addr addr;
+
+  /* the real servers */
+  struct ip_vs_dest_entry entrytable[0];
+};
+
+/* The argument to IP_VS_SO_GET_SERVICES */
+struct ip_vs_get_services {
+  /* number of virtual services */
+  unsigned int num_services;
+
+  /* service table */
+  struct ip_vs_service_entry entrytable[0];
+};
+
+struct ip_vs_get_services_kern {
+  /* number of virtual services */
+  unsigned int num_services;
+
+  /* service table */
+  struct ip_vs_service_entry_kern entrytable[0];
+};
+
+/* The argument to IP_VS_SO_GET_TIMEOUT */
+struct ip_vs_timeout_user {
+  int tcp_timeout;
+  int tcp_fin_timeout;
+  int udp_timeout;
+};
+
+/* The argument to IP_VS_SO_GET_DAEMON */
+// struct ip_vs_daemon_kern {
+/* sync daemon state (master/backup) */
+//  int			state;
+
+/* multicast interface name */
+// char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
+
+/* SyncID we belong to */
+// int			syncid;
+//};
+
+// struct ip_vs_daemon_user {
+/* sync daemon state (master/backup) */
+//  int			state;
+
+/* multicast interface name */
+// char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
+
+/* SyncID we belong to */
+// int			syncid;
+
+/* UDP Payload Size */
+// int			sync_maxlen;
+
+/* Multicast Port (base) */
+// u_int16_t		mcast_port;
+
+/* Multicast TTL */
+// u_int16_t		mcast_ttl;
+
+/* Multicast Address Family */
+// u_int16_t		mcast_af;
+
+/* Multicast Address */
+// union nf_inet_addr	mcast_group;
+//};
+
+/*
+ *
+ * IPVS Generic Netlink interface definitions
+ *
+ */
+
+/* Generic Netlink family info */
+
+#define IPVS_GENL_NAME "IPVS"
+#define IPVS_GENL_VERSION 0x1
+
+struct ip_vs_flags {
+  __be32 flags;
+  __be32 mask;
+};
+
+/* Generic Netlink command attributes */
+enum {
+  IPVS_CMD_UNSPEC = 0,
+
+  IPVS_CMD_NEW_SERVICE, /* add service */
+  IPVS_CMD_SET_SERVICE, /* modify service */
+  IPVS_CMD_DEL_SERVICE, /* delete service */
+  IPVS_CMD_GET_SERVICE, /* get info about specific service */
+
+  IPVS_CMD_NEW_DEST, /* add destination */
+  IPVS_CMD_SET_DEST, /* modify destination */
+  IPVS_CMD_DEL_DEST, /* delete destination */
+  IPVS_CMD_GET_DEST, /* get list of all service dests */
+
+  IPVS_CMD_NEW_DAEMON, /* start sync daemon */
+  IPVS_CMD_DEL_DAEMON, /* stop sync daemon */
+  IPVS_CMD_GET_DAEMON, /* get sync daemon status */
+
+  IPVS_CMD_SET_TIMEOUT, /* set TCP and UDP timeouts */
+  IPVS_CMD_GET_TIMEOUT, /* get TCP and UDP timeouts */
+
+  IPVS_CMD_SET_INFO, /* only used in GET_INFO reply */
+  IPVS_CMD_GET_INFO, /* get general IPVS info */
+
+  IPVS_CMD_ZERO,  /* zero all counters and stats */
+  IPVS_CMD_FLUSH, /* flush services and dests */
+
+  __IPVS_CMD_MAX,
+};
+
+#define IPVS_CMD_MAX (__IPVS_CMD_MAX - 1)
+
+/* Attributes used in the first level of commands */
+enum {
+  IPVS_CMD_ATTR_UNSPEC = 0,
+  IPVS_CMD_ATTR_SERVICE,         /* nested service attribute */
+  IPVS_CMD_ATTR_DEST,            /* nested destination attribute */
+  IPVS_CMD_ATTR_DAEMON,          /* nested sync daemon attribute */
+  IPVS_CMD_ATTR_TIMEOUT_TCP,     /* TCP connection timeout */
+  IPVS_CMD_ATTR_TIMEOUT_TCP_FIN, /* TCP FIN wait timeout */
+  IPVS_CMD_ATTR_TIMEOUT_UDP,     /* UDP timeout */
+  __IPVS_CMD_ATTR_MAX,
+};
+
+#define IPVS_CMD_ATTR_MAX (__IPVS_CMD_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe a service
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_SERVICE
+ */
+enum {
+  IPVS_SVC_ATTR_UNSPEC = 0,
+  IPVS_SVC_ATTR_AF,       /* address family */
+  IPVS_SVC_ATTR_PROTOCOL, /* virtual service protocol */
+  IPVS_SVC_ATTR_ADDR,     /* virtual service address */
+  IPVS_SVC_ATTR_PORT,     /* virtual service port */
+  IPVS_SVC_ATTR_FWMARK,   /* firewall mark of service */
+
+  IPVS_SVC_ATTR_SCHED_NAME, /* name of scheduler */
+  IPVS_SVC_ATTR_FLAGS,      /* virtual service flags */
+  IPVS_SVC_ATTR_TIMEOUT,    /* persistent timeout */
+  IPVS_SVC_ATTR_NETMASK,    /* persistent netmask */
+
+  IPVS_SVC_ATTR_STATS, /* nested attribute for service stats */
+
+  IPVS_SVC_ATTR_PE_NAME, /* name of scheduler */
+
+  IPVS_SVC_ATTR_STATS64, /* nested attribute for service stats */
+
+  __IPVS_SVC_ATTR_MAX,
+};
+
+#define IPVS_SVC_ATTR_MAX (__IPVS_SVC_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe a destination (real server)
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_DEST
+ */
+enum {
+  IPVS_DEST_ATTR_UNSPEC = 0,
+  IPVS_DEST_ATTR_ADDR, /* real server address */
+  IPVS_DEST_ATTR_PORT, /* real server port */
+
+  IPVS_DEST_ATTR_FWD_METHOD, /* forwarding method */
+  IPVS_DEST_ATTR_WEIGHT,     /* destination weight */
+
+  IPVS_DEST_ATTR_U_THRESH, /* upper threshold */
+  IPVS_DEST_ATTR_L_THRESH, /* lower threshold */
+
+  IPVS_DEST_ATTR_ACTIVE_CONNS,  /* active connections */
+  IPVS_DEST_ATTR_INACT_CONNS,   /* inactive connections */
+  IPVS_DEST_ATTR_PERSIST_CONNS, /* persistent connections */
+
+  IPVS_DEST_ATTR_STATS, /* nested attribute for dest stats */
+
+  IPVS_DEST_ATTR_ADDR_FAMILY, /* Address family of address */
+
+  IPVS_DEST_ATTR_STATS64, /* nested attribute for dest stats */
+
+  __IPVS_DEST_ATTR_MAX,
+};
+
+#define IPVS_DEST_ATTR_MAX (__IPVS_DEST_ATTR_MAX - 1)
+
+/*
+ * Attributes describing a sync daemon
+ *
+ * Used inside nested attribute IPVS_CMD_ATTR_DAEMON
+ */
+enum {
+  IPVS_DAEMON_ATTR_UNSPEC = 0,
+  IPVS_DAEMON_ATTR_STATE,        /* sync daemon state (master/backup) */
+  IPVS_DAEMON_ATTR_MCAST_IFN,    /* multicast interface name */
+  IPVS_DAEMON_ATTR_SYNC_ID,      /* SyncID we belong to */
+  IPVS_DAEMON_ATTR_SYNC_MAXLEN,  /* UDP Payload Size */
+  IPVS_DAEMON_ATTR_MCAST_GROUP,  /* IPv4 Multicast Address */
+  IPVS_DAEMON_ATTR_MCAST_GROUP6, /* IPv6 Multicast Address */
+  IPVS_DAEMON_ATTR_MCAST_PORT,   /* Multicast Port (base) */
+  IPVS_DAEMON_ATTR_MCAST_TTL,    /* Multicast TTL */
+  __IPVS_DAEMON_ATTR_MAX,
+};
+
+#define IPVS_DAEMON_ATTR_MAX (__IPVS_DAEMON_ATTR_MAX - 1)
+
+/*
+ * Attributes used to describe service or destination entry statistics
+ *
+ * Used inside nested attributes IPVS_SVC_ATTR_STATS, IPVS_DEST_ATTR_STATS,
+ * IPVS_SVC_ATTR_STATS64 and IPVS_DEST_ATTR_STATS64.
+ */
+enum {
+  IPVS_STATS_ATTR_UNSPEC = 0,
+  IPVS_STATS_ATTR_CONNS,    /* connections scheduled */
+  IPVS_STATS_ATTR_INPKTS,   /* incoming packets */
+  IPVS_STATS_ATTR_OUTPKTS,  /* outgoing packets */
+  IPVS_STATS_ATTR_INBYTES,  /* incoming bytes */
+  IPVS_STATS_ATTR_OUTBYTES, /* outgoing bytes */
+
+  IPVS_STATS_ATTR_CPS,    /* current connection rate */
+  IPVS_STATS_ATTR_INPPS,  /* current in packet rate */
+  IPVS_STATS_ATTR_OUTPPS, /* current out packet rate */
+  IPVS_STATS_ATTR_INBPS,  /* current in byte rate */
+  IPVS_STATS_ATTR_OUTBPS, /* current out byte rate */
+  __IPVS_STATS_ATTR_MAX,
+};
+
+#define IPVS_STATS_ATTR_MAX (__IPVS_STATS_ATTR_MAX - 1)
+
+/* Attributes used in response to IPVS_CMD_GET_INFO command */
+enum {
+  IPVS_INFO_ATTR_UNSPEC = 0,
+  IPVS_INFO_ATTR_VERSION,       /* IPVS version number */
+  IPVS_INFO_ATTR_CONN_TAB_SIZE, /* size of connection hash table */
+  __IPVS_INFO_ATTR_MAX,
+};
+
+#define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
+
+#ifdef LIBIPVS_USE_NL
+extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
+extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
+extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
+extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
+extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
+extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
+#endif
+// todo sort out the nla_policy and associated structs
+#ifdef LIBIPVS_USE_NL
+/* Policy definitions */
+struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
+        [IPVS_CMD_ATTR_SERVICE] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DEST] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DAEMON] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_UDP] = {.type = NLA_U32},
+};
+
+struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
+        [IPVS_SVC_ATTR_AF] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_PROTOCOL] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                .maxlen = sizeof(struct in6_addr)},
+        [IPVS_SVC_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_FWMARK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_SCHED_NAME] = {.type = NLA_STRING,
+                                      .maxlen = IP_VS_SCHEDNAME_MAXLEN},
+        [IPVS_SVC_ATTR_FLAGS] = {.type = NLA_UNSPEC,
+                                 .minlen = sizeof(struct ip_vs_flags),
+                                 .maxlen = sizeof(struct ip_vs_flags)},
+        [IPVS_SVC_ATTR_TIMEOUT] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_NETMASK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_STATS] = {.type = NLA_NESTED},
+};
+
+struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
+        [IPVS_DEST_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                 .maxlen = sizeof(struct in6_addr)},
+        [IPVS_DEST_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_DEST_ATTR_FWD_METHOD] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_WEIGHT] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_U_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_L_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_ACTIVE_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_INACT_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_PERSIST_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_STATS] = {.type = NLA_NESTED},
+};
+
+struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
+        [IPVS_STATS_ATTR_CONNS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_OUTBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_CPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTBPS] = {.type = NLA_U32},
+};
+
+struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
+        [IPVS_INFO_ATTR_VERSION] = {.type = NLA_U32},
+        [IPVS_INFO_ATTR_CONN_TAB_SIZE] = {.type = NLA_U32},
+};
+#endif
+/* End of Generic Netlink interface definitions */
+
+#endif /* _IP_VS_H */

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -12,9 +12,6 @@
 #include <netlink/genl/ctrl.h>
 #include <netlink/genl/genl.h>
 #include <netlink/netlink.h>
-//#include <libnl3/netlink/netlink.h>
-//#include <libnl3/netlink/genl/genl.h>
-//#include <libnl3/netlink/genl/ctrl.h>
 
 #endif
 
@@ -460,16 +457,13 @@ enum {
 
 #define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
 
-#ifdef LIBIPVS_USE_NL
 extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
 extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
 extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
 extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
 extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
-#endif
-// todo sort out the nla_policy and associated structs
-#ifdef LIBIPVS_USE_NL
+
 /* Policy definitions */
 struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
         [IPVS_CMD_ATTR_SERVICE] = {.type = NLA_NESTED},
@@ -528,7 +522,5 @@ struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
         [IPVS_INFO_ATTR_VERSION] = {.type = NLA_U32},
         [IPVS_INFO_ATTR_CONN_TAB_SIZE] = {.type = NLA_U32},
 };
-#endif
-/* End of Generic Netlink interface definitions */
 
-//#endif /* _IP_VS_H */
+/* End of Generic Netlink interface definitions */


### PR DESCRIPTION
Added support for IPV6 services. Using libnl1, libnl3 and libnl-genl (http://www.infradead.org/~tgr/libnl/) to query IPV6 ipvs services through netlink. Different distributions include different version of libnl by default so this covers Debian / CentOS bases. 
A new header has been included which contain the necessary structures for IPV6 which are not included in the standard kernel headers.
This work is based on the IPV6 updates made to ipvsadm by Vince Busam and Julius Volz.