### PR TITLE
curl plugins: Use configured URL for all poll cycles

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -328,7 +328,6 @@ static int init_host(apache_t *st) /* {{{ */
 #endif
   }
 
-  curl_easy_setopt(st->curl, CURLOPT_URL, st->url);
   curl_easy_setopt(st->curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(st->curl, CURLOPT_MAXREDIRS, 50L);
 
@@ -510,6 +509,9 @@ static int apache_read_host(user_data_t *user_data) /* {{{ */
   assert(st->curl != NULL);
 
   st->apache_buffer_fill = 0;
+
+  curl_easy_setopt(st->curl, CURLOPT_URL, st->url);
+
   if (curl_easy_perform(st->curl) != CURLE_OK) {
     ERROR("apache: curl_easy_perform failed: %s", st->apache_curl_error);
     return -1;

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -511,7 +511,6 @@ static int ascent_init(void) /* {{{ */
 #endif
   }
 
-  curl_easy_setopt(curl, CURLOPT_URL, url);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
 
@@ -554,6 +553,9 @@ static int ascent_read(void) /* {{{ */
   }
 
   ascent_buffer_fill = 0;
+
+  curl_easy_setopt(curl, CURLOPT_URL, url);
+
   if (curl_easy_perform(curl) != CURLE_OK) {
     ERROR("ascent plugin: curl_easy_perform failed: %s", ascent_curl_error);
     return -1;

--- a/src/bind.c
+++ b/src/bind.c
@@ -1598,7 +1598,6 @@ static int bind_init(void) /* {{{ */
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, bind_curl_callback);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, bind_curl_error);
-  curl_easy_setopt(curl, CURLOPT_URL, (url != NULL) ? url : BIND_DEFAULT_URL);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
 #ifdef HAVE_CURLOPT_TIMEOUT_MS
@@ -1620,6 +1619,9 @@ static int bind_read(void) /* {{{ */
   }
 
   bind_buffer_fill = 0;
+
+  curl_easy_setopt(curl, CURLOPT_URL, (url != NULL) ? url : BIND_DEFAULT_URL);
+
   if (curl_easy_perform(curl) != CURLE_OK) {
     ERROR("bind plugin: curl_easy_perform failed: %s", bind_curl_error);
     return -1;

--- a/src/curl.c
+++ b/src/curl.c
@@ -347,7 +347,6 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
   curl_easy_setopt(wp->curl, CURLOPT_WRITEDATA, wp);
   curl_easy_setopt(wp->curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
   curl_easy_setopt(wp->curl, CURLOPT_ERRORBUFFER, wp->curl_errbuf);
-  curl_easy_setopt(wp->curl, CURLOPT_URL, wp->url);
   curl_easy_setopt(wp->curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(wp->curl, CURLOPT_MAXREDIRS, 50L);
 
@@ -611,6 +610,9 @@ static int cc_read_page(web_page_t *wp) /* {{{ */
     start = cdtime();
 
   wp->buffer_fill = 0;
+
+  curl_easy_setopt(wp->curl, CURLOPT_URL, wp->url);
+
   status = curl_easy_perform(wp->curl);
   if (status != CURLE_OK) {
     ERROR("curl plugin: curl_easy_perform failed with status %i: %s", status,

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -578,7 +578,6 @@ static int cj_init_curl(cj_t *db) /* {{{ */
   curl_easy_setopt(db->curl, CURLOPT_WRITEDATA, db);
   curl_easy_setopt(db->curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
   curl_easy_setopt(db->curl, CURLOPT_ERRORBUFFER, db->curl_errbuf);
-  curl_easy_setopt(db->curl, CURLOPT_URL, db->url);
   curl_easy_setopt(db->curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(db->curl, CURLOPT_MAXREDIRS, 50L);
 
@@ -858,12 +857,13 @@ static int cj_curl_perform(cj_t *db) /* {{{ */
   int status;
   long rc;
   char *url;
-  url = db->url;
+
+  curl_easy_setopt(db->curl, CURLOPT_URL, db->url);
 
   status = curl_easy_perform(db->curl);
   if (status != CURLE_OK) {
     ERROR("curl_json plugin: curl_easy_perform failed with status %i: %s (%s)",
-          status, db->curl_errbuf, url);
+          status, db->curl_errbuf, db->url);
     return -1;
   }
   if (db->stats != NULL)

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -602,13 +602,15 @@ static int cx_curl_perform(cx_t *db, CURL *curl) /* {{{ */
   long rc;
   char *ptr;
   char *url;
-  url = db->url;
 
   db->buffer_fill = 0;
+
+  curl_easy_setopt(db->curl, CURLOPT_URL, db->url);
+
   status = curl_easy_perform(curl);
   if (status != CURLE_OK) {
     ERROR("curl_xml plugin: curl_easy_perform failed with status %i: %s (%s)",
-          status, db->curl_errbuf, url);
+          status, db->curl_errbuf, db->url);
     return -1;
   }
   if (db->stats != NULL)
@@ -817,7 +819,6 @@ static int cx_init_curl(cx_t *db) /* {{{ */
   curl_easy_setopt(db->curl, CURLOPT_WRITEDATA, db);
   curl_easy_setopt(db->curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
   curl_easy_setopt(db->curl, CURLOPT_ERRORBUFFER, db->curl_errbuf);
-  curl_easy_setopt(db->curl, CURLOPT_URL, db->url);
   curl_easy_setopt(db->curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(db->curl, CURLOPT_MAXREDIRS, 50L);
 

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -133,9 +133,6 @@ static int init(void) {
 #endif
   }
 
-  if (url != NULL) {
-    curl_easy_setopt(curl, CURLOPT_URL, url);
-  }
 
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
@@ -207,6 +204,9 @@ static int nginx_read(void) {
     return -1;
 
   nginx_buffer_len = 0;
+
+  curl_easy_setopt(curl, CURLOPT_URL, url);
+
   if (curl_easy_perform(curl) != CURLE_OK) {
     WARNING("nginx plugin: curl_easy_perform failed: %s", nginx_curl_error);
     return -1;

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -119,6 +119,7 @@ static int wh_post_nolock(wh_callback_t *cb, char const *data) /* {{{ */
 {
   int status = 0;
 
+  curl_easy_setopt(cb->curl, CURLOPT_URL, cb->location);
   curl_easy_setopt(cb->curl, CURLOPT_POSTFIELDS, data);
   status = curl_easy_perform(cb->curl);
 
@@ -168,7 +169,6 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
   curl_easy_setopt(cb->curl, CURLOPT_HTTPHEADER, cb->headers);
 
   curl_easy_setopt(cb->curl, CURLOPT_ERRORBUFFER, cb->curl_errbuf);
-  curl_easy_setopt(cb->curl, CURLOPT_URL, cb->location);
   curl_easy_setopt(cb->curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(cb->curl, CURLOPT_MAXREDIRS, 50L);
 


### PR DESCRIPTION
Issue: #2328

After redirect received, Collectd send subsequent requests to new location.
That is wrong - Collectd should use configured URL for all poll cycles, regardless of the responses received previously.

Problem was caused by https://github.com/curl/curl/issues/1631. To avoid that when old `libcurl` version used, we set request url in each poll cycle.
