### PR TITLE
Add metadata support to GRPC plugin

### DIFF
--- a/proto/types.proto
+++ b/proto/types.proto
@@ -38,6 +38,16 @@ message Identifier {
   string type_instance = 5;
 }
 
+message MetadataValue {
+  oneof value {
+    string string_value = 1;
+    int64 int64_value = 2;
+    uint64 uint64_value = 3;
+    double double_value = 4;
+    bool bool_value = 5;
+  };
+}
+
 message Value {
   oneof value {
     uint64 counter = 1;
@@ -56,4 +66,5 @@ message ValueList {
   Identifier identifier = 4;
 
   repeated string ds_names = 5;
+  map<string, MetadataValue> meta_data = 6;
 }

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -917,11 +917,6 @@ int uc_iterator_get_meta(uc_iter_t *iter, meta_data_t **ret_meta) {
   if ((iter == NULL) || (iter->entry == NULL) || (ret_meta == NULL))
     return -1;
 
-  if (iter->entry->meta == NULL) {
-    *ret_meta = NULL;
-    return 0;
-  }
-
   *ret_meta = meta_data_clone(iter->entry->meta);
 
   return 0;

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -913,6 +913,20 @@ int uc_iterator_get_interval(uc_iter_t *iter, cdtime_t *ret_interval) {
   return 0;
 } /* int uc_iterator_get_name */
 
+int uc_iterator_get_meta(uc_iter_t *iter, meta_data_t **ret_meta) {
+  if ((iter == NULL) || (iter->entry == NULL) || (ret_meta == NULL))
+    return -1;
+
+  if (iter->entry->meta == NULL) {
+    *ret_meta = NULL;
+    return 0;
+  }
+
+  *ret_meta = meta_data_clone(iter->entry->meta);
+
+  return 0;
+} /* int uc_iterator_get_meta */
+
 /*
  * Meta data interface
  */

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -106,6 +106,8 @@ int uc_iterator_get_values(uc_iter_t *iter, value_t **ret_values,
                            size_t *ret_num);
 /* Return the interval of the value at the current position. */
 int uc_iterator_get_interval(uc_iter_t *iter, cdtime_t *ret_interval);
+/* Return the metadata for the value at the current position. */
+int uc_iterator_get_meta(uc_iter_t *iter, meta_data_t **ret_meta);
 
 /*
  * Meta data interface


### PR DESCRIPTION
As mentioned in #2370, I've added metadata support to the GRPC plugin. In order to do this, I also had to add the `uc_iterator_get_meta` function for getting metadata out of a cache iterator.

I'm still relatively inexperienced in C/C++, so let me know if there are any changes I should make to be more idiomatic.