### PR TITLE
Fixed failed compilation on AIX

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -255,14 +255,14 @@ static int ipc_read_shm(void) /* {{{ */
   ipcinfo_shm_t *pshm;
   unsigned int shm_segments = 0;
   size64_t shm_bytes = 0;
-  int n;
+  int i, n;
 
   ipcinfo_shm = (ipcinfo_shm_t *)ipc_get_info(
       0, GET_IPCINFO_SHM_ALL, IPCINFO_SHM_VERSION, sizeof(ipcinfo_shm_t), &n);
   if (ipcinfo_shm == NULL)
     return -1;
 
-  for (int i = 0, pshm = ipcinfo_shm; i < n; i++, pshm++) {
+  for (i = 0, pshm = ipcinfo_shm; i < n; i++, pshm++) {
     shm_segments++;
     shm_bytes += pshm->shm_segsz;
   }


### PR DESCRIPTION
Compilation fail caused by typo in 2761915bed8c6caea41018be3e675aa712cc0b0a / #1842.

This change already released since collectd-5.6.0 and collectd-5.7.0, so PR created against 5.6.

I have checked that commit by eyes and found no another occurences of such typo.

Issue: #2305 

CC @rubenk 
