### PR TITLE
snmp_agent: Fixes and improvements

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7189,6 +7189,7 @@ B<Synopsis:>
   <Plugin snmp_agent>
     <Data "memAvailReal">
       Plugin "memory"
+      #PluginInstance "some"
       Type "memory"
       TypeInstance "free"
       OIDs "1.3.6.1.4.1.2021.4.6.0"
@@ -7232,6 +7233,12 @@ scalar data type B<Instance> has no effect and can be omitted.
 
 Read plugin name whose collected data will be mapped to specified OIDs.
 
+=item B<PluginInstance> I<String>
+
+Read plugin instance whose collected data will be mapped to specified OIDs.
+The field is optional and by default there is no plugin instance check.
+Allowed only if B<Data> block defines scalar data type.
+
 =item B<Type> I<String>
 
 Collectd's type that is to be used for specified OID, e.E<nbsp>g. "if_octets"
@@ -7244,9 +7251,9 @@ Collectd's type-instance that is to be used for specified OID.
 =item B<OIDs> I<OID> [I<OID> ...]
 
 Configures the OIDs to be handled by I<snmp_agent> plugin. Values for these OIDs
-are taken from collectd data type specified by B<Plugin>, B<Type>,
-B<TypeInstance> fields of this B<Data> block. Number of the OIDs configured
-should correspond to number of values in specified B<Type>.
+are taken from collectd data type specified by B<Plugin>, B<PluginInstance>,
+B<Type>, B<TypeInstance> fields of this B<Data> block. Number of the OIDs
+configured should correspond to number of values in specified B<Type>.
 For example two OIDs "IF-MIB::ifInOctets" "IF-MIB::ifOutOctets" can be mapped to
 "rx" and "tx" values of "if_octets" type.
 

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -1364,12 +1364,21 @@ static int snmp_agent_preinit(void) {
   g_agent->tables = llist_create();
   g_agent->scalars = llist_create();
 
+  if (g_agent->tables == NULL || g_agent->scalars == NULL) {
+    ERROR(PLUGIN_NAME ": llist_create() failed");
+    llist_destroy(g_agent->scalars);
+    llist_destroy(g_agent->tables);
+    return -ENOMEM;
+  }
+
   int err;
   /* make us a agentx client. */
   err = netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_ROLE,
                                1);
   if (err != 0) {
     ERROR(PLUGIN_NAME ": Failed to set agent role (%d)", err);
+    llist_destroy(g_agent->scalars);
+    llist_destroy(g_agent->tables);
     return -1;
   }
 
@@ -1381,6 +1390,8 @@ static int snmp_agent_preinit(void) {
   err = init_agent(PLUGIN_NAME);
   if (err != 0) {
     ERROR(PLUGIN_NAME ": Failed to initialize the agent library (%d)", err);
+    llist_destroy(g_agent->scalars);
+    llist_destroy(g_agent->tables);
     return -1;
   }
 

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -1406,13 +1406,6 @@ static int snmp_agent_init(void) {
   if (ret != 0)
     return ret;
 
-  /* create a second thread to listen for requests from AgentX*/
-  ret = pthread_create(&g_agent->thread, NULL, &snmp_agent_thread_run, NULL);
-  if (ret != 0) {
-    ERROR(PLUGIN_NAME ": Failed to create a separate thread, err %u", ret);
-    return ret;
-  }
-
   ret = pthread_mutex_init(&g_agent->lock, NULL);
   if (ret != 0) {
     ERROR(PLUGIN_NAME ": Failed to initialize mutex, err %u", ret);
@@ -1422,6 +1415,13 @@ static int snmp_agent_init(void) {
   ret = pthread_mutex_init(&g_agent->agentx_lock, NULL);
   if (ret != 0) {
     ERROR(PLUGIN_NAME ": Failed to initialize AgentX mutex, err %u", ret);
+    return ret;
+  }
+
+  /* create a second thread to listen for requests from AgentX*/
+  ret = pthread_create(&g_agent->thread, NULL, &snmp_agent_thread_run, NULL);
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Failed to create a separate thread, err %u", ret);
     return ret;
   }
 


### PR DESCRIPTION
List of changes:

* Added comments into code;
* Fixed possible race conditions between thread start and locks initialization. Lock initialization should be done before starting pthread;
* Added missing `llist_destroy()` calls;
* Added a check for `llist_create()` success;
* Fix null pointer dereference (Issue #2338);
* Changed plugin initialization:
  * Do not start working thread if plugin not configured.
   That allows to avoid useless CPU consumption by polling loop.
  * Do not register 'write' / 'missing' callbacks if there was no `<Table>` configured.
   These callbacks do not do anything in this case.
  * Registration of 'shutdown' callback delayed to 'init' phase.
* Documented `PluginInstance` option.
