### PR TITLE
Free `userdata` if plugin_register_complex_read() has failed.

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -216,29 +216,25 @@ static int config_add(oconfig_item_t *ci) {
     status = -1;
   }
 
-  if (status == 0) {
-    char callback_name[3 * DATA_MAX_NAME_LEN];
-
-    snprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
-             (st->host != NULL) ? st->host : hostname_g,
-             (st->name != NULL) ? st->name : "default");
-
-    status = plugin_register_complex_read(
-        /* group = */ NULL,
-        /* name      = */ callback_name,
-        /* callback  = */ apache_read_host,
-        /* interval  = */ 0,
-        &(user_data_t){
-            .data = st, .free_func = apache_free,
-        });
-  }
-
   if (status != 0) {
     apache_free(st);
     return -1;
   }
 
-  return 0;
+  char callback_name[3 * DATA_MAX_NAME_LEN];
+
+  snprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
+           (st->host != NULL) ? st->host : hostname_g,
+           (st->name != NULL) ? st->name : "default");
+
+  return plugin_register_complex_read(
+      /* group = */ NULL,
+      /* name      = */ callback_name,
+      /* callback  = */ apache_read_host,
+      /* interval  = */ 0,
+      &(user_data_t){
+          .data = st, .free_func = apache_free,
+      });
 } /* int config_add */
 
 static int config(oconfig_item_t *ci) {

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -191,16 +191,21 @@ static int plugin_update_internal_statistics(void) { /* {{{ */
   return 0;
 } /* }}} int plugin_update_internal_statistics */
 
+static void free_userdata(user_data_t const *ud) /* {{{ */
+{
+  if (ud == NULL)
+    return;
+
+  if ((ud->data != NULL) && (ud->free_func != NULL)) {
+    ud->free_func(ud->data);
+  }
+} /* }}} void free_userdata */
+
 static void destroy_callback(callback_func_t *cf) /* {{{ */
 {
   if (cf == NULL)
     return;
-
-  if ((cf->cf_udata.data != NULL) && (cf->cf_udata.free_func != NULL)) {
-    cf->cf_udata.free_func(cf->cf_udata.data);
-    cf->cf_udata.data = NULL;
-    cf->cf_udata.free_func = NULL;
-  }
+  free_userdata(&cf->cf_udata);
   sfree(cf);
 } /* }}} void destroy_callback */
 
@@ -345,6 +350,7 @@ static int create_register_callback(llist_t **list, /* {{{ */
 
   cf = calloc(1, sizeof(*cf));
   if (cf == NULL) {
+    free_userdata(ud);
     ERROR("plugin: create_register_callback: calloc failed.");
     return -1;
   }
@@ -1186,6 +1192,7 @@ int plugin_register_complex_read(const char *group, const char *name,
 
   rf = calloc(1, sizeof(*rf));
   if (rf == NULL) {
+    free_userdata(user_data);
     ERROR("plugin_register_complex_read: calloc failed.");
     return ENOMEM;
   }
@@ -1211,6 +1218,7 @@ int plugin_register_complex_read(const char *group, const char *name,
 
   status = plugin_insert_read(rf);
   if (status != 0) {
+    free_userdata(&rf->rf_udata);
     sfree(rf->rf_name);
     sfree(rf);
   }
@@ -1303,11 +1311,7 @@ int plugin_register_flush(const char *name, plugin_flush_cb callback,
         });
 
     sfree(flush_name);
-    if (status != 0) {
-      sfree(cb->name);
-      sfree(cb);
-      return status;
-    }
+    return status;
   }
 
   return 0;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1126,8 +1126,7 @@ static int plugin_insert_read(read_func_t *rf) {
   if (le != NULL) {
     pthread_mutex_unlock(&read_lock);
     WARNING("The read function \"%s\" is already registered. "
-            "Check for duplicate \"LoadPlugin\" lines "
-            "in your configuration!",
+            "Check for duplicates in your configuration!",
             rf->rf_name);
     return EINVAL;
   }

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -535,7 +535,7 @@ static int cldap_init(void) /* {{{ */
 static int cldap_shutdown(void) /* {{{ */
 {
   for (size_t i = 0; i < databases_num; i++)
-    if (databases[i]->ld != NULL)
+    if (databases[i] != NULL && databases[i]->ld != NULL)
       ldap_unbind_ext_s(databases[i]->ld, NULL, NULL);
   sfree(databases);
   databases_num = 0;

--- a/src/perl.c
+++ b/src/perl.c
@@ -1626,18 +1626,19 @@ static void _plugin_register_generic_userdata(pTHX, int type,
       ret = plugin_register_flush("perl", perl_flush, /* user_data = */ NULL);
     }
 
-    if (0 == ret)
+    if (0 == ret) {
       ret = plugin_register_flush(pluginname, perl_flush, &userdata);
+    } else {
+      free(userdata.data);
+    }
   } else {
     ret = -1;
   }
 
   if (0 == ret)
     XSRETURN_YES;
-  else {
-    free(userdata.data);
+  else
     XSRETURN_EMPTY;
-  }
 } /* static void _plugin_register_generic_userdata ( ... ) */
 
 /*

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -376,18 +376,17 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  snprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
-  if (status == 0)
-    status = plugin_register_complex_read(
-        /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
-        &(user_data_t){
-            .data = router_data, .free_func = (void *)cr_free_data,
-        });
-
-  if (status != 0)
+  if (status != 0) {
     cr_free_data(router_data);
+    return status;
+  }
 
-  return status;
+  snprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
+  return plugin_register_complex_read(
+      /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
+      &(user_data_t){
+          .data = router_data, .free_func = (void *)cr_free_data,
+      });
 } /* }}} int cr_config_router */
 
 static int cr_config(oconfig_item_t *ci) {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -711,7 +711,6 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
       });
   if (status != 0) {
     ERROR("snmp plugin: Registering complex read function failed.");
-    csnmp_host_definition_destroy(hd);
     return -1;
   }
 

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -484,7 +484,6 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
       });
   if (status != 0) {
     ERROR("tail_csv plugin: Registering complex read function failed.");
-    tcsv_instance_definition_destroy(id);
     return -1;
   }
 


### PR DESCRIPTION
Citation from Collectd wiki (https://collectd.org/wiki/index.php/User_data_t):

> If the callback is deleted or callback registration is failed, the struct is freed using the my_config_free function.

There are several functions which register callbacks and has `user_data_t` argument:

- `plugin_register_write(), plugin_register_log(), plugin_register_notification(), plugin_register_flush()` - which calls `create_register_callback()`.
- `plugin_register_complex_read()`, which implemented in other way.

Most of plugins expects what free() will happen if registration failed.

For first functions group, in case of failure, `create_register_callback()` calls `destroy_callback()` which frees userdata.
But there was no code in `plugin_register_complex_read()` for userdata free.

That code was added, and some plugins (and Collectd itself) code was adjusted to new behaviour.