### PR TITLE
network: Fix free() before use

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1230,9 +1230,9 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
                             part_size - buffer_offset,
                             /* in = */ NULL, /* in len = */ 0);
   if (err != 0) {
-    sfree(pea.username);
     ERROR("network plugin: gcry_cipher_decrypt returned: %s. Username: %s",
           gcry_strerror(err), pea.username);
+    sfree(pea.username);
     return (-1);
   }
 
@@ -1253,8 +1253,6 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
 
   parse_packet(se, buffer + buffer_offset, payload_len, flags | PP_ENCRYPTED,
                pea.username);
-
-  /* XXX: Free pea.username?!? */
 
   /* Update return values */
   *ret_buffer = buffer + part_size;


### PR DESCRIPTION
@rubenk, please merge this.

The issue appeared in 3e2272cea52a2dace364c82fbcfeecf9dd9fbd34 (#1735) which is merged to 5.6, so rebased to that branch.

Thanks.