### PR TITLE
Fix errno handling, and getgrnam_r on OpenBSD

### DIFF
--- a/src/email.c
+++ b/src/email.c
@@ -411,7 +411,7 @@ static void *open_connection(void __attribute__((unused)) * arg) {
     if (status != 0) {
       char errbuf[1024];
       log_warn("getgrnam_r (%s) failed: %s", group,
-               sstrerror(errno, errbuf, sizeof(errbuf)));
+               sstrerror(status, errbuf, sizeof(errbuf)));
     } else if (grp == NULL) {
       log_warn("No such group: `%s'", group);
     } else {

--- a/src/email.c
+++ b/src/email.c
@@ -403,7 +403,7 @@ static void *open_connection(void __attribute__((unused)) * arg) {
   {
     struct group sg;
     struct group *grp;
-    char grbuf[2048];
+    char grbuf[4096];
     int status;
 
     grp = NULL;

--- a/src/exec.c
+++ b/src/exec.c
@@ -382,7 +382,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   status = getpwnam_r(pl->user, &sp, nambuf, sizeof(nambuf), &sp_ptr);
   if (status != 0) {
     ERROR("exec plugin: Failed to get user information for user ``%s'': %s",
-          pl->user, sstrerror(errno, errbuf, sizeof(errbuf)));
+          pl->user, sstrerror(status, errbuf, sizeof(errbuf)));
     goto failed;
   }
 
@@ -410,7 +410,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
       if (0 != status) {
         ERROR("exec plugin: Failed to get group information "
               "for group ``%s'': %s",
-              pl->group, sstrerror(errno, errbuf, sizeof(errbuf)));
+              pl->group, sstrerror(status, errbuf, sizeof(errbuf)));
         goto failed;
       }
       if (NULL == gr_ptr) {

--- a/src/exec.c
+++ b/src/exec.c
@@ -369,7 +369,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
 
   struct passwd *sp_ptr;
   struct passwd sp;
-  char nambuf[2048];
+  char nambuf[4096];
 
   if (pl->pid != 0)
     return -1;

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -134,7 +134,7 @@ static int us_open_socket(void) {
     const char *grpname;
     struct group *g;
     struct group sg;
-    char grbuf[2048];
+    char grbuf[4096];
 
     grpname = (sock_group != NULL) ? sock_group : COLLECTD_GRP_NAME;
     g = NULL;

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -143,7 +143,7 @@ static int us_open_socket(void) {
     if (status != 0) {
       char errbuf[1024];
       WARNING("unixsock plugin: getgrnam_r (%s) failed: %s", grpname,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              sstrerror(status, errbuf, sizeof(errbuf)));
       break;
     }
     if (g == NULL) {


### PR DESCRIPTION
Hi,

I read Guidelines.md, I acknowledge that it says
`Focus: Fix one thing in your PR. The smaller your change, the faster it will be reviewed and merged.`

This PR fixes two things but they're really related so hopefully you won't get (too much) mad at me :3

Anyway here's my story. I began to use the plugin exec stating:
<Plugin exec>
        Exec "_collectd:_collectd" "/usr/local/some/really/nice/thing"
</Plugin>
but it said

> collectd[32946]: exec plugin: Failed to get group information for group ``_collectd'': Undefined error:

which is not really helpful, so I asked help from a friend who came with first commit. Then it said 

> collectd[55462]: exec plugin: Failed to get group information for group ``_collectd'': Result too large

So I bumped the size and it worked fine. So I fixed the similar results grep would give me in the whole src/. It's already committed downstream (i.e. OpenBSD): https://marc.info/?l=openbsd-ports-cvs&m=149869644612265&w=2

edit: added a third commit which does the same than the first.
edit: and a fourth now, which does the same than the first, sorry :D

Cheers,
Daniel