### PR TITLE
apcups: allow to use plugin without explicit configuration

### DIFF
--- a/src/apcups.c
+++ b/src/apcups.c
@@ -421,13 +421,11 @@ static int apcups_read(void) {
       .linefreq = NAN,
   };
 
-  int status =
-      apc_query_server(conf_node == NULL ? APCUPS_DEFAULT_NODE : conf_node,
-                       conf_service, &apcups_detail);
+  int status = apc_query_server(conf_node, conf_service, &apcups_detail);
+
   if (status != 0) {
     DEBUG("apcups plugin: apc_query_server (\"%s\", \"%s\") = %d",
-          conf_node == NULL ? APCUPS_DEFAULT_NODE : conf_node, conf_service,
-          status);
+          conf_node, conf_service, status);
     return status;
   }
 
@@ -436,8 +434,19 @@ static int apcups_read(void) {
   return 0;
 } /* apcups_read */
 
+static int apcups_init(void) {
+  if (conf_node == NULL)
+    conf_node = APCUPS_DEFAULT_NODE;
+
+  if (conf_service == NULL)
+    conf_service = APCUPS_DEFAULT_SERVICE;
+
+  return 0;
+} /* apcups_init */
+
 void module_register(void) {
   plugin_register_complex_config("apcups", apcups_config);
+  plugin_register_init("apcups", apcups_init);
   plugin_register_read("apcups", apcups_read);
   plugin_register_shutdown("apcups", apcups_shutdown);
 } /* void module_register */


### PR DESCRIPTION
Previously the apcups plugin could not be used without defining
an explicit configuration.

While the apcups plugin did provide a localhost fallback, it
did not however provide a 3551 port fallback in practice,
eventhough a constant for that purpose was already present.

Thanks to Pascal de Bruijn for report.

Supersedes: #2347