### PR TITLE
rrdtool plugin: Fix flushing

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6957,7 +6957,8 @@ one (exclusive).
 
 When the C<rrdtool> plugin uses a cache (by setting B<CacheTimeout>, see below)
 it writes all values for a certain RRD-file if the oldest value is older than
-(or equal to) the number of seconds specified. If some RRD-file is not updated
+(or equal to) the number of seconds specified by B<CacheTimeout>.
+That check happens on new values arriwal. If some RRD-file is not updated
 anymore for some reason (the computer was shut down, the network is broken,
 etc.) some values may still be in the cache. If B<CacheFlush> is set, then the
 entire cache is searched for entries older than B<CacheTimeout> seconds and
@@ -6965,6 +6966,10 @@ written to disk every I<Seconds> seconds. Since this is kind of expensive and
 does nothing under normal circumstances, this value should not be too small.
 900 seconds might be a good value, though setting this to 7200 seconds doesn't
 normally do much harm either.
+
+Default value for this option is 10x of B<CacheTimeout>.
+If value of B<CacheFlush> less than value of B<CacheTimeout> then default value
+used too.
 
 =item B<CacheTimeout> I<Seconds>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6963,13 +6963,14 @@ anymore for some reason (the computer was shut down, the network is broken,
 etc.) some values may still be in the cache. If B<CacheFlush> is set, then
 every I<Seconds> seconds the entire cache is searched for entries older than
 B<CacheTimeout> + B<RandomTimeout> seconds. The entries found are written to
-disk. Since entire cache scan is kind of expensive and does nothing under normal
-circumstances, this value should not be too small. 900 seconds might be a good
-value, though setting this to 7200 seconds doesn't normally do much harm either.
+disk. Since scanning the entire cache is kind of expensive and does nothing
+under normal circumstances, this value should not be too small. 900 seconds
+might be a good value, though setting this to 7200 seconds doesn't normally
+do much harm either.
 
