### PR TITLE
Treewide: replace ssnprintf with snprintf

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -200,15 +200,15 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      ssnprintf(inst->ident.plugin_instance,
+      snprintf(inst->ident.plugin_instance,
                 sizeof(inst->ident.plugin_instance), "%s-%s", tmp_plugin,
                 AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      ssnprintf(inst->ident.plugin_instance,
+      snprintf(inst->ident.plugin_instance,
                 sizeof(inst->ident.plugin_instance), "%s-%s",
                 tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
-      ssnprintf(inst->ident.plugin_instance,
+      snprintf(inst->ident.plugin_instance,
                 sizeof(inst->ident.plugin_instance), "%s-%s-%s", tmp_plugin,
                 tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
   }

--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -200,17 +200,15 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      snprintf(inst->ident.plugin_instance,
-                sizeof(inst->ident.plugin_instance), "%s-%s", tmp_plugin,
-                AGG_FUNC_PLACEHOLDER);
+      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+               "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      snprintf(inst->ident.plugin_instance,
-                sizeof(inst->ident.plugin_instance), "%s-%s",
-                tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
+      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+               "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
-      snprintf(inst->ident.plugin_instance,
-                sizeof(inst->ident.plugin_instance), "%s-%s-%s", tmp_plugin,
-                tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
+      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+               "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
+               AGG_FUNC_PLACEHOLDER);
   }
 
   /* Type */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -217,23 +217,23 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
     if (r.reply.id == AMQP_CONNECTION_CLOSE_METHOD) {
       amqp_connection_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      ssnprintf(buffer, buffer_size, "Server connection error %d: %s",
+      snprintf(buffer, buffer_size, "Server connection error %d: %s",
                 m->reply_code, tmp);
       sfree(tmp);
     } else if (r.reply.id == AMQP_CHANNEL_CLOSE_METHOD) {
       amqp_channel_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      ssnprintf(buffer, buffer_size, "Server channel error %d: %s",
+      snprintf(buffer, buffer_size, "Server channel error %d: %s",
                 m->reply_code, tmp);
       sfree(tmp);
     } else {
-      ssnprintf(buffer, buffer_size, "Server error method %#" PRIx32,
+      snprintf(buffer, buffer_size, "Server error method %#" PRIx32,
                 r.reply.id);
     }
     break;
 
   default:
-    ssnprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
+    snprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
   }
 
   return buffer;
@@ -758,7 +758,7 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (conf->routing_key != NULL) {
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
   } else {
-    ssnprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
+    snprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
               vl->host, vl->plugin, vl->plugin_instance, vl->type,
               vl->type_instance);
 
@@ -980,7 +980,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
 
   if (publish) {
     char cbname[128];
-    ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
+    snprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
     status = plugin_register_write(
         cbname, camqp_write, &(user_data_t){

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -218,17 +218,17 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
       amqp_connection_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
       snprintf(buffer, buffer_size, "Server connection error %d: %s",
-                m->reply_code, tmp);
+               m->reply_code, tmp);
       sfree(tmp);
     } else if (r.reply.id == AMQP_CHANNEL_CLOSE_METHOD) {
       amqp_channel_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
       snprintf(buffer, buffer_size, "Server channel error %d: %s",
-                m->reply_code, tmp);
+               m->reply_code, tmp);
       sfree(tmp);
     } else {
       snprintf(buffer, buffer_size, "Server error method %#" PRIx32,
-                r.reply.id);
+               r.reply.id);
     }
     break;
 
@@ -759,8 +759,8 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
   } else {
     snprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
-              vl->host, vl->plugin, vl->plugin_instance, vl->type,
-              vl->type_instance);
+             vl->host, vl->plugin, vl->plugin_instance, vl->type,
+             vl->type_instance);
 
     /* Switch slashes (the only character forbidden by collectd) and dots
      * (the separation character used by AMQP). */

--- a/src/apache.c
+++ b/src/apache.c
@@ -220,16 +220,17 @@ static int config_add(oconfig_item_t *ci) {
     char callback_name[3 * DATA_MAX_NAME_LEN];
 
     snprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
-              (st->host != NULL) ? st->host : hostname_g,
-              (st->name != NULL) ? st->name : "default");
+             (st->host != NULL) ? st->host : hostname_g,
+             (st->name != NULL) ? st->name : "default");
 
     status = plugin_register_complex_read(
         /* group = */ NULL,
         /* name      = */ callback_name,
         /* callback  = */ apache_read_host,
-        /* interval  = */ 0, &(user_data_t){
-                                 .data = st, .free_func = apache_free,
-                             });
+        /* interval  = */ 0,
+        &(user_data_t){
+            .data = st, .free_func = apache_free,
+        });
   }
 
   if (status != 0) {
@@ -314,7 +315,7 @@ static int init_host(apache_t *st) /* {{{ */
     int status;
 
     status = snprintf(credentials, sizeof(credentials), "%s:%s", st->user,
-                       (st->pass == NULL) ? "" : st->pass);
+                      (st->pass == NULL) ? "" : st->pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("apache plugin: init_host: Returning an error "
             "because the credentials have been "

--- a/src/apache.c
+++ b/src/apache.c
@@ -219,7 +219,7 @@ static int config_add(oconfig_item_t *ci) {
   if (status == 0) {
     char callback_name[3 * DATA_MAX_NAME_LEN];
 
-    ssnprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
+    snprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
               (st->host != NULL) ? st->host : hostname_g,
               (st->name != NULL) ? st->name : "default");
 
@@ -313,7 +313,7 @@ static int init_host(apache_t *st) /* {{{ */
     static char credentials[1024];
     int status;
 
-    status = ssnprintf(credentials, sizeof(credentials), "%s:%s", st->user,
+    status = snprintf(credentials, sizeof(credentials), "%s:%s", st->user,
                        (st->pass == NULL) ? "" : st->pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("apache plugin: init_host: Returning an error "

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -500,7 +500,7 @@ static int ascent_init(void) /* {{{ */
     int status;
 
     status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
-                       (pass == NULL) ? "" : pass);
+                      (pass == NULL) ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "
             "credentials have been truncated.");

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -499,7 +499,7 @@ static int ascent_init(void) /* {{{ */
     static char credentials[1024];
     int status;
 
-    status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
+    status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
                        (pass == NULL) ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "

--- a/src/battery.c
+++ b/src/battery.c
@@ -347,7 +347,7 @@ static int sysfs_file_to_buffer(char const *dir, /* {{{ */
   char filename[PATH_MAX];
   int status;
 
-  ssnprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply,
+  snprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply,
             basename);
 
   status = (int)read_file_contents(filename, buffer, buffer_size - 1);
@@ -479,7 +479,7 @@ static int read_acpi_full_capacity(char const *dir, /* {{{ */
 
   FILE *fh;
 
-  ssnprintf(filename, sizeof(filename), "%s/%s/info", dir, power_supply);
+  snprintf(filename, sizeof(filename), "%s/%s/info", dir, power_supply);
   fh = fopen(filename, "r");
   if (fh == NULL)
     return errno;
@@ -532,7 +532,7 @@ static int read_acpi_callback(char const *dir, /* {{{ */
 
   FILE *fh;
 
-  ssnprintf(filename, sizeof(filename), "%s/%s/state", dir, power_supply);
+  snprintf(filename, sizeof(filename), "%s/%s/state", dir, power_supply);
   fh = fopen(filename, "r");
   if (fh == NULL) {
     if ((errno == EAGAIN) || (errno == EINTR) || (errno == ENOENT))
@@ -641,11 +641,11 @@ static int read_pmu(void) /* {{{ */
     gauge_t voltage = NAN;
     gauge_t charge = NAN;
 
-    ssnprintf(filename, sizeof(filename), PROC_PMU_PATH_FORMAT, i);
+    snprintf(filename, sizeof(filename), PROC_PMU_PATH_FORMAT, i);
     if (access(filename, R_OK) != 0)
       break;
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "%i", i);
+    snprintf(plugin_instance, sizeof(plugin_instance), "%i", i);
 
     fh = fopen(filename, "r");
     if (fh == NULL) {

--- a/src/battery.c
+++ b/src/battery.c
@@ -347,8 +347,7 @@ static int sysfs_file_to_buffer(char const *dir, /* {{{ */
   char filename[PATH_MAX];
   int status;
 
-  snprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply,
-            basename);
+  snprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply, basename);
 
   status = (int)read_file_contents(filename, buffer, buffer_size - 1);
   if (status < 0)

--- a/src/bind.c
+++ b/src/bind.c
@@ -737,8 +737,8 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
                                          nsstats_translation_table_length,
                                          plugin_instance};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s",
-              view->name, zone_name);
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s", view->name,
+             zone_name);
 
     if (version == 3) {
       list_info_ptr_t list_info = {plugin_instance,
@@ -868,8 +868,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     list_info_ptr_t list_info = {plugin_instance,
                                  /* type = */ "dns_qtype"};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes",
-              view->name);
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes", view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
           /* xpath = */ "counters[@type='resqtype']",
@@ -892,7 +891,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
                                          plugin_instance};
 
     snprintf(plugin_instance, sizeof(plugin_instance), "%s-resolver_stats",
-              view->name);
+             view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
           "counters[@type='resstats']",
@@ -915,7 +914,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
                                  /* type = */ "dns_qtype_cached"};
 
     snprintf(plugin_instance, sizeof(plugin_instance), "%s-cache_rr_sets",
-              view->name);
+             view->name);
 
     bind_parse_generic_name_value(/* xpath = */ "cache/rrset",
                                   /* callback = */ bind_xml_list_callback,

--- a/src/bind.c
+++ b/src/bind.c
@@ -737,7 +737,7 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
                                          nsstats_translation_table_length,
                                          plugin_instance};
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s",
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s",
               view->name, zone_name);
 
     if (version == 3) {
@@ -868,7 +868,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     list_info_ptr_t list_info = {plugin_instance,
                                  /* type = */ "dns_qtype"};
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes",
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes",
               view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
@@ -891,7 +891,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
                                          resstats_translation_table_length,
                                          plugin_instance};
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-resolver_stats",
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-resolver_stats",
               view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
@@ -914,7 +914,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     list_info_ptr_t list_info = {plugin_instance,
                                  /* type = */ "dns_qtype_cached"};
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-cache_rr_sets",
+    snprintf(plugin_instance, sizeof(plugin_instance), "%s-cache_rr_sets",
               view->name);
 
     bind_parse_generic_name_value(/* xpath = */ "cache/rrset",

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -76,7 +76,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
     return 0;
 
   snprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
-            cgroup_name);
+           cgroup_name);
   fh = fopen(abs_path, "r");
   if (fh == NULL) {
     char errbuf[1024];

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -63,7 +63,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   if (ignorelist_match(il_cgroup, cgroup_name))
     return 0;
 
-  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, cgroup_name);
+  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, cgroup_name);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {
@@ -75,7 +75,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   if (!S_ISDIR(statbuf.st_mode))
     return 0;
 
-  ssnprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
+  snprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
             cgroup_name);
   fh = fopen(abs_path, "r");
   if (fh == NULL) {
@@ -138,7 +138,7 @@ static int read_cpuacct_root(const char *dirname, const char *filename,
   struct stat statbuf;
   int status;
 
-  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
+  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -326,7 +326,7 @@ static void submit_value(int cpu_num, int cpu_state, const char *type,
            sizeof(vl.type_instance));
 
   if (cpu_num >= 0) {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
   }
   plugin_dispatch_values(&vl);
 }

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -34,7 +34,7 @@ static int cpufreq_init(void) {
   num_cpu = 0;
 
   while (1) {
-    status = ssnprintf(filename, sizeof(filename),
+    status = snprintf(filename, sizeof(filename),
                        "/sys/devices/system/cpu/cpu%d/cpufreq/"
                        "scaling_cur_freq",
                        num_cpu);
@@ -62,7 +62,7 @@ static void cpufreq_submit(int cpu_num, value_t value) {
   vl.values_len = 1;
   sstrncpy(vl.plugin, "cpufreq", sizeof(vl.plugin));
   sstrncpy(vl.type, "cpufreq", sizeof(vl.type));
-  ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i", cpu_num);
+  snprintf(vl.type_instance, sizeof(vl.type_instance), "%i", cpu_num);
 
   plugin_dispatch_values(&vl);
 }
@@ -70,7 +70,7 @@ static void cpufreq_submit(int cpu_num, value_t value) {
 static int cpufreq_read(void) {
   for (int i = 0; i < num_cpu; i++) {
     char filename[PATH_MAX];
-    ssnprintf(filename, sizeof(filename),
+    snprintf(filename, sizeof(filename),
               "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", i);
 
     value_t v;

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -35,9 +35,9 @@ static int cpufreq_init(void) {
 
   while (1) {
     status = snprintf(filename, sizeof(filename),
-                       "/sys/devices/system/cpu/cpu%d/cpufreq/"
-                       "scaling_cur_freq",
-                       num_cpu);
+                      "/sys/devices/system/cpu/cpu%d/cpufreq/"
+                      "scaling_cur_freq",
+                      num_cpu);
     if ((status < 1) || ((unsigned int)status >= sizeof(filename)))
       break;
 
@@ -71,7 +71,7 @@ static int cpufreq_read(void) {
   for (int i = 0; i < num_cpu; i++) {
     char filename[PATH_MAX];
     snprintf(filename, sizeof(filename),
-              "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", i);
+             "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", i);
 
     value_t v;
     if (parse_value_file(filename, &v, DS_TYPE_GAUGE) != 0) {

--- a/src/csv.c
+++ b/src/csv.c
@@ -47,7 +47,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
   memset(buffer, '\0', buffer_len);
 
-  status = ssnprintf(buffer, buffer_len, "%.3f", CDTIME_T_TO_DOUBLE(vl->time));
+  status = snprintf(buffer, buffer_len, "%.3f", CDTIME_T_TO_DOUBLE(vl->time));
   if ((status < 1) || (status >= buffer_len))
     return -1;
   offset = status;
@@ -62,7 +62,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
     }
 
     if (ds->ds[i].type == DS_TYPE_GAUGE) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ",%lf",
+      status = snprintf(buffer + offset, buffer_len - offset, ",%lf",
                          vl->values[i].gauge);
     } else if (store_rates != 0) {
       if (rates == NULL)
@@ -73,15 +73,15 @@ static int value_list_to_string(char *buffer, int buffer_len,
         return -1;
       }
       status =
-          ssnprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
+          snprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ",%llu",
+      status = snprintf(buffer + offset, buffer_len - offset, ",%llu",
                          vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ",%" PRIi64,
+      status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIi64,
                          vl->values[i].derive);
     } else if (ds->ds[i].type == DS_TYPE_ABSOLUTE) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ",%" PRIu64,
+      status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIu64,
                          vl->values[i].absolute);
     }
 

--- a/src/csv.c
+++ b/src/csv.c
@@ -63,7 +63,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
     if (ds->ds[i].type == DS_TYPE_GAUGE) {
       status = snprintf(buffer + offset, buffer_len - offset, ",%lf",
-                         vl->values[i].gauge);
+                        vl->values[i].gauge);
     } else if (store_rates != 0) {
       if (rates == NULL)
         rates = uc_get_rate(ds, vl);
@@ -72,17 +72,16 @@ static int value_list_to_string(char *buffer, int buffer_len,
                 "uc_get_rate failed.");
         return -1;
       }
-      status =
-          snprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
+      status = snprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER) {
       status = snprintf(buffer + offset, buffer_len - offset, ",%llu",
-                         vl->values[i].counter);
+                        vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
       status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIi64,
-                         vl->values[i].derive);
+                        vl->values[i].derive);
     } else if (ds->ds[i].type == DS_TYPE_ABSOLUTE) {
       status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIu64,
-                         vl->values[i].absolute);
+                        vl->values[i].absolute);
     }
 
     if ((status < 1) || (status >= (buffer_len - offset))) {

--- a/src/curl.c
+++ b/src/curl.c
@@ -370,7 +370,7 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
     }
 
     snprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
-              (wp->pass == NULL) ? "" : wp->pass);
+             (wp->pass == NULL) ? "" : wp->pass);
     curl_easy_setopt(wp->curl, CURLOPT_USERPWD, wp->credentials);
 #endif
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -369,7 +369,7 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
       return -1;
     }
 
-    ssnprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
+    snprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
               (wp->pass == NULL) ? "" : wp->pass);
     curl_easy_setopt(wp->curl, CURLOPT_USERPWD, wp->credentials);
 #endif

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -217,7 +217,7 @@ static void cj_advance_array(cj_t *db) {
   db->state[db->depth].index++;
 
   char name[DATA_MAX_NAME_LEN];
-  ssnprintf(name, sizeof(name), "%d", db->state[db->depth].index);
+  snprintf(name, sizeof(name), "%d", db->state[db->depth].index);
   cj_load_key(db, name);
 }
 
@@ -600,7 +600,7 @@ static int cj_init_curl(cj_t *db) /* {{{ */
       return -1;
     }
 
