### PR TITLE
Skip `0.0.0.0` hosts in ntpd plugin

### DIFF
--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -894,6 +894,12 @@ static int ntpd_read(void) {
       continue;
     }
 
+    // `0.0.0.0` hosts are caused by POOL servers
+    // see https://github.com/collectd/collectd/issues/2358
+    if (strcmp(peername, "0.0.0.0") == 0) {
+      continue;
+    }
+
     refclock_id = ntpd_get_refclock_id(ptr);
 
     /* Convert the `long floating point' offset value to double */


### PR DESCRIPTION
This PR addresses https://github.com/collectd/collectd/issues/2358

Here I'm simply skipping `0.0.0.0` hosts that are returned for POOL servers that should not be reported.