-Default value for this option is 10x of B<CacheTimeout>.
-If value of B<CacheFlush> less than value of B<CacheTimeout> then default value
-used too.
+Defaults to 10x B<CacheTimeout>.
+B<CacheFlush> must be larger than or equal to B<CacheTimeout>, otherwise the
+above default is used.
 
 =item B<CacheTimeout> I<Seconds>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6960,12 +6960,12 @@ it writes all values for a certain RRD-file if the oldest value is older than
 (or equal to) the number of seconds specified by B<CacheTimeout>.
 That check happens on new values arriwal. If some RRD-file is not updated
 anymore for some reason (the computer was shut down, the network is broken,
-etc.) some values may still be in the cache. If B<CacheFlush> is set, then the
-entire cache is searched for entries older than B<CacheTimeout> seconds and
-written to disk every I<Seconds> seconds. Since this is kind of expensive and
-does nothing under normal circumstances, this value should not be too small.
-900 seconds might be a good value, though setting this to 7200 seconds doesn't
-normally do much harm either.
+etc.) some values may still be in the cache. If B<CacheFlush> is set, then
+every I<Seconds> seconds the entire cache is searched for entries older than
+B<CacheTimeout> + B<RandomTimeout> seconds. The entries found are written to
+disk. Since entire cache scan is kind of expensive and does nothing under normal
+circumstances, this value should not be too small. 900 seconds might be a good
+value, though setting this to 7200 seconds doesn't normally do much harm either.
 
 Default value for this option is 10x of B<CacheTimeout>.
 If value of B<CacheFlush> less than value of B<CacheTimeout> then default value

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -863,7 +863,7 @@ static int rrd_config(const char *key, const char *value) {
     }
     cache_timeout = DOUBLE_TO_CDTIME_T(tmp);
   } else if (strcasecmp("CacheFlush", key) == 0) {
-    int tmp = atoi(value);
+    double tmp = atof(value);
     if (tmp < 0) {
       fprintf(stderr, "rrdtool: `CacheFlush' must "
                       "be greater than 0.\n");
@@ -871,7 +871,7 @@ static int rrd_config(const char *key, const char *value) {
             "be greater than 0.\n");
       return 1;
     }
-    cache_flush_timeout = TIME_T_TO_CDTIME_T(tmp);
+    cache_flush_timeout = DOUBLE_TO_CDTIME_T(tmp);
   } else if (strcasecmp("DataDir", key) == 0) {
     char *tmp;
     size_t len;
@@ -1054,11 +1054,11 @@ static int rrd_init(void) {
     random_timeout = 0;
     cache_flush_timeout = 0;
   } else if (cache_flush_timeout < cache_timeout) {
-    INFO("rrdtool plugin: \"CacheFlush %u\" is less than \"CacheTimeout %u\". "
-         "Ajusting \"CacheFlush\" to %u seconds.",
-         (unsigned int)CDTIME_T_TO_TIME_T(cache_flush_timeout),
-         (unsigned int)CDTIME_T_TO_TIME_T(cache_timeout),
-         (unsigned int)CDTIME_T_TO_TIME_T(cache_timeout * 10));
+    INFO("rrdtool plugin: \"CacheFlush %.3f\" is less than \"CacheTimeout %.3f\". "
+         "Ajusting \"CacheFlush\" to %.3f seconds.",
+         CDTIME_T_TO_DOUBLE(cache_flush_timeout),
+         CDTIME_T_TO_DOUBLE(cache_timeout),
+         CDTIME_T_TO_DOUBLE(cache_timeout * 10));
     cache_flush_timeout = 10 * cache_timeout;
   }
 

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -605,9 +605,6 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
 } /* int rrd_cache_flush_identifier */
 
 static int64_t rrd_get_random_variation(void) {
-  long min;
-  long max;
-
   if (random_timeout == 0)
     return 0;
 
@@ -618,10 +615,7 @@ static int64_t rrd_get_random_variation(void) {
     random_timeout = cache_timeout;
   }
 
-  max = (long)(random_timeout / 2);
-  min = max - ((long)random_timeout);
-
-  return (int64_t)cdrand_range(min, max);
+  return (int64_t)cdrand_range(-random_timeout, random_timeout);
 } /* int64_t rrd_get_random_variation */
 
 static int rrd_cache_insert(const char *filename, const char *value,

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -87,7 +87,7 @@ static rrdcreate_config_t rrdcreate_config = {
  * ALWAYS lock `cache_lock' first! */
 static cdtime_t cache_timeout = 0;
 static cdtime_t cache_flush_timeout = 0;
-static cdtime_t random_timeout = TIME_T_TO_CDTIME_T_STATIC(1);
+static cdtime_t random_timeout = 0;
 static cdtime_t cache_flush_last;
 static c_avl_tree_t *cache = NULL;
 static pthread_mutex_t cache_lock = PTHREAD_MUTEX_INITIALIZER;

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -726,7 +726,7 @@ static int rrd_cache_insert(const char *filename, const char *value,
 
   if ((cache_timeout > 0) &&
       ((cdtime() - cache_flush_last) > cache_flush_timeout))
-    rrd_cache_flush(cache_timeout);
+    rrd_cache_flush(cache_timeout + random_timeout);
 
   pthread_mutex_unlock(&cache_lock);
 


### PR DESCRIPTION
Last days I wanted to spent some time to tune its performance and smooth his disk IO load.

I have the following chart of disk operations:

![disk_ops](https://user-images.githubusercontent.com/13328211/28249114-0c63abda-6a7a-11e7-9d87-09f8dba3af16.png)

The configuration is:

```
WritesPerSecond 60
RandomTimeout 900     # 15 min
CacheTimeout 3600     #  1 hour
CacheFlush 600          # 10 min
```

The `CacheFlush` was set to such a small value during one of previous attempts to smooth load.
My logic was: 'I will do that check more often so less values will be flushed to disk at once, 
even at the cost of high CPU load.`.

The expected smoothness of disk IO was not achieved. 
But this does not bother anyone, so it works this way for a long time.

Later code review shows that my logic is unallowed. 

The next attempt to smooth load came. It started from IO analysis.

On chart I see IO bursts. Their period matches to `CacheTimeout` option value.
The width of the bursts corresponds to `RandomTimeout` value and increases with time, while height decreases.
That is expected behaviuor. 

But observed bursts with a period of 10h were not expected.

While Collectd code explore I found a cause of 10 hour periodical action.

```
  if (cache_timeout == 0) {
    cache_flush_timeout = 0;
  } else if (cache_flush_timeout < cache_timeout)
    cache_flush_timeout = 10 * cache_timeout;
```

This limitation was not documented.


So, my configuration treated as

```
WritesPerSecond 60
RandomTimeout 900     # 15 min
CacheTimeout 3600     #  1 hour
CacheFlush 36000      # 10 hours
```

The `cache_flush_timeout` (set from `CacheFlush` option) used in 

```
  if ((cache_timeout > 0) &&
      ((cdtime() - cache_flush_last) > cache_flush_timeout))
    rrd_cache_flush(cache_flush_timeout);
```

The `rrd_cache_flush(cdtime_t timeout)` flushes cache elements if their 'age' greater than 'timeout'.

While the value is '10h' the flush should not occur either! But it happens...

Then I found a strange code:

```
static void rrd_cache_flush(cdtime_t timeout) {
   ...
  
   timeout = TIME_T_TO_CDTIME_T(timeout);
   ...

```

That looks like mistake.

For `CacheTimeout 3600` the `cache_timeout` value is 0x0384 0000 0000.
The `cache_flush_timeout` then equal to 0x0000 2328 0000 0000 and that value passed to `rrd_cache_flush()`.

After `<< 30` operation done in `TIME_T_TO_CDTIME_T`, there will be a zero value in `timeout`, 
so flush occurs for all cache elements.

Also, the value to `cache_flush_timeout` was assigned as a simple integer seconds, while it was later used as a `cdtime_t`, so the condition

```
if (cache_flush_timeout < cache_timeout)
    cache_flush_timeout = 10 * cache_timeout;
```
is always true.

These all was fixed in this PR.

That patch was put to my production server (and RandomTimeout set to 1800). 
After update it works as expected, no full cache flush occurs anymore.

![disk_ops_2](https://user-images.githubusercontent.com/13328211/28254201-b7d5a054-6ad4-11e7-86a5-531df8661a34.png)

Spike after 10h of work caused by the fact what `rrd_cache_flush(cache_timeout);` call does not honour `RandomTimeout`.

All cache values with positive `random_variation` value are flushed.
In my case, that is 1/4 of cache ( RandomTimeout 1800 / 2 / CacheTimeout 3600) was flushed.