### PR TITLE
apcups plugin: fix missing rrd files

### DIFF
--- a/src/apcups.c
+++ b/src/apcups.c
@@ -385,9 +385,6 @@ static int apcups_config(oconfig_item_t *ci) {
 
 static void apc_submit_generic(const char *type, const char *type_inst,
                                gauge_t value) {
-  if (isnan(value))
-    return;
-
   value_list_t vl = VALUE_LIST_INIT;
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;


### PR DESCRIPTION
The collect 5.5.3 release included commit 0a95eb509bebdd867a65105cdcbc0325d1cccddc to fix issue https://github.com/collectd/collectd/issues/2025, but it introduced a regression that broke existing graphing as seen on OpenWRT and LEDE.

Since not all APC UPSes report the same information, the apcups plugin acts as an abstraction layer and provides default values for unreported details. Some of those values were non-physical however (e.g. -300 degree temp). The commit 0a95eb509bebdd867a65105cdcbc0325d1cccddc changed the defaults to NaN (and rightly so) but then also threw away any NaNs.  This later change meant that some `.rrd` files previously created for unreported details would now be missing, which breaks both the consistent abstraction and also some working graphing.

This PR simply preserves the NaNs and restores the previous working graphing. It has been tested on 5.5.3 but still applies to master.