### PR TITLE
Add micro-seconds resolution in write_riemann

### DIFF
--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -214,6 +214,11 @@ wrr_notification_to_message(struct riemann_host *host, /* {{{ */
       RIEMANN_EVENT_FIELD_SERVICE, &service_buffer[1],
       RIEMANN_EVENT_FIELD_NONE);
 
+#if RCC_VERSION_NUMBER >= 0x010A00
+  riemann_event_set(event, RIEMANN_EVENT_FIELD_TIME_MICROS,
+                    (int64_t)CDTIME_T_TO_US(n->time));
+#endif
+
   if (n->host[0] != 0)
     riemann_event_string_attribute_add(event, "host", n->host);
   if (n->plugin[0] != 0)
@@ -309,6 +314,11 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
       RIEMANN_EVENT_FIELD_STRING_ATTRIBUTES, "plugin", vl->plugin, "type",
       vl->type, "ds_name", ds->ds[index].name, NULL,
       RIEMANN_EVENT_FIELD_SERVICE, service_buffer, RIEMANN_EVENT_FIELD_NONE);
+
+#if RCC_VERSION_NUMBER >= 0x010A00
+  riemann_event_set(event, RIEMANN_EVENT_FIELD_TIME_MICROS,
+                    (int64_t)CDTIME_T_TO_US(vl->time));
+#endif
 
   if (host->check_thresholds) {
     const char *state = NULL;


### PR DESCRIPTION
Since [0.2.13](https://github.com/riemann/riemann/releases/tag/0.2.13), Riemann supports microseconds time resolution. riemann-c-client supports it since [1.10.0](https://github.com/algernon/riemann-c-client/blob/master/NEWS.md).

This PR adds microseconds resolution in write_riemann.

I tested it locally, example event received by Riemann with my PR:

```
INFO [2017-06-13 21:20:04,058] defaultEventExecutorGroup-2-1 - riemann.config - #riemann.codec.Event{:host foo.bar, :service processes/ps_state-paging, :state nil, :description nil, :metric 0.0, :tags nil, :time 1.497381604056424E9, :ttl 20.0, :plugin processes, :type ps_state, :ds_name value, :type_instance paging, :ds_type gauge, :ds_index 0}
```

without my PR:

```
INFO [2017-06-13 21:22:03,810] defaultEventExecutorGroup-2-2 - riemann.config - #riemann.codec.Event{:host foo.bar, :service processes/ps_state-paging, :state nil, :description nil, :metric 0.0, :tags nil, :time 1497381724, :ttl 20.0, :plugin processes, :type ps_state, :ds_name value, :type_instance paging, :ds_type gauge, :ds_index 0}
```