-    ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
+    snprintf(db->credentials, credentials_size, "%s:%s", db->user,
               (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif
@@ -800,7 +800,7 @@ static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
   if (key->instance == NULL) {
     int len = 0;
     for (int i = 0; i < db->depth; i++)
-      len += ssnprintf(vl.type_instance + len, sizeof(vl.type_instance) - len,
+      len += snprintf(vl.type_instance + len, sizeof(vl.type_instance) - len,
                        i ? "-%s" : "%s", db->state[i + 1].name);
   } else
     sstrncpy(vl.type_instance, key->instance, sizeof(vl.type_instance));

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -601,7 +601,7 @@ static int cj_init_curl(cj_t *db) /* {{{ */
     }
 
     snprintf(db->credentials, credentials_size, "%s:%s", db->user,
-              (db->pass == NULL) ? "" : db->pass);
+             (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif
 
@@ -801,7 +801,7 @@ static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
     int len = 0;
     for (int i = 0; i < db->depth; i++)
       len += snprintf(vl.type_instance + len, sizeof(vl.type_instance) - len,
-                       i ? "-%s" : "%s", db->state[i + 1].name);
+                      i ? "-%s" : "%s", db->state[i + 1].name);
   } else
     sstrncpy(vl.type_instance, key->instance, sizeof(vl.type_instance));
 

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -441,7 +441,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
   if (xpath->instance_prefix != NULL) {
     if (instance_node != NULL) {
       char *node_value = (char *)xmlNodeGetContent(instance_node->nodeTab[0]);
-      ssnprintf(vl->type_instance, sizeof(vl->type_instance), "%s%s",
+      snprintf(vl->type_instance, sizeof(vl->type_instance), "%s%s",
                 xpath->instance_prefix, node_value);
       sfree(node_value);
     } else
@@ -839,7 +839,7 @@ static int cx_init_curl(cx_t *db) /* {{{ */
       return -1;
     }
 
-    ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
+    snprintf(db->credentials, credentials_size, "%s:%s", db->user,
               (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -369,7 +369,7 @@ static int cx_handle_all_value_xpaths(xmlXPathContextPtr xpath_ctx, /* {{{ */
     status = cx_handle_single_value_xpath(xpath_ctx, xpath, ds, vl, i);
     if (status != 0)
       return -1; /* An error has been printed. */
-  }                /* for (i = 0; i < xpath->values_len; i++) */
+  }              /* for (i = 0; i < xpath->values_len; i++) */
 
   plugin_dispatch_values(vl);
   vl->values = NULL;
@@ -442,7 +442,7 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
     if (instance_node != NULL) {
       char *node_value = (char *)xmlNodeGetContent(instance_node->nodeTab[0]);
       snprintf(vl->type_instance, sizeof(vl->type_instance), "%s%s",
-                xpath->instance_prefix, node_value);
+               xpath->instance_prefix, node_value);
       sfree(node_value);
     } else
       sstrncpy(vl->type_instance, xpath->instance_prefix,
@@ -840,7 +840,7 @@ static int cx_init_curl(cx_t *db) /* {{{ */
     }
 
     snprintf(db->credentials, credentials_size, "%s:%s", db->user,
-              (db->pass == NULL) ? "" : db->pass);
+             (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif
 

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -180,8 +180,8 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
     snprintf(buf, buflen, "Error #%i; "
-                           "Additionally, strerror_r failed.",
-              errnum);
+                          "Additionally, strerror_r failed.",
+             errnum);
   }
 #endif /* STRERROR_R_CHAR_P */
 

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -84,18 +84,6 @@ char *sstrncpy(char *dest, const char *src, size_t n) {
   return dest;
 } /* char *sstrncpy */
 
-int ssnprintf(char *dest, size_t n, const char *format, ...) {
-  int ret = 0;
-  va_list ap;
-
-  va_start(ap, format);
-  ret = vsnprintf(dest, n, format, ap);
-  dest[n - 1] = '\0';
-  va_end(ap);
-
-  return ret;
-} /* int ssnprintf */
-
 char *ssnprintf_alloc(char const *format, ...) /* {{{ */
 {
   char static_buffer[1024] = "";
@@ -191,7 +179,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
-    ssnprintf(buf, buflen, "Error #%i; "
+    snprintf(buf, buflen, "Error #%i; "
                            "Additionally, strerror_r failed.",
               errnum);
   }
@@ -675,7 +663,7 @@ int get_kstat(kstat_t **ksp_ptr, char *module, int instance, char *name) {
   if (kc == NULL)
     return -1;
 
-  ssnprintf(ident, sizeof(ident), "%s,%i,%s", module, instance, name);
+  snprintf(ident, sizeof(ident), "%s,%i,%s", module, instance, name);
 
   *ksp_ptr = kstat_lookup(kc, module, instance, name);
   if (*ksp_ptr == NULL) {
@@ -882,7 +870,7 @@ int format_values(char *ret, size_t ret_len, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
+    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);            \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -66,9 +66,6 @@ typedef struct value_to_rate_state_s value_to_rate_state_t;
 
 char *sstrncpy(char *dest, const char *src, size_t n);
 
-__attribute__((format(printf, 3, 4))) int ssnprintf(char *dest, size_t n,
-                                                    const char *format, ...);
-
 __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
                                                             ...);
 

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -58,27 +58,6 @@ DEF_TEST(sstrncpy) {
   return 0;
 }
 
-DEF_TEST(ssnprintf) {
-  char buffer[16] = "";
-  char *ptr = &buffer[4];
-  int status;
-
-  buffer[0] = buffer[1] = buffer[2] = buffer[3] = 0xff;
-  buffer[12] = buffer[13] = buffer[14] = buffer[15] = 0xff;
-
-  status = ssnprintf(ptr, 8, "%i", 1337);
-  OK(status == 4);
-  EXPECT_EQ_STR("1337", ptr);
-
-  status = ssnprintf(ptr, 8, "%s", "collectd");
-  OK(status == 8);
-  OK(ptr[7] == 0);
-  EXPECT_EQ_STR("collect", ptr);
-  OK(buffer[3] == buffer[12]);
-
-  return 0;
-}
-
 DEF_TEST(sstrdup) {
   char *ptr;
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -307,11 +307,11 @@ static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
       status =
           snprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
     else if (ci->values[i].type == OCONFIG_TYPE_NUMBER)
-      status = snprintf(buffer_ptr, buffer_free, " %lf",
-                         ci->values[i].value.number);
+      status =
+          snprintf(buffer_ptr, buffer_free, " %lf", ci->values[i].value.number);
     else if (ci->values[i].type == OCONFIG_TYPE_BOOLEAN)
       status = snprintf(buffer_ptr, buffer_free, " %s",
-                         ci->values[i].value.boolean ? "true" : "false");
+                        ci->values[i].value.boolean ? "true" : "false");
 
     if ((status < 0) || (status >= buffer_free))
       return -1;

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -196,7 +196,7 @@ static int dispatch_global_option(const oconfig_item_t *ci) {
     return global_option_set(ci->key, ci->values[0].value.string, 0);
   else if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     char tmp[128];
-    ssnprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
+    snprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
     return global_option_set(ci->key, tmp, 0);
   } else if (ci->values[0].type == OCONFIG_TYPE_BOOLEAN) {
     if (ci->values[0].value.boolean)
@@ -305,12 +305,12 @@ static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
 
     if (ci->values[i].type == OCONFIG_TYPE_STRING)
       status =
-          ssnprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
+          snprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
     else if (ci->values[i].type == OCONFIG_TYPE_NUMBER)
-      status = ssnprintf(buffer_ptr, buffer_free, " %lf",
+      status = snprintf(buffer_ptr, buffer_free, " %lf",
                          ci->values[i].value.number);
     else if (ci->values[i].type == OCONFIG_TYPE_BOOLEAN)
-      status = ssnprintf(buffer_ptr, buffer_free, " %s",
+      status = snprintf(buffer_ptr, buffer_free, " %s",
                          ci->values[i].value.boolean ? "true" : "false");
 
     if ((status < 0) || (status >= buffer_free))
@@ -653,7 +653,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
     if ((de->d_name[0] == '.') || (de->d_name[0] == 0))
       continue;
 
-    status = ssnprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
+    status = snprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
     if ((status < 0) || ((size_t)status >= sizeof(name))) {
       ERROR("configfile: Not including `%s/%s' because its"
             " name is too long.",
@@ -1246,7 +1246,7 @@ int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
     ERROR("cf_util_get_service: Out of memory.");
     return -1;
   }
-  ssnprintf(service, 6, "%i", port);
+  snprintf(service, 6, "%i", port);
 
   sfree(*ret_string);
   *ret_string = service;

--- a/src/daemon/filter_chain.c
+++ b/src/daemon/filter_chain.c
@@ -343,7 +343,7 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
 
   if (ci->values_num == 1) {
     sstrncpy(rule->name, ci->values[0].value.string, sizeof(rule->name));
-    ssnprintf(rule_name, sizeof(rule_name), "Rule \"%s\"",
+    snprintf(rule_name, sizeof(rule_name), "Rule \"%s\"",
               ci->values[0].value.string);
   }
 

--- a/src/daemon/filter_chain.c
+++ b/src/daemon/filter_chain.c
@@ -344,7 +344,7 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
   if (ci->values_num == 1) {
     sstrncpy(rule->name, ci->values[0].value.string, sizeof(rule->name));
     snprintf(rule_name, sizeof(rule_name), "Rule \"%s\"",
-              ci->values[0].value.string);
+             ci->values[0].value.string);
   }
 
   for (int i = 0; i < ci->children_num; i++) {

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -713,15 +713,15 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
     actual = e->value.mv_string;
     break;
   case MD_TYPE_SIGNED_INT:
-    ssnprintf(buffer, sizeof(buffer), "%" PRIi64, e->value.mv_signed_int);
+    snprintf(buffer, sizeof(buffer), "%" PRIi64, e->value.mv_signed_int);
     actual = buffer;
     break;
   case MD_TYPE_UNSIGNED_INT:
-    ssnprintf(buffer, sizeof(buffer), "%" PRIu64, e->value.mv_unsigned_int);
+    snprintf(buffer, sizeof(buffer), "%" PRIu64, e->value.mv_unsigned_int);
     actual = buffer;
     break;
   case MD_TYPE_DOUBLE:
-    ssnprintf(buffer, sizeof(buffer), GAUGE_FORMAT, e->value.mv_double);
+    snprintf(buffer, sizeof(buffer), GAUGE_FORMAT, e->value.mv_double);
     actual = buffer;
     break;
   case MD_TYPE_BOOLEAN:

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -400,7 +400,7 @@ static int plugin_load_file(const char *file, _Bool global) {
   if (dlh == NULL) {
     char errbuf[1024] = "";
 
-    ssnprintf(errbuf, sizeof(errbuf),
+    snprintf(errbuf, sizeof(errbuf),
               "dlopen (\"%s\") failed: %s. "
               "The most common cause for this problem is "
               "missing dependencies. Use ldd(1) to check "
@@ -640,7 +640,7 @@ static void start_read_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    ssnprintf(name, sizeof(name), "reader#%zu", read_threads_num);
+    snprintf(name, sizeof(name), "reader#%zu", read_threads_num);
     set_thread_name(read_threads[read_threads_num], name);
 
     read_threads_num++;
@@ -847,7 +847,7 @@ static void start_write_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    ssnprintf(name, sizeof(name), "writer#%zu", write_threads_num);
+    snprintf(name, sizeof(name), "writer#%zu", write_threads_num);
     set_thread_name(write_threads[write_threads_num], name);
 
     write_threads_num++;
@@ -996,7 +996,7 @@ int plugin_load(char const *plugin_name, _Bool global) {
 
   /* `cpu' should not match `cpufreq'. To solve this we add `.so' to the
    * type when matching the filename */
-  status = ssnprintf(typename, sizeof(typename), "%s.so", plugin_name);
+  status = snprintf(typename, sizeof(typename), "%s.so", plugin_name);
   if ((status < 0) || ((size_t)status >= sizeof(typename))) {
     WARNING("plugin_load: Filename too long: \"%s.so\"", plugin_name);
     return -1;
@@ -1013,7 +1013,7 @@ int plugin_load(char const *plugin_name, _Bool global) {
     if (strcasecmp(de->d_name, typename))
       continue;
 
-    status = ssnprintf(filename, sizeof(filename), "%s/%s", dir, de->d_name);
+    status = snprintf(filename, sizeof(filename), "%s/%s", dir, de->d_name);
     if ((status < 0) || ((size_t)status >= sizeof(filename))) {
       WARNING("plugin_load: Filename too long: \"%s/%s\"", dir, de->d_name);
       continue;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -401,12 +401,12 @@ static int plugin_load_file(const char *file, _Bool global) {
     char errbuf[1024] = "";
 
     snprintf(errbuf, sizeof(errbuf),
-              "dlopen (\"%s\") failed: %s. "
-              "The most common cause for this problem is "
-              "missing dependencies. Use ldd(1) to check "
-              "the dependencies of the plugin "
-              "/ shared object.",
-              file, dlerror());
+             "dlopen (\"%s\") failed: %s. "
+             "The most common cause for this problem is "
+             "missing dependencies. Use ldd(1) to check "
+             "the dependencies of the plugin "
+             "/ shared object.",
+             file, dlerror());
 
     ERROR("%s", errbuf);
     /* Make sure this is printed to STDERR in any case, but also

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -164,7 +164,7 @@ int format_rfc3339(char *buffer, size_t buffer_size, struct tm const *t_tm,
   size_left -= len;
 
   if (print_nano) {
-    if ((len = ssnprintf(pos, size_left, ".%09ld", nsec)) == 0)
+    if ((len = snprintf(pos, size_left, ".%09ld", nsec)) == 0)
       return ENOMEM;
     pos += len;
     size_left -= len;

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -107,9 +107,9 @@ static const char *cdbi_strerror(dbi_conn conn, /* {{{ */
   msg = NULL;
   status = dbi_conn_error(conn, &msg);
   if ((status >= 0) && (msg != NULL))
-    ssnprintf(buffer, buffer_size, "%s (status %i)", msg, status);
+    snprintf(buffer, buffer_size, "%s (status %i)", msg, status);
   else
-    ssnprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
+    snprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
               status);
 
   return buffer;
@@ -131,12 +131,12 @@ static int cdbi_result_get_field(dbi_result res, /* {{{ */
     long long value;
 
     value = dbi_result_get_longlong_idx(res, index);
-    ssnprintf(buffer, buffer_size, "%lli", value);
+    snprintf(buffer, buffer_size, "%lli", value);
   } else if (src_type == DBI_TYPE_DECIMAL) {
     double value;
 
     value = dbi_result_get_double_idx(res, index);
-    ssnprintf(buffer, buffer_size, "%63.15g", value);
+    snprintf(buffer, buffer_size, "%63.15g", value);
   } else if (src_type == DBI_TYPE_STRING) {
     const char *value;
 

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -110,7 +110,7 @@ static const char *cdbi_strerror(dbi_conn conn, /* {{{ */
     snprintf(buffer, buffer_size, "%s (status %i)", msg, status);
   else
     snprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
-              status);
+             status);
 
   return buffer;
 } /* }}} const char *cdbi_conn_error */

--- a/src/disk.c
+++ b/src/disk.c
@@ -490,11 +490,11 @@ static int disk_read(void) {
         sstrncpy(disk_name, props_disk_name_bsd, sizeof(disk_name));
       else {
         ERROR("disk plugin: can't find bsd disk name.");
-        ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major,
+        snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major,
                   disk_minor);
       }
     } else
-      ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+      snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
 
     DEBUG("disk plugin: disk_name = \"%s\"", disk_name);
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -405,8 +405,8 @@ static int disk_read(void) {
 
   /* Get the list of all disk objects. */
   if (IOServiceGetMatchingServices(
-                                   io_master_port, IOServiceMatching(kIOBlockStorageDriverClass),
-                                   &disk_list) != kIOReturnSuccess) {
+          io_master_port, IOServiceMatching(kIOBlockStorageDriverClass),
+          &disk_list) != kIOReturnSuccess) {
     ERROR("disk plugin: IOServiceGetMatchingServices failed.");
     return -1;
   }
@@ -490,8 +490,7 @@ static int disk_read(void) {
         sstrncpy(disk_name, props_disk_name_bsd, sizeof(disk_name));
       else {
         ERROR("disk plugin: can't find bsd disk name.");
-        snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major,
-                  disk_minor);
+        snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
       }
     } else
       snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -232,7 +232,7 @@ static int dpdk_events_link_status_config(dpdk_events_ctx_t *ec,
       while (!(ec->config.link_status.enabled_port_mask & (1 << port_num)))
         port_num++;
       snprintf(ec->config.link_status.port_name[port_num], DATA_MAX_NAME_LEN,
-                "%s", child->values[0].value.string);
+               "%s", child->values[0].value.string);
       DEBUG(DPDK_EVENTS_PLUGIN ": LinkStatus:Port %d Name: %s", port_num,
             ec->config.link_status.port_name[port_num]);
       port_num++;
@@ -257,7 +257,7 @@ static int dpdk_events_keep_alive_config(dpdk_events_ctx_t *ec,
     } else if (strcasecmp("LCoreMask", child->key) == 0) {
       char lcore_mask[DATA_MAX_NAME_LEN];
       snprintf(lcore_mask, sizeof(lcore_mask), "%s",
-                child->values[0].value.string);
+               child->values[0].value.string);
       ec->config.keep_alive.lcore_mask =
           str_to_uint128(lcore_mask, strlen(lcore_mask));
       DEBUG(DPDK_EVENTS_PLUGIN ": KeepAlive:LCoreMask 0x%" PRIX64 "%" PRIX64 "",
@@ -265,8 +265,8 @@ static int dpdk_events_keep_alive_config(dpdk_events_ctx_t *ec,
             ec->config.keep_alive.lcore_mask.low);
     } else if (strcasecmp("KeepAliveShmName", child->key) == 0) {
       snprintf(ec->config.keep_alive.shm_name,
-                sizeof(ec->config.keep_alive.shm_name), "%s",
-                child->values[0].value.string);
+               sizeof(ec->config.keep_alive.shm_name), "%s",
+               child->values[0].value.string);
       DEBUG(DPDK_EVENTS_PLUGIN ": KeepAlive:KeepAliveShmName %s",
             ec->config.keep_alive.shm_name);
     } else if (strcasecmp("SendNotification", child->key) == 0) {
@@ -406,7 +406,7 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
         char dev_name[DATA_MAX_NAME_LEN];
         if (ec->config.link_status.port_name[i][0] != 0) {
           snprintf(dev_name, sizeof(dev_name), "%s",
-                    ec->config.link_status.port_name[i]);
+                   ec->config.link_status.port_name[i]);
         } else {
           snprintf(dev_name, sizeof(dev_name), "port.%d", i);
         }
@@ -415,7 +415,7 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
           int sev = ec->link_info[i].link_status ? NOTIF_OKAY : NOTIF_WARNING;
           char msg[DATA_MAX_NAME_LEN];
           snprintf(msg, sizeof(msg), "Link Status: %s",
-                    ec->link_info[i].link_status ? "UP" : "DOWN");
+                   ec->link_info[i].link_status ? "UP" : "DOWN");
           dpdk_events_notification_dispatch(sev, dev_name,
                                             ec->link_info[i].read_time, msg);
         } else {

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -231,7 +231,7 @@ static int dpdk_events_link_status_config(dpdk_events_ctx_t *ec,
     if (strcasecmp("PortName", child->key) == 0) {
       while (!(ec->config.link_status.enabled_port_mask & (1 << port_num)))
         port_num++;
-      ssnprintf(ec->config.link_status.port_name[port_num], DATA_MAX_NAME_LEN,
+      snprintf(ec->config.link_status.port_name[port_num], DATA_MAX_NAME_LEN,
                 "%s", child->values[0].value.string);
       DEBUG(DPDK_EVENTS_PLUGIN ": LinkStatus:Port %d Name: %s", port_num,
             ec->config.link_status.port_name[port_num]);
@@ -256,7 +256,7 @@ static int dpdk_events_keep_alive_config(dpdk_events_ctx_t *ec,
             (int)child->values[0].value.boolean);
     } else if (strcasecmp("LCoreMask", child->key) == 0) {
       char lcore_mask[DATA_MAX_NAME_LEN];
-      ssnprintf(lcore_mask, sizeof(lcore_mask), "%s",
+      snprintf(lcore_mask, sizeof(lcore_mask), "%s",
                 child->values[0].value.string);
       ec->config.keep_alive.lcore_mask =
           str_to_uint128(lcore_mask, strlen(lcore_mask));
@@ -264,7 +264,7 @@ static int dpdk_events_keep_alive_config(dpdk_events_ctx_t *ec,
             ec->config.keep_alive.lcore_mask.high,
             ec->config.keep_alive.lcore_mask.low);
     } else if (strcasecmp("KeepAliveShmName", child->key) == 0) {
-      ssnprintf(ec->config.keep_alive.shm_name,
+      snprintf(ec->config.keep_alive.shm_name,
                 sizeof(ec->config.keep_alive.shm_name), "%s",
                 child->values[0].value.string);
       DEBUG(DPDK_EVENTS_PLUGIN ": KeepAlive:KeepAliveShmName %s",
@@ -405,16 +405,16 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
 
         char dev_name[DATA_MAX_NAME_LEN];
         if (ec->config.link_status.port_name[i][0] != 0) {
-          ssnprintf(dev_name, sizeof(dev_name), "%s",
+          snprintf(dev_name, sizeof(dev_name), "%s",
                     ec->config.link_status.port_name[i]);
         } else {
-          ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
+          snprintf(dev_name, sizeof(dev_name), "port.%d", i);
         }
 
         if (ec->config.link_status.notify) {
           int sev = ec->link_info[i].link_status ? NOTIF_OKAY : NOTIF_WARNING;
           char msg[DATA_MAX_NAME_LEN];
-          ssnprintf(msg, sizeof(msg), "Link Status: %s",
+          snprintf(msg, sizeof(msg), "Link Status: %s",
                     ec->link_info[i].link_status ? "UP" : "DOWN");
           dpdk_events_notification_dispatch(sev, dev_name,
                                             ec->link_info[i].read_time, msg);
@@ -451,7 +451,7 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
     }
 
     char core_name[DATA_MAX_NAME_LEN];
-    ssnprintf(core_name, sizeof(core_name), "lcore%u", i);
+    snprintf(core_name, sizeof(core_name), "lcore%u", i);
 
     if (!ec->config.keep_alive.send_updated ||
         (ec->core_info[i].lcore_state !=
@@ -466,34 +466,34 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
         switch (ec->config.keep_alive.shm->core_state[i]) {
         case RTE_KA_STATE_ALIVE:
           sev = NOTIF_OKAY;
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
           break;
         case RTE_KA_STATE_MISSING:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
           sev = NOTIF_WARNING;
           break;
         case RTE_KA_STATE_DEAD:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_UNUSED:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_GONE:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_DOZING:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_SLEEP:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
           sev = NOTIF_OKAY;
           break;
         default:
-          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
+          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
           sev = NOTIF_FAILURE;
         }
 

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -376,9 +376,9 @@ static int dpdk_stats_counters_dispatch(dpdk_helper_ctx_t *phc) {
 
     char dev_name[64];
     if (ctx->config.port_name[i][0] != 0) {
-      ssnprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
+      snprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
     } else {
-      ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
+      snprintf(dev_name, sizeof(dev_name), "port.%d", i);
     }
 
     DEBUG(" === Dispatch stats for port %d (name=%s; stats_count=%d)", i,

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -77,7 +77,7 @@ static int drbd_submit_fields(long int resource, char **fields,
     return EINVAL;
   }
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "r%ld", resource);
+  snprintf(plugin_instance, sizeof(plugin_instance), "r%ld", resource);
 
   for (size_t i = 0; i < drbd_names_num; i++) {
     char *data;

--- a/src/exec.c
+++ b/src/exec.c
@@ -187,7 +187,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
       pl->argv[i] = strdup(ci->values[i + 1].value.string);
     } else {
       if (ci->values[i + 1].type == OCONFIG_TYPE_NUMBER) {
-        ssnprintf(buffer, sizeof(buffer), "%lf",
+        snprintf(buffer, sizeof(buffer), "%lf",
                   ci->values[i + 1].value.number);
       } else {
         if (ci->values[i + 1].value.boolean)
@@ -246,18 +246,18 @@ static void set_environment(void) /* {{{ */
   char buffer[1024];
 
 #ifdef HAVE_SETENV
-  ssnprintf(buffer, sizeof(buffer), "%.3f",
+  snprintf(buffer, sizeof(buffer), "%.3f",
             CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   setenv("COLLECTD_INTERVAL", buffer, /* overwrite = */ 1);
 
   sstrncpy(buffer, hostname_g, sizeof(buffer));
   setenv("COLLECTD_HOSTNAME", buffer, /* overwrite = */ 1);
 #else
-  ssnprintf(buffer, sizeof(buffer), "COLLECTD_INTERVAL=%.3f",
+  snprintf(buffer, sizeof(buffer), "COLLECTD_INTERVAL=%.3f",
             CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   putenv(buffer);
 
-  ssnprintf(buffer, sizeof(buffer), "COLLECTD_HOSTNAME=%s", hostname_g);
+  snprintf(buffer, sizeof(buffer), "COLLECTD_HOSTNAME=%s", hostname_g);
   putenv(buffer);
 #endif
 } /* }}} void set_environment */

--- a/src/exec.c
+++ b/src/exec.c
@@ -187,8 +187,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
       pl->argv[i] = strdup(ci->values[i + 1].value.string);
     } else {
       if (ci->values[i + 1].type == OCONFIG_TYPE_NUMBER) {
-        snprintf(buffer, sizeof(buffer), "%lf",
-                  ci->values[i + 1].value.number);
+        snprintf(buffer, sizeof(buffer), "%lf", ci->values[i + 1].value.number);
       } else {
         if (ci->values[i + 1].value.boolean)
           sstrncpy(buffer, "true", sizeof(buffer));
@@ -247,14 +246,14 @@ static void set_environment(void) /* {{{ */
 
 #ifdef HAVE_SETENV
   snprintf(buffer, sizeof(buffer), "%.3f",
-            CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+           CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   setenv("COLLECTD_INTERVAL", buffer, /* overwrite = */ 1);
 
   sstrncpy(buffer, hostname_g, sizeof(buffer));
   setenv("COLLECTD_HOSTNAME", buffer, /* overwrite = */ 1);
 #else
   snprintf(buffer, sizeof(buffer), "COLLECTD_INTERVAL=%.3f",
-            CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+           CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   putenv(buffer);
 
   snprintf(buffer, sizeof(buffer), "COLLECTD_HOSTNAME=%s", hostname_g);

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -419,7 +419,7 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
   if (dir == NULL)
     return -1;
 
-  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
+  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -417,7 +417,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   if (staging_tree == NULL)
     return NULL;
 
-  ssnprintf(key, sizeof(key), "%s/%s/%s", host, type,
+  snprintf(key, sizeof(key), "%s/%s/%s", host, type,
             (type_instance != NULL) ? type_instance : "");
 
   se = NULL;

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -418,7 +418,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
     return NULL;
 
   snprintf(key, sizeof(key), "%s/%s/%s", host, type,
-            (type_instance != NULL) ? type_instance : "");
+           (type_instance != NULL) ? type_instance : "");
 
   se = NULL;
   status = c_avl_get(staging_tree, key, (void *)&se);

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -214,7 +214,7 @@ static int hddtemp_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "Port") == 0) {
     int port = (int)(atof(value));
     if ((port > 0) && (port <= 65535))
-      ssnprintf(hddtemp_port, sizeof(hddtemp_port), "%i", port);
+      snprintf(hddtemp_port, sizeof(hddtemp_port), "%i", port);
     else
       sstrncpy(hddtemp_port, value, sizeof(hddtemp_port));
   } else {

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -88,10 +88,10 @@ static void submit_hp(const struct entry_info *info) {
   sstrncpy(vl.plugin, g_plugin_name, sizeof(vl.plugin));
   if (info->node) {
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",
-              info->node, info->page_size_kb);
+             info->node, info->page_size_kb);
   } else {
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%zuKb",
-              info->page_size_kb);
+             info->page_size_kb);
   }
 
   /* ensure all metrics have the same timestamp */

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -87,10 +87,10 @@ static void submit_hp(const struct entry_info *info) {
 
   sstrncpy(vl.plugin, g_plugin_name, sizeof(vl.plugin));
   if (info->node) {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",
               info->node, info->page_size_kb);
   } else {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%zuKb",
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%zuKb",
               info->page_size_kb);
   }
 
@@ -125,7 +125,7 @@ static int read_hugepage_entry(const char *path, const char *entry,
   struct entry_info *info = e_info;
   double value;
 
-  ssnprintf(path2, sizeof(path2), "%s/%s", path, entry);
+  snprintf(path2, sizeof(path2), "%s/%s", path, entry);
 
   FILE *fh = fopen(path2, "rt");
   if (fh == NULL) {
@@ -193,7 +193,7 @@ static int read_syshugepages(const char *path, const char *node) {
     }
 
     /* /sys/devices/system/node/node?/hugepages/ */
-    ssnprintf(path2, sizeof(path2), "%s/%s", path, result->d_name);
+    snprintf(path2, sizeof(path2), "%s/%s", path, result->d_name);
 
     walk_directory(path2, read_hugepage_entry,
                    &(struct entry_info){
@@ -238,7 +238,7 @@ static int read_nodes(void) {
       continue;
     }
 
-    ssnprintf(path, sizeof(path), sys_node_hugepages, result->d_name);
+    snprintf(path, sizeof(path), sys_node_hugepages, result->d_name);
     read_syshugepages(path, result->d_name);
     errno = 0;
   }

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -375,7 +375,7 @@ static int rdt_default_cgroups(void) {
     char desc[DATA_MAX_NAME_LEN];
     uint64_t core = i;
 
-    ssnprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
+    snprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
 
     /* set core group info */
     ret = cgroup_set(&g_rdt->cgroups[i], desc, &core, 1);

--- a/src/interface.c
+++ b/src/interface.c
@@ -296,7 +296,7 @@ static int interface_read(void) {
       continue;
 
     if (unique_name)
-      ssnprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
+      snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
                 ksp[i]->ks_instance, ksp[i]->ks_name);
     else
       sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));

--- a/src/interface.c
+++ b/src/interface.c
@@ -297,7 +297,7 @@ static int interface_read(void) {
 
     if (unique_name)
       snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
-                ksp[i]->ks_instance, ksp[i]->ks_name);
+               ksp[i]->ks_instance, ksp[i]->ks_name);
     else
       sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));
 

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -83,7 +83,7 @@ static void c_ipmi_error(const char *func, int status) {
   }
 
   if (errbuf[0] == 0) {
-    ssnprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
+    snprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
   }
   errbuf[sizeof(errbuf) - 1] = 0;
 
@@ -123,7 +123,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
           sstrncpy(n.type_instance, list_item->sensor_name,
                    sizeof(n.type_instance));
           sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-          ssnprintf(n.message, sizeof(n.message), "sensor %s not present",
+          snprintf(n.message, sizeof(n.message), "sensor %s not present",
                     list_item->sensor_name);
 
           plugin_dispatch_notification(&n);
@@ -172,7 +172,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
       sstrncpy(n.type_instance, list_item->sensor_name,
                sizeof(n.type_instance));
       sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-      ssnprintf(n.message, sizeof(n.message), "sensor %s present",
+      snprintf(n.message, sizeof(n.message), "sensor %s present",
                 list_item->sensor_name);
 
       plugin_dispatch_notification(&n);
@@ -223,7 +223,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
   if (entity_id_string == NULL)
     sstrncpy(sensor_name, buffer, sizeof(sensor_name));
   else
-    ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", buffer,
+    snprintf(sensor_name, sizeof(sensor_name), "%s %s", buffer,
               entity_id_string);
 
   sstrncpy(buffer, sensor_name, sizeof(buffer));
@@ -244,7 +244,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     sensor_id_ptr = strstr(buffer, "(");
     if (sensor_id_ptr != NULL) {
       /* `sensor_id_ptr' now points to "(123)". */
-      ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
+      snprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
                 sensor_id_ptr);
     }
     /* else: don't touch sensor_name. */
@@ -327,7 +327,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     sstrncpy(n.host, hostname_g, sizeof(n.host));
     sstrncpy(n.type_instance, list_item->sensor_name, sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    ssnprintf(n.message, sizeof(n.message), "sensor %s added",
+    snprintf(n.message, sizeof(n.message), "sensor %s added",
               list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
@@ -375,7 +375,7 @@ static int sensor_list_remove(ipmi_sensor_t *sensor) {
     sstrncpy(n.host, hostname_g, sizeof(n.host));
     sstrncpy(n.type_instance, list_item->sensor_name, sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    ssnprintf(n.message, sizeof(n.message), "sensor %s removed",
+    snprintf(n.message, sizeof(n.message), "sensor %s removed",
               list_item->sensor_name);
 
     plugin_dispatch_notification(&n);

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -124,7 +124,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
                    sizeof(n.type_instance));
           sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
           snprintf(n.message, sizeof(n.message), "sensor %s not present",
-                    list_item->sensor_name);
+                   list_item->sensor_name);
 
           plugin_dispatch_notification(&n);
         }
@@ -173,7 +173,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
                sizeof(n.type_instance));
       sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
       snprintf(n.message, sizeof(n.message), "sensor %s present",
-                list_item->sensor_name);
+               list_item->sensor_name);
 
       plugin_dispatch_notification(&n);
     }
@@ -224,7 +224,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     sstrncpy(sensor_name, buffer, sizeof(sensor_name));
   else
     snprintf(sensor_name, sizeof(sensor_name), "%s %s", buffer,
-              entity_id_string);
+             entity_id_string);
 
   sstrncpy(buffer, sensor_name, sizeof(buffer));
   sensor_name_ptr = strstr(buffer, ").");
@@ -245,7 +245,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     if (sensor_id_ptr != NULL) {
       /* `sensor_id_ptr' now points to "(123)". */
       snprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
-                sensor_id_ptr);
+               sensor_id_ptr);
     }
     /* else: don't touch sensor_name. */
   }
@@ -328,7 +328,7 @@ static int sensor_list_add(ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->sensor_name, sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
     snprintf(n.message, sizeof(n.message), "sensor %s added",
-              list_item->sensor_name);
+             list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }
@@ -376,7 +376,7 @@ static int sensor_list_remove(ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->sensor_name, sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
     snprintf(n.message, sizeof(n.message), "sensor %s removed",
-              list_item->sensor_name);
+             list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -101,7 +101,7 @@ static int iptables_config(const char *key, const char *value) {
     return 1;
 
   ip_chain_t temp = {0};
-  ip_chain_t * final, **list;
+  ip_chain_t *final, **list;
   char *table;
   int table_len;
   char *chain;
@@ -189,7 +189,7 @@ static int iptables_config(const char *key, const char *value) {
   }
 
   chain_list = list;
-  final = malloc(sizeof(* final));
+  final = malloc(sizeof(*final));
   if (final == NULL) {
     char errbuf[1024];
     ERROR("malloc failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
@@ -227,7 +227,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
 
   status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                     chain->table, chain->chain);
+                    chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -236,7 +236,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   } else {
     if (chain->rule_type == RTYPE_NUM)
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-                chain->rule.num);
+               chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }
@@ -275,7 +275,7 @@ static int submit_match(const struct ipt_entry_match *match,
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
 
   status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                     chain->table, chain->chain);
+                    chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -284,7 +284,7 @@ static int submit_match(const struct ipt_entry_match *match,
   } else {
     if (chain->rule_type == RTYPE_NUM)
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-                chain->rule.num);
+               chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -226,7 +226,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
 
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
 
-  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                      chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
@@ -235,7 +235,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
                 chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
@@ -274,7 +274,7 @@ static int submit_match(const struct ipt_entry_match *match,
 
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
 
-  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                      chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
@@ -283,7 +283,7 @@ static int submit_match(const struct ipt_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
                 chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -173,7 +173,7 @@ static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
 
   int len =
       snprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
-                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
+               (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
 
   if ((len < 0) || (size <= ((size_t)len))) {
     log_err("plugin instance truncated: %s", pi);

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -172,7 +172,7 @@ static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
   struct in_addr addr = {.s_addr = se->addr};
 
   int len =
-      ssnprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
+      snprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
                 (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
 
   if ((len < 0) || (size <= ((size_t)len))) {
@@ -189,7 +189,7 @@ static int get_ti(struct ip_vs_dest_entry *de, char *ti, size_t size) {
 
   struct in_addr addr = {.s_addr = de->addr};
 
-  int len = ssnprintf(ti, size, "%s_%u", inet_ntoa(addr), ntohs(de->port));
+  int len = snprintf(ti, size, "%s_%u", inet_ntoa(addr), ntohs(de->port));
 
   if ((len < 0) || (size <= ((size_t)len))) {
     log_err("type instance truncated: %s", ti);

--- a/src/java.c
+++ b/src/java.c
@@ -1213,9 +1213,9 @@ static int jtoc_notification(JNIEnv *jvm_env, notification_t *n, /* {{{ */
 
   return 0;
 } /* }}} int jtoc_notification */
-  /*
-   * Functions accessible from Java
-   */
+/*
+ * Functions accessible from Java
+ */
 static jint JNICALL cjni_api_dispatch_values(JNIEnv *jvm_env, /* {{{ */
                                              jobject this, jobject java_vl) {
   value_list_t vl = VALUE_LIST_INIT;

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -92,7 +92,6 @@
 #define LCC_SET_ERRSTR(c, ...)                                                 \
   do {                                                                         \
     snprintf((c)->errbuf, sizeof((c)->errbuf), __VA_ARGS__);                   \
-    (c)->errbuf[sizeof((c)->errbuf) - 1] = 0;                                  \
   } while (0)
 
 /*

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -99,7 +99,7 @@
  */
 struct lcc_connection_s {
   FILE *fh;
-  char errbuf[1024];
+  char errbuf[2048];
 };
 
 struct lcc_response_s {

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -177,7 +177,7 @@ static int logfile_notification(const notification_t *n,
 
 #define APPEND(bufptr, buflen, key, value)                                     \
   if ((buflen > 0) && (strlen(value) > 0)) {                                   \
-    status = snprintf(bufptr, buflen, ", %s = %s", key, value);               \
+    status = snprintf(bufptr, buflen, ", %s = %s", key, value);                \
     if (status > 0) {                                                          \
       bufptr += status;                                                        \
       buflen -= status;                                                        \

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -163,7 +163,7 @@ static int logfile_notification(const notification_t *n,
   int buf_len = sizeof(buf);
   int status;
 
-  status = ssnprintf(
+  status = snprintf(
       buf_ptr, buf_len, "Notification: severity = %s",
       (n->severity == NOTIF_FAILURE)
           ? "FAILURE"
@@ -177,7 +177,7 @@ static int logfile_notification(const notification_t *n,
 
 #define APPEND(bufptr, buflen, key, value)                                     \
   if ((buflen > 0) && (strlen(value) > 0)) {                                   \
-    status = ssnprintf(bufptr, buflen, ", %s = %s", key, value);               \
+    status = snprintf(bufptr, buflen, ", %s = %s", key, value);               \
     if (status > 0) {                                                          \
       bufptr += status;                                                        \
       buflen -= status;                                                        \

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -226,10 +226,10 @@ static int lpar_read(void) {
     if (pool_busy_cpus < 0.0)
       pool_busy_cpus = 0.0;
 
-    ssnprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
+    snprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
     lpar_submit(typinst, pool_busy_cpus);
 
-    ssnprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
+    snprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
     lpar_submit(typinst, pool_idle_cpus);
   }
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -306,9 +306,10 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
   int status = plugin_register_complex_read(/* group = */ "lua",
                                             /* name      = */ function_name,
                                             /* callback  = */ clua_read,
-                                            /* interval  = */ 0, &(user_data_t){
-                                                                     .data = cb,
-                                                                 });
+                                            /* interval  = */ 0,
+                                            &(user_data_t){
+                                                .data = cb,
+                                            });
 
   if (status != 0)
     return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -346,11 +347,11 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
   cb->lua_function_name = strdup(function_name);
   pthread_mutex_init(&cb->lock, NULL);
 
-  int status =
-      plugin_register_write(/* name = */ function_name,
-                            /* callback  = */ clua_write, &(user_data_t){
-                                                              .data = cb,
-                                                          });
+  int status = plugin_register_write(/* name = */ function_name,
+                                     /* callback  = */ clua_write,
+                                     &(user_data_t){
+                                         .data = cb,
+                                     });
 
   if (status != 0)
     return luaL_error(L, "%s", "plugin_register_write failed");

--- a/src/lua.c
+++ b/src/lua.c
@@ -282,7 +282,7 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
   luaL_checktype(L, 1, LUA_TFUNCTION);
 
   char function_name[DATA_MAX_NAME_LEN];
-  ssnprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
+  snprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
 
   int callback_id = clua_store_callback(L, 1);
   if (callback_id < 0)
@@ -325,7 +325,7 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
   luaL_checktype(L, 1, LUA_TFUNCTION);
 
   char function_name[DATA_MAX_NAME_LEN] = "";
-  ssnprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
+  snprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
 
   int callback_id = clua_store_callback(L, 1);
   if (callback_id < 0)
@@ -533,7 +533,7 @@ static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
   if (base_path[0] == '\0')
     sstrncpy(abs_path, rel_path, sizeof(abs_path));
   else
-    ssnprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
+    snprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
 
   DEBUG("Lua plugin: abs_path = \"%s\";", abs_path);
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -77,7 +77,7 @@ static void report_lv_utilization(lv_t lv, char const *vg_name,
     return;
   used_bytes = lv_size * (used_percent_unscaled * PERCENT_SCALE_FACTOR);
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name,
+  snprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name,
             lv_name);
   lvm_submit(plugin_instance, "used", used_bytes);
   lvm_submit(plugin_instance, "free", lv_size - used_bytes);

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -77,8 +77,7 @@ static void report_lv_utilization(lv_t lv, char const *vg_name,
     return;
   used_bytes = lv_size * (used_percent_unscaled * PERCENT_SCALE_FACTOR);
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name,
-            lv_name);
+  snprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name, lv_name);
   lvm_submit(plugin_instance, "used", used_bytes);
   lvm_submit(plugin_instance, "free", lv_size - used_bytes);
 }

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -561,7 +561,7 @@ static void submit_antx(const char *dev, const char *name, u_int32_t *vals,
 static inline void macaddr_to_str(char *buf, size_t bufsize,
                                   const uint8_t mac[IEEE80211_ADDR_LEN]) {
   snprintf(buf, bufsize, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
-            mac[2], mac[3], mac[4], mac[5]);
+           mac[2], mac[3], mac[4], mac[5]);
 }
 
 static void process_stat_struct(int which, const void *ptr, const char *dev,

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -519,7 +519,7 @@ static void submit(const char *dev, const char *type, const char *ti1,
   sstrncpy(vl.type, type, sizeof(vl.type));
 
   if ((ti1 != NULL) && (ti2 != NULL))
-    ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s", ti1, ti2);
+    snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s", ti1, ti2);
   else if ((ti1 != NULL) && (ti2 == NULL))
     sstrncpy(vl.type_instance, ti1, sizeof(vl.type_instance));
 
@@ -553,14 +553,14 @@ static void submit_antx(const char *dev, const char *name, u_int32_t *vals,
     if (vals[i] == 0)
       continue;
 
-    ssnprintf(ti2, sizeof(ti2), "%i", i);
+    snprintf(ti2, sizeof(ti2), "%i", i);
     submit_derive(dev, "ath_stat", name, ti2, (derive_t)vals[i]);
   }
 }
 
 static inline void macaddr_to_str(char *buf, size_t bufsize,
                                   const uint8_t mac[IEEE80211_ADDR_LEN]) {
-  ssnprintf(buf, bufsize, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
+  snprintf(buf, bufsize, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
             mac[2], mac[3], mac[4], mac[5]);
 }
 
@@ -753,7 +753,7 @@ static int check_devname(const char *dev) {
   if (dev[0] == '.')
     return 0;
 
-  ssnprintf(buf, sizeof(buf), "/sys/class/net/%s/device/driver", dev);
+  snprintf(buf, sizeof(buf), "/sys/class/net/%s/device/driver", dev);
   buf[sizeof(buf) - 1] = '\0';
 
   i = readlink(buf, buf2, sizeof(buf2) - 1);

--- a/src/match_regex.c
+++ b/src/match_regex.c
@@ -224,7 +224,7 @@ static int mr_config_add_meta_regex(llist_t **meta, /* {{{ */
     llist_append(*meta, entry);
   }
 
-  ssnprintf(buffer, sizeof(buffer), "%s `%s'", ci->key, meta_key);
+  snprintf(buffer, sizeof(buffer), "%s `%s'", ci->key, meta_key);
   /* Can't pass &entry->value into mr_add_regex, so copy in/out. */
   re_head = entry->value;
   status = mr_add_regex(&re_head, ci->values[1].value.string, buffer);

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -291,14 +291,14 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
       .type_instance = "corrected_memory_errors"};
 
   if (mr->dimm_name[0] != '\0')
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s_%s",
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s_%s",
               mr->location, mr->dimm_name);
   else
     sstrncpy(vl.plugin_instance, mr->location, sizeof(vl.plugin_instance));
 
   plugin_dispatch_values(&vl);
 
-  ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+  snprintf(vl.type_instance, sizeof(vl.type_instance),
             "corrected_memory_errors_in_%s", mr->corrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->corrected_err_timed};
   plugin_dispatch_values(&vl);
@@ -308,7 +308,7 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_total};
   plugin_dispatch_values(&vl);
 
-  ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+  snprintf(vl.type_instance, sizeof(vl.type_instance),
             "uncorrected_memory_errors_in_%s",
             mr->uncorrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_timed};

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -292,14 +292,14 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
 
   if (mr->dimm_name[0] != '\0')
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s_%s",
-              mr->location, mr->dimm_name);
+             mr->location, mr->dimm_name);
   else
     sstrncpy(vl.plugin_instance, mr->location, sizeof(vl.plugin_instance));
 
   plugin_dispatch_values(&vl);
 
   snprintf(vl.type_instance, sizeof(vl.type_instance),
-            "corrected_memory_errors_in_%s", mr->corrected_err_timed_period);
+           "corrected_memory_errors_in_%s", mr->corrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->corrected_err_timed};
   plugin_dispatch_values(&vl);
 
@@ -309,8 +309,7 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
   plugin_dispatch_values(&vl);
 
   snprintf(vl.type_instance, sizeof(vl.type_instance),
-            "uncorrected_memory_errors_in_%s",
-            mr->uncorrected_err_timed_period);
+           "uncorrected_memory_errors_in_%s", mr->uncorrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_timed};
   plugin_dispatch_values(&vl);
 

--- a/src/md.c
+++ b/src/md.c
@@ -66,7 +66,7 @@ static void md_submit(const int minor, const char *type_instance,
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
   sstrncpy(vl.plugin, "md", sizeof(vl.plugin));
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", minor);
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", minor);
   sstrncpy(vl.type, "md_disks", sizeof(vl.type));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -180,7 +180,7 @@ static int md_read(void) {
      * major/minor, but that again can be tricky if the filesystem
      * with the device file is mounted using the "nodev" option.
      */
-    ssnprintf(path, sizeof(path), "%s/%s", DEV_DIR, name);
+    snprintf(path, sizeof(path), "%s/%s", DEV_DIR, name);
 
     md_process(minor, path);
   }

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -477,7 +477,7 @@ static int memcached_add_read_callback(memcached_t *st) {
   char callback_name[3 * DATA_MAX_NAME_LEN];
   int status;
 
-  ssnprintf(callback_name, sizeof(callback_name), "memcached/%s",
+  snprintf(callback_name, sizeof(callback_name), "memcached/%s",
             (st->name != NULL) ? st->name : "__legacy__");
 
   /* If no <Address> used then:

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -478,7 +478,7 @@ static int memcached_add_read_callback(memcached_t *st) {
   int status;
 
   snprintf(callback_name, sizeof(callback_name), "memcached/%s",
-            (st->name != NULL) ? st->name : "__legacy__");
+           (st->name != NULL) ? st->name : "__legacy__");
 
   /* If no <Address> used then:
    * - Connect to the destination specified by <Host>, if present.
@@ -520,9 +520,10 @@ static int memcached_add_read_callback(memcached_t *st) {
       /* group = */ "memcached",
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
-      /* interval  = */ 0, &(user_data_t){
-                               .data = st, .free_func = memcached_free,
-                           });
+      /* interval  = */ 0,
+      &(user_data_t){
+          .data = st, .free_func = memcached_free,
+      });
 
   return status;
 } /* int memcached_add_read_callback */

--- a/src/mic.c
+++ b/src/mic.c
@@ -132,7 +132,7 @@ static void mic_submit_memory_use(int micnumber, const char *type_instance,
   vl.values_len = 1;
 
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, "memory", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -165,7 +165,7 @@ static void mic_submit_temp(int micnumber, const char *type, gauge_t value) {
 
   strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, "temperature", sizeof(vl.type));
   strncpy(vl.type_instance, type, sizeof(vl.type_instance));
 
@@ -208,9 +208,9 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
   strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
   if (core < 0) /* global aggregation */
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   else /* per-core statistics */
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
               micnumber, core);
   strncpy(vl.type, "cpu", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
@@ -261,7 +261,7 @@ static void mic_submit_power(int micnumber, const char *type,
 
   strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, type, sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 

--- a/src/mic.c
+++ b/src/mic.c
@@ -211,7 +211,7 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   else /* per-core statistics */
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
-              micnumber, core);
+             micnumber, core);
   strncpy(vl.type, "cpu", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -248,7 +248,7 @@ static int mb_submit(mb_host_t *host, mb_slave_t *slave, /* {{{ */
     host->interval = plugin_get_interval();
 
   if (slave->instance[0] == 0)
-    ssnprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
+    snprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
 
   vl.values = &value;
   vl.values_len = 1;
@@ -934,7 +934,7 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char name[1024];
 
-    ssnprintf(name, sizeof(name), "modbus-%s", host->host);
+    snprintf(name, sizeof(name), "modbus-%s", host->host);
 
     plugin_register_complex_read(/* group = */ NULL, name,
                                  /* callback = */ mb_read,

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -475,8 +475,8 @@ static int format_topic(char *buf, size_t buf_len, data_set_t const *ds,
   if ((status < 0) || (((size_t)status) >= buf_len))
     return ENOMEM;
 
-  while((c = strchr(buf, '#')) || (c = strchr(buf, '+'))) {
-       *c = '_';
+  while ((c = strchr(buf, '#')) || (c = strchr(buf, '+'))) {
+    *c = '_';
   }
 
   return 0;
@@ -609,9 +609,10 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
   }
 
   snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
-  plugin_register_write(cb_name, mqtt_write, &(user_data_t){
-                                                 .data = conf,
-                                             });
+  plugin_register_write(cb_name, mqtt_write,
+                        &(user_data_t){
+                            .data = conf,
+                        });
   return 0;
 } /* mqtt_config_publisher */
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -471,7 +471,7 @@ static int format_topic(char *buf, size_t buf_len, data_set_t const *ds,
   if (status != 0)
     return status;
 
-  status = ssnprintf(buf, buf_len, "%s/%s", conf->topic_prefix, name);
+  status = snprintf(buf, buf_len, "%s/%s", conf->topic_prefix, name);
   if ((status < 0) || (((size_t)status) >= buf_len))
     return ENOMEM;
 
@@ -608,7 +608,7 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
       ERROR("mqtt plugin: Unknown config option: %s", child->key);
   }
 
-  ssnprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
+  snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
   plugin_register_write(cb_name, mqtt_write, &(user_data_t){
                                                  .data = conf,
                                              });

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -218,7 +218,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
           (db->database != NULL) ? db->database : "<default>");
 
     if (db->instance != NULL)
-      ssnprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
+      snprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
     else
       sstrncpy(cb_name, "mysql", sizeof(cb_name));
 
@@ -496,14 +496,14 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((io == NULL) || (strcasecmp(io, "yes") != 0)) &&
         (db->slave_io_running)) {
       n.severity = NOTIF_WARNING;
-      ssnprintf(n.message, sizeof(n.message),
+      snprintf(n.message, sizeof(n.message),
                 "slave I/O thread not started or not connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = 0;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                (!db->slave_io_running)) {
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message),
+      snprintf(n.message, sizeof(n.message),
                 "slave I/O thread started and connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = 1;
@@ -512,13 +512,13 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((sql == NULL) || (strcasecmp(sql, "yes") != 0)) &&
         (db->slave_sql_running)) {
       n.severity = NOTIF_WARNING;
-      ssnprintf(n.message, sizeof(n.message), "slave SQL thread not started");
+      snprintf(n.message, sizeof(n.message), "slave SQL thread not started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = 0;
     } else if (((sql != NULL) && (strcasecmp(sql, "yes") == 0)) &&
                (!db->slave_sql_running)) {
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message), "slave SQL thread started");
+      snprintf(n.message, sizeof(n.message), "slave SQL thread started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = 1;
     }

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -497,14 +497,14 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
         (db->slave_io_running)) {
       n.severity = NOTIF_WARNING;
       snprintf(n.message, sizeof(n.message),
-                "slave I/O thread not started or not connected to master");
+               "slave I/O thread not started or not connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = 0;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                (!db->slave_io_running)) {
       n.severity = NOTIF_OKAY;
       snprintf(n.message, sizeof(n.message),
-                "slave I/O thread started and connected to master");
+               "slave I/O thread started and connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = 1;
     }

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -654,9 +654,11 @@ static int submit_derive(const char *host, const char *plugin_inst, /* {{{ */
                          const char *type, const char *type_inst,
                          derive_t counter, cdtime_t timestamp,
                          cdtime_t interval) {
-  return submit_values(host, plugin_inst, type, type_inst, &(value_t){
-      .derive=counter,
-    }, 1, timestamp, interval);
+  return submit_values(host, plugin_inst, type, type_inst,
+                       &(value_t){
+                           .derive = counter,
+                       },
+                       1, timestamp, interval);
 } /* }}} int submit_derive */
 
 static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
@@ -674,9 +676,11 @@ static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
 static int submit_double(const char *host, const char *plugin_inst, /* {{{ */
                          const char *type, const char *type_inst, double d,
                          cdtime_t timestamp, cdtime_t interval) {
-  return submit_values(host, plugin_inst, type, type_inst, &(value_t){
-      .gauge=d,
-    }, 1, timestamp, interval);
+  return submit_values(host, plugin_inst, type, type_inst,
+                       &(value_t){
+                           .gauge = d,
+                       },
+                       1, timestamp, interval);
 } /* }}} int submit_uint64 */
 
 /* Calculate hit ratio from old and new counters and submit the resulting
@@ -770,12 +774,13 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
     return -1;
 
   snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
-            old_data->name);
+           old_data->name);
 
   /* Check for and submit disk-octet values */
   if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_IO) &&
-      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_BYTES_READ |
-                                         HAVE_VOLUME_PERF_BYTES_WRITE)) {
+      HAS_ALL_FLAGS(new_data->flags,
+                    HAVE_VOLUME_PERF_BYTES_READ |
+                        HAVE_VOLUME_PERF_BYTES_WRITE)) {
     submit_two_derive(
         hostname, plugin_instance, "disk_octets", /* type instance = */ NULL,
         (derive_t)new_data->read_bytes, (derive_t)new_data->write_bytes,
@@ -793,15 +798,15 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   }
 
   /* Check for, calculate and submit disk-latency values */
-  if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_LATENCY |
-                                         HAVE_VOLUME_PERF_OPS_READ |
-                                         HAVE_VOLUME_PERF_OPS_WRITE |
-                                         HAVE_VOLUME_PERF_LATENCY_READ |
-                                         HAVE_VOLUME_PERF_LATENCY_WRITE) &&
-      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_OPS_READ |
-                                         HAVE_VOLUME_PERF_OPS_WRITE |
-                                         HAVE_VOLUME_PERF_LATENCY_READ |
-                                         HAVE_VOLUME_PERF_LATENCY_WRITE)) {
+  if (HAS_ALL_FLAGS(old_data->flags,
+                    CFG_VOLUME_PERF_LATENCY | HAVE_VOLUME_PERF_OPS_READ |
+                        HAVE_VOLUME_PERF_OPS_WRITE |
+                        HAVE_VOLUME_PERF_LATENCY_READ |
+                        HAVE_VOLUME_PERF_LATENCY_WRITE) &&
+      HAS_ALL_FLAGS(new_data->flags,
+                    HAVE_VOLUME_PERF_OPS_READ | HAVE_VOLUME_PERF_OPS_WRITE |
+                        HAVE_VOLUME_PERF_LATENCY_READ |
+                        HAVE_VOLUME_PERF_LATENCY_WRITE)) {
     gauge_t latency_per_op_read;
     gauge_t latency_per_op_write;
 
@@ -1401,8 +1406,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_RSVD)) {
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_SNAP_USED |
+                          HAVE_VOLUME_USAGE_SNAP_RSVD)) {
       if (v->snap_reserved > v->snap_used) {
         snap_reserve_free = v->snap_reserved - v->snap_used;
         snap_reserve_used = v->snap_used;
@@ -1416,8 +1422,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     /* The space used by snapshots but not reserved for them is included in
      * both, norm_used and snap_norm_used. If possible, subtract this here. */
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_NORM_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_USED)) {
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_NORM_USED |
+                          HAVE_VOLUME_USAGE_SNAP_USED)) {
       if (norm_used >= snap_norm_used)
         norm_used -= snap_norm_used;
       else {
@@ -1459,8 +1466,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
                     "df_complex", "snap_reserved", (double)snap_reserve_free,
                     /* timestamp = */ 0, interval);
 
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_RSVD))
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_SNAP_USED |
+                          HAVE_VOLUME_USAGE_SNAP_RSVD))
       submit_double(hostname, /* plugin instance = */ plugin_instance,
                     "df_complex", "snap_reserve_used",
                     (double)snap_reserve_used, /* timestamp = */ 0, interval);
@@ -1490,13 +1498,12 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
 
   if ((v->flags & IS_VOLUME_USAGE_OFFLINE) != 0) {
     n.severity = NOTIF_OKAY;
-    snprintf(n.message, sizeof(n.message), "Volume %s is now online.",
-              v->name);
+    snprintf(n.message, sizeof(n.message), "Volume %s is now online.", v->name);
     v->flags &= ~IS_VOLUME_USAGE_OFFLINE;
   } else {
     n.severity = NOTIF_WARNING;
     snprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
-              v->name);
+             v->name);
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
 
@@ -1723,8 +1730,8 @@ static int cna_handle_volume_usage_data(const host_config_t *host, /* {{{ */
     }
   } /* for (elem_volume) */
 
-  return cna_submit_volume_usage_data(host->name, cfg_volume,
-                                      host->cfg_volume_usage->interval.interval);
+  return cna_submit_volume_usage_data(
+      host->name, cfg_volume, host->cfg_volume_usage->interval.interval);
 } /* }}} int cna_handle_volume_usage_data */
 
 static int cna_setup_volume_usage(cfg_volume_usage_t *cvu) /* {{{ */
@@ -1826,7 +1833,7 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
       continue;
 
     snprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
-              volume_name, tree_name);
+             volume_name, tree_name);
 
     value = na_child_get_uint64(elem_quota, "disk-used", UINT64_MAX);
     if (value != UINT64_MAX) {
@@ -1939,7 +1946,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
 
     /* possible TODO: make plugin instance configurable */
     snprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
-              dest_path);
+             dest_path);
     submit_double(hostname, plugin_instance, /* type = */ "delay", NULL,
                   (double)value, /* timestamp = */ 0, interval);
 
@@ -2817,7 +2824,7 @@ static int cna_register_host(host_config_t *host) /* {{{ */
 
   if (host->vfiler)
     snprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
-              host->vfiler);
+             host->vfiler);
   else
     snprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
 

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -769,7 +769,7 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   if ((hostname == NULL) || (old_data == NULL) || (new_data == NULL))
     return -1;
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
+  snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
             old_data->name);
 
   /* Check for and submit disk-octet values */
@@ -1399,7 +1399,7 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
     uint64_t snap_reserve_free = v->snap_reserved;
     uint64_t snap_norm_used = v->snap_used;
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
+    snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
     if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
                                     HAVE_VOLUME_USAGE_SNAP_RSVD)) {
@@ -1490,12 +1490,12 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
 
   if ((v->flags & IS_VOLUME_USAGE_OFFLINE) != 0) {
     n.severity = NOTIF_OKAY;
-    ssnprintf(n.message, sizeof(n.message), "Volume %s is now online.",
+    snprintf(n.message, sizeof(n.message), "Volume %s is now online.",
               v->name);
     v->flags &= ~IS_VOLUME_USAGE_OFFLINE;
   } else {
     n.severity = NOTIF_WARNING;
-    ssnprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
+    snprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
               v->name);
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
@@ -1825,7 +1825,7 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
     if (volume_name == NULL)
       continue;
 
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
+    snprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
               volume_name, tree_name);
 
     value = na_child_get_uint64(elem_quota, "disk-used", UINT64_MAX);
@@ -1938,7 +1938,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
       continue;
 
     /* possible TODO: make plugin instance configurable */
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
+    snprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
               dest_path);
     submit_double(hostname, plugin_instance, /* type = */ "delay", NULL,
                   (double)value, /* timestamp = */ 0, interval);
@@ -2816,10 +2816,10 @@ static int cna_register_host(host_config_t *host) /* {{{ */
   char cb_name[256];
 
   if (host->vfiler)
-    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
+    snprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
               host->vfiler);
   else
-    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
+    snprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
 
   plugin_register_complex_read(
       /* group = */ NULL, cb_name,

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -495,7 +495,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (strcmp(tc_type, "filter") == 0)
       numberic_id = tm->tcm_parent;
 
-    ssnprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
+    snprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
               numberic_id & 0x0000FFFF);
   }
 
@@ -527,7 +527,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
       stats_submitted = 1;
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
+      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                 tc_inst);
 
       if (q_stats.bs != NULL) {
@@ -560,7 +560,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (!stats_submitted && ts != NULL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
+      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                 tc_inst);
 
       submit_one(dev, "ipt_bytes", type_instance, ts->bytes);

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -496,7 +496,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       numberic_id = tm->tcm_parent;
 
     snprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
-              numberic_id & 0x0000FFFF);
+             numberic_id & 0x0000FFFF);
   }
 
   DEBUG("netlink plugin: qos_filter_cb: got %s for %s (%i).", tc_type, dev,
@@ -527,8 +527,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
       stats_submitted = 1;
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
-                tc_inst);
+      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type, tc_inst);
 
       if (q_stats.bs != NULL) {
         submit_one(dev, "ipt_bytes", type_instance, q_stats.bs->bytes);
@@ -560,8 +559,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (!stats_submitted && ts != NULL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
-                tc_inst);
+      snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type, tc_inst);
 
       submit_one(dev, "ipt_bytes", type_instance, ts->bytes);
       submit_one(dev, "ipt_packets", type_instance, ts->packets);

--- a/src/network.c
+++ b/src/network.c
@@ -2652,10 +2652,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
 
   pthread_mutex_lock(&send_buffer_lock);
 
-  status =
-      add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                         (send_buffer_fill + BUFF_SIG_SIZE),
-                    &send_buffer_vl, ds, vl);
+  status = add_to_buffer(send_buffer_ptr,
+                         network_config_packet_size -
+                             (send_buffer_fill + BUFF_SIG_SIZE),
+                         &send_buffer_vl, ds, vl);
   if (status >= 0) {
     /* status == bytes added to the buffer */
     send_buffer_fill += status;
@@ -2666,10 +2666,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
   } else {
     flush_buffer();
 
-    status =
-        add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                           (send_buffer_fill + BUFF_SIG_SIZE),
-                      &send_buffer_vl, ds, vl);
+    status = add_to_buffer(send_buffer_ptr,
+                           network_config_packet_size -
+                               (send_buffer_fill + BUFF_SIG_SIZE),
+                           &send_buffer_vl, ds, vl);
 
     if (status >= 0) {
       send_buffer_fill += status;

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -357,7 +357,7 @@ static void nfs_submit_fields(int nfs_version, const char *instance,
   char plugin_instance[DATA_MAX_NAME_LEN];
   value_t values[fields_num];
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
+  snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
             instance);
 
   for (size_t i = 0; i < fields_num; i++)
@@ -523,7 +523,7 @@ static int nfs_read_kstat(kstat_t *ksp, int nfs_version, const char *inst,
   if (ksp == NULL)
     return EINVAL;
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
+  snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
             inst);
 
   kstat_read(kc, ksp, NULL);

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -358,7 +358,7 @@ static void nfs_submit_fields(int nfs_version, const char *instance,
   value_t values[fields_num];
 
   snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
-            instance);
+           instance);
 
   for (size_t i = 0; i < fields_num; i++)
     (void)parse_value(fields[i], &values[i], DS_TYPE_DERIVE);
@@ -524,7 +524,7 @@ static int nfs_read_kstat(kstat_t *ksp, int nfs_version, const char *inst,
     return EINVAL;
 
   snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
-            inst);
+           inst);
 
   kstat_read(kc, ksp, NULL);
   for (size_t i = 0; i < proc_names_num; i++) {

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -122,7 +122,7 @@ static int init(void) {
     curl_easy_setopt(curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
 #else
     static char credentials[1024];
-    int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
+    int status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
                            pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -123,7 +123,7 @@ static int init(void) {
 #else
     static char credentials[1024];
     int status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
-                           pass == NULL ? "" : pass);
+                          pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");
       return -1;

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -93,7 +93,7 @@ static int c_notify(const notification_t *n,
     timeout = fail_timeout;
   }
 
-  ssnprintf(summary, sizeof(summary), "collectd %s notification",
+  snprintf(summary, sizeof(summary), "collectd %s notification",
             (NOTIF_FAILURE == n->severity)
                 ? "FAILURE"
                 : (NOTIF_WARNING == n->severity)

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -94,11 +94,11 @@ static int c_notify(const notification_t *n,
   }
 
   snprintf(summary, sizeof(summary), "collectd %s notification",
-            (NOTIF_FAILURE == n->severity)
-                ? "FAILURE"
-                : (NOTIF_WARNING == n->severity)
-                      ? "WARNING"
-                      : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
+           (NOTIF_FAILURE == n->severity)
+               ? "FAILURE"
+               : (NOTIF_WARNING == n->severity)
+                     ? "WARNING"
+                     : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
 
   notification = notify_notification_new(summary, n->message, NULL
 #if NOTIFY_CHECK_VERSION(0, 7, 0)

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -105,7 +105,7 @@ static int notify_email_init(void) {
   char server[MAXSTRING];
 
   snprintf(server, sizeof(server), "%s:%i",
-            (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
+           (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
 
   pthread_mutex_lock(&session_lock);
 
@@ -215,15 +215,15 @@ static int notify_email_notification(const notification_t *n,
   int i;
 
   snprintf(severity, sizeof(severity), "%s",
-            (n->severity == NOTIF_FAILURE)
-                ? "FAILURE"
-                : ((n->severity == NOTIF_WARNING)
-                       ? "WARNING"
-                       : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
+           (n->severity == NOTIF_FAILURE)
+               ? "FAILURE"
+               : ((n->severity == NOTIF_WARNING)
+                      ? "WARNING"
+                      : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
 
   snprintf(subject, sizeof(subject),
-            (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
-            severity, n->host);
+           (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
+           severity, n->host);
 
   localtime_r(&CDTIME_T_TO_TIME_T(n->time), &timestamp_tm);
   strftime(timestamp_str, sizeof(timestamp_str), "%Y-%m-%d %H:%M:%S",
@@ -232,14 +232,14 @@ static int notify_email_notification(const notification_t *n,
 
   /* Let's make RFC822 message text with \r\n EOLs */
   snprintf(buf, buf_len, "MIME-Version: 1.0\r\n"
-                          "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
-                          "Content-Transfer-Encoding: 8bit\r\n"
-                          "Subject: %s\r\n"
-                          "\r\n"
-                          "%s - %s@%s\r\n"
-                          "\r\n"
-                          "Message: %s",
-            subject, timestamp_str, severity, n->host, n->message);
+                         "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
+                         "Content-Transfer-Encoding: 8bit\r\n"
+                         "Subject: %s\r\n"
+                         "\r\n"
+                         "%s - %s@%s\r\n"
+                         "\r\n"
+                         "Message: %s",
+           subject, timestamp_str, severity, n->host, n->message);
 
   pthread_mutex_lock(&session_lock);
 

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -104,7 +104,7 @@ static void monitor_cb(const char *buf, int buflen, int writing,
 static int notify_email_init(void) {
   char server[MAXSTRING];
 
-  ssnprintf(server, sizeof(server), "%s:%i",
+  snprintf(server, sizeof(server), "%s:%i",
             (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
 
   pthread_mutex_lock(&session_lock);
@@ -214,14 +214,14 @@ static int notify_email_notification(const notification_t *n,
   int buf_len = sizeof(buf);
   int i;
 
-  ssnprintf(severity, sizeof(severity), "%s",
+  snprintf(severity, sizeof(severity), "%s",
             (n->severity == NOTIF_FAILURE)
                 ? "FAILURE"
                 : ((n->severity == NOTIF_WARNING)
                        ? "WARNING"
                        : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
 
-  ssnprintf(subject, sizeof(subject),
+  snprintf(subject, sizeof(subject),
             (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
             severity, n->host);
 
@@ -231,7 +231,7 @@ static int notify_email_notification(const notification_t *n,
   timestamp_str[sizeof(timestamp_str) - 1] = '\0';
 
   /* Let's make RFC822 message text with \r\n EOLs */
-  ssnprintf(buf, buf_len, "MIME-Version: 1.0\r\n"
+  snprintf(buf, buf_len, "MIME-Version: 1.0\r\n"
                           "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
                           "Content-Transfer-Encoding: 8bit\r\n"
                           "Subject: %s\r\n"

--- a/src/notify_nagios.c
+++ b/src/notify_nagios.c
@@ -142,9 +142,9 @@ static int nagios_notify(const notification_t *n, /* {{{ */
   }
 
   snprintf(buffer, sizeof(buffer),
-            "[%.0f] PROCESS_SERVICE_CHECK_RESULT;%s;%s;%d;%s\n",
-            CDTIME_T_TO_DOUBLE(n->time), n->host, &svc_description[1], code,
-            n->message);
+           "[%.0f] PROCESS_SERVICE_CHECK_RESULT;%s;%s;%d;%s\n",
+           CDTIME_T_TO_DOUBLE(n->time), n->host, &svc_description[1], code,
+           n->message);
 
   return nagios_print(buffer);
 } /* }}} int nagios_notify */

--- a/src/notify_nagios.c
+++ b/src/notify_nagios.c
@@ -141,7 +141,7 @@ static int nagios_notify(const notification_t *n, /* {{{ */
     break;
   }
 
-  ssnprintf(buffer, sizeof(buffer),
+  snprintf(buffer, sizeof(buffer),
             "[%.0f] PROCESS_SERVICE_CHECK_RESULT;%s;%s;%d;%s\n",
             CDTIME_T_TO_DOUBLE(n->time), n->host, &svc_description[1], code,
             n->message);

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -267,7 +267,7 @@ static int ntpd_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "Port") == 0) {
     int port = (int)(atof(value));
     if ((port > 0) && (port <= 65535))
-      ssnprintf(ntpd_port, sizeof(ntpd_port), "%i", port);
+      snprintf(ntpd_port, sizeof(ntpd_port), "%i", port);
     else
       sstrncpy(ntpd_port, value, sizeof(ntpd_port));
   } else if (strcasecmp(key, "ReverseLookups") == 0) {
@@ -782,7 +782,7 @@ static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
     return ntpd_get_name_from_address(buffer, buffer_size, peer_info, 0);
 
   if (include_unit_id)
-    ssnprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
+    snprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
               unit_id);
   else
     sstrncpy(buffer, refclock_names[refclock_id], buffer_size);

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -783,7 +783,7 @@ static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
 
   if (include_unit_id)
     snprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
-              unit_id);
+             unit_id);
   else
     sstrncpy(buffer, refclock_names[refclock_id], buffer_size);
 

--- a/src/numa.c
+++ b/src/numa.c
@@ -47,7 +47,7 @@ static void numa_dispatch_value(int node, /* {{{ */
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, "numa", sizeof(vl.plugin));
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "node%i", node);
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "node%i", node);
   sstrncpy(vl.type, "vmpage_action", sizeof(vl.type));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -62,7 +62,7 @@ static int numa_read_node(int node) /* {{{ */
   int status;
   int success;
 
-  ssnprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i/numastat", node);
+  snprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i/numastat", node);
 
   fh = fopen(path, "r");
   if (fh == NULL) {
@@ -127,7 +127,7 @@ static int numa_init(void) /* {{{ */
     struct stat statbuf = {0};
     int status;
 
-    ssnprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i", max_node + 1);
+    snprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i", max_node + 1);
 
     status = stat(path, &statbuf);
     if (status == 0) {

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -295,7 +295,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
       char type_instance[DATA_MAX_NAME_LEN];
 
       snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
-                fields[1]);
+               fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s;  lq = %g;", type_instance,
             lq);
@@ -319,7 +319,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
       char type_instance[DATA_MAX_NAME_LEN];
 
       snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", fields[0],
-                fields[1]);
+               fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s; nlq = %g;", type_instance,
             lq);
@@ -497,7 +497,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
       snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
-                fields[1]);
+               fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; lq = %g;", type_instance, lq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
                    type_instance, lq);
@@ -516,7 +516,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
       snprintf(type_instance, sizeof(type_instance), "%s-%s-nlq", fields[0],
-                fields[1]);
+               fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; nlq = %g;", type_instance, nlq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
                    type_instance, nlq);

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -294,7 +294,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     if (config_want_links == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
+      snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
                 fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s;  lq = %g;", type_instance,
@@ -318,7 +318,7 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     if (config_want_links == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", fields[0],
+      snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", fields[0],
                 fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s; nlq = %g;", type_instance,
@@ -496,7 +496,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     if (config_want_topology == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
+      snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
                 fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; lq = %g;", type_instance, lq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
@@ -515,7 +515,7 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     } else {
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
-      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-nlq", fields[0],
+      snprintf(type_instance, sizeof(type_instance), "%s-%s-nlq", fields[0],
                 fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; nlq = %g;", type_instance, nlq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -350,11 +350,11 @@ static int cow_read_ds2409(const char *path) {
   char subpath[4096];
   int status;
 
-  status = ssnprintf(subpath, sizeof(subpath), "%s/main", path);
+  status = snprintf(subpath, sizeof(subpath), "%s/main", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
-  status = ssnprintf(subpath, sizeof(subpath), "%s/aux", path);
+  status = snprintf(subpath, sizeof(subpath), "%s/aux", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
@@ -388,9 +388,9 @@ static int cow_read_bus(const char *path) {
     dummy = NULL;
 
     if (strcmp("/", path) == 0)
-      status = ssnprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
+      status = snprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
     else
-      status = ssnprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
+      status = snprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
     if ((status <= 0) || (status >= (int)sizeof(subpath)))
       continue;
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -314,7 +314,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list =
                  ldap_get_values_len(st->ld, e, "olmBDBEntryCache")) != NULL) {
           olmbdb_data = *olmbdb_list[0];
-          ssnprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
+          snprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
                     nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
@@ -324,7 +324,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBDNCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          ssnprintf(typeinst, sizeof(typeinst), "bdbdncache-%s",
+          snprintf(typeinst, sizeof(typeinst), "bdbdncache-%s",
                     nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
@@ -334,7 +334,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBIDLCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          ssnprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
+          snprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
                     nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
@@ -480,7 +480,7 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
       databases[databases_num] = st;
       databases_num++;
 
-      ssnprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
+      snprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
                 (st->host != NULL) ? st->host : hostname_g,
                 (st->name != NULL) ? st->name : "default");
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -315,7 +315,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
                  ldap_get_values_len(st->ld, e, "olmBDBEntryCache")) != NULL) {
           olmbdb_data = *olmbdb_list[0];
           snprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
-                    nc_data.bv_val);
+                   nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -324,8 +324,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBDNCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbdncache-%s",
-                    nc_data.bv_val);
+          snprintf(typeinst, sizeof(typeinst), "bdbdncache-%s", nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -335,7 +334,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
             NULL) {
           olmbdb_data = *olmbdb_list[0];
           snprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
-                    nc_data.bv_val);
+                   nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -481,15 +480,16 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
       databases_num++;
 
       snprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
-                (st->host != NULL) ? st->host : hostname_g,
-                (st->name != NULL) ? st->name : "default");
+               (st->host != NULL) ? st->host : hostname_g,
+               (st->name != NULL) ? st->name : "default");
 
       status = plugin_register_complex_read(/* group = */ NULL,
                                             /* name      = */ callback_name,
                                             /* callback  = */ cldap_read_host,
-                                            /* interval  = */ 0, &(user_data_t){
-                                                                     .data = st,
-                                                                 });
+                                            /* interval  = */ 0,
+                                            &(user_data_t){
+                                                .data = st,
+                                            });
     }
   }
 

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -636,7 +636,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
     if ((status != OCI_SUCCESS) && (status != OCI_SUCCESS_WITH_INFO)) {
       char errfunc[256];
 
-      ssnprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
+      snprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
 
       o_report_error("o_read_database", db->name, NULL, errfunc, oci_error);
       DEBUG("oracle plugin: OCILogon (%s): db->oci_service_context = %p;",

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -476,8 +476,7 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
     column_names[i] = column_names[i - 1] + DATA_MAX_NAME_LEN;
 
   ALLOC_OR_FAIL(column_values, column_num * sizeof(char *));
-  ALLOC_OR_FAIL(column_values[0],
-                column_num * DATA_MAX_NAME_LEN);
+  ALLOC_OR_FAIL(column_values[0], column_num * DATA_MAX_NAME_LEN);
   for (size_t i = 1; i < column_num; i++)
     column_values[i] = column_values[i - 1] + DATA_MAX_NAME_LEN;
 

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -3,14 +3,17 @@
  *
  * Copyright(c) 2016 Intel Corporation. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ *of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
+ * of the Software, and to permit persons to whom the Software is furnished to
+ *do
  * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
+ * The above copyright notice and this permission notice shall be included in
+ *all
  * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -156,7 +159,7 @@ static char *ovs_events_get_select_params() {
     }
     opt_buff = new_buff;
     int ret = snprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
-                        iface->name);
+                       iface->name);
     if (ret < 0) {
       sfree(opt_buff);
       return NULL;
@@ -202,8 +205,8 @@ static int ovs_events_config_get_interfaces(const oconfig_item_t *ci) {
   for (int j = 0; j < ci->values_num; j++) {
     /* check interface name type */
     if (ci->values[j].type != OCONFIG_TYPE_STRING) {
-      ERROR(OVS_EVENTS_PLUGIN
-            ": given interface name is not a string [idx=%d]", j);
+      ERROR(OVS_EVENTS_PLUGIN ": given interface name is not a string [idx=%d]",
+            j);
       return -1;
     }
     /* allocate memory for configured interface */
@@ -278,9 +281,10 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
   }
   /* Check and warn about invalid configuration */
   if (!ovs_events_ctx.config.send_notification && !dispatch_values) {
-      WARNING(OVS_EVENTS_PLUGIN ": send notification and dispatch values "
-              "options are disabled. No information will be dispatched by the "
-              "plugin. Please check your configuration");
+    WARNING(OVS_EVENTS_PLUGIN
+            ": send notification and dispatch values "
+            "options are disabled. No information will be dispatched by the "
+            "plugin. Please check your configuration");
   }
   /* Dispatch link status values if configured */
   if (dispatch_values)
@@ -291,7 +295,8 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
 }
 
 /* Dispatch OVS interface link status event to collectd */
-static void ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifinfo) {
+static void
+ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifinfo) {
   const char *msg_link_status = NULL;
   notification_t n = {
       NOTIF_FAILURE, cdtime(), "", "", OVS_EVENTS_PLUGIN, "", "", "", NULL};
@@ -335,8 +340,8 @@ static void ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifin
 
   /* fill the notification data */
   snprintf(n.message, sizeof(n.message),
-            "link state of \"%s\" interface has been changed to \"%s\"",
-            ifinfo->name, msg_link_status);
+           "link state of \"%s\" interface has been changed to \"%s\"",
+           ifinfo->name, msg_link_status);
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ifinfo->name, sizeof(n.plugin_instance));
   sstrncpy(n.type, "gauge", sizeof(n.type));
@@ -345,7 +350,8 @@ static void ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifin
 }
 
 /* Dispatch OVS interface link status value to collectd */
-static void ovs_events_link_status_submit(const ovs_events_iface_info_t *ifinfo) {
+static void
+ovs_events_link_status_submit(const ovs_events_iface_info_t *ifinfo) {
   value_list_t vl = VALUE_LIST_INIT;
   meta_data_t *meta = NULL;
 

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -155,7 +155,7 @@ static char *ovs_events_get_select_params() {
       return NULL;
     }
     opt_buff = new_buff;
-    int ret = ssnprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
+    int ret = snprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
                         iface->name);
     if (ret < 0) {
       sfree(opt_buff);
@@ -177,7 +177,7 @@ static char *ovs_events_get_select_params() {
   }
 
   /* create OVS DB select params */
-  if (ssnprintf(params_buff, params_size, params_fmt, opt_buff) < 0)
+  if (snprintf(params_buff, params_size, params_fmt, opt_buff) < 0)
     sfree(params_buff);
 
   sfree(opt_buff);
@@ -334,7 +334,7 @@ static void ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifin
   }
 
   /* fill the notification data */
-  ssnprintf(n.message, sizeof(n.message),
+  snprintf(n.message, sizeof(n.message),
             "link state of \"%s\" interface has been changed to \"%s\"",
             ifinfo->name, msg_link_status);
   sstrncpy(n.host, hostname_g, sizeof(n.host));

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -3,14 +3,17 @@
  *
  * Copyright(c) 2016 Intel Corporation. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
+ * of the Software, and to permit persons to whom the Software is furnished to
+ * do
  * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
+ * The above copyright notice and this permission notice shall be included in
+ * all
  * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -711,33 +714,30 @@ static void ovs_stats_initialize(ovs_db_t *pdb) {
                                      "external_ids", NULL};
 
   /* subscribe to a tables */
-  ovs_db_table_cb_register(pdb, "Bridge", bridge_columns,
-                           ovs_stats_bridge_table_change_cb,
+  ovs_db_table_cb_register(
+      pdb, "Bridge", bridge_columns, ovs_stats_bridge_table_change_cb,
       ovs_stats_bridge_table_result_cb,
-                           OVS_DB_TABLE_CB_FLAG_INITIAL |
-                           OVS_DB_TABLE_CB_FLAG_INSERT |
+      OVS_DB_TABLE_CB_FLAG_INITIAL | OVS_DB_TABLE_CB_FLAG_INSERT |
           OVS_DB_TABLE_CB_FLAG_MODIFY);
 
   ovs_db_table_cb_register(pdb, "Bridge", bridge_columns,
                            ovs_stats_bridge_table_delete_cb, NULL,
                            OVS_DB_TABLE_CB_FLAG_DELETE);
 
-  ovs_db_table_cb_register(pdb, "Port", port_columns,
-                           ovs_stats_port_table_change_cb,
+  ovs_db_table_cb_register(
+      pdb, "Port", port_columns, ovs_stats_port_table_change_cb,
       ovs_stats_port_table_result_cb,
-                           OVS_DB_TABLE_CB_FLAG_INITIAL |
-                           OVS_DB_TABLE_CB_FLAG_INSERT |
+      OVS_DB_TABLE_CB_FLAG_INITIAL | OVS_DB_TABLE_CB_FLAG_INSERT |
           OVS_DB_TABLE_CB_FLAG_MODIFY);
 
   ovs_db_table_cb_register(pdb, "Port", port_columns,
                            ovs_stats_port_table_delete_cb, NULL,
                            OVS_DB_TABLE_CB_FLAG_DELETE);
 
-  ovs_db_table_cb_register(pdb, "Interface", interface_columns,
-                           ovs_stats_interface_table_change_cb,
+  ovs_db_table_cb_register(
+      pdb, "Interface", interface_columns, ovs_stats_interface_table_change_cb,
       ovs_stats_interface_table_result_cb,
-                           OVS_DB_TABLE_CB_FLAG_INITIAL |
-                           OVS_DB_TABLE_CB_FLAG_INSERT |
+      OVS_DB_TABLE_CB_FLAG_INITIAL | OVS_DB_TABLE_CB_FLAG_INSERT |
           OVS_DB_TABLE_CB_FLAG_MODIFY);
 }
 
@@ -862,8 +862,8 @@ static int ovs_stats_plugin_init(void) {
        plugin_name, ovs_stats_cfg.ovs_db_node, ovs_stats_cfg.ovs_db_serv,
        ovs_stats_cfg.ovs_db_unix);
   /* connect to OvS DB */
-  if ((g_ovs_db = ovs_db_init (ovs_stats_cfg.ovs_db_node,
-                             ovs_stats_cfg.ovs_db_serv,
+  if ((g_ovs_db =
+           ovs_db_init(ovs_stats_cfg.ovs_db_node, ovs_stats_cfg.ovs_db_serv,
                        ovs_stats_cfg.ovs_db_unix, &cb)) == NULL) {
     ERROR("%s: plugin: failed to connect to OvS DB server", plugin_name);
     return -1;

--- a/src/perl.c
+++ b/src/perl.c
@@ -494,7 +494,8 @@ static int av2data_set(pTHX_ AV *array, char *name, data_set_t *ds) {
  *   meta     => [ { name => <name>, value => <value> }, ... ]
  * }
  */
-static int av2notification_meta(pTHX_ AV *array, notification_meta_t **ret_meta) {
+static int av2notification_meta(pTHX_ AV *array,
+                                notification_meta_t **ret_meta) {
   notification_meta_t *tail = NULL;
 
   int len = av_len(array);
@@ -2349,14 +2350,25 @@ static int g_interval_set(pTHX_ SV *var, MAGIC *mg) {
   return 0;
 } /* static int g_interval_set (pTHX_ SV *, MAGIC *) */
 
-static MGVTBL g_pv_vtbl = {g_pv_get, g_pv_set, NULL, NULL, NULL, NULL, NULL
+static MGVTBL g_pv_vtbl = {g_pv_get,
+                           g_pv_set,
+                           NULL,
+                           NULL,
+                           NULL,
+                           NULL,
+                           NULL
 #if HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL
                            ,
                            NULL
 #endif
 };
-static MGVTBL g_interval_vtbl = {g_interval_get, g_interval_set, NULL, NULL,
-                                 NULL, NULL, NULL
+static MGVTBL g_interval_vtbl = {g_interval_get,
+                                 g_interval_set,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL
 #if HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL
                                  ,
                                  NULL

--- a/src/perl.c
+++ b/src/perl.c
@@ -881,9 +881,9 @@ static int oconfig_item2hv(pTHX_ oconfig_item_t *ci, HV *hash) {
 static char *get_module_name(char *buf, size_t buf_len, const char *module) {
   int status = 0;
   if (base_name[0] == '\0')
-    status = ssnprintf(buf, buf_len, "%s", module);
+    status = snprintf(buf, buf_len, "%s", module);
   else
-    status = ssnprintf(buf, buf_len, "%s::%s", base_name, module);
+    status = snprintf(buf, buf_len, "%s::%s", base_name, module);
   if ((status < 0) || ((unsigned int)status >= buf_len))
     return NULL;
   return buf;

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
+    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -322,7 +322,7 @@ static int c_psql_connect(c_psql_database_t *db) {
   if ((!db) || (!db->database))
     return -1;
 
-  status = ssnprintf(buf, buf_len, "dbname = '%s'", db->database);
+  status = snprintf(buf, buf_len, "dbname = '%s'", db->database);
   if (0 < status) {
     buf += status;
     buf_len -= status;
@@ -424,7 +424,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
       params[i] = db->user;
       break;
     case C_PSQL_PARAM_INTERVAL:
-      ssnprintf(interval, sizeof(interval), "%.3f",
+      snprintf(interval, sizeof(interval), "%.3f",
                 (db->interval > 0) ? CDTIME_T_TO_DOUBLE(db->interval)
                                    : plugin_get_interval());
       params[i] = interval;
@@ -629,7 +629,7 @@ static char *values_name_to_sqlarray(const data_set_t *ds, char *string,
   str_len = string_len;
 
   for (size_t i = 0; i < ds->ds_num; ++i) {
-    int status = ssnprintf(str_ptr, str_len, ",'%s'", ds->ds[i].name);
+    int status = snprintf(str_ptr, str_len, ",'%s'", ds->ds[i].name);
 
     if (status < 1)
       return NULL;
@@ -667,9 +667,9 @@ static char *values_type_to_sqlarray(const data_set_t *ds, char *string,
     int status;
 
     if (store_rates)
-      status = ssnprintf(str_ptr, str_len, ",'gauge'");
+      status = snprintf(str_ptr, str_len, ",'gauge'");
     else
-      status = ssnprintf(str_ptr, str_len, ",'%s'",
+      status = snprintf(str_ptr, str_len, ",'%s'",
                          DS_TYPE_TO_STRING(ds->ds[i].type));
 
     if (status < 1) {
@@ -722,7 +722,7 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       status =
-          ssnprintf(str_ptr, str_len, "," GAUGE_FORMAT, vl->values[i].gauge);
+          snprintf(str_ptr, str_len, "," GAUGE_FORMAT, vl->values[i].gauge);
     else if (store_rates) {
       if (rates == NULL)
         rates = uc_get_rate(ds, vl);
@@ -732,13 +732,13 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
         return NULL;
       }
 
-      status = ssnprintf(str_ptr, str_len, ",%lf", rates[i]);
+      status = snprintf(str_ptr, str_len, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = ssnprintf(str_ptr, str_len, ",%llu", vl->values[i].counter);
+      status = snprintf(str_ptr, str_len, ",%llu", vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      status = ssnprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
+      status = snprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)
-      status = ssnprintf(str_ptr, str_len, ",%" PRIu64, vl->values[i].absolute);
+      status = snprintf(str_ptr, str_len, ",%" PRIu64, vl->values[i].absolute);
 
     if (status < 1) {
       str_len = 0;
@@ -936,7 +936,7 @@ static int c_psql_shutdown(void) {
 
     if (db->writers_num > 0) {
       char cb_name[DATA_MAX_NAME_LEN];
-      ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
+      snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
 
       if (!had_flush) {
         plugin_unregister_flush("postgresql");
@@ -1194,7 +1194,7 @@ static int c_psql_config_database(oconfig_item_t *ci) {
     }
   }
 
-  ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
+  snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
 
   user_data_t ud = {.data = db, .free_func = c_psql_database_delete};
 

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
+    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -425,8 +425,8 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
       break;
     case C_PSQL_PARAM_INTERVAL:
       snprintf(interval, sizeof(interval), "%.3f",
-                (db->interval > 0) ? CDTIME_T_TO_DOUBLE(db->interval)
-                                   : plugin_get_interval());
+               (db->interval > 0) ? CDTIME_T_TO_DOUBLE(db->interval)
+                                  : plugin_get_interval());
       params[i] = interval;
       break;
     case C_PSQL_PARAM_INSTANCE:
@@ -438,7 +438,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
   }
 
   return PQexecParams(db->conn, udb_query_get_statement(q), data->params_num,
-                      NULL, (const char *const*)params, NULL, NULL, 0);
+                      NULL, (const char *const *)params, NULL, NULL, 0);
 } /* c_psql_exec_query_params */
 
 /* db->db_lock must be locked when calling this function */
@@ -670,7 +670,7 @@ static char *values_type_to_sqlarray(const data_set_t *ds, char *string,
       status = snprintf(str_ptr, str_len, ",'gauge'");
     else
       status = snprintf(str_ptr, str_len, ",'%s'",
-                         DS_TYPE_TO_STRING(ds->ds[i].type));
+                        DS_TYPE_TO_STRING(ds->ds[i].type));
 
     if (status < 1) {
       str_len = 0;

--- a/src/processes.c
+++ b/src/processes.c
@@ -820,8 +820,12 @@ static int ps_read_tasks_status(process_entry_t *ps) {
 
     tpid = ent->d_name;
 
-    snprintf(filename, sizeof(filename), "/proc/%li/task/%s/status", ps->id,
-              tpid);
+    if (snprintf(filename, sizeof(filename), "/proc/%li/task/%s/status", ps->id,
+                 tpid) >= sizeof(filename)) {
+      DEBUG("Filename too long: `%s'", filename);
+      continue;
+    }
+
     if ((fh = fopen(filename, "r")) == NULL) {
       DEBUG("Failed to open file `%s'", filename);
       continue;

--- a/src/processes.c
+++ b/src/processes.c
@@ -805,7 +805,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  ssnprintf(dirname, sizeof(dirname), "/proc/%li/task", ps->id);
+  snprintf(dirname, sizeof(dirname), "/proc/%li/task", ps->id);
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
@@ -820,7 +820,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
 
     tpid = ent->d_name;
 
-    ssnprintf(filename, sizeof(filename), "/proc/%li/task/%s/status", ps->id,
+    snprintf(filename, sizeof(filename), "/proc/%li/task/%s/status", ps->id,
               tpid);
     if ((fh = fopen(filename, "r")) == NULL) {
       DEBUG("Failed to open file `%s'", filename);
@@ -878,7 +878,7 @@ static int ps_read_status(long pid, process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  ssnprintf(filename, sizeof(filename), "/proc/%li/status", pid);
+  snprintf(filename, sizeof(filename), "/proc/%li/status", pid);
   if ((fh = fopen(filename, "r")) == NULL)
     return -1;
 
@@ -931,7 +931,7 @@ static int ps_read_io(process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  ssnprintf(filename, sizeof(filename), "/proc/%li/io", ps->id);
+  snprintf(filename, sizeof(filename), "/proc/%li/io", ps->id);
   if ((fh = fopen(filename, "r")) == NULL) {
     DEBUG("ps_read_io: Failed to open file `%s'", filename);
     return -1;
@@ -980,7 +980,7 @@ static int ps_count_fd(int pid) {
   struct dirent *ent;
   int count = 0;
 
-  ssnprintf(dirname, sizeof(dirname), "/proc/%i/fd", pid);
+  snprintf(dirname, sizeof(dirname), "/proc/%i/fd", pid);
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
@@ -1041,7 +1041,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   ssize_t status;
 
-  ssnprintf(filename, sizeof(filename), "/proc/%li/stat", pid);
+  snprintf(filename, sizeof(filename), "/proc/%li/stat", pid);
 
   status = read_file_contents(filename, buffer, sizeof(buffer) - 1);
   if (status <= 0)
@@ -1165,7 +1165,7 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
   if ((pid < 1) || (NULL == buf) || (buf_len < 2))
     return NULL;
 
-  ssnprintf(file, sizeof(file), "/proc/%li/cmdline", pid);
+  snprintf(file, sizeof(file), "/proc/%li/cmdline", pid);
 
   errno = 0;
   fd = open(file, O_RDONLY);
@@ -1220,7 +1220,7 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
     if (NULL == name)
       return NULL;
 
-    ssnprintf(buf, buf_len, "[%s]", name);
+    snprintf(buf, buf_len, "[%s]", name);
     return buf;
   }
 

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -157,7 +157,7 @@ static int read_file(const char *path) {
         char match_name[2 * DATA_MAX_NAME_LEN];
 
         snprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
-                  key_fields[i]);
+                 key_fields[i]);
 
         if (ignorelist_match(values_list, match_name))
           continue;

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -156,7 +156,7 @@ static int read_file(const char *path) {
       if (values_list != NULL) {
         char match_name[2 * DATA_MAX_NAME_LEN];
 
-        ssnprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
+        snprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
                   key_fields[i]);
 
         if (ignorelist_match(values_list, match_name))

--- a/src/python.c
+++ b/src/python.c
@@ -784,8 +784,8 @@ static PyObject *cpy_register_write(PyObject *self, PyObject *args,
 static PyObject *cpy_register_notification(PyObject *self, PyObject *args,
                                            PyObject *kwds) {
   return cpy_register_generic_userdata((void *)plugin_register_notification,
-                                       (void *)cpy_notification_callback,
-                                       args, kwds);
+                                       (void *)cpy_notification_callback, args,
+                                       kwds);
 }
 
 static PyObject *cpy_register_flush(PyObject *self, PyObject *args,
@@ -944,8 +944,7 @@ static PyObject *cpy_unregister_read(PyObject *self, PyObject *arg) {
 }
 
 static PyObject *cpy_unregister_write(PyObject *self, PyObject *arg) {
-  return cpy_unregister_generic_userdata(plugin_unregister_write, arg,
-                                         "write");
+  return cpy_unregister_generic_userdata(plugin_unregister_write, arg, "write");
 }
 
 static PyObject *cpy_unregister_notification(PyObject *self, PyObject *arg) {
@@ -954,8 +953,7 @@ static PyObject *cpy_unregister_notification(PyObject *self, PyObject *arg) {
 }
 
 static PyObject *cpy_unregister_flush(PyObject *self, PyObject *arg) {
-  return cpy_unregister_generic_userdata(plugin_unregister_flush, arg,
-                                         "flush");
+  return cpy_unregister_generic_userdata(plugin_unregister_flush, arg, "flush");
 }
 
 static PyObject *cpy_unregister_shutdown(PyObject *self, PyObject *arg) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -370,7 +370,7 @@ static int redis_db_stats(char *node, char const *info_line) /* {{{ */
     char *str;
     int i;
 
-    ssnprintf(field_name, sizeof(field_name), "db%d:keys=", db);
+    snprintf(field_name, sizeof(field_name), "db%d:keys=", db);
 
     str = strstr(info_line, field_name);
     if (!str)
@@ -386,7 +386,7 @@ static int redis_db_stats(char *node, char const *info_line) /* {{{ */
       return -1;
     }
 
-    ssnprintf(db_id, sizeof(db_id), "%d", db);
+    snprintf(db_id, sizeof(db_id), "%d", db);
     redis_submit(node, "records", db_id, val);
   }
   return 0;

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -89,8 +89,7 @@ static void submit_interface(cr_data_t *rd, /* {{{ */
 
 static int handle_interface(__attribute__((unused))
                             ros_connection_t *c, /* {{{ */
-                            const ros_interface_t *i,
-                            void *user_data) {
+                            const ros_interface_t *i, void *user_data) {
   if ((i == NULL) || (user_data == NULL))
     return EINVAL;
 
@@ -143,7 +142,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** RX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
-            r->radio_name);
+           r->radio_name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -152,7 +151,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** TX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
-            r->radio_name);
+           r->radio_name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -161,7 +160,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** RX / TX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface,
-            r->radio_name);
+           r->radio_name);
   cr_submit_io(rd, "if_octets", type_instance, (derive_t)r->rx_bytes,
                (derive_t)r->tx_bytes);
   cr_submit_gauge(rd, "snr", type_instance, (gauge_t)r->signal_to_noise);
@@ -171,8 +170,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
 static int handle_regtable(__attribute__((unused))
                            ros_connection_t *c, /* {{{ */
-                           const ros_registration_table_t *r,
-                           void *user_data) {
+                           const ros_registration_table_t *r, void *user_data) {
   if ((r == NULL) || (user_data == NULL))
     return EINVAL;
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -142,7 +142,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
     return;
 
   /*** RX ***/
-  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
+  snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
             r->radio_name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
@@ -151,7 +151,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->rx_ccq);
 
   /*** TX ***/
-  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
+  snprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
             r->radio_name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
@@ -160,7 +160,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->tx_ccq);
 
   /*** RX / TX ***/
-  ssnprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface,
+  snprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface,
             r->radio_name);
   cr_submit_io(rd, "if_octets", type_instance, (derive_t)r->rx_bytes,
                (derive_t)r->tx_bytes);
@@ -378,7 +378,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  ssnprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
+  snprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
   if (status == 0)
     status = plugin_register_complex_read(
         /* group = */ NULL, read_name, cr_read, /* interval = */ 0,

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -75,7 +75,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
   memset(buffer, '\0', buffer_len);
 
   t = CDTIME_T_TO_TIME_T(vl->time);
-  status = ssnprintf(buffer, buffer_len, "%lu", (unsigned long)t);
+  status = snprintf(buffer, buffer_len, "%lu", (unsigned long)t);
   if ((status < 1) || (status >= buffer_len))
     return -1;
   offset = status;
@@ -88,16 +88,16 @@ static int value_list_to_string(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%llu",
+      status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
                          vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_GAUGE) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%f",
+      status = snprintf(buffer + offset, buffer_len - offset, ":%f",
                          vl->values[i].gauge);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
                          vl->values[i].derive);
     } else /* if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */ {
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                          vl->values[i].absolute);
     }
 
@@ -482,9 +482,9 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
     return EINVAL;
 
   if (datadir != NULL)
-    ssnprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
+    snprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
   else
-    ssnprintf(filename, sizeof(filename), "%s.rrd", identifier);
+    snprintf(filename, sizeof(filename), "%s.rrd", identifier);
 
   rrd_clear_error();
   status = rrdc_connect(daemon_address);

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -89,16 +89,16 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
       status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
-                         vl->values[i].counter);
+                        vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_GAUGE) {
       status = snprintf(buffer + offset, buffer_len - offset, ":%f",
-                         vl->values[i].gauge);
+                        vl->values[i].gauge);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
       status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
-                         vl->values[i].derive);
+                        vl->values[i].derive);
     } else /* if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */ {
       status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                         vl->values[i].absolute);
+                        vl->values[i].absolute);
     }
 
     if ((status < 1) || (status >= (buffer_len - offset)))

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -177,7 +177,7 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
   memset(buffer, '\0', buffer_len);
 
   tt = CDTIME_T_TO_TIME_T(vl->time);
-  status = ssnprintf(buffer, buffer_len, "%u", (unsigned int)tt);
+  status = snprintf(buffer, buffer_len, "%u", (unsigned int)tt);
   if ((status < 1) || (status >= buffer_len))
     return -1;
   offset = status;
@@ -190,16 +190,16 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%llu",
+      status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
                          vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
+      status = snprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
                          vl->values[i].gauge);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
                          vl->values[i].derive);
     else /*if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */
-      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                          vl->values[i].absolute);
 
     if ((status < 1) || (status >= (buffer_len - offset)))
@@ -222,19 +222,19 @@ static int value_list_to_string(char *buffer, int buffer_len,
   tt = CDTIME_T_TO_TIME_T(vl->time);
   switch (ds->ds[0].type) {
   case DS_TYPE_DERIVE:
-    status = ssnprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
+    status = snprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
                        vl->values[0].derive);
     break;
   case DS_TYPE_GAUGE:
-    status = ssnprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
+    status = snprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
                        vl->values[0].gauge);
     break;
   case DS_TYPE_COUNTER:
-    status = ssnprintf(buffer, buffer_len, "%u:%llu", (unsigned)tt,
+    status = snprintf(buffer, buffer_len, "%u:%llu", (unsigned)tt,
                        vl->values[0].counter);
     break;
   case DS_TYPE_ABSOLUTE:
-    status = ssnprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
+    status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
                        vl->values[0].absolute);
     break;
   default:

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -191,16 +191,16 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
       status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
-                         vl->values[i].counter);
+                        vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)
       status = snprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
-                         vl->values[i].gauge);
+                        vl->values[i].gauge);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
-                         vl->values[i].derive);
+                        vl->values[i].derive);
     else /*if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */
       status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                         vl->values[i].absolute);
+                        vl->values[i].absolute);
 
     if ((status < 1) || (status >= (buffer_len - offset)))
       return -1;
@@ -223,19 +223,19 @@ static int value_list_to_string(char *buffer, int buffer_len,
   switch (ds->ds[0].type) {
   case DS_TYPE_DERIVE:
     status = snprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
-                       vl->values[0].derive);
+                      vl->values[0].derive);
     break;
   case DS_TYPE_GAUGE:
     status = snprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
-                       vl->values[0].gauge);
+                      vl->values[0].gauge);
     break;
   case DS_TYPE_COUNTER:
     status = snprintf(buffer, buffer_len, "%u:%llu", (unsigned)tt,
-                       vl->values[0].counter);
+                      vl->values[0].counter);
     break;
   case DS_TYPE_ABSOLUTE:
     status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
-                       vl->values[0].absolute);
+                      vl->values[0].absolute);
     break;
   default:
     return EINVAL;

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -437,7 +437,7 @@ static void sensors_submit(const char *plugin_instance, const char *type,
   value_list_t vl = VALUE_LIST_INIT;
 
   status = snprintf(match_key, sizeof(match_key), "%s/%s-%s", plugin_instance,
-                     type, type_instance);
+                    type, type_instance);
   if (status < 1)
     return;
 

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -176,7 +176,7 @@ static int sensors_snprintf_chip_name(char *buf, size_t buf_size,
   int status = -1;
 
   if (chip->bus == SENSORS_CHIP_NAME_BUS_ISA) {
-    status = ssnprintf(buf, buf_size, "%s-isa-%04x", chip->prefix, chip->addr);
+    status = snprintf(buf, buf_size, "%s-isa-%04x", chip->prefix, chip->addr);
   } else if (chip->bus == SENSORS_CHIP_NAME_BUS_DUMMY) {
     status = snprintf(buf, buf_size, "%s-%s-%04x", chip->prefix, chip->busname,
                       chip->addr);
@@ -436,7 +436,7 @@ static void sensors_submit(const char *plugin_instance, const char *type,
 
   value_list_t vl = VALUE_LIST_INIT;
 
-  status = ssnprintf(match_key, sizeof(match_key), "%s/%s-%s", plugin_instance,
+  status = snprintf(match_key, sizeof(match_key), "%s/%s-%s", plugin_instance,
                      type, type_instance);
   if (status < 1)
     return;

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -247,7 +247,7 @@ static int sigrok_init_driver(struct config_device *cfdev,
   }
   cfdev->sdi = devlist->data;
   g_slist_free(devlist);
-  ssnprintf(hwident, sizeof(hwident), "%s %s %s",
+  snprintf(hwident, sizeof(hwident), "%s %s %s",
             cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
             cfdev->sdi->model ? cfdev->sdi->model : "",
             cfdev->sdi->version ? cfdev->sdi->version : "");

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -248,9 +248,9 @@ static int sigrok_init_driver(struct config_device *cfdev,
   cfdev->sdi = devlist->data;
   g_slist_free(devlist);
   snprintf(hwident, sizeof(hwident), "%s %s %s",
-            cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
-            cfdev->sdi->model ? cfdev->sdi->model : "",
-            cfdev->sdi->version ? cfdev->sdi->version : "");
+           cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
+           cfdev->sdi->model ? cfdev->sdi->model : "",
+           cfdev->sdi->version ? cfdev->sdi->version : "");
   INFO("sigrok plugin: Device \"%s\" is a %s", cfdev->name, hwident);
 
   if (sr_dev_open(cfdev->sdi) != SR_OK)

--- a/src/smart.c
+++ b/src/smart.c
@@ -116,7 +116,7 @@ static void handle_attribute(SkDisk *d, const SkSmartAttributeParsedData *a,
     sstrncpy(notif.host, hostname_g, sizeof(notif.host));
     sstrncpy(notif.plugin_instance, name, sizeof(notif.plugin_instance));
     sstrncpy(notif.type_instance, a->name, sizeof(notif.type_instance));
-    ssnprintf(notif.message, sizeof(notif.message),
+    snprintf(notif.message, sizeof(notif.message),
               "attribute %s is below allowed threshold (%d < %d)", a->name,
               a->current_value, a->threshold);
     plugin_dispatch_notification(&notif);

--- a/src/smart.c
+++ b/src/smart.c
@@ -117,8 +117,8 @@ static void handle_attribute(SkDisk *d, const SkSmartAttributeParsedData *a,
     sstrncpy(notif.plugin_instance, name, sizeof(notif.plugin_instance));
     sstrncpy(notif.type_instance, a->name, sizeof(notif.type_instance));
     snprintf(notif.message, sizeof(notif.message),
-              "attribute %s is below allowed threshold (%d < %d)", a->name,
-              a->current_value, a->threshold);
+             "attribute %s is below allowed threshold (%d < %d)", a->name,
+             a->current_value, a->threshold);
     plugin_dispatch_notification(&notif);
   }
 }

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -130,8 +130,7 @@ static void csnmp_oid_init(oid_t *dst, oid const *src, size_t n) {
 }
 
 static int csnmp_oid_compare(oid_t const *left, oid_t const *right) {
-  return snmp_oid_compare(left->oid, left->oid_len, right->oid,
-                          right->oid_len);
+  return snmp_oid_compare(left->oid, left->oid_len, right->oid, right->oid_len);
 }
 
 static int csnmp_oid_suffix(oid_t *dst, oid_t const *src, oid_t const *root) {
@@ -998,9 +997,9 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
     src = (char *)vb->val.bitstring;
   else if (vb->type == ASN_IPADDRESS) {
     return snprintf(dst, dst_size,
-                     "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
-                     (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
-                     (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
+                    "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
+                    (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
+                    (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
   } else {
     dst[0] = 0;
     return EINVAL;
@@ -1223,7 +1222,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
         sstrncpy(vl.type_instance, temp, sizeof(vl.type_instance));
       else
         snprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
-                  data->instance_prefix, temp);
+                 data->instance_prefix, temp);
     }
 
     vl.values_len = data->values_len;

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -155,7 +155,7 @@ static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -703,7 +703,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
         "= %i }",
         hd->name, hd->address, hd->community, hd->version);
 
-  ssnprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
+  snprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
 
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, hd->interval,
@@ -997,7 +997,7 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
   else if (vb->type == ASN_BIT_STR)
     src = (char *)vb->val.bitstring;
   else if (vb->type == ASN_IPADDRESS) {
-    return ssnprintf(dst, dst_size,
+    return snprintf(dst, dst_size,
                      "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
                      (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
                      (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
@@ -1092,7 +1092,7 @@ static int csnmp_instance_list_add(csnmp_list_instances_t **head,
     value_t val = csnmp_value_list_to_value(
         vb, DS_TYPE_COUNTER,
         /* scale = */ 1.0, /* shift = */ 0.0, hd->name, dd->name);
-    ssnprintf(il->instance, sizeof(il->instance), "%llu", val.counter);
+    snprintf(il->instance, sizeof(il->instance), "%llu", val.counter);
   }
 
   /* TODO: Debugging output */
@@ -1222,7 +1222,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->instance_prefix == NULL)
         sstrncpy(vl.type_instance, temp, sizeof(vl.type_instance));
       else
-        ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
+        snprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
                   data->instance_prefix, temp);
     }
 

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -282,7 +282,8 @@ static int snmp_agent_validate_data(void) {
   return 0;
 }
 
-static void snmp_agent_generate_oid2string(oid_t *oid, size_t offset, char *key) {
+static void snmp_agent_generate_oid2string(oid_t *oid, size_t offset,
+                                           char *key) {
   int key_len = oid->oid[offset];
   int i;
 
@@ -369,8 +370,8 @@ static int snmp_agent_table_row_remove(table_definition_t *td,
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ins, sizeof(n.plugin_instance));
   snprintf(n.message, sizeof(n.message),
-            "Removed data row from table %s instance %s index %d", td->name,
-            ins, (index != NULL) ? *index : -1);
+           "Removed data row from table %s instance %s index %d", td->name, ins,
+           (index != NULL) ? *index : -1);
   plugin_dispatch_notification(&n);
 
   if (td->index_oid.oid_len) {
@@ -616,9 +617,9 @@ snmp_agent_table_oid_handler(struct netsnmp_mib_handler_s *handler,
 
         if (dd->is_instance) {
           requests->requestvb->type = ASN_OCTET_STR;
-          snmp_set_var_typed_value(requests->requestvb,
-                                   requests->requestvb->type, (const u_char *)instance,
-                                   strlen((instance)));
+          snmp_set_var_typed_value(
+              requests->requestvb, requests->requestvb->type,
+              (const u_char *)instance, strlen((instance)));
 
           pthread_mutex_unlock(&g_agent->lock);
 
@@ -1306,8 +1307,8 @@ static int snmp_agent_update_index(table_definition_t *td,
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ins, sizeof(n.plugin_instance));
   snprintf(n.message, sizeof(n.message),
-            "Data row added to table %s instance %s index %d", td->name, ins,
-            (index != NULL) ? *index : -1);
+           "Data row added to table %s instance %s index %d", td->name, ins,
+           (index != NULL) ? *index : -1);
   plugin_dispatch_notification(&n);
 
   return 0;

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -123,7 +123,7 @@ static int snmp_agent_oid_to_string(char *buf, size_t buf_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -368,7 +368,7 @@ static int snmp_agent_table_row_remove(table_definition_t *td,
       .severity = NOTIF_WARNING, .time = cdtime(), .plugin = PLUGIN_NAME};
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ins, sizeof(n.plugin_instance));
-  ssnprintf(n.message, sizeof(n.message),
+  snprintf(n.message, sizeof(n.message),
             "Removed data row from table %s instance %s index %d", td->name,
             ins, (index != NULL) ? *index : -1);
   plugin_dispatch_notification(&n);
@@ -1305,7 +1305,7 @@ static int snmp_agent_update_index(table_definition_t *td,
       .severity = NOTIF_OKAY, .time = cdtime(), .plugin = PLUGIN_NAME};
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ins, sizeof(n.plugin_instance));
-  ssnprintf(n.message, sizeof(n.message),
+  snprintf(n.message, sizeof(n.message),
             "Data row added to table %s instance %s index %d", td->name, ins,
             (index != NULL) ? *index : -1);
   plugin_dispatch_notification(&n);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -605,8 +605,9 @@ static int statsd_config_timer_percentile(oconfig_item_t *ci) /* {{{ */
     return ERANGE;
   }
 
-  tmp = realloc(conf_timer_percentile, sizeof(*conf_timer_percentile) *
-                                           (conf_timer_percentile_num + 1));
+  tmp =
+      realloc(conf_timer_percentile,
+              sizeof(*conf_timer_percentile) * (conf_timer_percentile_num + 1));
   if (tmp == NULL) {
     ERROR("statsd plugin: realloc failed.");
     return ENOMEM;
@@ -766,8 +767,8 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     for (size_t i = 0; i < conf_timer_percentile_num; i++) {
-      snprintf(vl.type_instance, sizeof(vl.type_instance),
-                "%s-percentile-%.0f", name, conf_timer_percentile[i]);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-percentile-%.0f",
+               name, conf_timer_percentile[i]);
       vl.values[0].gauge =
           have_events ? CDTIME_T_TO_DOUBLE(latency_counter_get_percentile(
                             metric->latency, conf_timer_percentile[i]))

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -731,7 +731,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     /* Make sure all timer metrics share the *same* timestamp. */
     vl.time = cdtime();
 
-    ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-average", name);
+    snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-average", name);
     vl.values[0].gauge =
         have_events
             ? CDTIME_T_TO_DOUBLE(latency_counter_get_average(metric->latency))
@@ -739,7 +739,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     plugin_dispatch_values(&vl);
 
     if (conf_timer_lower) {
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-lower", name);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-lower", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_min(metric->latency))
@@ -748,7 +748,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     if (conf_timer_upper) {
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-upper", name);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-upper", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_max(metric->latency))
@@ -757,7 +757,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     if (conf_timer_sum) {
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-sum", name);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-sum", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_sum(metric->latency))
@@ -766,7 +766,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     for (size_t i = 0; i < conf_timer_percentile_num; i++) {
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+      snprintf(vl.type_instance, sizeof(vl.type_instance),
                 "%s-percentile-%.0f", name, conf_timer_percentile[i]);
       vl.values[0].gauge =
           have_events ? CDTIME_T_TO_DOUBLE(latency_counter_get_percentile(
@@ -779,7 +779,7 @@ static int statsd_metric_submit_unsafe(char const *name,
      * vl.type's above are implicitly set to "latency". */
     if (conf_timer_count) {
       sstrncpy(vl.type, "gauge", sizeof(vl.type));
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-count", name);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-count", name);
       vl.values[0].gauge = latency_counter_get_num(metric->latency);
       plugin_dispatch_values(&vl);
     }

--- a/src/swap.c
+++ b/src/swap.c
@@ -410,7 +410,7 @@ static int swap_read(void) /* {{{ */
 
   return 0;
 } /* }}} int swap_read */
-  /* #endif KERNEL_LINUX */
+/* #endif KERNEL_LINUX */
 
 /*
  * Under Solaris, two mechanisms can be used to read swap statistics, swapctl

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -107,7 +107,7 @@ static int sl_notification(const notification_t *n,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(&buf[offset], sizeof(buf) - offset, __VA_ARGS__);       \
+    status = snprintf(&buf[offset], sizeof(buf) - offset, __VA_ARGS__);       \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (sizeof(buf) - offset))                       \

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -107,7 +107,7 @@ static int sl_notification(const notification_t *n,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(&buf[offset], sizeof(buf) - offset, __VA_ARGS__);       \
+    status = snprintf(&buf[offset], sizeof(buf) - offset, __VA_ARGS__);        \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (sizeof(buf) - offset))                       \

--- a/src/tail.c
+++ b/src/tail.c
@@ -309,7 +309,7 @@ static int ctail_init(void) {
   }
 
   for (size_t i = 0; i < tail_match_list_num; i++) {
-    ssnprintf(str, sizeof(str), "tail-%zu", i);
+    snprintf(str, sizeof(str), "tail-%zu", i);
 
     plugin_register_complex_read(NULL, str, ctail_read,
                                  tail_match_list_intervals[i],

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -475,7 +475,7 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
     return -1;
   }
 
-  ssnprintf(cb_name, sizeof(cb_name), "tail_csv/%s", id->path);
+  snprintf(cb_name, sizeof(cb_name), "tail_csv/%s", id->path);
 
   status = plugin_register_complex_read(
       NULL, cb_name, tcsv_read, id->interval,

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -221,7 +221,7 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
     char template[DATA_MAX_NAME_LEN];
     char value_str[DATA_MAX_NAME_LEN];
 
-    ssnprintf(template, sizeof(template), "%%{ds:%s}", ds->ds[i].name);
+    snprintf(template, sizeof(template), "%%{ds:%s}", ds->ds[i].name);
 
     if (ds->ds[i].type != DS_TYPE_GAUGE) {
       if ((rates == NULL) && (rates_failed == 0)) {
@@ -233,12 +233,12 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
     /* If this is a gauge value, use the current value. */
     if (ds->ds[i].type == DS_TYPE_GAUGE)
-      ssnprintf(value_str, sizeof(value_str), GAUGE_FORMAT,
+      snprintf(value_str, sizeof(value_str), GAUGE_FORMAT,
                 (double)vl->values[i].gauge);
     /* If it's a counter, try to use the current rate. This may fail, if the
      * value has been renamed. */
     else if (rates != NULL)
-      ssnprintf(value_str, sizeof(value_str), GAUGE_FORMAT, (double)rates[i]);
+      snprintf(value_str, sizeof(value_str), GAUGE_FORMAT, (double)rates[i]);
     /* Since we don't know any better, use the string `unknown'. */
     else
       sstrncpy(value_str, "unknown", sizeof(value_str));

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -234,7 +234,7 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
     /* If this is a gauge value, use the current value. */
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       snprintf(value_str, sizeof(value_str), GAUGE_FORMAT,
-                (double)vl->values[i].gauge);
+               (double)vl->values[i].gauge);
     /* If it's a counter, try to use the current rate. This may fail, if the
      * value has been renamed. */
     else if (rates != NULL)

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -57,11 +57,11 @@ static int ts_invoke_counter(const data_set_t *ds, value_list_t *vl, /* {{{ */
   curr_counter = (uint64_t)vl->values[dsrc_index].counter;
 
   snprintf(key_prev_counter, sizeof(key_prev_counter),
-            "target_scale[%p,%i]:prev_counter", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:prev_counter", (void *)data, dsrc_index);
   snprintf(key_int_counter, sizeof(key_int_counter),
-            "target_scale[%p,%i]:int_counter", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:int_counter", (void *)data, dsrc_index);
   snprintf(key_int_fraction, sizeof(key_int_fraction),
-            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_counter = curr_counter;
   int_counter = 0;
@@ -150,11 +150,11 @@ static int ts_invoke_derive(const data_set_t *ds, value_list_t *vl, /* {{{ */
   curr_derive = (int64_t)vl->values[dsrc_index].derive;
 
   snprintf(key_prev_derive, sizeof(key_prev_derive),
-            "target_scale[%p,%i]:prev_derive", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:prev_derive", (void *)data, dsrc_index);
   snprintf(key_int_derive, sizeof(key_int_derive),
-            "target_scale[%p,%i]:int_derive", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:int_derive", (void *)data, dsrc_index);
   snprintf(key_int_fraction, sizeof(key_int_fraction),
-            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_derive = curr_derive;
   int_derive = 0;
@@ -233,7 +233,7 @@ static int ts_invoke_absolute(const data_set_t *ds, value_list_t *vl, /* {{{ */
   curr_absolute = (uint64_t)vl->values[dsrc_index].absolute;
 
   snprintf(key_int_fraction, sizeof(key_int_fraction),
-            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   int_fraction = 0.0;
 

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -56,11 +56,11 @@ static int ts_invoke_counter(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_counter = (uint64_t)vl->values[dsrc_index].counter;
 
-  ssnprintf(key_prev_counter, sizeof(key_prev_counter),
+  snprintf(key_prev_counter, sizeof(key_prev_counter),
             "target_scale[%p,%i]:prev_counter", (void *)data, dsrc_index);
-  ssnprintf(key_int_counter, sizeof(key_int_counter),
+  snprintf(key_int_counter, sizeof(key_int_counter),
             "target_scale[%p,%i]:int_counter", (void *)data, dsrc_index);
-  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+  snprintf(key_int_fraction, sizeof(key_int_fraction),
             "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_counter = curr_counter;
@@ -149,11 +149,11 @@ static int ts_invoke_derive(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_derive = (int64_t)vl->values[dsrc_index].derive;
 
-  ssnprintf(key_prev_derive, sizeof(key_prev_derive),
+  snprintf(key_prev_derive, sizeof(key_prev_derive),
             "target_scale[%p,%i]:prev_derive", (void *)data, dsrc_index);
-  ssnprintf(key_int_derive, sizeof(key_int_derive),
+  snprintf(key_int_derive, sizeof(key_int_derive),
             "target_scale[%p,%i]:int_derive", (void *)data, dsrc_index);
-  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+  snprintf(key_int_fraction, sizeof(key_int_fraction),
             "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_derive = curr_derive;
@@ -232,7 +232,7 @@ static int ts_invoke_absolute(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_absolute = (uint64_t)vl->values[dsrc_index].absolute;
 
-  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+  snprintf(key_int_fraction, sizeof(key_int_fraction),
             "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   int_fraction = 0.0;

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -193,7 +193,7 @@ static void ts_subst(char *dest, size_t size, const char *string, /* {{{ */
       char *value_str;
       const char *key = meta_toc[i];
 
-      ssnprintf(meta_name, sizeof(meta_name), "%%{meta:%s}", key);
+      snprintf(meta_name, sizeof(meta_name), "%%{meta:%s}", key);
       if (meta_data_as_string(vl->meta, key, &value_str) != 0)
         continue;
 

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -238,23 +238,23 @@ static int v5_zfs_arc_counts(const data_set_t *ds, value_list_t *vl) /* {{{ */
 
   /* Dispatch new value lists instead of this one */
   new_vl.values[0].derive = (derive_t)vl->values[0].counter;
-  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-            "demand_data-%s", is_hits ? "hit" : "miss");
+  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance), "demand_data-%s",
+           is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[1].counter;
   snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-            "demand_metadata-%s", is_hits ? "hit" : "miss");
+           "demand_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[2].counter;
   snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-            "prefetch_data-%s", is_hits ? "hit" : "miss");
+           "prefetch_data-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[3].counter;
   snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-            "prefetch_metadata-%s", is_hits ? "hit" : "miss");
+           "prefetch_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -238,22 +238,22 @@ static int v5_zfs_arc_counts(const data_set_t *ds, value_list_t *vl) /* {{{ */
 
   /* Dispatch new value lists instead of this one */
   new_vl.values[0].derive = (derive_t)vl->values[0].counter;
-  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
             "demand_data-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[1].counter;
-  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
             "demand_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[2].counter;
-  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
             "prefetch_data-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[3].counter;
-  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
             "prefetch_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -292,7 +292,7 @@ static void conn_submit_port_entry(port_entry_t *pe) {
 
   if (((port_collect_listening != 0) && (pe->flags & PORT_IS_LISTENING)) ||
       (pe->flags & PORT_COLLECT_LOCAL)) {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
               "%" PRIu16 "-local", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {
@@ -305,7 +305,7 @@ static void conn_submit_port_entry(port_entry_t *pe) {
   }
 
   if (pe->flags & PORT_COLLECT_REMOTE) {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
               "%" PRIu16 "-remote", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -70,7 +70,8 @@
 #undef HAVE_SYSCTLBYNAME /* force HAVE_LIBKVM_NLIST path */
 #endif
 
-#if !KERNEL_LINUX && !HAVE_SYSCTLBYNAME && !HAVE_KVM_GETFILES && !HAVE_LIBKVM_NLIST && !KERNEL_AIX
+#if !KERNEL_LINUX && !HAVE_SYSCTLBYNAME && !HAVE_KVM_GETFILES &&               \
+    !HAVE_LIBKVM_NLIST && !KERNEL_AIX
 #error "No applicable input method."
 #endif
 
@@ -110,8 +111,8 @@
 /* #endif HAVE_SYSCTLBYNAME */
 
 #elif HAVE_KVM_GETFILES
-#include <sys/types.h>
 #include <sys/sysctl.h>
+#include <sys/types.h>
 #define _KERNEL /* for DTYPE_SOCKET */
 #include <sys/file.h>
 #undef _KERNEL
@@ -127,9 +128,9 @@
 #include <net/route.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <netinet/ip.h>
 #include <netinet/in_pcb.h>
 #include <netinet/in_systm.h>
+#include <netinet/ip.h>
 #include <netinet/ip_var.h>
 #include <netinet/tcp.h>
 #include <netinet/tcp_timer.h>
@@ -293,7 +294,7 @@ static void conn_submit_port_entry(port_entry_t *pe) {
   if (((port_collect_listening != 0) && (pe->flags & PORT_IS_LISTENING)) ||
       (pe->flags & PORT_COLLECT_LOCAL)) {
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
-              "%" PRIu16 "-local", pe->port);
+             "%" PRIu16 "-local", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {
       vl.values[0].gauge = pe->count_local[i];
@@ -306,7 +307,7 @@ static void conn_submit_port_entry(port_entry_t *pe) {
 
   if (pe->flags & PORT_COLLECT_REMOTE) {
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
-              "%" PRIu16 "-remote", pe->port);
+             "%" PRIu16 "-remote", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {
       vl.values[0].gauge = pe->count_remote[i];
@@ -830,8 +831,7 @@ static int conn_read(void) {
 
   conn_reset_port_entry();
 
-  kf = kvm_getfiles(kvmd, KERN_FILE_BYFILE, DTYPE_SOCKET,
-		    sizeof(*kf), &fcnt);
+  kf = kvm_getfiles(kvmd, KERN_FILE_BYFILE, DTYPE_SOCKET, sizeof(*kf), &fcnt);
   if (kf == NULL) {
     ERROR("tcpconns plugin: kvm_getfiles failed.");
     return -1;

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -464,7 +464,7 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
   } else {
     /* Request server information */
     snprintf(plugin_instance, sizeof(plugin_instance), "vserver%i",
-              vserver->port);
+             vserver->port);
 
     /* Select the server */
     status = tss2_select_vserver(read_fh, write_fh, vserver);

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -333,7 +333,7 @@ static int tss2_select_vserver(FILE *read_fh, FILE *write_fh,
   int status;
 
   /* Send request */
-  ssnprintf(command, sizeof(command), "sel %i\r\n", vserver->port);
+  snprintf(command, sizeof(command), "sel %i\r\n", vserver->port);
 
   status = tss2_send_request(write_fh, command);
   if (status != 0) {
@@ -463,7 +463,7 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
     status = tss2_send_request(write_fh, "gi\r\n");
   } else {
     /* Request server information */
-    ssnprintf(plugin_instance, sizeof(plugin_instance), "vserver%i",
+    snprintf(plugin_instance, sizeof(plugin_instance), "vserver%i",
               vserver->port);
 
     /* Select the server */

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -99,7 +99,7 @@ static int thermal_procfs_device_read(const char __attribute__((unused)) * dir,
    */
 
   len = snprintf(filename, sizeof(filename), "%s/%s/temperature",
-                  dirname_procfs, name);
+                 dirname_procfs, name);
   if ((len < 0) || ((size_t)len >= sizeof(filename)))
     return -1;
 

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -65,14 +65,14 @@ static int thermal_sysfs_device_read(const char __attribute__((unused)) * dir,
   if (device_list && ignorelist_match(device_list, name))
     return -1;
 
-  ssnprintf(filename, sizeof(filename), "%s/%s/temp", dirname_sysfs, name);
+  snprintf(filename, sizeof(filename), "%s/%s/temp", dirname_sysfs, name);
   if (parse_value_file(filename, &value, DS_TYPE_GAUGE) == 0) {
     value.gauge /= 1000.0;
     thermal_submit(name, TEMP, value);
     success = 1;
   }
 
-  ssnprintf(filename, sizeof(filename), "%s/%s/cur_state", dirname_sysfs, name);
+  snprintf(filename, sizeof(filename), "%s/%s/cur_state", dirname_sysfs, name);
   if (parse_value_file(filename, &value, DS_TYPE_GAUGE) == 0) {
     thermal_submit(name, COOLING_DEV, value);
     success = 1;
@@ -98,7 +98,7 @@ static int thermal_procfs_device_read(const char __attribute__((unused)) * dir,
    * temperature:             55 C
    */
 
-  len = ssnprintf(filename, sizeof(filename), "%s/%s/temperature",
+  len = snprintf(filename, sizeof(filename), "%s/%s/temperature",
                   dirname_procfs, name);
   if ((len < 0) || ((size_t)len >= sizeof(filename)))
     return -1;

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -356,9 +356,9 @@ static int ut_config_host(const threshold_t *th_orig, oconfig_item_t *ci) {
 
   return status;
 } /* int ut_config_host */
-  /*
-   * End of the functions used to configure threshold values.
-   */
+/*
+ * End of the functions used to configure threshold values.
+ */
 /* }}} */
 
 /*
@@ -457,8 +457,8 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
       snprintf(buf, bufsize, ": Value is no longer missing.");
     else
       snprintf(buf, bufsize, ": All data sources are within range again. "
-                              "Current value of \"%s\" is %f.",
-                ds->ds[ds_index].name, values[ds_index]);
+                             "Current value of \"%s\" is %f.",
+               ds->ds[ds_index].name, values[ds_index]);
   } else {
     double min;
     double max;
@@ -469,20 +469,20 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
     if (th->flags & UT_FLAG_INVERT) {
       if (!isnan(min) && !isnan(max)) {
         snprintf(buf, bufsize,
-                  ": Data source \"%s\" is currently "
-                  "%f. That is within the %s region of %f%s and %f%s.",
-                  ds->ds[ds_index].name, values[ds_index],
-                  (state == STATE_ERROR) ? "failure" : "warning", min,
-                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
-                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+                 ": Data source \"%s\" is currently "
+                 "%f. That is within the %s region of %f%s and %f%s.",
+                 ds->ds[ds_index].name, values[ds_index],
+                 (state == STATE_ERROR) ? "failure" : "warning", min,
+                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
+                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
         snprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                                "%f. That is %s the %s threshold of %f%s.",
-                  ds->ds[ds_index].name, values[ds_index],
-                  isnan(min) ? "below" : "above",
-                  (state == STATE_ERROR) ? "failure" : "warning",
-                  isnan(min) ? max : min,
-                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+                               "%f. That is %s the %s threshold of %f%s.",
+                 ds->ds[ds_index].name, values[ds_index],
+                 isnan(min) ? "below" : "above",
+                 (state == STATE_ERROR) ? "failure" : "warning",
+                 isnan(min) ? max : min,
+                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       }
     } else if (th->flags & UT_FLAG_PERCENTAGE) {
       gauge_t value;
@@ -502,20 +502,20 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
         value = 100.0 * values[ds_index] / sum;
 
       snprintf(buf, bufsize,
-                ": Data source \"%s\" is currently "
-                "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
-                ds->ds[ds_index].name, values[ds_index], value,
-                (value < min) ? "below" : "above",
-                (state == STATE_ERROR) ? "failure" : "warning",
-                (value < min) ? min : max);
+               ": Data source \"%s\" is currently "
+               "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
+               ds->ds[ds_index].name, values[ds_index], value,
+               (value < min) ? "below" : "above",
+               (state == STATE_ERROR) ? "failure" : "warning",
+               (value < min) ? min : max);
     } else /* is not inverted */
     {
       snprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                              "%f. That is %s the %s threshold of %f.",
-                ds->ds[ds_index].name, values[ds_index],
-                (values[ds_index] < min) ? "below" : "above",
-                (state == STATE_ERROR) ? "failure" : "warning",
-                (values[ds_index] < min) ? min : max);
+                             "%f. That is %s the %s threshold of %f.",
+               ds->ds[ds_index].name, values[ds_index],
+               (values[ds_index] < min) ? "below" : "above",
+               (state == STATE_ERROR) ? "failure" : "warning",
+               (values[ds_index] < min) ? min : max);
     }
   }
 
@@ -773,8 +773,8 @@ static int ut_missing(const value_list_t *vl,
 
   NOTIFICATION_INIT_VL(&n, vl);
   snprintf(n.message, sizeof(n.message),
-            "%s has not been updated for %.3f seconds.", identifier,
-            CDTIME_T_TO_DOUBLE(missing_time));
+           "%s has not been updated for %.3f seconds.", identifier,
+           CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;
 
   plugin_dispatch_notification(&n);

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -424,22 +424,22 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
   n.time = vl->time;
 
-  status = ssnprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
+  status = snprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
   buf += status;
   bufsize -= status;
 
   if (vl->plugin_instance[0] != '\0') {
-    status = ssnprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
+    status = snprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
     buf += status;
     bufsize -= status;
   }
 
-  status = ssnprintf(buf, bufsize, " type %s", vl->type);
+  status = snprintf(buf, bufsize, " type %s", vl->type);
   buf += status;
   bufsize -= status;
 
   if (vl->type_instance[0] != '\0') {
-    status = ssnprintf(buf, bufsize, " (instance %s)", vl->type_instance);
+    status = snprintf(buf, bufsize, " (instance %s)", vl->type_instance);
     buf += status;
     bufsize -= status;
   }
@@ -454,9 +454,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
   /* Send an okay notification */
   if (state == STATE_OKAY) {
     if (state_old == STATE_MISSING)
-      ssnprintf(buf, bufsize, ": Value is no longer missing.");
+      snprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      ssnprintf(buf, bufsize, ": All data sources are within range again. "
+      snprintf(buf, bufsize, ": All data sources are within range again. "
                               "Current value of \"%s\" is %f.",
                 ds->ds[ds_index].name, values[ds_index]);
   } else {
@@ -468,7 +468,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
     if (th->flags & UT_FLAG_INVERT) {
       if (!isnan(min) && !isnan(max)) {
-        ssnprintf(buf, bufsize,
+        snprintf(buf, bufsize,
                   ": Data source \"%s\" is currently "
                   "%f. That is within the %s region of %f%s and %f%s.",
                   ds->ds[ds_index].name, values[ds_index],
@@ -476,7 +476,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+        snprintf(buf, bufsize, ": Data source \"%s\" is currently "
                                 "%f. That is %s the %s threshold of %f%s.",
                   ds->ds[ds_index].name, values[ds_index],
                   isnan(min) ? "below" : "above",
@@ -501,7 +501,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
       else
         value = 100.0 * values[ds_index] / sum;
 
-      ssnprintf(buf, bufsize,
+      snprintf(buf, bufsize,
                 ": Data source \"%s\" is currently "
                 "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
                 ds->ds[ds_index].name, values[ds_index], value,
@@ -510,7 +510,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                 (value < min) ? min : max);
     } else /* is not inverted */
     {
-      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+      snprintf(buf, bufsize, ": Data source \"%s\" is currently "
                               "%f. That is %s the %s threshold of %f.",
                 ds->ds[ds_index].name, values[ds_index],
                 (values[ds_index] < min) ? "below" : "above",
@@ -772,7 +772,7 @@ static int ut_missing(const value_list_t *vl,
   FORMAT_VL(identifier, sizeof(identifier), vl);
 
   NOTIFICATION_INIT_VL(&n, vl);
-  ssnprintf(n.message, sizeof(n.message),
+  snprintf(n.message, sizeof(n.message),
             "%s has not been updated for %.3f seconds.", identifier,
             CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -266,7 +266,7 @@ open_msr(unsigned int cpu, _Bool multiple_read) {
     }
   }
 
-  ssnprintf(pathname, sizeof(pathname), "/dev/cpu/%d/msr", cpu);
+  snprintf(pathname, sizeof(pathname), "/dev/cpu/%d/msr", cpu);
   fd = open(pathname, O_RDONLY);
   if (fd < 0) {
     ERROR("turbostat plugin: failed to open %s", pathname);
@@ -556,7 +556,7 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   DEBUG("turbostat plugin: submit stats for cpu: %d, core: %d, pkg: %d",
         t->cpu_id, c->core_id, p->package_id);
 
-  ssnprintf(name, sizeof(name), "cpu%02d", t->cpu_id);
+  snprintf(name, sizeof(name), "cpu%02d", t->cpu_id);
 
   if (!aperf_mperf_unstable)
     turbostat_submit(name, "percent", "c0", 100.0 * t->mperf / t->tsc);
@@ -585,7 +585,7 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
 
   /* If not using logical core numbering, set core id */
   if (!config_lcn) {
-    ssnprintf(name, sizeof(name), "core%02d", c->core_id);
+    snprintf(name, sizeof(name), "core%02d", c->core_id);
   }
 
   if (do_core_cstate & (1 << 3))
@@ -602,7 +602,7 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   if (!(t->flags & CPU_IS_FIRST_CORE_IN_PACKAGE))
     goto done;
 
-  ssnprintf(name, sizeof(name), "pkg%02d", p->package_id);
+  snprintf(name, sizeof(name), "pkg%02d", p->package_id);
 
   if (do_ptm)
     turbostat_submit(name, "temperature", NULL, p->pkg_temp_c);
@@ -1064,7 +1064,7 @@ static int get_threads_on_core(unsigned int cpu) {
   int matches;
   char character;
 
-  ssnprintf(path, sizeof(path),
+  snprintf(path, sizeof(path),
             "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
   filep = fopen(path, "r");
   if (!filep) {

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -567,9 +567,9 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
                    1.0 / 1000000 * t->aperf / interval_float);
 
   if ((!aperf_mperf_unstable) || (!(t->aperf > t->tsc || t->mperf > t->tsc)))
-    turbostat_submit(name, "frequency", "busy", 1.0 * t->tsc / 1000000 *
-                                                    t->aperf / t->mperf /
-                                                    interval_float);
+    turbostat_submit(name, "frequency", "busy",
+                     1.0 * t->tsc / 1000000 * t->aperf / t->mperf /
+                         interval_float);
 
   /* Sanity check (should stay stable) */
   turbostat_submit(name, "gauge", "TSC",
@@ -1065,7 +1065,7 @@ static int get_threads_on_core(unsigned int cpu) {
   char character;
 
   snprintf(path, sizeof(path),
-            "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
+           "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
   filep = fopen(path, "r");
   if (!filep) {
     ERROR("turbostat plugin: Failed to open '%s'", path);

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -277,9 +277,9 @@ int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
   escape_string(buffer_values, sizeof(buffer_values));
 
   snprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
-            (vl->interval > 0) ? CDTIME_T_TO_DOUBLE(vl->interval)
-                               : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
-            buffer_values);
+           (vl->interval > 0) ? CDTIME_T_TO_DOUBLE(vl->interval)
+                              : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
+           buffer_values);
 
   return 0;
 } /* }}} int cmd_create_putval */

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -276,7 +276,7 @@ int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
     return status;
   escape_string(buffer_values, sizeof(buffer_values));
 
-  ssnprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
+  snprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
             (vl->interval > 0) ? CDTIME_T_TO_DOUBLE(vl->interval)
                                : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
             buffer_values);

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -26,12 +26,12 @@
  *   Sebastian 'tokkee' Harl <sh at tokkee.org>
  **/
 
+#include "utils_cmds.h"
 #include "daemon/common.h"
 #include "utils_cmd_flush.h"
 #include "utils_cmd_getval.h"
 #include "utils_cmd_listval.h"
 #include "utils_cmd_putval.h"
-#include "utils_cmds.h"
 #include "utils_parse_option.h"
 
 #include <stdbool.h>

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -912,7 +912,7 @@ const char *qtype_str(int t) {
     return "ANY"; /* ... 255 */
 #endif /* __BIND >= 19950621 */
   default:
-    ssnprintf(buf, sizeof(buf), "#%i", t);
+    snprintf(buf, sizeof(buf), "#%i", t);
     return buf;
   } /* switch (t) */
 }
@@ -931,7 +931,7 @@ const char *opcode_str(int o) {
   case 5:
     return "Update";
   default:
-    ssnprintf(buf, sizeof(buf), "Opcode%d", o);
+    snprintf(buf, sizeof(buf), "Opcode%d", o);
     return buf;
   }
 }
@@ -998,7 +998,7 @@ const char *rcode_str(int rcode) {
 #endif /* RFC2136 rcodes */
 #endif /* __BIND >= 19950621 */
   default:
-    ssnprintf(buf, sizeof(buf), "RCode%i", rcode);
+    snprintf(buf, sizeof(buf), "RCode%i", rcode);
     return buf;
   }
 } /* const char *rcode_str (int rcode) */

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -107,7 +107,7 @@ static void dpdk_helper_config_default(dpdk_helper_ctx_t *phc) {
   snprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
   snprintf(phc->eal_config.process_type, DATA_MAX_NAME_LEN, "%s", "secondary");
   snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
-            DPDK_DEFAULT_RTE_CONFIG);
+           DPDK_DEFAULT_RTE_CONFIG);
 }
 
 int dpdk_helper_eal_config_set(dpdk_helper_ctx_t *phc, dpdk_eal_config_t *ec) {
@@ -183,7 +183,7 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
     } else if ((strcasecmp("FilePrefix", child->key) == 0) &&
                (child->values[0].type == OCONFIG_TYPE_STRING)) {
       snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
-                "/var/run/.%s_config", child->values[0].value.string);
+               "/var/run/.%s_config", child->values[0].value.string);
       DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
     } else {
       ERROR("dpdk_common: Invalid '%s' configuration option", child->key);

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -103,10 +103,10 @@ static void dpdk_helper_config_default(dpdk_helper_ctx_t *phc) {
 
   DPDK_HELPER_TRACE(phc->shm_name);
 
-  ssnprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
-  ssnprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
-  ssnprintf(phc->eal_config.process_type, DATA_MAX_NAME_LEN, "%s", "secondary");
-  ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
+  snprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
+  snprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
+  snprintf(phc->eal_config.process_type, DATA_MAX_NAME_LEN, "%s", "secondary");
+  snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
             DPDK_DEFAULT_RTE_CONFIG);
 }
 
@@ -182,7 +182,7 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
       DEBUG("dpdk_common: EAL:Process type %s", phc->eal_config.process_type);
     } else if ((strcasecmp("FilePrefix", child->key) == 0) &&
                (child->values[0].type == OCONFIG_TYPE_STRING)) {
-      ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
+      snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
                 "/var/run/.%s_config", child->values[0].value.string);
       DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
     } else {

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -46,7 +46,7 @@ static int gr_format_values(char *ret, size_t ret_len, int ds_num,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
+    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);            \
     if (status < 1) {                                                          \
       return -1;                                                               \
     } else if (((size_t)status) >= (ret_len - offset)) {                       \
@@ -132,8 +132,8 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
 
   if (n_plugin_instance[0] != '\0')
     snprintf(tmp_plugin, sizeof(tmp_plugin), "%s%c%s", n_plugin,
-              (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
-              n_plugin_instance);
+             (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
+             n_plugin_instance);
   else
     sstrncpy(tmp_plugin, n_plugin, sizeof(tmp_plugin));
 
@@ -142,8 +142,8 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
       sstrncpy(tmp_type, n_type_instance, sizeof(tmp_type));
     else
       snprintf(tmp_type, sizeof(tmp_type), "%s%c%s", n_type,
-                (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
-                n_type_instance);
+               (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
+               n_type_instance);
   } else
     sstrncpy(tmp_type, n_type, sizeof(tmp_type));
 
@@ -153,13 +153,13 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) &&
         strcmp(tmp_plugin, tmp_type) == 0)
       snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix,
-                tmp_plugin, ds_name);
+               tmp_plugin, ds_name);
     else
       snprintf(ret, ret_len, "%s%s%s.%s.%s.%s", prefix, n_host, postfix,
-                tmp_plugin, tmp_type, ds_name);
+               tmp_plugin, tmp_type, ds_name);
   } else
     snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
-              tmp_type);
+             tmp_type);
 
   return 0;
 }
@@ -220,7 +220,7 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
     /* Compute the graphite command */
     message_len =
         (size_t)snprintf(message, sizeof(message), "%s %s %u\r\n", key, values,
-                          (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
+                         (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
     if (message_len >= sizeof(message)) {
       ERROR("format_graphite: message buffer too small: "
             "Need %zu bytes.",

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -46,7 +46,7 @@ static int gr_format_values(char *ret, size_t ret_len, int ds_num,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
+    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
     if (status < 1) {                                                          \
       return -1;                                                               \
     } else if (((size_t)status) >= (ret_len - offset)) {                       \
@@ -131,7 +131,7 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
                       sizeof(n_type_instance), escape_char, preserve_separator);
 
   if (n_plugin_instance[0] != '\0')
-    ssnprintf(tmp_plugin, sizeof(tmp_plugin), "%s%c%s", n_plugin,
+    snprintf(tmp_plugin, sizeof(tmp_plugin), "%s%c%s", n_plugin,
               (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
               n_plugin_instance);
   else
@@ -141,7 +141,7 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
       sstrncpy(tmp_type, n_type_instance, sizeof(tmp_type));
     else
-      ssnprintf(tmp_type, sizeof(tmp_type), "%s%c%s", n_type,
+      snprintf(tmp_type, sizeof(tmp_type), "%s%c%s", n_type,
                 (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
                 n_type_instance);
   } else
@@ -152,13 +152,13 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
   if (ds_name != NULL) {
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) &&
         strcmp(tmp_plugin, tmp_type) == 0)
-      ssnprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix,
+      snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix,
                 tmp_plugin, ds_name);
     else
-      ssnprintf(ret, ret_len, "%s%s%s.%s.%s.%s", prefix, n_host, postfix,
+      snprintf(ret, ret_len, "%s%s%s.%s.%s.%s", prefix, n_host, postfix,
                 tmp_plugin, tmp_type, ds_name);
   } else
-    ssnprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
+    snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
               tmp_type);
 
   return 0;
@@ -219,7 +219,7 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
 
     /* Compute the graphite command */
     message_len =
-        (size_t)ssnprintf(message, sizeof(message), "%s %s %u\r\n", key, values,
+        (size_t)snprintf(message, sizeof(message), "%s %s %u\r\n", key, values,
                           (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
     if (message_len >= sizeof(message)) {
       ERROR("format_graphite: message buffer too small: "

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -95,7 +95,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -159,7 +159,7 @@ static int dstypes_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -193,7 +193,7 @@ static int dsnames_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -228,7 +228,7 @@ static int meta_data_keys_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -318,7 +318,7 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -577,11 +577,12 @@ static int format_alert(yajl_gen g, notification_t const *n) /* {{{ */
   }
 
   JSON_ADD(g, "severity");
-  JSON_ADD(g, (n->severity == NOTIF_FAILURE)
-                  ? "FAILURE"
-                  : (n->severity == NOTIF_WARNING)
-                        ? "WARNING"
-                        : (n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN");
+  JSON_ADD(g,
+           (n->severity == NOTIF_FAILURE)
+               ? "FAILURE"
+               : (n->severity == NOTIF_WARNING)
+                     ? "WARNING"
+                     : (n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN");
 
   JSON_ADD(g, "service");
   JSON_ADD(g, "collectd");

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -95,7 +95,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -159,7 +159,7 @@ static int dstypes_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -193,7 +193,7 @@ static int dsnames_to_json(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -228,7 +228,7 @@ static int meta_data_keys_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -318,7 +318,7 @@ static int value_list_to_json(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -103,7 +103,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -192,7 +192,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);     \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \
@@ -345,12 +345,9 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
   if (*ret_buffer_free < 3)
     return -ENOMEM;
 
-  return format_kairosdb_value_list_nocheck(buffer, ret_buffer_fill,
-                                            ret_buffer_free, ds, vl,
-                                            store_rates,
-                                            (*ret_buffer_free) - 2,
-                                            http_attrs, http_attrs_num,
-                                            data_ttl);
+  return format_kairosdb_value_list_nocheck(
+      buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
+      (*ret_buffer_free) - 2, http_attrs, http_attrs_num, data_ttl);
 } /* }}} int format_kairosdb_value_list */
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -103,7 +103,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
     int status;                                                                \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -192,7 +192,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
+    status = snprintf(buffer + offset, buffer_size - offset, __VA_ARGS__);    \
     if (status < 1)                                                            \
       return -1;                                                               \
     else if (((size_t)status) >= (buffer_size - offset))                       \

--- a/src/utils_latency_config.c
+++ b/src/utils_latency_config.c
@@ -25,8 +25,8 @@
  *   Pavel Rochnyack <pavel2000 at ngs.ru>
  */
 
-#include "common.h"
 #include "utils_latency_config.h"
+#include "common.h"
 #include "collectd.h"
 
 static int latency_config_add_percentile(latency_config_t *conf,

--- a/src/utils_lua.c
+++ b/src/utils_lua.c
@@ -28,8 +28,8 @@
  * GCC will complain about the macro definition. */
 #define DONT_POISON_SPRINTF_YET
 
-#include "common.h"
 #include "utils_lua.h"
+#include "common.h"
 
 static int ltoc_values(lua_State *L, /* {{{ */
                        const data_set_t *ds, value_t *ret_values) {

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -258,7 +258,7 @@ static void uuidcache_init(void) {
         * (This is useful, if the cdrom on /dev/hdc must not
         * be accessed.)
         */
-        ssnprintf(device, sizeof(device), "%s/%s", DEVLABELDIR, ptname);
+        snprintf(device, sizeof(device), "%s/%s", DEVLABELDIR, ptname);
         if (!get_label_uuid(device, &label, uuid)) {
           uuidcache_addentry(sstrdup(device), label, uuid);
         }

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -527,7 +527,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
 
   return first;
 } /* static cu_mount_t *cu_mount_gen_getmntent (void) */
-/* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
+  /* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
 
 #elif HAVE_SEQ_GETMNTENT
 #warn "This version of `getmntent' hat not yet been implemented!"

--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -3,14 +3,17 @@
  *
  * Copyright(c) 2016 Intel Corporation. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ *of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
+ * of the Software, and to permit persons to whom the Software is furnished to
+ *do
  * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
+ * The above copyright notice and this permission notice shall be included in
+ *all
  * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -314,8 +317,7 @@ static int ovs_db_data_send(const ovs_db_t *pdb, const char *data, size_t len) {
  */
 static yajl_gen_status ovs_yajl_gen_tstring(yajl_gen hander,
                                             const char *string) {
-  return yajl_gen_string(hander, (const unsigned char *)string,
-                         strlen(string));
+  return yajl_gen_string(hander, (const unsigned char *)string, strlen(string));
 }
 
 /* Add YAJL value into YAJL generator handle (JSON object)

--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -1091,7 +1091,7 @@ int ovs_db_send_request(ovs_db_t *pdb, const char *method, const char *params,
   /* generate id field */
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, "id");
   uid = ovs_uid_generate();
-  ssnprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
+  snprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_buff);
 
   OVS_YAJL_CALL(yajl_gen_map_close, jgen);
@@ -1177,7 +1177,7 @@ int ovs_db_table_cb_register(ovs_db_t *pdb, const char *tb_name,
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, OVS_DB_DEFAULT_DB_NAME);
 
     /* uid string <json-value> */
-    ssnprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
+    snprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_str);
 
     /* <monitor-requests> */

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -208,7 +208,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
       if (rra_num >= rra_max)
         break;
 
-      status = ssnprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
+      status = snprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
                          rra_types[j], cfg->xff, cdp_len, cdp_num);
 
       if ((status < 0) || ((size_t)status >= sizeof(buffer))) {
@@ -280,14 +280,14 @@ static int ds_get(char ***ret, /* {{{ */
     if (isnan(d->min)) {
       sstrncpy(min, "U", sizeof(min));
     } else
-      ssnprintf(min, sizeof(min), "%f", d->min);
+      snprintf(min, sizeof(min), "%f", d->min);
 
     if (isnan(d->max)) {
       sstrncpy(max, "U", sizeof(max));
     } else
-      ssnprintf(max, sizeof(max), "%f", d->max);
+      snprintf(max, sizeof(max), "%f", d->max);
 
-    status = ssnprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
+    status = snprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
                        type, (cfg->heartbeat > 0)
                                  ? cfg->heartbeat
                                  : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
@@ -369,8 +369,8 @@ static int srrd_create(const char *filename, /* {{{ */
   if (last_up == 0)
     last_up = time(NULL) - 10;
 
-  ssnprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
-  ssnprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
+  snprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
+  snprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
 
   new_argv[0] = "create";
   new_argv[1] = (void *)filename;
@@ -497,7 +497,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     return 0;
   }
 
-  ssnprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
+  snprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
 
   status = srrd_create(tmpfile, args->pdp_step, args->last_up, args->argc,
                        (void *)args->argv);

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -209,7 +209,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
         break;
 
       status = snprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
-                         rra_types[j], cfg->xff, cdp_len, cdp_num);
+                        rra_types[j], cfg->xff, cdp_len, cdp_num);
 
       if ((status < 0) || ((size_t)status >= sizeof(buffer))) {
         ERROR("rra_get: Buffer would have been truncated.");
@@ -287,11 +287,11 @@ static int ds_get(char ***ret, /* {{{ */
     } else
       snprintf(max, sizeof(max), "%f", d->max);
 
-    status = snprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
-                       type, (cfg->heartbeat > 0)
-                                 ? cfg->heartbeat
-                                 : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
-                       min, max);
+    status = snprintf(
+        buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name, type,
+        (cfg->heartbeat > 0) ? cfg->heartbeat
+                             : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
+        min, max);
     if ((status < 1) || ((size_t)status >= sizeof(buffer)))
       break;
 

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -119,10 +119,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   sstrncpy(vl.type, data->type, sizeof(vl.type));
   for (size_t i = 0; i < data->latency_config.percentile_num; i++) {
     if (strlen(data->type_instance) != 0)
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%.0f",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%.0f",
                 data->type_instance, data->latency_config.percentile[i]);
     else
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%.0f",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.0f",
                 data->latency_config.percentile[i]);
 
     vl.values = &(value_t){
@@ -147,10 +147,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
         bucket.upper_bound ? CDTIME_T_TO_DOUBLE(bucket.upper_bound) : INFINITY;
 
     if (strlen(data->type_instance) != 0)
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s-%g_%g",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s-%g_%g",
                 data->type, data->type_instance, lower_bound, upper_bound);
     else
-      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%g_%g",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%g_%g",
                 data->type, lower_bound, upper_bound);
 
     vl.values = &(value_t){

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -120,10 +120,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   for (size_t i = 0; i < data->latency_config.percentile_num; i++) {
     if (strlen(data->type_instance) != 0)
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%.0f",
-                data->type_instance, data->latency_config.percentile[i]);
+               data->type_instance, data->latency_config.percentile[i]);
     else
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%.0f",
-                data->latency_config.percentile[i]);
+               data->latency_config.percentile[i]);
 
     vl.values = &(value_t){
         .gauge =
@@ -148,10 +148,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
 
     if (strlen(data->type_instance) != 0)
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s-%g_%g",
-                data->type, data->type_instance, lower_bound, upper_bound);
+               data->type, data->type_instance, lower_bound, upper_bound);
     else
       snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%g_%g",
-                data->type, lower_bound, upper_bound);
+               data->type, lower_bound, upper_bound);
 
     vl.values = &(value_t){
         .gauge =

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -99,7 +99,7 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
   if (plugin_instance == NULL)
     plugin_instance = "default";
   snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-            plugin_instance, category);
+           plugin_instance, category);
 
   sstrncpy(vl.type, type, sizeof(vl.type));
 
@@ -113,18 +113,20 @@ static int varnish_submit_gauge(const char *plugin_instance, /* {{{ */
                                 const char *category, const char *type,
                                 const char *type_instance,
                                 uint64_t gauge_value) {
-  return varnish_submit(plugin_instance, category, type, type_instance, (value_t){
-      .gauge=(gauge_t)gauge_value,
-    });
+  return varnish_submit(plugin_instance, category, type, type_instance,
+                        (value_t){
+                            .gauge = (gauge_t)gauge_value,
+                        });
 } /* }}} int varnish_submit_gauge */
 
 static int varnish_submit_derive(const char *plugin_instance, /* {{{ */
                                  const char *category, const char *type,
                                  const char *type_instance,
                                  uint64_t derive_value) {
-  return varnish_submit(plugin_instance, category, type, type_instance, (value_t){
-      .derive=(derive_t)derive_value,
-    });
+  return varnish_submit(plugin_instance, category, type, type_instance,
+                        (value_t){
+                            .derive = (derive_t)derive_value,
+                        });
 } /* }}} int varnish_submit_derive */
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
@@ -172,21 +174,21 @@ static int varnish_monitor(void *priv,
 
   if (conf->collect_connections) {
     if (strcmp(name, "client_conn") == 0)
-      return varnish_submit_derive(conf->instance, "connections",
-                                   "connections", "accepted", val);
+      return varnish_submit_derive(conf->instance, "connections", "connections",
+                                   "accepted", val);
     else if (strcmp(name, "client_drop") == 0)
-      return varnish_submit_derive(conf->instance, "connections",
-                                   "connections", "dropped", val);
+      return varnish_submit_derive(conf->instance, "connections", "connections",
+                                   "dropped", val);
     else if (strcmp(name, "client_req") == 0)
-      return varnish_submit_derive(conf->instance, "connections",
-                                   "connections", "received", val);
+      return varnish_submit_derive(conf->instance, "connections", "connections",
+                                   "received", val);
   }
 
 #ifdef HAVE_VARNISH_V3
   if (conf->collect_dirdns) {
     if (strcmp(name, "dir_dns_lookups") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns",
-                                   "cache_operation", "lookups", val);
+      return varnish_submit_derive(conf->instance, "dirdns", "cache_operation",
+                                   "lookups", val);
     else if (strcmp(name, "dir_dns_failed") == 0)
       return varnish_submit_derive(conf->instance, "dirdns", "cache_result",
                                    "failed", val);
@@ -441,26 +443,26 @@ static int varnish_monitor(void *priv,
       return varnish_submit_gauge(conf->instance, "sms", "requests",
                                   "outstanding", val);
     else if (strcmp(name, "sms_nbytes") == 0)
-      return varnish_submit_gauge(conf->instance, "sms", "bytes",
-                                  "outstanding", val);
+      return varnish_submit_gauge(conf->instance, "sms", "bytes", "outstanding",
+                                  val);
     else if (strcmp(name, "sms_balloc") == 0)
       return varnish_submit_derive(conf->instance, "sms", "total_bytes",
                                    "allocated", val);
     else if (strcmp(name, "sms_bfree") == 0)
-      return varnish_submit_derive(conf->instance, "sms", "total_bytes",
-                                   "free", val);
+      return varnish_submit_derive(conf->instance, "sms", "total_bytes", "free",
+                                   val);
   }
 
   if (conf->collect_struct) {
     if (strcmp(name, "n_sess_mem") == 0)
-      return varnish_submit_gauge(conf->instance, "struct",
-                                  "current_sessions", "sess_mem", val);
+      return varnish_submit_gauge(conf->instance, "struct", "current_sessions",
+                                  "sess_mem", val);
     else if (strcmp(name, "n_sess") == 0)
-      return varnish_submit_gauge(conf->instance, "struct",
-                                  "current_sessions", "sess", val);
+      return varnish_submit_gauge(conf->instance, "struct", "current_sessions",
+                                  "sess", val);
     else if (strcmp(name, "n_object") == 0)
-      return varnish_submit_gauge(conf->instance, "struct", "objects",
-                                  "object", val);
+      return varnish_submit_gauge(conf->instance, "struct", "objects", "object",
+                                  val);
     else if (strcmp(name, "n_vampireobject") == 0)
       return varnish_submit_gauge(conf->instance, "struct", "objects",
                                   "vampireobject", val);
@@ -495,14 +497,14 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_requests",
                                    "requests", val);
     else if (strcmp(name, "s_pipe") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "pipe", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "pipe", val);
     else if (strcmp(name, "s_pass") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "pass", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "pass", val);
     else if (strcmp(name, "s_fetch") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "fetches", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "fetches", val);
     else if (strcmp(name, "s_synth") == 0)
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "synth", val);
@@ -528,8 +530,8 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "pipe_out", val);
     else if (strcmp(name, "n_purges") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "purges", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "purges", val);
     else if (strcmp(name, "s_hdrbytes") == 0)
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "header-bytes", val);
@@ -537,11 +539,11 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "totals", "total_bytes",
                                    "body-bytes", val);
     else if (strcmp(name, "n_gzip") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "gzip", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "gzip", val);
     else if (strcmp(name, "n_gunzip") == 0)
-      return varnish_submit_derive(conf->instance, "totals",
-                                   "total_operations", "gunzip", val);
+      return varnish_submit_derive(conf->instance, "totals", "total_operations",
+                                   "gunzip", val);
   }
 
   if (conf->collect_uptime) {
@@ -558,8 +560,8 @@ static int varnish_monitor(void *priv,
       return varnish_submit_gauge(conf->instance, "vcl", "vcl", "avail_vcl",
                                   val);
     else if (strcmp(name, "n_vcl_discard") == 0)
-      return varnish_submit_gauge(conf->instance, "vcl", "vcl",
-                                  "discarded_vcl", val);
+      return varnish_submit_gauge(conf->instance, "vcl", "vcl", "discarded_vcl",
+                                  val);
     else if (strcmp(name, "vmods") == 0)
       return varnish_submit_gauge(conf->instance, "vcl", "objects", "vmod",
                                   val);
@@ -600,17 +602,17 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "workers", "total_threads",
                                    "dropped", val);
     else if (strcmp(name, "n_wrk_queue") == 0)
-      return varnish_submit_derive(conf->instance, "workers",
-                                   "total_requests", "queued", val);
+      return varnish_submit_derive(conf->instance, "workers", "total_requests",
+                                   "queued", val);
     else if (strcmp(name, "n_wrk_overflow") == 0)
-      return varnish_submit_derive(conf->instance, "workers",
-                                   "total_requests", "overflowed", val);
+      return varnish_submit_derive(conf->instance, "workers", "total_requests",
+                                   "overflowed", val);
     else if (strcmp(name, "n_wrk_queued") == 0)
-      return varnish_submit_derive(conf->instance, "workers",
-                                   "total_requests", "queued", val);
+      return varnish_submit_derive(conf->instance, "workers", "total_requests",
+                                   "queued", val);
     else if (strcmp(name, "n_wrk_lqueue") == 0)
-      return varnish_submit_derive(conf->instance, "workers",
-                                   "total_requests", "queue_length", val);
+      return varnish_submit_derive(conf->instance, "workers", "total_requests",
+                                   "queue_length", val);
   }
 
 #if HAVE_VARNISH_V4
@@ -1135,9 +1137,10 @@ static int varnish_init(void) /* {{{ */
       /* group = */ "varnish",
       /* name      = */ "varnish/localhost",
       /* callback  = */ varnish_read,
-      /* interval  = */ 0, &(user_data_t){
-                               .data = conf, .free_func = varnish_config_free,
-                           });
+      /* interval  = */ 0,
+      &(user_data_t){
+          .data = conf, .free_func = varnish_config_free,
+      });
 
   return 0;
 } /* }}} int varnish_init */
@@ -1296,15 +1299,16 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
   }
 
   snprintf(callback_name, sizeof(callback_name), "varnish/%s",
-            (conf->instance == NULL) ? "localhost" : conf->instance);
+           (conf->instance == NULL) ? "localhost" : conf->instance);
 
   plugin_register_complex_read(
       /* group = */ "varnish",
       /* name      = */ callback_name,
       /* callback  = */ varnish_read,
-      /* interval  = */ 0, &(user_data_t){
-                               .data = conf, .free_func = varnish_config_free,
-                           });
+      /* interval  = */ 0,
+      &(user_data_t){
+          .data = conf, .free_func = varnish_config_free,
+      });
 
   have_instance = 1;
 

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -98,7 +98,7 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
 
   if (plugin_instance == NULL)
     plugin_instance = "default";
-  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
             plugin_instance, category);
 
   sstrncpy(vl.type, type, sizeof(vl.type));
@@ -1295,7 +1295,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     return EINVAL;
   }
 
-  ssnprintf(callback_name, sizeof(callback_name), "varnish/%s",
+  snprintf(callback_name, sizeof(callback_name), "varnish/%s",
             (conf->instance == NULL) ? "localhost" : conf->instance);
 
   plugin_register_complex_read(

--- a/src/virt.c
+++ b/src/virt.c
@@ -753,7 +753,7 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
 
   char flush_type_instance[DATA_MAX_NAME_LEN];
   snprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
-            type_instance);
+           type_instance);
 
   if ((binfo->bi.rd_req != -1) && (binfo->bi.wr_req != -1))
     submit_derive2("disk_ops", (derive_t)binfo->bi.rd_req,
@@ -829,7 +829,7 @@ static void domain_state_submit(virDomainPtr dom, int state, int reason) {
 #endif
 
   snprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
-            reason_str);
+           reason_str);
 
   int severity;
   switch (state) {
@@ -1180,8 +1180,7 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
     char type_instance[DATA_MAX_NAME_LEN];
     _Bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? 1 : 0;
 
-    snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
-              cpu);
+    snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
   }
 }
@@ -1722,7 +1721,7 @@ static int lv_domain_get_tag(xmlXPathContextPtr xpath_ctx, const char *dom_name,
   }
 
   snprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
-            METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
+           METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
   xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
   if (xpath_obj == NULL) {
     ERROR(PLUGIN_NAME " plugin: xmlXPathEval(%s) failed on domain %s",

--- a/src/virt.c
+++ b/src/virt.c
@@ -731,7 +731,7 @@ static void vcpu_submit(derive_t value, virDomainPtr dom, int vcpu_nr,
                         const char *type) {
   char type_instance[DATA_MAX_NAME_LEN];
 
-  ssnprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
+  snprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
   submit(dom, type, type_instance, &(value_t){.derive = value}, 1);
 }
 
@@ -752,7 +752,7 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
   }
 
   char flush_type_instance[DATA_MAX_NAME_LEN];
-  ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
+  snprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
             type_instance);
 
   if ((binfo->bi.rd_req != -1) && (binfo->bi.wr_req != -1))
@@ -828,7 +828,7 @@ static void domain_state_submit(virDomainPtr dom, int state, int reason) {
   const char *reason_str = "N/A";
 #endif
 
-  ssnprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
+  snprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
             reason_str);
 
   int severity;
@@ -1180,7 +1180,7 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
     char type_instance[DATA_MAX_NAME_LEN];
     _Bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? 1 : 0;
 
-    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
+    snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
               cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
   }
@@ -1661,7 +1661,7 @@ static int lv_init_instance(size_t i, plugin_read_cb callback) {
 
   memset(lv_ud, 0, sizeof(*lv_ud));
 
-  ssnprintf(inst->tag, sizeof(inst->tag), "%s-%zu", PLUGIN_NAME, i);
+  snprintf(inst->tag, sizeof(inst->tag), "%s-%zu", PLUGIN_NAME, i);
   inst->id = i;
 
   user_data_t *ud = &(lv_ud->ud);
@@ -1721,7 +1721,7 @@ static int lv_domain_get_tag(xmlXPathContextPtr xpath_ctx, const char *dom_name,
     goto done;
   }
 
-  ssnprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
+  snprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
             METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
   xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
   if (xpath_obj == NULL) {
@@ -2157,7 +2157,7 @@ static int ignore_device_match(ignorelist_t *il, const char *domname,
     ERROR(PLUGIN_NAME " plugin: malloc failed.");
     return 0;
   }
-  ssnprintf(name, n, "%s:%s", domname, devpath);
+  snprintf(name, n, "%s:%s", domname, devpath);
   r = ignorelist_match(il, name);
   sfree(name);
   return r;

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -22,8 +22,8 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
-#include "virt.c" /* sic */
 #include "testing.h"
+#include "virt.c" /* sic */
 
 #include <unistd.h>
 

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -160,7 +160,7 @@ static int vserver_read(void) {
     if (dent->d_name[0] == '.')
       continue;
 
-    len = ssnprintf(file, sizeof(file), PROCDIR "/%s", dent->d_name);
+    len = snprintf(file, sizeof(file), PROCDIR "/%s", dent->d_name);
     if ((len < 0) || (len >= BUFSIZE))
       continue;
 
@@ -176,7 +176,7 @@ static int vserver_read(void) {
       continue;
 
     /* socket message accounting */
-    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/cacct", dent->d_name);
+    len = snprintf(file, sizeof(file), PROCDIR "/%s/cacct", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 
@@ -220,7 +220,7 @@ static int vserver_read(void) {
     }
 
     /* thread information and load */
-    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/cvirt", dent->d_name);
+    len = snprintf(file, sizeof(file), PROCDIR "/%s/cvirt", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 
@@ -266,7 +266,7 @@ static int vserver_read(void) {
     }
 
     /* processes and memory usage */
-    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/limit", dent->d_name);
+    len = snprintf(file, sizeof(file), PROCDIR "/%s/limit", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -545,10 +545,10 @@ static int wg_config_node(oconfig_item_t *ci) {
 
   /* FIXME: Legacy configuration syntax. */
   if (cb->name == NULL)
-    ssnprintf(callback_name, sizeof(callback_name), "write_graphite/%s/%s/%s",
+    snprintf(callback_name, sizeof(callback_name), "write_graphite/%s/%s/%s",
               cb->node, cb->service, cb->protocol);
   else
-    ssnprintf(callback_name, sizeof(callback_name), "write_graphite/%s",
+    snprintf(callback_name, sizeof(callback_name), "write_graphite/%s",
               cb->name);
 
   plugin_register_write(callback_name, wg_write,

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -546,10 +546,10 @@ static int wg_config_node(oconfig_item_t *ci) {
   /* FIXME: Legacy configuration syntax. */
   if (cb->name == NULL)
     snprintf(callback_name, sizeof(callback_name), "write_graphite/%s/%s/%s",
-              cb->node, cb->service, cb->protocol);
+             cb->node, cb->service, cb->protocol);
   else
     snprintf(callback_name, sizeof(callback_name), "write_graphite/%s",
-              cb->name);
+             cb->name);
 
   plugin_register_write(callback_name, wg_write,
                         &(user_data_t){

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -190,7 +190,7 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
       return -1;
     }
 
-    ssnprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
+    snprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
               (cb->pass == NULL) ? "" : cb->pass);
     curl_easy_setopt(cb->curl, CURLOPT_USERPWD, cb->credentials);
 #endif
@@ -369,7 +369,7 @@ static int wh_write_command(const data_set_t *ds,
     return status;
   }
 
-  command_len = (size_t)ssnprintf(command, sizeof(command),
+  command_len = (size_t)snprintf(command, sizeof(command),
                                   "PUTVAL %s interval=%.3f %s\r\n", key,
                                   CDTIME_T_TO_DOUBLE(vl->interval), values);
   if (command_len >= sizeof(command)) {
@@ -791,7 +791,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   /* Nulls the buffer and sets ..._free and ..._fill. */
   wh_reset_buffer(cb);
 
-  ssnprintf(callback_name, sizeof(callback_name), "write_http/%s", cb->name);
+  snprintf(callback_name, sizeof(callback_name), "write_http/%s", cb->name);
   DEBUG("write_http: Registering write callback '%s' with URL '%s'",
         callback_name, cb->location);
 

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -191,7 +191,7 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
     }
 
     snprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
-              (cb->pass == NULL) ? "" : cb->pass);
+             (cb->pass == NULL) ? "" : cb->pass);
     curl_easy_setopt(cb->curl, CURLOPT_USERPWD, cb->credentials);
 #endif
     curl_easy_setopt(cb->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
@@ -370,8 +370,8 @@ static int wh_write_command(const data_set_t *ds,
   }
 
   command_len = (size_t)snprintf(command, sizeof(command),
-                                  "PUTVAL %s interval=%.3f %s\r\n", key,
-                                  CDTIME_T_TO_DOUBLE(vl->interval), values);
+                                 "PUTVAL %s interval=%.3f %s\r\n", key,
+                                 CDTIME_T_TO_DOUBLE(vl->interval), values);
   if (command_len >= sizeof(command)) {
     ERROR("write_http plugin: Command buffer too small: "
           "Need %zu bytes.",

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -399,7 +399,7 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   rd_kafka_topic_conf_set_opaque(tctx->conf, tctx);
 
   snprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
-            tctx->topic_name);
+           tctx->topic_name);
 
   status = plugin_register_write(
       callback_name, kafka_write,

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -89,7 +89,7 @@ static uint32_t kafka_hash(const char *keydata, size_t keylen) {
 #define KAFKA_RANDOM_KEY_BUFFER                                                \
   (char[KAFKA_RANDOM_KEY_SIZE]) { "" }
 static char *kafka_random_key(char buffer[static KAFKA_RANDOM_KEY_SIZE]) {
-  ssnprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
+  snprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
   return buffer;
 }
 
@@ -398,7 +398,7 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   rd_kafka_topic_conf_set_partitioner_cb(tctx->conf, kafka_partition);
   rd_kafka_topic_conf_set_opaque(tctx->conf, tctx);
 
-  ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
+  snprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
             tctx->topic_name);
 
   status = plugin_register_write(

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -96,7 +96,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (int i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    ssnprintf(key, sizeof(key), "%i", i);
+    snprintf(key, sizeof(key), "%i", i);
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       BSON_APPEND_DOUBLE(&subarray, key, vl->values[i].gauge);
@@ -121,7 +121,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (int i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    ssnprintf(key, sizeof(key), "%i", i);
+    snprintf(key, sizeof(key), "%i", i);
 
     if (store_rates)
       BSON_APPEND_UTF8(&subarray, key, "gauge");
@@ -134,7 +134,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (int i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    ssnprintf(key, sizeof(key), "%i", i);
+    snprintf(key, sizeof(key), "%i", i);
     BSON_APPEND_UTF8(&subarray, key, ds->ds[i].name);
   }
   bson_append_array_end(ret, &subarray); /* }}} dsnames */
@@ -368,7 +368,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char cb_name[DATA_MAX_NAME_LEN];
 
-    ssnprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
+    snprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
 
     status =
         plugin_register_write(cb_name, wm_write,

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -366,7 +366,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
   }
 
   if (status == 0) {
-    char cb_name[DATA_MAX_NAME_LEN];
+    char cb_name[sizeof("write_mongodb/") + DATA_MAX_NAME_LEN];
 
     snprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
 

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -160,7 +160,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
   for (size_t i = 0; i < m->n_label; i++) {
     char value[LABEL_VALUE_SIZE];
     snprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
-              escape_label_value(value, sizeof(value), m->label[i]->value));
+             escape_label_value(value, sizeof(value), m->label[i]->value));
   }
 
   strjoin(buffer, buffer_size, labels, m->n_label, ",");
@@ -182,9 +182,9 @@ static void format_text(ProtobufCBuffer *buffer) {
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
     snprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
-              (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-                  ? "gauge"
-                  : "counter");
+             (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
+                 ? "gauge"
+                 : "counter");
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
     for (size_t i = 0; i < fam->n_metric; i++) {
@@ -195,16 +195,16 @@ static void format_text(ProtobufCBuffer *buffer) {
       char timestamp_ms[24] = "";
       if (m->has_timestamp_ms)
         snprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
-                  m->timestamp_ms);
+                 m->timestamp_ms);
 
       if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
         snprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
-                  format_labels(labels, sizeof(labels), m), m->gauge->value,
-                  timestamp_ms);
+                 format_labels(labels, sizeof(labels), m), m->gauge->value,
+                 timestamp_ms);
       else /* if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__COUNTER) */
         snprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
-                  format_labels(labels, sizeof(labels), m), m->counter->value,
-                  timestamp_ms);
+                 format_labels(labels, sizeof(labels), m), m->counter->value,
+                 timestamp_ms);
 
       buffer->append(buffer, strlen(line), (uint8_t *)line);
     }
@@ -213,7 +213,7 @@ static void format_text(ProtobufCBuffer *buffer) {
 
   char server[1024];
   snprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
-            PACKAGE_VERSION, hostname_g);
+           PACKAGE_VERSION, hostname_g);
   buffer->append(buffer, strlen(server), (uint8_t *)server);
 
   pthread_mutex_unlock(&metrics_lock);
@@ -599,8 +599,8 @@ static int metric_family_update(Io__Prometheus__Client__MetricFamily *fam,
   if (m == NULL)
     return -1;
 
-  return metric_update(m, vl->values[ds_index], ds->ds[ds_index].type,
-                       vl->time, vl->interval);
+  return metric_update(m, vl->values[ds_index], ds->ds[ds_index].type, vl->time,
+                       vl->interval);
 }
 
 /* metric_family_destroy frees the memory used by a metric family. */

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -159,7 +159,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
    * know that they are sane. */
   for (size_t i = 0; i < m->n_label; i++) {
     char value[LABEL_VALUE_SIZE];
-    ssnprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
+    snprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
               escape_label_value(value, sizeof(value), m->label[i]->value));
   }
 
@@ -178,10 +178,10 @@ static void format_text(ProtobufCBuffer *buffer) {
   while (c_avl_iterator_next(iter, (void *)&unused_name, (void *)&fam) == 0) {
     char line[1024]; /* 4x DATA_MAX_NAME_LEN? */
 
-    ssnprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
+    snprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
-    ssnprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
+    snprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
               (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
                   ? "gauge"
                   : "counter");
@@ -194,15 +194,15 @@ static void format_text(ProtobufCBuffer *buffer) {
 
       char timestamp_ms[24] = "";
       if (m->has_timestamp_ms)
-        ssnprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
+        snprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
                   m->timestamp_ms);
 
       if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-        ssnprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
+        snprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
                   format_labels(labels, sizeof(labels), m), m->gauge->value,
                   timestamp_ms);
       else /* if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__COUNTER) */
-        ssnprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
+        snprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
                   format_labels(labels, sizeof(labels), m), m->counter->value,
                   timestamp_ms);
 
@@ -212,7 +212,7 @@ static void format_text(ProtobufCBuffer *buffer) {
   c_avl_iterator_destroy(iter);
 
   char server[1024];
-  ssnprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
+  snprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
             PACKAGE_VERSION, hostname_g);
   buffer->append(buffer, strlen(server), (uint8_t *)server);
 
@@ -631,7 +631,7 @@ metric_family_create(char *name, data_set_t const *ds, value_list_t const *vl,
   msg->name = name;
 
   char help[1024];
-  ssnprintf(
+  snprintf(
       help, sizeof(help),
       "write_prometheus plugin: '%s' Type: '%s', Dstype: '%s', Dsname: '%s'",
       vl->plugin, vl->type, DS_TYPE_TO_STRING(ds->ds[ds_index].type),

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -70,10 +70,10 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   status = FORMAT_VL(ident, sizeof(ident), vl);
   if (status != 0)
     return status;
-  ssnprintf(key, sizeof(key), "%s%s",
+  snprintf(key, sizeof(key), "%s%s",
             (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX,
             ident);
-  ssnprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
+  snprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   value_size = sizeof(value);
   value_ptr = &value[0];
@@ -219,7 +219,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char cb_name[DATA_MAX_NAME_LEN];
 
-    ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
+    snprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
     status = plugin_register_write(
         cb_name, wr_write, &(user_data_t){

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -71,8 +71,7 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   if (status != 0)
     return status;
   snprintf(key, sizeof(key), "%s%s",
-            (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX,
-            ident);
+           (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX, ident);
   snprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   value_size = sizeof(value);
@@ -221,10 +220,11 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
 
     snprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
-    status = plugin_register_write(
-        cb_name, wr_write, &(user_data_t){
-                               .data = node, .free_func = wr_config_free,
-                           });
+    status =
+        plugin_register_write(cb_name, wr_write,
+                              &(user_data_t){
+                                  .data = node, .free_func = wr_config_free,
+                              });
   }
 
   if (status != 0)

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -217,7 +217,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   } /* for (i = 0; i < ci->children_num; i++) */
 
   if (status == 0) {
-    char cb_name[DATA_MAX_NAME_LEN];
+    char cb_name[sizeof("write_redis/") + DATA_MAX_NAME_LEN];
 
     snprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -293,17 +293,17 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
               vl->type_instance);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s/%s",
+      snprintf(service_buffer, sizeof(service_buffer), "%s/%s",
                 &name_buffer[1], ds->ds[index].name);
     else
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
+      snprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
                 host->event_service_prefix, &name_buffer[1],
                 ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, &name_buffer[1], sizeof(service_buffer));
     else
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
+      snprintf(service_buffer, sizeof(service_buffer), "%s%s",
                 host->event_service_prefix, &name_buffer[1]);
   }
 
@@ -352,7 +352,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
 
-    ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
+    snprintf(ds_type, sizeof(ds_type), "%s:rate",
               DS_TYPE_TO_STRING(ds->ds[index].type));
     riemann_event_string_attribute_add(event, "ds_type", ds_type);
   } else {
@@ -363,7 +363,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   {
     char ds_index[DATA_MAX_NAME_LEN];
 
-    ssnprintf(ds_index, sizeof(ds_index), "%zu", index);
+    snprintf(ds_index, sizeof(ds_index), "%zu", index);
     riemann_event_string_attribute_add(event, "ds_index", ds_index);
   }
 
@@ -802,7 +802,7 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
     return status;
   }
 
-  ssnprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
+  snprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
             host->name);
 
   user_data_t ud = {.data = host, .free_func = wrr_free};

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -293,18 +293,17 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
               vl->type_instance);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      snprintf(service_buffer, sizeof(service_buffer), "%s/%s",
-                &name_buffer[1], ds->ds[index].name);
+      snprintf(service_buffer, sizeof(service_buffer), "%s/%s", &name_buffer[1],
+               ds->ds[index].name);
     else
       snprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
-                host->event_service_prefix, &name_buffer[1],
-                ds->ds[index].name);
+               host->event_service_prefix, &name_buffer[1], ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, &name_buffer[1], sizeof(service_buffer));
     else
       snprintf(service_buffer, sizeof(service_buffer), "%s%s",
-                host->event_service_prefix, &name_buffer[1]);
+               host->event_service_prefix, &name_buffer[1]);
   }
 
   riemann_event_set(
@@ -353,7 +352,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
     char ds_type[DATA_MAX_NAME_LEN];
 
     snprintf(ds_type, sizeof(ds_type), "%s:rate",
-              DS_TYPE_TO_STRING(ds->ds[index].type));
+             DS_TYPE_TO_STRING(ds->ds[index].type));
     riemann_event_string_attribute_add(event, "ds_type", ds_type);
   } else {
     riemann_event_string_attribute_add(event, "ds_type",
@@ -803,7 +802,7 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
   }
 
   snprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
-            host->name);
+           host->name);
 
   user_data_t ud = {.data = host, .free_func = wrr_free};
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -420,7 +420,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   // incorporate the data source type
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
-    ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
+    snprintf(ds_type, sizeof(ds_type), "%s:rate",
               DS_TYPE_TO_STRING(ds->ds[index].type));
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_type\": \"%s\"",
                       ret_str, ds_type);
@@ -454,7 +454,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   // incorporate the data source index
   {
     char ds_index[DATA_MAX_NAME_LEN];
-    ssnprintf(ds_index, sizeof(ds_index), "%zu", index);
+    snprintf(ds_index, sizeof(ds_index), "%zu", index);
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_index\": %s",
                       ret_str, ds_index);
     free(ret_str);
@@ -534,16 +534,16 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
                      host->separator);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s.%s", name_buffer,
+      snprintf(service_buffer, sizeof(service_buffer), "%s.%s", name_buffer,
                 ds->ds[index].name);
     else
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s.%s",
+      snprintf(service_buffer, sizeof(service_buffer), "%s%s.%s",
                 host->event_service_prefix, name_buffer, ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, name_buffer, sizeof(service_buffer));
     else
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
+      snprintf(service_buffer, sizeof(service_buffer), "%s%s",
                 host->event_service_prefix, name_buffer);
   }
 
@@ -1141,7 +1141,7 @@ static int sensu_config_node(oconfig_item_t *ci) /* {{{ */
     return -1;
   }
 
-  ssnprintf(callback_name, sizeof(callback_name), "write_sensu/%s", host->name);
+  snprintf(callback_name, sizeof(callback_name), "write_sensu/%s", host->name);
 
   user_data_t ud = {.data = host, .free_func = sensu_free};
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -421,7 +421,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
     snprintf(ds_type, sizeof(ds_type), "%s:rate",
-              DS_TYPE_TO_STRING(ds->ds[index].type));
+             DS_TYPE_TO_STRING(ds->ds[index].type));
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_type\": \"%s\"",
                       ret_str, ds_type);
     free(ret_str);
@@ -535,16 +535,16 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
       snprintf(service_buffer, sizeof(service_buffer), "%s.%s", name_buffer,
-                ds->ds[index].name);
+               ds->ds[index].name);
     else
       snprintf(service_buffer, sizeof(service_buffer), "%s%s.%s",
-                host->event_service_prefix, name_buffer, ds->ds[index].name);
+               host->event_service_prefix, name_buffer, ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, name_buffer, sizeof(service_buffer));
     else
       snprintf(service_buffer, sizeof(service_buffer), "%s%s",
-                host->event_service_prefix, name_buffer);
+               host->event_service_prefix, name_buffer);
   }
 
   // Replace collectd sensor name reserved characters so that time series DB is

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -325,7 +325,7 @@ static int wt_format_values(char *ret, size_t ret_len, int ds_num,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
+    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);            \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -389,18 +389,18 @@ static int wt_format_name(char *ret, int ret_len, const value_list_t *vl,
     if (vl->plugin_instance[0] == '\0') {
       if (vl->type_instance[0] == '\0') {
         snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin, vl->type,
-                  ds_name);
+                 ds_name);
       } else {
         snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin, vl->type,
-                  vl->type_instance, ds_name);
+                 vl->type_instance, ds_name);
       }
     } else { /* vl->plugin_instance != "" */
       if (vl->type_instance[0] == '\0') {
         snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
-                  vl->plugin_instance, vl->type, ds_name);
+                 vl->plugin_instance, vl->type, ds_name);
       } else {
         snprintf(ret, ret_len, "%s%s.%s.%s.%s.%s", prefix, vl->plugin,
-                  vl->plugin_instance, vl->type, vl->type_instance, ds_name);
+                 vl->plugin_instance, vl->type, vl->type_instance, ds_name);
       }
     }
   } else { /* ds_name == NULL */
@@ -409,15 +409,15 @@ static int wt_format_name(char *ret, int ret_len, const value_list_t *vl,
         snprintf(ret, ret_len, "%s%s.%s", prefix, vl->plugin, vl->type);
       } else {
         snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
-                  vl->type_instance, vl->type);
+                 vl->type_instance, vl->type);
       }
     } else { /* vl->plugin_instance != "" */
       if (vl->type_instance[0] == '\0') {
         snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
-                  vl->plugin_instance, vl->type);
+                 vl->plugin_instance, vl->type);
       } else {
         snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
-                  vl->plugin_instance, vl->type, vl->type_instance);
+                 vl->plugin_instance, vl->type, vl->type_instance);
       }
     }
   }
@@ -457,7 +457,7 @@ static int wt_send_message(const char *key, const char *value, cdtime_t time,
 
   status =
       snprintf(message, sizeof(message), "put %s %.0f %s fqdn=%s %s %s\r\n",
-                key, CDTIME_T_TO_DOUBLE(time), value, host, tags, host_tags);
+               key, CDTIME_T_TO_DOUBLE(time), value, host, tags, host_tags);
   sfree(temp);
   if (status < 0)
     return -1;
@@ -608,8 +608,8 @@ static int wt_config_tsd(oconfig_item_t *ci) {
   }
 
   snprintf(callback_name, sizeof(callback_name), "write_tsdb/%s/%s",
-            cb->node != NULL ? cb->node : WT_DEFAULT_NODE,
-            cb->service != NULL ? cb->service : WT_DEFAULT_SERVICE);
+           cb->node != NULL ? cb->node : WT_DEFAULT_NODE,
+           cb->service != NULL ? cb->service : WT_DEFAULT_SERVICE);
 
   user_data_t user_data = {.data = cb, .free_func = wt_callback_free};
 

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -325,7 +325,7 @@ static int wt_format_values(char *ret, size_t ret_len, int ds_num,
 
 #define BUFFER_ADD(...)                                                        \
   do {                                                                         \
-    status = ssnprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
+    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);           \
     if (status < 1) {                                                          \
       sfree(rates);                                                            \
       return -1;                                                               \
@@ -388,35 +388,35 @@ static int wt_format_name(char *ret, int ret_len, const value_list_t *vl,
   if (ds_name != NULL) {
     if (vl->plugin_instance[0] == '\0') {
       if (vl->type_instance[0] == '\0') {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin, vl->type,
+        snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin, vl->type,
                   ds_name);
       } else {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin, vl->type,
+        snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin, vl->type,
                   vl->type_instance, ds_name);
       }
     } else { /* vl->plugin_instance != "" */
       if (vl->type_instance[0] == '\0') {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
+        snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
                   vl->plugin_instance, vl->type, ds_name);
       } else {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s.%s.%s", prefix, vl->plugin,
+        snprintf(ret, ret_len, "%s%s.%s.%s.%s.%s", prefix, vl->plugin,
                   vl->plugin_instance, vl->type, vl->type_instance, ds_name);
       }
     }
   } else { /* ds_name == NULL */
     if (vl->plugin_instance[0] == '\0') {
       if (vl->type_instance[0] == '\0') {
-        ssnprintf(ret, ret_len, "%s%s.%s", prefix, vl->plugin, vl->type);
+        snprintf(ret, ret_len, "%s%s.%s", prefix, vl->plugin, vl->type);
       } else {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
+        snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
                   vl->type_instance, vl->type);
       }
     } else { /* vl->plugin_instance != "" */
       if (vl->type_instance[0] == '\0') {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
+        snprintf(ret, ret_len, "%s%s.%s.%s", prefix, vl->plugin,
                   vl->plugin_instance, vl->type);
       } else {
-        ssnprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
+        snprintf(ret, ret_len, "%s%s.%s.%s.%s", prefix, vl->plugin,
                   vl->plugin_instance, vl->type, vl->type_instance);
       }
     }
@@ -456,7 +456,7 @@ static int wt_send_message(const char *key, const char *value, cdtime_t time,
   }
 
   status =
-      ssnprintf(message, sizeof(message), "put %s %.0f %s fqdn=%s %s %s\r\n",
+      snprintf(message, sizeof(message), "put %s %.0f %s fqdn=%s %s %s\r\n",
                 key, CDTIME_T_TO_DOUBLE(time), value, host, tags, host_tags);
   sfree(temp);
   if (status < 0)
@@ -607,7 +607,7 @@ static int wt_config_tsd(oconfig_item_t *ci) {
     }
   }
 
-  ssnprintf(callback_name, sizeof(callback_name), "write_tsdb/%s/%s",
+  snprintf(callback_name, sizeof(callback_name), "write_tsdb/%s/%s",
             cb->node != NULL ? cb->node : WT_DEFAULT_NODE,
             cb->service != NULL ? cb->service : WT_DEFAULT_SERVICE);
 

--- a/src/xencpu.c
+++ b/src/xencpu.c
@@ -112,7 +112,7 @@ static void submit_value(int cpu_num, gauge_t value) {
   sstrncpy(vl.type_instance, "load", sizeof(vl.type_instance));
 
   if (cpu_num >= 0) {
-    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
+    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
   }
   plugin_dispatch_values(&vl);
 } /* static void submit_value */

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -118,7 +118,7 @@ static long long get_zfs_value(kstat_t *dummy __attribute__((unused)),
   size_t valuelen = sizeof(value);
   int rv;
 
-  ssnprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
+  snprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
   rv = sysctlbyname(buffer, (void *)&value, &valuelen,
                     /* new value = */ NULL, /* new length = */ (size_t)0);
   if (rv == 0)

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -216,12 +216,14 @@ static int za_read(void) {
   // See kstat_seq_show_headers module/spl/spl-kstat.c of the spl kernel
   // module.
   if (fgets(buffer, sizeof(buffer), fh) == NULL) {
-    ERROR("zfs_arc plugin: \"%s\" does not contain a single line.", ZOL_ARCSTATS_FILE);
+    ERROR("zfs_arc plugin: \"%s\" does not contain a single line.",
+          ZOL_ARCSTATS_FILE);
     fclose(fh);
     return -1;
   }
   if (fgets(buffer, sizeof(buffer), fh) == NULL) {
-    ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.", ZOL_ARCSTATS_FILE);
+    ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.",
+          ZOL_ARCSTATS_FILE);
     fclose(fh);
     return -1;
   }


### PR DESCRIPTION
ssnprintf supposedly was a safer version of snprintf, but they both
always NUL-terminate the buffer.

After this change GCC >= 7 will start warning when snprintf silenty
truncates, which is good since I want to see when that happens.