### PR TITLE
Plugin for  PCIe Advanced Error Reporting

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1308,15 +1308,15 @@ ovs_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBYAJL_LDFLAGS)
 ovs_stats_la_LIBADD = $(BUILD_WITH_LIBYAJL_LIBS)
 endif
 
-if BUILD_PLUGIN_PCIE
-pkglib_LTLIBRARIES += pcie.la
-pcie_la_SOURCES = src/pcie.c src/utils_message_parser.c src/utils_message_parser.h \
+if BUILD_PLUGIN_PCIE_ERRORS
+pkglib_LTLIBRARIES += pcie_errors.la
+pcie_errors_la_SOURCES = src/pcie_errors.c src/utils_message_parser.c src/utils_message_parser.h \
                   src/utils_tail_match.c src/utils_tail_match.h \
                   src/utils_tail.c src/utils_tail.h \
                   src/utils_match.c src/utils_match.h
-pcie_la_CPPFLAGS = $(AM_CPPFLAGS)
-pcie_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-pcie_la_LIBADD = liblatency.la
+pcie_errors_la_CPPFLAGS = $(AM_CPPFLAGS)
+pcie_errors_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+pcie_errors_la_LIBADD = liblatency.la
 endif
 
 if BUILD_PLUGIN_PERL

--- a/Makefile.am
+++ b/Makefile.am
@@ -1308,6 +1308,13 @@ ovs_stats_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBYAJL_LDFLAGS)
 ovs_stats_la_LIBADD = $(BUILD_WITH_LIBYAJL_LIBS)
 endif
 
+if BUILD_PLUGIN_PCIE
+pkglib_LTLIBRARIES += pcie.la
+pcie_la_SOURCES = src/pcie.c
+pcie_la_CPPFLAGS = $(AM_CPPFLAGS)
+pcie_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+endif
+
 if BUILD_PLUGIN_PERL
 pkglib_LTLIBRARIES += perl.la
 perl_la_SOURCES = src/perl.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -1310,9 +1310,13 @@ endif
 
 if BUILD_PLUGIN_PCIE
 pkglib_LTLIBRARIES += pcie.la
-pcie_la_SOURCES = src/pcie.c
+pcie_la_SOURCES = src/pcie.c src/utils_message_parser.c src/utils_message_parser.h \
+                  src/utils_tail_match.c src/utils_tail_match.h \
+                  src/utils_tail.c src/utils_tail.h \
+                  src/utils_match.c src/utils_match.h
 pcie_la_CPPFLAGS = $(AM_CPPFLAGS)
 pcie_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+pcie_la_LIBADD = liblatency.la
 endif
 
 if BUILD_PLUGIN_PERL

--- a/README
+++ b/README
@@ -304,6 +304,11 @@ Features
       OVS documentation.
       <http://openvswitch.org/support/dist-docs/INSTALL.rst.html>
 
+    - pcie
+      Read errors from PCI Express Device Status and AER extended
+      capabilities.
+      <https://www.design-reuse.com/articles/38374/pcie-error-logging-and-handling-on-a-typical-soc.html>
+
     - perl
       The perl plugin implements a Perl-interpreter into collectd. You can
       write your own plugins in Perl and return arbitrary values using this

--- a/README
+++ b/README
@@ -304,7 +304,7 @@ Features
       OVS documentation.
       <http://openvswitch.org/support/dist-docs/INSTALL.rst.html>
 
-    - pcie
+    - pcie_errors
       Read errors from PCI Express Device Status and AER extended
       capabilities.
       <https://www.design-reuse.com/articles/38374/pcie-error-logging-and-handling-on-a-typical-soc.html>

--- a/configure.ac
+++ b/configure.ac
@@ -603,6 +603,12 @@ if test "x$ac_system" = "xLinux"; then
     AC_DEFINE([HAVE_CAPABILITY], [1], [Define to 1 if you have cap_get_proc() (-lcap).])
   fi
 
+  # For pcie plugin
+  AC_CHECK_HEADERS([linux/pci_regs.h],
+    [have_pci_regs_h="yes"],
+    [have_pci_regs_h="no (linux/pci_regs.h not found)"]
+  )
+
 else
   have_linux_raid_md_u_h="no"
   have_linux_wireless_h="no"
@@ -5934,6 +5940,7 @@ plugin_nfs="no"
 plugin_numa="no"
 plugin_ovs_events="no"
 plugin_ovs_stats="no"
+plugin_pcie="no"
 plugin_perl="no"
 plugin_pinba="no"
 plugin_processes="no"
@@ -6009,6 +6016,10 @@ if test "x$ac_system" = "xLinux"; then
   if test "x$with_libyajl" = "xyes" && test "x$with_libyajl2" = "xyes"; then
     plugin_ovs_events="yes"
     plugin_ovs_stats="yes"
+  fi
+
+  if test "x$have_pci_regs_h" = "xyes"; then
+    plugin_pcie="yes"
   fi
 fi
 
@@ -6376,6 +6387,7 @@ AC_PLUGIN([openvpn],             [yes],                     [OpenVPN client stat
 AC_PLUGIN([oracle],              [$with_oracle],            [Oracle plugin])
 AC_PLUGIN([ovs_events],          [$plugin_ovs_events],      [OVS events plugin])
 AC_PLUGIN([ovs_stats],           [$plugin_ovs_stats],       [OVS statistics plugin])
+AC_PLUGIN([pcie],                [$plugin_pcie],            [PCIe errors])
 AC_PLUGIN([perl],                [$plugin_perl],            [Embed a Perl interpreter])
 AC_PLUGIN([pf],                  [$have_net_pfvar_h],       [BSD packet filter (PF) statistics])
 # FIXME: Check for libevent, too.
@@ -6803,6 +6815,7 @@ AC_MSG_RESULT([    openvpn . . . . . . . $enable_openvpn])
 AC_MSG_RESULT([    oracle  . . . . . . . $enable_oracle])
 AC_MSG_RESULT([    ovs_events  . . . . . $enable_ovs_events])
 AC_MSG_RESULT([    ovs_stats . . . . . . $enable_ovs_stats])
+AC_MSG_RESULT([    pcie  . . . . . . . . $enable_pcie])
 AC_MSG_RESULT([    perl  . . . . . . . . $enable_perl])
 AC_MSG_RESULT([    pf  . . . . . . . . . $enable_pf])
 AC_MSG_RESULT([    pinba . . . . . . . . $enable_pinba])

--- a/configure.ac
+++ b/configure.ac
@@ -603,7 +603,7 @@ if test "x$ac_system" = "xLinux"; then
     AC_DEFINE([HAVE_CAPABILITY], [1], [Define to 1 if you have cap_get_proc() (-lcap).])
   fi
 
-  # For pcie plugin
+  # For pcie_errors plugin
   AC_CHECK_HEADERS([linux/pci_regs.h],
     [have_pci_regs_h="yes"],
     [have_pci_regs_h="no (linux/pci_regs.h not found)"]
@@ -5940,7 +5940,7 @@ plugin_nfs="no"
 plugin_numa="no"
 plugin_ovs_events="no"
 plugin_ovs_stats="no"
-plugin_pcie="no"
+plugin_pcie_errors="no"
 plugin_perl="no"
 plugin_pinba="no"
 plugin_processes="no"
@@ -6019,7 +6019,7 @@ if test "x$ac_system" = "xLinux"; then
   fi
 
   if test "x$have_pci_regs_h" = "xyes"; then
-    plugin_pcie="yes"
+    plugin_pcie_errors="yes"
   fi
 fi
 
@@ -6387,7 +6387,7 @@ AC_PLUGIN([openvpn],             [yes],                     [OpenVPN client stat
 AC_PLUGIN([oracle],              [$with_oracle],            [Oracle plugin])
 AC_PLUGIN([ovs_events],          [$plugin_ovs_events],      [OVS events plugin])
 AC_PLUGIN([ovs_stats],           [$plugin_ovs_stats],       [OVS statistics plugin])
-AC_PLUGIN([pcie],                [$plugin_pcie],            [PCIe errors])
+AC_PLUGIN([pcie_errors],         [$plugin_pcie_errors],     [PCIe errors])
 AC_PLUGIN([perl],                [$plugin_perl],            [Embed a Perl interpreter])
 AC_PLUGIN([pf],                  [$have_net_pfvar_h],       [BSD packet filter (PF) statistics])
 # FIXME: Check for libevent, too.
@@ -6815,7 +6815,7 @@ AC_MSG_RESULT([    openvpn . . . . . . . $enable_openvpn])
 AC_MSG_RESULT([    oracle  . . . . . . . $enable_oracle])
 AC_MSG_RESULT([    ovs_events  . . . . . $enable_ovs_events])
 AC_MSG_RESULT([    ovs_stats . . . . . . $enable_ovs_stats])
-AC_MSG_RESULT([    pcie  . . . . . . . . $enable_pcie])
+AC_MSG_RESULT([    pcie_errors . . . . . $enable_pcie_errors])
 AC_MSG_RESULT([    perl  . . . . . . . . $enable_perl])
 AC_MSG_RESULT([    pf  . . . . . . . . . $enable_pf])
 AC_MSG_RESULT([    pinba . . . . . . . . $enable_pinba])

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1048,19 +1048,20 @@
 #	LogFile "/var/log/syslog"
 #	<MsgPattern "aer syslog">
 #		<Match>
+#			Name "incident time"
+#			Regex "(... .. ..:..:..) .* pcieport.*AER"
+#		</Match>
+#		<Match>
 #			Name "root port"
 #			Regex "pcieport (.*): AER:"
-#			IsMandatory true
 #		</Match>
 #		<Match>
 #			Name "device"
 #			Regex " ([0-9a-fA-F:\\.]*): PCIe Bus Error"
-#			IsMandatory true
 #		</Match>
 #		<Match>
 #			Name "severity"
 #			Regex "severity=([^,]*)"
-#			IsMandatory true
 #		</Match>
 #		<Match>
 #			Name "error type"
@@ -1070,7 +1071,6 @@
 #		<Match>
 #			Name "id"
 #			Regex ", id=(.*)"
-#			IsMandatory true
 #		</Match>
 #	</MsgPattern>
 #</Plugin>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -171,7 +171,7 @@
 #@BUILD_PLUGIN_ORACLE_TRUE@LoadPlugin oracle
 #@BUILD_PLUGIN_OVS_EVENTS_TRUE@LoadPlugin ovs_events
 #@BUILD_PLUGIN_OVS_STATS_TRUE@LoadPlugin ovs_stats
-#@BUILD_PLUGIN_PCIE_TRUE@LoadPlugin pcie
+#@BUILD_PLUGIN_PCIE_ERRORS_TRUE@LoadPlugin pcie_errors
 #@BUILD_PLUGIN_PERL_TRUE@LoadPlugin perl
 #@BUILD_PLUGIN_PINBA_TRUE@LoadPlugin pinba
 #@BUILD_PLUGIN_PING_TRUE@LoadPlugin ping
@@ -1039,7 +1039,7 @@
 #  Bridges "br0" "br_ext"
 #</Plugin>
 
-#<Plugin pcie>
+#<Plugin pcie_errors>
 #	Source "sysfs"
 #	AccessDir "/sys/bus/pci"
 #	ReportMasked false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1044,7 +1044,6 @@
 #	AccessDir "/sys/bus/pci"
 #	ReportMasked false
 #	PersistentNotifications false
-#	ReadLog false
 #	FirstFullRead false
 #	LogFile "/var/log/syslog"
 #	<MsgPattern "aer syslog">

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -171,6 +171,7 @@
 #@BUILD_PLUGIN_ORACLE_TRUE@LoadPlugin oracle
 #@BUILD_PLUGIN_OVS_EVENTS_TRUE@LoadPlugin ovs_events
 #@BUILD_PLUGIN_OVS_STATS_TRUE@LoadPlugin ovs_stats
+#@BUILD_PLUGIN_PCIE_TRUE@LoadPlugin pcie
 #@BUILD_PLUGIN_PERL_TRUE@LoadPlugin perl
 #@BUILD_PLUGIN_PINBA_TRUE@LoadPlugin pinba
 #@BUILD_PLUGIN_PING_TRUE@LoadPlugin ping
@@ -1036,6 +1037,13 @@
 #  Address "127.0.0.1"
 #  Socket "/var/run/openvswitch/db.sock"
 #  Bridges "br0" "br_ext"
+#</Plugin>
+
+#<Plugin pcie>
+#	Source "sysfs"
+#	AccessDir "/sys/bus/pci"
+#	ReportMasked false
+#	Persistent false
 #</Plugin>
 
 #<Plugin perl>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1043,7 +1043,37 @@
 #	Source "sysfs"
 #	AccessDir "/sys/bus/pci"
 #	ReportMasked false
-#	Persistent false
+#	PersistentNotifications false
+#	ReadLog false
+#	FirstFullRead false
+#	LogFile "/var/log/syslog"
+#	<MsgPattern "aer syslog">
+#		<Match>
+#			Name "root port"
+#			Regex "pcieport (.*): AER:"
+#			IsMandatory true
+#		</Match>
+#		<Match>
+#			Name "device"
+#			Regex " ([0-9a-fA-F:\\.]*): PCIe Bus Error"
+#			IsMandatory true
+#		</Match>
+#		<Match>
+#			Name "severity"
+#			Regex "severity=([^,]*)"
+#			IsMandatory true
+#		</Match>
+#		<Match>
+#			Name "error type"
+#			Regex "type=(.*),"
+#			IsMandatory false
+#		</Match>
+#		<Match>
+#			Name "id"
+#			Regex ", id=(.*)"
+#			IsMandatory true
+#		</Match>
+#	</MsgPattern>
 #</Plugin>
 
 #<Plugin perl>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1046,10 +1046,16 @@
 #	PersistentNotifications false
 #	FirstFullRead false
 #	LogFile "/var/log/syslog"
-#	<MsgPattern "aer syslog">
+#	<MsgPattern "AER">
+#		<Match>
+#			Name "aer error"
+#			Regex "AER:.*error received"
+#			SubmatchIdx -1
+#		</Match>
 #		<Match>
 #			Name "incident time"
 #			Regex "(... .. ..:..:..) .* pcieport.*AER"
+#			IsMandatory false
 #		</Match>
 #		<Match>
 #			Name "root port"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5852,8 +5852,9 @@ be omitted.
 =item B<IsMandatory>  I<true>|I<false>
 
 Flag specifying if message item string described by above parameters is
-mandatory for whole I<MsgPattern> validation. If set to 1, whole message is
-discarded if it's missing. For 0 its presence is optional.
+mandatory for whole I<MsgPattern> validation. If set to true, whole message
+is discarded if it's missing. For false its presence is optional. Default
+value is set to true.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5816,7 +5816,7 @@ is "/var/log/syslog".
 Optional definition of regular expressions used to parse the error messages
 in a log file when B<Source> is set to B<logfile>. I<Name> is the type instance
 of message. Multiple definitions are allowed to parse different messages.
-Contains several I<Match> subsections described bellow. There are two special
+Contains several I<Match> subsections described below. There are two special
 match names that should be present in the message pattern definition: "device"
 and "severity". They are used to set plugin instance, severity and type instance
 for notification. If B<MsgPattern> is not specified the default configuration
@@ -5826,7 +5826,8 @@ is used.
 
 Multiple I<Match> blocks define regular expression patterns for extracting or
 excluding specific string patterns from parsing. First and last I<Match> items
-set boundaries of multiline AER message and are mandatory.
+in the same I<MsgPattern> set boundaries of multiline AER message and are
+mandatory.
 
 =item B<Name> I<name>
 
@@ -5852,10 +5853,9 @@ be omitted.
 
 =item B<IsMandatory>  I<true>|I<false>
 
-Flag specifying if message item string described by above parameters is
-mandatory for whole I<MsgPattern> validation. If set to true, whole message
-is discarded if it's missing. For false its presence is optional. Default
-value is set to true.
+Flag indicating if I<Match> item is mandatory for message validation. If set to
+true, whole message is discarded if it's missing. For false its presence is
+optional. Default value is set to true.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5740,9 +5740,9 @@ Default: empty (monitor all bridges)
 
 =back
 
-=head2 Plugin C<pcie>
+=head2 Plugin C<pcie_errors>
 
-The I<pcie> plugin collects PCI Express errors from Device Status in Capability
+The I<pcie_errors> plugin collects PCI Express errors from Device Status in Capability
 structure and from Advanced Error Reporting Extended Capability where available.
 At every read it polls config space of PCI Express devices and dispatches
 notification for every error that is set. It can be configured to parse log file
@@ -5754,7 +5754,7 @@ Fatal errros are reported as I<NOTIF_FAILURE> and all others as I<NOTIF_WARNING>
 
 B<Synopsis:>
 
-  <Plugin "pcie">
+  <Plugin "pcie_errors">
     Source "sysfs"
     AccessDir "/sys/bus/pci"
     ReportMasked false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5841,7 +5841,8 @@ so next option B<SubmatchIdx> specifies which subexpression should be stored.
 
 Index of subexpression to be used for AER error notification. Multiple
 subexpressions are allowed. Index value 0 takes whole regular expression match
-as a result. Can be ommited, default value is 1.
+as a result. Index value -1 does not add result to message item. Can be omitted,
+default value is 1.
 
 =item B<Excluderegex> I<regex>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5779,8 +5779,8 @@ B<Options:>
 
 =item B<Source> B<sysfs>|B<proc>|B<off>
 
-Use sysfs or proc for reading data from registers. If set to "off" or option
-is not provided, no data is being read from devices.
+Use sysfs or proc for reading data from registers. If set to B<off> no data is
+being read from devices. The default value is B<sysfs>.
 
 =item B<AccessDir> I<dir>
 
@@ -5789,14 +5789,15 @@ Directory used to access device config space. It is optional and defaults to
 
 =item B<ReportMasked> B<false>|B<true>
 
-If true plugin will notify errors that are set to masked in
-Error Mask register. Such errors are not reported to the PCI
-Express Root Complex. Defaults to B<false>.
+If true plugin will notify errors that are set to masked in Error Mask register.
+Such errors are not reported to the PCI Express Root Complex. Defaults to
+B<false>. This parameter takes effect only if B<Source> is set.
 
 =item B<PersistentNotifications> B<false>|B<true>
 
 If false plugin will dispatch notfication only on set/clear of error.
 The ones already reported will be ignored. Defaults to B<false>.
+This parameter takes effect only if B<Source> is set.
 
 =item B<ReadLog> B<false>|B<true>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5740,6 +5740,52 @@ Default: empty (monitor all bridges)
 
 =back
 
+=head2 Plugin C<pcie>
+
+The I<pcie> plugin collects PCI Express errors from Device Status in Capability
+structure and from Advanced Error Reporting Extended Capability where available.
+At every read it polls config space of PCI Express devices and dispatches
+notification for every error that is set. The device is indicated in
+plugin_instance according to format "domain:bus:dev.fn". Errors are divided
+into categories indicated by type: "Correctable" and "Uncorrectable" and
+type_instance: "Fatal" and "Non-Fatal". All correctable errors are non-fatal.
+Fatal errros are reported as I<NOTIF_FAILURE> and all others as I<NOTIF_WARNING>.
+
+B<Synopsis:>
+
+  <Plugin "pcie">
+    Source "sysfs"
+    AccessDir "/sys/bus/pci"
+    ReportMasked false
+    Persistent false
+  </Plugin>
+
+B<Options:>
+
+=over 4
+
+=item B<Source> B<sysfs>|B<proc>
+
+Use sysfs or proc for reading data from registers.
+
+=item B<AccessDir> I<dir>
+
+Directory used to access device config space. It is optional and defaults to
+/sys/bus/pci for B<sysfs> and to /proc/bus/pci for B<proc>.
+
+=item B<ReportMasked> B<false>|B<true>
+
+If true plugin will notify errors that are set to masked in
+Error Mask register. Such errors are not reported to the PCI
+Express Root Complex. Defaults to B<false>.
+
+=item B<Persistent> B<false>|B<true>
+
+If false plugin will dispatch notfication only on set/clear of error.
+The ones already reported will be ignored. Defaults to B<false>.
+
+=back
+
 =head2 Plugin C<perl>
 
 This plugin embeds a Perl-interpreter into collectd and provides an interface

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5759,7 +5759,6 @@ B<Synopsis:>
     AccessDir "/sys/bus/pci"
     ReportMasked false
     PersistentNotifications false
-    ReadLog false
     FirstFullRead false
     LogFile "/var/log/syslog"
     <MsgPattern "correctable">
@@ -5777,10 +5776,11 @@ B<Options:>
 
 =over 4
 
-=item B<Source> B<sysfs>|B<proc>|B<off>
+=item B<Source> B<sysfs>|B<proc>|B<logfile>
 
-Use sysfs or proc for reading data from registers. If set to B<off> no data is
-being read from devices. The default value is B<sysfs>.
+Use B<sysfs> or B<proc> for reading data from registers. If set to B<logfile> the
+file is parsed for reported AER errors and corresponding notifications are sent.
+The default value is B<sysfs>.
 
 =item B<AccessDir> I<dir>
 
@@ -5791,34 +5791,36 @@ Directory used to access device config space. It is optional and defaults to
 
 If true plugin will notify errors that are set to masked in Error Mask register.
 Such errors are not reported to the PCI Express Root Complex. Defaults to
-B<false>. This parameter takes effect only if B<Source> is set.
+B<false>. This parameter takes effect only if B<Source> is set to B<sysfs>
+or B<proc>.
 
 =item B<PersistentNotifications> B<false>|B<true>
 
 If false plugin will dispatch notfication only on set/clear of error.
 The ones already reported will be ignored. Defaults to B<false>.
-This parameter takes effect only if B<Source> is set.
-
-=item B<ReadLog> B<false>|B<true>
-
-If set to true, LogFile is parsed for reported AER errors and corresponding
-notifications are sent. Default value is B<false>.
+This parameter takes effect only if B<Source> is set to B<sysfs> or B<proc>.
 
 =item B<FirstFullRead> B<false>|B<true>
 
 If set to true, the full scan of existing log file is done during first read.
-Otherwise only new incoming entries will be parsed. Default value is B<false>.
+Otherwise only new incoming entries will be parsed. This parameter only affects
+the plugin if B<Source> is set to B<logfile>. Default value is B<false>.
 
 =item B<LogFile> I<dir>
 
-Log file name to use when ReadLog is true. Default value is "/var/log/syslog".
+Log file name to use when B<Source> is set to B<logfile>. Default value
+is "/var/log/syslog".
 
 =item B<MsgPattern> I<name>
 
 Optional definition of regular expressions used to parse the error messages
-in I<LogFile>. I<Name> is the type instance of message. Multiple definitions are
-allowed to parse different messages. Contains several I<Match> subsections
-described bellow. If not specified the default configuration is used.
+in a log file when B<Source> is set to B<logfile>. I<Name> is the type instance
+of message. Multiple definitions are allowed to parse different messages.
+Contains several I<Match> subsections described bellow. There are two special
+match names that should be present in the message pattern definition: "device"
+and "severity". They are used to set plugin instance, severity and type instance
+for notification. If B<MsgPattern> is not specified the default configuration
+is used.
 
 =item B<Match>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5745,10 +5745,11 @@ Default: empty (monitor all bridges)
 The I<pcie> plugin collects PCI Express errors from Device Status in Capability
 structure and from Advanced Error Reporting Extended Capability where available.
 At every read it polls config space of PCI Express devices and dispatches
-notification for every error that is set. The device is indicated in
-plugin_instance according to format "domain:bus:dev.fn". Errors are divided
-into categories indicated by type: "Correctable" and "Uncorrectable" and
-type_instance: "Fatal" and "Non-Fatal". All correctable errors are non-fatal.
+notification for every error that is set. It can be configured to parse log file
+for system reported AER errors. It checks for new errors at every read.
+The device is indicated in plugin_instance according to format "domain:bus:dev.fn".
+Errors are divided into categories indicated by type_instance: "correctable", and
+for uncorrectable errors "non_fatal" or "fatal".
 Fatal errros are reported as I<NOTIF_FAILURE> and all others as I<NOTIF_WARNING>.
 
 B<Synopsis:>
@@ -5757,16 +5758,29 @@ B<Synopsis:>
     Source "sysfs"
     AccessDir "/sys/bus/pci"
     ReportMasked false
-    Persistent false
+    PersistentNotifications false
+    ReadLog false
+    FirstFullRead false
+    LogFile "/var/log/syslog"
+    <MsgPattern "correctable">
+      <Match>
+        Name "root port"
+        Regex "pcieport (.*): AER: Corrected"
+        SubmatchIdx 1
+        Excluderegex "collectd"
+        IsMandatory true
+      </Match>
+    </MsgPattern>
   </Plugin>
 
 B<Options:>
 
 =over 4
 
-=item B<Source> B<sysfs>|B<proc>
+=item B<Source> B<sysfs>|B<proc>|B<off>
 
-Use sysfs or proc for reading data from registers.
+Use sysfs or proc for reading data from registers. If set to "off" or option
+is not provided, no data is being read from devices.
 
 =item B<AccessDir> I<dir>
 
@@ -5779,10 +5793,64 @@ If true plugin will notify errors that are set to masked in
 Error Mask register. Such errors are not reported to the PCI
 Express Root Complex. Defaults to B<false>.
 
-=item B<Persistent> B<false>|B<true>
+=item B<PersistentNotifications> B<false>|B<true>
 
 If false plugin will dispatch notfication only on set/clear of error.
 The ones already reported will be ignored. Defaults to B<false>.
+
+=item B<ReadLog> B<false>|B<true>
+
+If set to true, LogFile is parsed for reported AER errors and corresponding
+notifications are sent. Default value is B<false>.
+
+=item B<FirstFullRead> B<false>|B<true>
+
+If set to true, the full scan of existing log file is done during first read.
+Otherwise only new incoming entries will be parsed. Default value is B<false>.
+
+=item B<LogFile> I<dir>
+
+Log file name to use when ReadLog is true. Default value is "/var/log/syslog".
+
+=item B<MsgPattern> I<name>
+
+Optional definition of regular expressions used to parse the error messages
+in I<LogFile>. I<Name> is the type instance of message. Multiple definitions are
+allowed to parse different messages. Contains several I<Match> subsections
+described bellow. If not specified the default configuration is used.
+
+=item B<Match>
+
+Multiple I<Match> blocks define regular expression patterns for extracting or
+excluding specific string patterns from parsing. First and last I<Match> items
+set boundaries of multiline AER message and are mandatory.
+
+=item B<Name> I<name>
+
+Name of regular expression, used in AER error notification.
+
+=item B<Regex> I<regex>
+
+Regular expression with pattern matching string. It may contain subexpressions,
+so next option B<SubmatchIdx> specifies which subexpression should be stored.
+
+=item B<SubmatchIdx> I<index>
+
+Index of subexpression to be used for AER error notification. Multiple
+subexpressions are allowed. Index value 0 takes whole regular expression match
+as a result. Can be ommited, default value is 1.
+
+=item B<Excluderegex> I<regex>
+
+Regular expression for excluding lines containing specific matching strings.
+This is processed before checking I<Regex> pattern. It is optional and can
+be omitted.
+
+=item B<IsMandatory>  I<true>|I<false>
+
+Flag specifying if message item string described by above parameters is
+mandatory for whole I<MsgPattern> validation. If set to 1, whole message is
+discarded if it's missing. For 0 its presence is optional.
 
 =back
 

--- a/src/pcie.c
+++ b/src/pcie.c
@@ -26,9 +26,12 @@
  **/
 
 #include "collectd.h"
+
 #include "common.h"
 #include "utils_llist.h"
+#include "utils_message_parser.h"
 
+#include <fnmatch.h>
 #include <linux/pci_regs.h>
 
 #define PCIE_PLUGIN "pcie"
@@ -47,11 +50,23 @@
 
 #define PCIE_ECAP_OFFSET 0x100 /* ECAP always begin at offset 0x100 */
 
+#define PCIE_LOG_PORT "root port"
+#define PCIE_LOG_SEVERITY "severity"
+#define PCIE_LOG_DEV "device"
+#define PCIE_LOG_TYPE "error type"
+#define PCIE_LOG_ID "id"
+
 typedef struct pcie_config_s {
   _Bool use_sysfs;
   _Bool notif_masked;
   _Bool persistent;
-  char access_dir[PCIE_NAME_LEN];
+  _Bool first_read;
+  _Bool read_devices;
+  _Bool read_log;
+  _Bool default_patterns;
+  char access_dir[PATH_MAX];
+  char logfile[PATH_MAX];
+  _Bool config_error;
 } pcie_config_t;
 
 typedef struct pcie_device_s {
@@ -81,8 +96,16 @@ typedef struct pcie_error_s {
   const char *desc;
 } pcie_error_t;
 
+typedef struct pcie_msg_parser_s {
+  char name[PCIE_NAME_LEN];
+  parser_job_data *job;
+  message_pattern *patterns;
+  size_t patterns_len;
+} pcie_msg_parser_t;
+
 static llist_t *pcie_dev_list;
-static pcie_config_t pcie_config = {.access_dir = ""};
+static pcie_config_t pcie_config = {.access_dir = "",
+                                    .logfile = "/var/log/syslog"};
 static pcie_fops_t pcie_fops;
 
 /* Device Error Status */
@@ -125,24 +148,53 @@ static pcie_error_t pcie_aer_ces[] = {
     {PCI_ERR_COR_LOG_OVER, "Header Log Overflow"}};
 static const int pcie_aer_ces_num = STATIC_ARRAY_SIZE(pcie_aer_ces);
 
-static void pcie_add_device(llist_t *list, int domain, uint8_t bus,
-                            uint8_t device, uint8_t fn) {
+static pcie_msg_parser_t *pcie_parsers = NULL;
+static size_t pcie_parsers_len = 0;
+
+/* Default patterns for AER errors in syslog */
+static message_pattern pcie_default_patterns[] = {
+    {.name = PCIE_LOG_PORT,
+     .regex = "pcieport (.*): AER:",
+     .submatch_idx = 1,
+     .is_mandatory = 1},
+    {.name = PCIE_LOG_DEV,
+     .regex = " ([0-9a-fA-F:\\.]*): PCIe Bus Error",
+     .submatch_idx = 1,
+     .is_mandatory = 1},
+    {.name = PCIE_LOG_SEVERITY,
+     .regex = "severity=([^,]*)",
+     .submatch_idx = 1,
+     .is_mandatory = 1},
+    {.name = PCIE_LOG_TYPE,
+     .regex = "type=(.*),",
+     .submatch_idx = 1,
+     .is_mandatory = 0},
+    {.name = PCIE_LOG_ID,
+     .regex = ", id=(.*)",
+     .submatch_idx = 1,
+     .is_mandatory = 1}};
+
+static int pcie_add_device(llist_t *list, int domain, uint8_t bus,
+                           uint8_t device, uint8_t fn) {
   llentry_t *entry;
-  pcie_device_t *dev = smalloc(sizeof(*dev));
+  pcie_device_t *dev = calloc(1, sizeof(*dev));
+  if (dev == NULL) {
+    ERROR(PCIE_PLUGIN ": Failed to allocate device");
+    return -ENOMEM;
+  }
 
   dev->domain = domain;
   dev->bus = bus;
   dev->device = device;
   dev->function = fn;
-  dev->excluded = 0;
   dev->cap_exp = -1;
   dev->ecap_aer = -1;
-  dev->aer_not_found = 0;
   entry = llentry_create(NULL, dev);
   llist_append(list, entry);
 
   DEBUG(PCIE_PLUGIN ": pci device added to list: %04x:%02x:%02x.%d", domain,
         bus, device, fn);
+  return 0;
 }
 
 static void pcie_clear_list(llist_t *list) {
@@ -161,6 +213,7 @@ static int pcie_list_devices_proc(llist_t *dev_list) {
   char file_name[PCIE_NAME_LEN];
   char buf[PCIE_BUFF_SIZE];
   unsigned int i = 0;
+  int ret = 0;
 
   if (dev_list == NULL)
     return -EINVAL;
@@ -186,19 +239,22 @@ static int pcie_list_devices_proc(llist_t *dev_list) {
     bus = slot >> 8U;
     dev = PCIE_DEV(slot);
     fn = PCIE_FN(slot);
-    pcie_add_device(dev_list, 0, bus, dev, fn);
+    ret = pcie_add_device(dev_list, 0, bus, dev, fn);
+    if (ret)
+      break;
 
     ++i;
   }
 
   fclose(fd);
-  return 0;
+  return ret;
 }
 
 static int pcie_list_devices_sysfs(llist_t *dev_list) {
   DIR *dir;
   struct dirent *item;
   char dir_name[PCIE_NAME_LEN];
+  int ret = 0;
 
   if (dev_list == NULL)
     return -EINVAL;
@@ -224,11 +280,13 @@ static int pcie_list_devices_sysfs(llist_t *dev_list) {
       continue;
     }
 
-    pcie_add_device(dev_list, dom, bus, dev, fn);
+    ret = pcie_add_device(dev_list, dom, bus, dev, fn);
+    if (ret)
+      break;
   }
 
   closedir(dir);
-  return 0;
+  return ret;
 }
 
 static void pcie_close(pcie_device_t *dev) {
@@ -311,16 +369,23 @@ static uint32_t pcie_read32(pcie_device_t *dev, int pos) {
   return value;
 }
 
+static void pcie_do_dispatch_notification(notification_t *n, const char *type) {
+  sstrncpy(n->host, hostname_g, sizeof(n->host));
+  sstrncpy(n->type, type, sizeof(n->type));
+
+  plugin_dispatch_notification(n);
+  if (n->meta != NULL)
+    plugin_notification_meta_free(n->meta);
+}
+
 static void pcie_dispatch_notification(pcie_device_t *dev, notification_t *n,
                                        const char *type,
                                        const char *type_instance) {
-  sstrncpy(n->host, hostname_g, sizeof(n->host));
   ssnprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
             dev->domain, dev->bus, dev->device, dev->function);
-  sstrncpy(n->type, type, sizeof(n->type));
   sstrncpy(n->type_instance, type_instance, sizeof(n->type_instance));
 
-  plugin_dispatch_notification(n);
+  pcie_do_dispatch_notification(n, type);
 }
 
 /* Report errors found in AER Correctable Error Status register */
@@ -597,9 +662,96 @@ static int pcie_process_devices(llist_t *devs) {
   return ret;
 }
 
-static int pcie_plugin_read(__attribute__((unused)) user_data_t *ud) {
+static void pcie_parse_msg(message *msg, unsigned int max_items) {
+  notification_t n = {.severity = NOTIF_WARNING,
+                      .time = cdtime(),
+                      .plugin = PCIE_PLUGIN,
+                      .meta = NULL};
 
-  return pcie_process_devices(pcie_dev_list);
+  for (int i = 0; i < max_items; i++) {
+    message_item *item = msg->message_items + i;
+    if (!item->value[0])
+      break;
+
+    DEBUG(PCIE_PLUGIN "[%02d] %s:%s", i, item->name, item->value);
+
+    if (strncmp(item->name, PCIE_LOG_SEVERITY, strlen(PCIE_LOG_SEVERITY)) ==
+        0) {
+      if (fnmatch("*[nN]on-[fF]atal*", item->value, 0) == 0) {
+        sstrncpy(n.type_instance, PCIE_SEV_NOFATAL, sizeof(n.type_instance));
+      } else if (fnmatch("*[fF]atal*", item->value, 0) == 0) {
+        n.severity = NOTIF_FAILURE;
+        sstrncpy(n.type_instance, PCIE_SEV_FATAL, sizeof(n.type_instance));
+      } else {
+        sstrncpy(n.type_instance, PCIE_SEV_CE, sizeof(n.type_instance));
+      }
+    } else if (strncmp(item->name, PCIE_LOG_DEV, strlen(PCIE_LOG_DEV)) == 0) {
+      sstrncpy(n.plugin_instance, item->value, sizeof(n.plugin_instance));
+    } else {
+      if (plugin_notification_meta_add_string(&n, item->name, item->value))
+        ERROR(PCIE_PLUGIN ": Failed to add notification meta data %s:%s",
+              item->name, item->value);
+    }
+  }
+  ssnprintf(n.message, sizeof(n.message), "AER %s error reported in log",
+            n.type_instance);
+
+  pcie_do_dispatch_notification(&n, PCIE_ERROR);
+}
+
+static int pcie_logfile_read(parser_job_data *job, const char *name) {
+  message *messages_storage;
+  unsigned int max_item_num;
+  int msg_num =
+      message_parser_read(job, &messages_storage, pcie_config.first_read);
+  if (msg_num < 0) {
+    notification_t n = {.severity = NOTIF_FAILURE,
+                        .time = cdtime(),
+                        .message = "Failed to read from log file",
+                        .plugin = PCIE_PLUGIN,
+                        .meta = NULL};
+    pcie_do_dispatch_notification(&n, "");
+    return -1;
+  }
+
+  max_item_num = STATIC_ARRAY_SIZE(messages_storage[0].message_items);
+
+  DEBUG(PCIE_PLUGIN ": read %d messages, %s", msg_num, name);
+
+  for (int i = 0; i < msg_num; i++) {
+    message *msg = messages_storage + i;
+    pcie_parse_msg(msg, max_item_num);
+  }
+  return 0;
+}
+
+static int pcie_plugin_read(__attribute__((unused)) user_data_t *ud) {
+  int ret = 0;
+
+  if (pcie_config.read_devices) {
+    ret = pcie_process_devices(pcie_dev_list);
+    if (ret < 0) {
+      ERROR(PCIE_PLUGIN ": Failed to read devices state");
+      return -1;
+    }
+  }
+
+  if (!pcie_config.read_log)
+    return 0;
+
+  for (int i = 0; i < pcie_parsers_len; i++) {
+    ret = pcie_logfile_read(pcie_parsers[i].job, pcie_parsers[i].name);
+    if (ret < 0) {
+      ERROR(PCIE_PLUGIN ": Failed to parse %s messages from %s",
+            pcie_parsers[i].name, pcie_config.logfile);
+      break;
+    }
+  }
+
+  if (pcie_config.first_read)
+    pcie_config.first_read = 0;
+
+  return ret;
 }
 
 static void pcie_access_config(void) {
@@ -624,56 +776,127 @@ static void pcie_access_config(void) {
   pcie_fops.read = pcie_read;
 }
 
-static int pcie_plugin_config(oconfig_item_t *ci) {
-  for (int i = 0; i < ci->children_num; i++) {
-    oconfig_item_t *child = ci->children + i;
+static int pcie_patterns_config(message_pattern *patterns,
+                                oconfig_item_t *match_opt, int num) {
+  for (int i = 0; i < num; i++) {
+    if (strcasecmp("Match", match_opt[i].key) == 0) {
+      /* set default submatch index to 1 since single submatch is the most
+       * common use case */
+      patterns[i].submatch_idx = 1;
+      for (int j = 0; j < match_opt[i].children_num; j++) {
+        int status = 0;
+        oconfig_item_t *regex_opt = match_opt[i].children + j;
+        if (strcasecmp("Name", regex_opt->key) == 0)
+          status = cf_util_get_string(regex_opt, &(patterns[i].name));
+        else if (strcasecmp("Regex", regex_opt->key) == 0)
+          status = cf_util_get_string(regex_opt, &(patterns[i].regex));
+        else if (strcasecmp("SubmatchIdx", regex_opt->key) == 0)
+          status = cf_util_get_int(regex_opt, &(patterns[i].submatch_idx));
+        else if (strcasecmp("Excluderegex", regex_opt->key) == 0)
+          status = cf_util_get_string(regex_opt, &(patterns[i].excluderegex));
+        else if (strcasecmp("IsMandatory", regex_opt->key) == 0)
+          status = cf_util_get_boolean(regex_opt, &(patterns[i].is_mandatory));
+        else {
+          ERROR(PCIE_PLUGIN ": Invalid configuration option \"%s\".",
+                regex_opt->key);
+          return -1;
+        }
 
-    if (strcasecmp("Source", child->key) == 0) {
-      if ((child->values_num != 1) ||
-          (child->values[0].type != OCONFIG_TYPE_STRING)) {
-        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
-              child->key);
-        return -1;
-      }
-      if (strcasecmp("sysfs", child->values[0].value.string) == 0)
-        pcie_config.use_sysfs = 1;
-    } else if (strcasecmp("AccessDir", child->key) == 0) {
-      if (cf_util_get_string_buffer(child, pcie_config.access_dir,
-                                    sizeof(pcie_config.access_dir))) {
-        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
-              child->key);
-        return -1;
-      }
-    } else if (strcasecmp("ReportMasked", child->key) == 0) {
-      if (cf_util_get_boolean(child, &pcie_config.notif_masked)) {
-        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
-              child->key);
-        return -1;
-      }
-    } else if (strcasecmp("Persistent", child->key) == 0) {
-      if (cf_util_get_boolean(child, &pcie_config.persistent)) {
-        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
-              child->key);
-        return -1;
+        if (status) {
+          ERROR(PCIE_PLUGIN ": Error setting regex option %s", regex_opt->key);
+        }
       }
     } else {
-      ERROR(PCIE_PLUGIN ": Invalid configuration option \"%s\".", child->key);
+      ERROR(PCIE_PLUGIN ": option \"%s\" is not allowed here.",
+            match_opt[i].key);
       return -1;
     }
   }
 
-  pcie_access_config();
-
   return 0;
 }
 
-static int pcie_init(void) {
-  pcie_dev_list = llist_create();
-  if (pcie_fops.list_devices(pcie_dev_list) != 0) {
-    ERROR(PCIE_PLUGIN ": Failed to find devices.");
-    pcie_clear_list(pcie_dev_list);
-    pcie_dev_list = NULL;
-    return -1;
+static int pcie_plugin_config(oconfig_item_t *ci) {
+  int parser_idx = 0;
+  /* Get number of configured parsers in advance */
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+    if (strcasecmp("MsgPattern", child->key) == 0)
+      pcie_parsers_len++;
+  }
+
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+    int status = 0;
+
+    if (strcasecmp("Source", child->key) == 0) {
+      if ((child->values_num != 1) ||
+          (child->values[0].type != OCONFIG_TYPE_STRING)) {
+        status = -1;
+      } else if (strcasecmp("sysfs", child->values[0].value.string) == 0) {
+        pcie_config.use_sysfs = 1;
+        pcie_config.read_devices = 1;
+      } else if (strcasecmp("proc", child->values[0].value.string) == 0) {
+        pcie_config.read_devices = 1;
+      }
+    } else if (strcasecmp("AccessDir", child->key) == 0) {
+      status = cf_util_get_string_buffer(child, pcie_config.access_dir,
+                                         sizeof(pcie_config.access_dir));
+    } else if (strcasecmp("ReportMasked", child->key) == 0) {
+      status = cf_util_get_boolean(child, &pcie_config.notif_masked);
+    } else if (strcasecmp("PersistentNotifications", child->key) == 0) {
+      status = cf_util_get_boolean(child, &pcie_config.persistent);
+    } else if (strcasecmp("LogFile", child->key) == 0) {
+      status = cf_util_get_string_buffer(child, pcie_config.logfile,
+                                         sizeof(pcie_config.logfile));
+    } else if (strcasecmp("ReadLog", child->key) == 0) {
+      status = cf_util_get_boolean(child, &pcie_config.read_log);
+    } else if (strcasecmp("FirstFullRead", child->key) == 0) {
+      status = cf_util_get_boolean(child, &pcie_config.first_read);
+    } else if (strcasecmp("MsgPattern", child->key) == 0) {
+      if (!pcie_parsers) {
+        pcie_parsers = calloc(pcie_parsers_len, sizeof(*pcie_parsers));
+        if (pcie_parsers == NULL) {
+          ERROR(PCIE_PLUGIN ": Error allocating message parsers");
+          pcie_config.config_error = 1;
+          break;
+        }
+      }
+      if (cf_util_get_string_buffer(child, pcie_parsers[parser_idx].name,
+                                    sizeof(pcie_parsers[parser_idx].name))) {
+        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+              child->key);
+        pcie_config.config_error = 1;
+        break;
+      }
+      pcie_parsers[parser_idx].patterns_len = child->children_num;
+      pcie_parsers[parser_idx].patterns =
+          calloc(pcie_parsers[parser_idx].patterns_len,
+                 sizeof(*(pcie_parsers[parser_idx].patterns)));
+      if (pcie_parsers[parser_idx].patterns == NULL) {
+        ERROR(PCIE_PLUGIN ": Error allocating message_patterns");
+        pcie_config.config_error = 1;
+        break;
+      }
+      if (pcie_patterns_config(pcie_parsers[parser_idx].patterns,
+                               child->children, child->children_num)) {
+        ERROR(PCIE_PLUGIN ": Failed to parse patterns for \"%s\".", child->key);
+        pcie_config.config_error = 1;
+        break;
+      }
+      parser_idx++;
+    } else {
+      ERROR(PCIE_PLUGIN ": Invalid configuration option \"%s\".", child->key);
+      pcie_config.config_error = 1;
+      break;
+    }
+
+    if (status) {
+      ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+            child->key);
+      pcie_config.config_error = 1;
+      break;
+    }
   }
 
   return 0;
@@ -682,6 +905,72 @@ static int pcie_init(void) {
 static int pcie_shutdown(void) {
   pcie_clear_list(pcie_dev_list);
   pcie_dev_list = NULL;
+
+  for (int i = 0; i < pcie_parsers_len; i++) {
+    if (pcie_parsers[i].job != NULL)
+      message_parser_cleanup(pcie_parsers[i].job);
+    if (!pcie_config.default_patterns)
+      sfree(pcie_parsers[i].patterns);
+  }
+
+  if (pcie_parsers)
+    sfree(pcie_parsers);
+
+  return 0;
+}
+
+static int pcie_init(void) {
+  if (pcie_config.config_error) {
+    ERROR(PCIE_PLUGIN ": Error in configuration, failed to init plugin.");
+    return -1;
+  }
+
+  if (!pcie_config.read_devices && !pcie_config.read_log) {
+    ERROR(PCIE_PLUGIN ": Plugin is not configured for any source of data.");
+    return -1;
+  }
+
+  if (pcie_config.read_devices) {
+    pcie_access_config();
+    pcie_dev_list = llist_create();
+    if (pcie_fops.list_devices(pcie_dev_list) != 0) {
+      ERROR(PCIE_PLUGIN ": Failed to find devices.");
+      pcie_shutdown();
+      return -1;
+    }
+  }
+
+  if (!pcie_config.read_log)
+    return 0;
+
+  if (pcie_parsers == NULL) {
+    /* Set default patterns if no config is provided */
+    INFO(PCIE_PLUGIN ": Using default message parser");
+    pcie_config.default_patterns = 1;
+    pcie_parsers = calloc(1, sizeof(*pcie_parsers));
+    if (pcie_parsers == NULL) {
+      ERROR(PCIE_PLUGIN ": Error allocating default message parser");
+      pcie_shutdown();
+      return -1;
+    }
+    pcie_parsers_len = 1;
+    sstrncpy(pcie_parsers[0].name, "default", sizeof(pcie_parsers[0].name));
+    pcie_parsers[0].patterns = pcie_default_patterns;
+    pcie_parsers[0].patterns_len = STATIC_ARRAY_SIZE(pcie_default_patterns);
+  }
+
+  for (int i = 0; i < pcie_parsers_len; i++) {
+    pcie_parsers[i].job = message_parser_init(
+        pcie_config.logfile, 0, pcie_parsers[i].patterns_len - 1,
+        pcie_parsers[i].patterns, pcie_parsers[i].patterns_len);
+    if (pcie_parsers[i].job == NULL) {
+      ERROR(PCIE_PLUGIN ": Failed to initialize %s parser.",
+            pcie_parsers[i].name);
+      pcie_shutdown();
+      return -1;
+    }
+  }
+
   return 0;
 }
 

--- a/src/pcie.c
+++ b/src/pcie.c
@@ -1,0 +1,693 @@
+/**
+ * collectd - src/pcie.c
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Kamil Wiatrowski <kamilx.wiatrowski@intel.com>
+ **/
+
+#include "collectd.h"
+#include "common.h"
+#include "utils_llist.h"
+
+#include <linux/pci_regs.h>
+
+#define PCIE_PLUGIN "pcie"
+#define PCIE_DEFAULT_PROCDIR "/proc/bus/pci"
+#define PCIE_DEFAULT_SYSFSDIR "/sys/bus/pci"
+#define PCIE_NAME_LEN 512
+#define PCIE_BUFF_SIZE 1024
+
+#define PCIE_ERROR "pcie_error"
+#define PCIE_SEV_CE "correctable"
+#define PCIE_SEV_FATAL "fatal"
+#define PCIE_SEV_NOFATAL "non_fatal"
+
+#define PCIE_DEV(x) (((x) >> 3) & 0x1f)
+#define PCIE_FN(x) ((x) & 0x07)
+
+#define PCIE_ECAP_OFFSET 0x100 /* ECAP always begin at offset 0x100 */
+
+typedef struct pcie_config_s {
+  _Bool use_sysfs;
+  _Bool notif_masked;
+  _Bool persistent;
+  char access_dir[PCIE_NAME_LEN];
+} pcie_config_t;
+
+typedef struct pcie_device_s {
+  int fd;
+  int domain;
+  uint8_t bus;
+  uint8_t device;
+  uint8_t function;
+  int cap_exp;
+  int ecap_aer;
+  _Bool excluded;
+  _Bool aer_not_found;
+  uint16_t device_status;
+  uint32_t correctable_errors;
+  uint32_t uncorrectable_errors;
+} pcie_device_t;
+
+typedef struct pcie_fops_s {
+  int (*list_devices)(llist_t *dev_list);
+  int (*open)(pcie_device_t *dev);
+  void (*close)(pcie_device_t *dev);
+  int (*read)(pcie_device_t *dev, void *buff, int size, int pos);
+} pcie_fops_t;
+
+typedef struct pcie_error_s {
+  int mask;
+  const char *desc;
+} pcie_error_t;
+
+static llist_t *pcie_dev_list;
+static pcie_config_t pcie_config = {.access_dir = ""};
+static pcie_fops_t pcie_fops;
+
+/* Device Error Status */
+static pcie_error_t pcie_base_errors[] = {
+    {PCI_EXP_DEVSTA_CED, "Correctable Error"},
+    {PCI_EXP_DEVSTA_NFED, "Non-Fatal Error"},
+    {PCI_EXP_DEVSTA_FED, "Fatal Error"},
+    {PCI_EXP_DEVSTA_URD, "Unsupported Request"}};
+static const int pcie_base_errors_num = STATIC_ARRAY_SIZE(pcie_base_errors);
+
+/* Uncorrectable Error Status */
+static pcie_error_t pcie_aer_ues[] = {
+    {PCI_ERR_UNC_DLP, "Data Link Protocol"},
+    {PCI_ERR_UNC_SURPDN, "Surprise Down"},
+    {PCI_ERR_UNC_POISON_TLP, "Poisoned TLP"},
+    {PCI_ERR_UNC_FCP, "Flow Control Protocol"},
+    {PCI_ERR_UNC_COMP_TIME, "Completion Timeout"},
+    {PCI_ERR_UNC_COMP_ABORT, "Completer Abort"},
+    {PCI_ERR_UNC_UNX_COMP, "Unexpected Completion"},
+    {PCI_ERR_UNC_RX_OVER, "Receiver Overflow"},
+    {PCI_ERR_UNC_MALF_TLP, "Malformed TLP"},
+    {PCI_ERR_UNC_ECRC, "ECRC Error Status"},
+    {PCI_ERR_UNC_UNSUP, "Unsupported Request"},
+    {PCI_ERR_UNC_ACSV, "ACS Violation"},
+    {PCI_ERR_UNC_INTN, "Internal"},
+    {PCI_ERR_UNC_MCBTLP, "MC blocked TLP"},
+    {PCI_ERR_UNC_ATOMEG, "Atomic egress blocked"},
+    {PCI_ERR_UNC_TLPPRE, "TLP prefix blocked"}};
+static const int pcie_aer_ues_num = STATIC_ARRAY_SIZE(pcie_aer_ues);
+
+/* Correctable Error Status */
+static pcie_error_t pcie_aer_ces[] = {
+    {PCI_ERR_COR_RCVR, "Receiver Error Status"},
+    {PCI_ERR_COR_BAD_TLP, "Bad TLP Status"},
+    {PCI_ERR_COR_BAD_DLLP, "Bad DLLP Status"},
+    {PCI_ERR_COR_REP_ROLL, "REPLAY_NUM Rollover"},
+    {PCI_ERR_COR_REP_TIMER, "Replay Timer Timeout"},
+    {PCI_ERR_COR_ADV_NFAT, "Advisory Non-Fatal"},
+    {PCI_ERR_COR_INTERNAL, "Corrected Internal"},
+    {PCI_ERR_COR_LOG_OVER, "Header Log Overflow"}};
+static const int pcie_aer_ces_num = STATIC_ARRAY_SIZE(pcie_aer_ces);
+
+static void pcie_add_device(llist_t *list, int domain, uint8_t bus,
+                            uint8_t device, uint8_t fn) {
+  llentry_t *entry;
+  pcie_device_t *dev = smalloc(sizeof(*dev));
+
+  dev->domain = domain;
+  dev->bus = bus;
+  dev->device = device;
+  dev->function = fn;
+  dev->excluded = 0;
+  dev->cap_exp = -1;
+  dev->ecap_aer = -1;
+  dev->aer_not_found = 0;
+  entry = llentry_create(NULL, dev);
+  llist_append(list, entry);
+
+  DEBUG(PCIE_PLUGIN ": pci device added to list: %04x:%02x:%02x.%d", domain,
+        bus, device, fn);
+}
+
+static void pcie_clear_list(llist_t *list) {
+  if (list == NULL)
+    return;
+
+  for (llentry_t *e = llist_head(list); e != NULL; e = e->next) {
+    sfree(e->value);
+  }
+
+  llist_destroy(list);
+}
+
+static int pcie_list_devices_proc(llist_t *dev_list) {
+  FILE *fd;
+  char file_name[PCIE_NAME_LEN];
+  char buf[PCIE_BUFF_SIZE];
+  unsigned int i = 0;
+
+  if (dev_list == NULL)
+    return -EINVAL;
+
+  ssnprintf(file_name, sizeof(file_name), "%s/devices", pcie_config.access_dir);
+  fd = fopen(file_name, "r");
+  if (!fd) {
+    char errbuf[PCIE_BUFF_SIZE];
+    ERROR(PCIE_PLUGIN ": Cannot open file %s to get devices list: %s",
+          file_name, sstrerror(errno, errbuf, sizeof(errbuf)));
+    return -ENOENT;
+  }
+
+  while (fgets(buf, sizeof(buf), fd)) {
+    unsigned int slot;
+    uint8_t bus, dev, fn;
+
+    if (sscanf(buf, "%x", &slot) != 1) {
+      ERROR(PCIE_PLUGIN ": Failed to read line %u from %s", i + 1, file_name);
+      continue;
+    }
+
+    bus = slot >> 8U;
+    dev = PCIE_DEV(slot);
+    fn = PCIE_FN(slot);
+    pcie_add_device(dev_list, 0, bus, dev, fn);
+
+    ++i;
+  }
+
+  fclose(fd);
+  return 0;
+}
+
+static int pcie_list_devices_sysfs(llist_t *dev_list) {
+  DIR *dir;
+  struct dirent *item;
+  char dir_name[PCIE_NAME_LEN];
+
+  if (dev_list == NULL)
+    return -EINVAL;
+
+  ssnprintf(dir_name, sizeof(dir_name), "%s/devices", pcie_config.access_dir);
+  dir = opendir(dir_name);
+  if (!dir) {
+    char errbuf[PCIE_BUFF_SIZE];
+    ERROR(PCIE_PLUGIN ": Cannot open dir %s to get devices list: %s", dir_name,
+          sstrerror(errno, errbuf, sizeof(errbuf)));
+    return -ENOENT;
+  }
+
+  while ((item = readdir(dir))) {
+    int dom, bus, dev, fn;
+
+    /* Omit special non-device entries */
+    if (item->d_name[0] == '.')
+      continue;
+
+    if (sscanf(item->d_name, "%x:%x:%x.%d", &dom, &bus, &dev, &fn) != 4) {
+      ERROR(PCIE_PLUGIN ": Failed to parse entry %s", item->d_name);
+      continue;
+    }
+
+    pcie_add_device(dev_list, dom, bus, dev, fn);
+  }
+
+  closedir(dir);
+  return 0;
+}
+
+static void pcie_close(pcie_device_t *dev) {
+  if (close(dev->fd) == -1) {
+    char errbuf[PCIE_BUFF_SIZE];
+    ERROR(PCIE_PLUGIN ": Failed to close %04x:%02x:%02x.%d, fd=%d: %s",
+          dev->domain, dev->bus, dev->device, dev->function, dev->fd,
+          sstrerror(errno, errbuf, sizeof(errbuf)));
+  }
+
+  dev->fd = -1;
+}
+
+static int pcie_open(pcie_device_t *dev, const char *name) {
+  dev->fd = open(name, O_RDWR);
+  if (dev->fd == -1) {
+    char errbuf[PCIE_BUFF_SIZE];
+    ERROR(PCIE_PLUGIN ": Failed to open file %s: %s", name,
+          sstrerror(errno, errbuf, sizeof(errbuf)));
+    return -ENOENT;
+  }
+
+  return 0;
+}
+
+static int pcie_open_proc(pcie_device_t *dev) {
+  char file_name[PCIE_NAME_LEN];
+
+  ssnprintf(file_name, sizeof(file_name), "%s/%02x/%02x.%d",
+            pcie_config.access_dir, dev->bus, dev->device, dev->function);
+
+  return pcie_open(dev, file_name);
+}
+
+static int pcie_open_sysfs(pcie_device_t *dev) {
+  char file_name[PCIE_NAME_LEN];
+
+  ssnprintf(file_name, sizeof(file_name), "%s/devices/%04x:%02x:%02x.%d/config",
+            pcie_config.access_dir, dev->domain, dev->bus, dev->device,
+            dev->function);
+
+  return pcie_open(dev, file_name);
+}
+
+static int pcie_read(pcie_device_t *dev, void *buff, int size, int pos) {
+  int len = pread(dev->fd, buff, size, pos);
+  if (len == size)
+    return 0;
+
+  if (len == -1) {
+    char errbuf[PCIE_BUFF_SIZE];
+    ERROR(PCIE_PLUGIN ": Failed to read %04x:%02x:%02x.%d at pos %d: %s",
+          dev->domain, dev->bus, dev->device, dev->function, pos,
+          sstrerror(errno, errbuf, sizeof(errbuf)));
+  } else {
+    ERROR(PCIE_PLUGIN ": %04x:%02x:%02x.%d Read only %d bytes, should be %d",
+          dev->domain, dev->bus, dev->device, dev->function, len, size);
+  }
+  return -1;
+}
+
+static uint8_t pcie_read8(pcie_device_t *dev, int pos) {
+  uint8_t value;
+  if (pcie_fops.read(dev, &value, 1, pos))
+    return 0;
+  return value;
+}
+
+static uint16_t pcie_read16(pcie_device_t *dev, int pos) {
+  uint16_t value;
+  if (pcie_fops.read(dev, &value, 2, pos))
+    return 0;
+  return value;
+}
+
+static uint32_t pcie_read32(pcie_device_t *dev, int pos) {
+  uint32_t value;
+  if (pcie_fops.read(dev, &value, 4, pos))
+    return 0;
+  return value;
+}
+
+static void pcie_dispatch_notification(pcie_device_t *dev, notification_t *n,
+                                       const char *type,
+                                       const char *type_instance) {
+  sstrncpy(n->host, hostname_g, sizeof(n->host));
+  ssnprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
+            dev->domain, dev->bus, dev->device, dev->function);
+  sstrncpy(n->type, type, sizeof(n->type));
+  sstrncpy(n->type_instance, type_instance, sizeof(n->type_instance));
+
+  plugin_dispatch_notification(n);
+}
+
+/* Report errors found in AER Correctable Error Status register */
+static void pcie_dispatch_correctable_errors(pcie_device_t *dev,
+                                             uint32_t errors, uint32_t masked) {
+  for (int i = 0; i < pcie_aer_ces_num; i++) {
+    pcie_error_t *err = pcie_aer_ces + i;
+    notification_t n = {.severity = NOTIF_WARNING,
+                        .time = cdtime(),
+                        .plugin = PCIE_PLUGIN,
+                        .meta = NULL};
+
+    /* If not specifically set by config option omit masked errors */
+    if (!pcie_config.notif_masked && (err->mask & masked))
+      continue;
+
+    if (err->mask & errors) {
+      /* Error already reported, notify only if persistent is set */
+      if (!pcie_config.persistent && (err->mask & dev->correctable_errors))
+        continue;
+
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain, dev->bus,
+            dev->device, dev->function, err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Correctable Error set: %s",
+                err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
+
+    } else if (err->mask & dev->correctable_errors) {
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s cleared", dev->domain,
+            dev->bus, dev->device, dev->function, err->desc);
+
+      n.severity = NOTIF_OKAY;
+      ssnprintf(n.message, sizeof(n.message), "Correctable Error cleared: %s",
+                err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
+    }
+  }
+}
+
+/* Report errors found in AER Uncorrectable Error Status register */
+static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
+                                               uint32_t errors, uint32_t masked,
+                                               uint32_t severity) {
+  for (int i = 0; i < pcie_aer_ues_num; i++) {
+    pcie_error_t *err = pcie_aer_ues + i;
+    const char *type_instance =
+        (severity & err->mask) ? PCIE_SEV_FATAL : PCIE_SEV_NOFATAL;
+    notification_t n = {.time = cdtime(), .plugin = PCIE_PLUGIN, .meta = NULL};
+
+    /* If not specifically set by config option omit masked errors */
+    if (!pcie_config.notif_masked && (err->mask & masked))
+      continue;
+
+    if (err->mask & errors) {
+      /* Error already reported, notify only if persistent is set */
+      if (!pcie_config.persistent && (err->mask & dev->uncorrectable_errors))
+        continue;
+
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s(%s) set", dev->domain,
+            dev->bus, dev->device, dev->function, err->desc, type_instance);
+
+      n.severity = (severity & err->mask) ? NOTIF_FAILURE : NOTIF_WARNING;
+      ssnprintf(n.message, sizeof(n.message), "Uncorrectable(%s) Error set: %s",
+                type_instance, err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
+
+    } else if (err->mask & dev->uncorrectable_errors) {
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s(%s) cleared", dev->domain,
+            dev->bus, dev->device, dev->function, err->desc, type_instance);
+
+      n.severity = NOTIF_OKAY;
+      ssnprintf(n.message, sizeof(n.message),
+                "Uncorrectable(%s) Error cleared: %s", type_instance,
+                err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
+    }
+  }
+}
+
+/* Find offset of PCI Express Capability Structure
+ * in PCI configuration space.
+ * Returns offset, -1 if not found.
+**/
+static int pcie_find_cap_exp(pcie_device_t *dev) {
+  int pos = pcie_read8(dev, PCI_CAPABILITY_LIST) & ~3;
+
+  while (pos) {
+    uint8_t id = pcie_read8(dev, pos + PCI_CAP_LIST_ID);
+
+    if (id == 0xff)
+      break;
+    if (id == PCI_CAP_ID_EXP)
+      return pos;
+
+    pos = pcie_read8(dev, pos + PCI_CAP_LIST_NEXT) & ~3;
+  }
+
+  DEBUG(PCIE_PLUGIN ": Cannot find CAP EXP for %04x:%02x:%02x.%d", dev->domain,
+        dev->bus, dev->device, dev->function);
+
+  return -1;
+}
+
+/* Find offset of Advanced Error Reporting Capability.
+ * Returns AER offset, -1 if not found.
+**/
+static int pcie_find_ecap_aer(pcie_device_t *dev) {
+  int pos = PCIE_ECAP_OFFSET;
+  uint32_t header = pcie_read32(dev, pos);
+  int id = PCI_EXT_CAP_ID(header);
+  int next = PCI_EXT_CAP_NEXT(header);
+
+  if (!id && !next)
+    return -1;
+
+  if (id == PCI_EXT_CAP_ID_ERR)
+    return pos;
+
+  while (next) {
+    if (next <= PCIE_ECAP_OFFSET)
+      break;
+
+    header = pcie_read32(dev, next);
+    id = PCI_EXT_CAP_ID(header);
+
+    if (id == PCI_EXT_CAP_ID_ERR)
+      return next;
+
+    next = PCI_EXT_CAP_NEXT(header);
+  }
+
+  return -1;
+}
+
+static void pcie_check_dev_status(pcie_device_t *dev, int pos) {
+  /* Read Device Status register with mask for errors only */
+  uint16_t new_status = pcie_read16(dev, pos + PCI_EXP_DEVSTA) & 0xf;
+
+  /* Check if anything new should be reported */
+  if (!(pcie_config.persistent && new_status) &&
+      (new_status == dev->device_status))
+    return;
+
+  /* Report errors found in Device Status register */
+  for (int i = 0; i < pcie_base_errors_num; i++) {
+    pcie_error_t *err = pcie_base_errors + i;
+    const char *type_instance = (err->mask == PCI_EXP_DEVSTA_FED)
+                                    ? PCIE_SEV_FATAL
+                                    : (err->mask == PCI_EXP_DEVSTA_CED)
+                                          ? PCIE_SEV_CE
+                                          : PCIE_SEV_NOFATAL;
+    const int severity =
+        (err->mask == PCI_EXP_DEVSTA_FED) ? NOTIF_FAILURE : NOTIF_WARNING;
+    notification_t n = {.severity = severity,
+                        .time = cdtime(),
+                        .plugin = PCIE_PLUGIN,
+                        .meta = NULL};
+
+    if (err->mask & new_status) {
+      /* Error already reported, notify only if persistent is set */
+      if (!pcie_config.persistent && (err->mask & dev->device_status))
+        continue;
+
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain, dev->bus,
+            dev->device, dev->function, err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Device Status Error set: %s",
+                err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
+
+    } else if (err->mask & dev->device_status) {
+      DEBUG(PCIE_PLUGIN ": %04x:%02x:%02x.%d: %s cleared", dev->domain,
+            dev->bus, dev->device, dev->function, err->desc);
+      n.severity = NOTIF_OKAY;
+      ssnprintf(n.message, sizeof(n.message), "Device Status Error cleared: %s",
+                err->desc);
+      pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
+    }
+  }
+
+  dev->device_status = new_status;
+}
+
+static void pcie_check_aer(pcie_device_t *dev, int pos) {
+  /* Check for AER uncorrectable errors */
+  uint32_t errors = pcie_read32(dev, pos + PCI_ERR_UNCOR_STATUS);
+
+  if ((pcie_config.persistent && errors) ||
+      (errors != dev->uncorrectable_errors)) {
+    uint32_t masked = pcie_read32(dev, pos + PCI_ERR_UNCOR_MASK);
+    uint32_t severity = pcie_read32(dev, pos + PCI_ERR_UNCOR_SEVER);
+    pcie_dispatch_uncorrectable_errors(dev, errors, masked, severity);
+  }
+  dev->uncorrectable_errors = errors;
+
+  /* Check for AER correctable errors */
+  errors = pcie_read32(dev, pos + PCI_ERR_COR_STATUS);
+  if ((pcie_config.persistent && errors) ||
+      (errors != dev->correctable_errors)) {
+    uint32_t masked = pcie_read32(dev, pos + PCI_ERR_COR_MASK);
+    pcie_dispatch_correctable_errors(dev, errors, masked);
+  }
+  dev->correctable_errors = errors;
+}
+
+static void pcie_process_device_with_aer(pcie_device_t *dev) {
+  if (dev->ecap_aer == -1)
+    dev->ecap_aer = pcie_find_ecap_aer(dev);
+
+  if (dev->ecap_aer != -1)
+    pcie_check_aer(dev, dev->ecap_aer);
+  else {
+    notification_t n = {.severity = NOTIF_OKAY,
+                        .time = cdtime(),
+                        .message = "Device is not AER capable",
+                        .plugin = PCIE_PLUGIN,
+                        .meta = NULL};
+    pcie_dispatch_notification(dev, &n, "", "");
+    dev->aer_not_found = 1;
+  }
+}
+
+static void pcie_process_device(pcie_device_t *dev) {
+  uint16_t status = pcie_read16(dev, PCI_STATUS);
+  if (!(status & PCI_STATUS_CAP_LIST)) {
+    DEBUG(PCIE_PLUGIN ": Not PCI Express device: %04x:%02x:%02x.%d",
+          dev->domain, dev->bus, dev->device, dev->function);
+    /* Exclude non PCIe devices, do not check them again */
+    dev->excluded = 1;
+    return;
+  }
+
+  /* Every PCIe device must have Capability Structure */
+  if (dev->cap_exp == -1)
+    dev->cap_exp = pcie_find_cap_exp(dev);
+
+  if (dev->cap_exp != -1) {
+    pcie_check_dev_status(dev, dev->cap_exp);
+  } else {
+    DEBUG(PCIE_PLUGIN ": Not PCI Express device: %04x:%02x:%02x.%d",
+          dev->domain, dev->bus, dev->device, dev->function);
+    dev->excluded = 1;
+    return;
+  }
+
+  if (dev->aer_not_found == 0)
+    pcie_process_device_with_aer(dev);
+}
+
+static int pcie_process_devices(llist_t *devs) {
+  int ret = 0;
+  if (devs == NULL)
+    return -1;
+
+  for (llentry_t *e = llist_head(devs); e != NULL; e = e->next) {
+    pcie_device_t *dev = e->value;
+
+    if (dev->excluded)
+      continue;
+
+    if (pcie_fops.open(dev) == 0) {
+      pcie_process_device(dev);
+      pcie_fops.close(dev);
+    } else {
+      notification_t n = {.severity = NOTIF_FAILURE,
+                          .time = cdtime(),
+                          .message = "Failed to read device status",
+                          .plugin = PCIE_PLUGIN,
+                          .meta = NULL};
+      pcie_dispatch_notification(dev, &n, "", "");
+      ret = -1;
+    }
+  }
+
+  return ret;
+}
+
+static int pcie_plugin_read(__attribute__((unused)) user_data_t *ud) {
+
+  return pcie_process_devices(pcie_dev_list);
+}
+
+static void pcie_access_config(void) {
+  /* Set functions for register access to
+   * use proc or sysfs depending on config. */
+  if (pcie_config.use_sysfs) {
+    pcie_fops.list_devices = pcie_list_devices_sysfs;
+    pcie_fops.open = pcie_open_sysfs;
+    if (pcie_config.access_dir[0] == '\0')
+      sstrncpy(pcie_config.access_dir, PCIE_DEFAULT_SYSFSDIR,
+               sizeof(pcie_config.access_dir));
+  } else {
+    /* use proc */
+    pcie_fops.list_devices = pcie_list_devices_proc;
+    pcie_fops.open = pcie_open_proc;
+    if (pcie_config.access_dir[0] == '\0')
+      sstrncpy(pcie_config.access_dir, PCIE_DEFAULT_PROCDIR,
+               sizeof(pcie_config.access_dir));
+  }
+  /* Common functions */
+  pcie_fops.close = pcie_close;
+  pcie_fops.read = pcie_read;
+}
+
+static int pcie_plugin_config(oconfig_item_t *ci) {
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("Source", child->key) == 0) {
+      if ((child->values_num != 1) ||
+          (child->values[0].type != OCONFIG_TYPE_STRING)) {
+        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+              child->key);
+        return -1;
+      }
+      if (strcasecmp("sysfs", child->values[0].value.string) == 0)
+        pcie_config.use_sysfs = 1;
+    } else if (strcasecmp("AccessDir", child->key) == 0) {
+      if (cf_util_get_string_buffer(child, pcie_config.access_dir,
+                                    sizeof(pcie_config.access_dir))) {
+        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+              child->key);
+        return -1;
+      }
+    } else if (strcasecmp("ReportMasked", child->key) == 0) {
+      if (cf_util_get_boolean(child, &pcie_config.notif_masked)) {
+        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+              child->key);
+        return -1;
+      }
+    } else if (strcasecmp("Persistent", child->key) == 0) {
+      if (cf_util_get_boolean(child, &pcie_config.persistent)) {
+        ERROR(PCIE_PLUGIN ": Invalid configuration parameter \"%s\".",
+              child->key);
+        return -1;
+      }
+    } else {
+      ERROR(PCIE_PLUGIN ": Invalid configuration option \"%s\".", child->key);
+      return -1;
+    }
+  }
+
+  pcie_access_config();
+
+  return 0;
+}
+
+static int pcie_init(void) {
+  pcie_dev_list = llist_create();
+  if (pcie_fops.list_devices(pcie_dev_list) != 0) {
+    ERROR(PCIE_PLUGIN ": Failed to find devices.");
+    pcie_clear_list(pcie_dev_list);
+    pcie_dev_list = NULL;
+    return -1;
+  }
+
+  return 0;
+}
+
+static int pcie_shutdown(void) {
+  pcie_clear_list(pcie_dev_list);
+  pcie_dev_list = NULL;
+  return 0;
+}
+
+void module_register(void) {
+  plugin_register_init(PCIE_PLUGIN, pcie_init);
+  plugin_register_complex_config(PCIE_PLUGIN, pcie_plugin_config);
+  plugin_register_complex_read(NULL, PCIE_PLUGIN, pcie_plugin_read, 0, NULL);
+  plugin_register_shutdown(PCIE_PLUGIN, pcie_shutdown);
+}

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -844,6 +844,9 @@ static int pcie_plugin_config(oconfig_item_t *ci) {
         pcie_config.use_sysfs = 0;
         pcie_config.read_devices = 0;
       }
+      if (strcasecmp("logfile", child->values[0].value.string) == 0) {
+        pcie_config.read_log = 1;
+      }
     } else if (strcasecmp("AccessDir", child->key) == 0) {
       status = cf_util_get_string_buffer(child, pcie_config.access_dir,
                                          sizeof(pcie_config.access_dir));
@@ -854,8 +857,6 @@ static int pcie_plugin_config(oconfig_item_t *ci) {
     } else if (strcasecmp("LogFile", child->key) == 0) {
       status = cf_util_get_string_buffer(child, pcie_config.logfile,
                                          sizeof(pcie_config.logfile));
-    } else if (strcasecmp("ReadLog", child->key) == 0) {
-      status = cf_util_get_boolean(child, &pcie_config.read_log);
     } else if (strcasecmp("FirstFullRead", child->key) == 0) {
       status = cf_util_get_boolean(child, &pcie_config.first_read);
     } else if (strcasecmp("MsgPattern", child->key) == 0) {

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -278,7 +278,7 @@ static int pcie_list_devices_proc(llist_t *dev_list) {
   if (dev_list == NULL)
     return -EINVAL;
 
-  ssnprintf(file_name, sizeof(file_name), "%s/devices", pcie_config.access_dir);
+  snprintf(file_name, sizeof(file_name), "%s/devices", pcie_config.access_dir);
   fd = fopen(file_name, "r");
   if (!fd) {
     char errbuf[PCIE_BUFF_SIZE];
@@ -320,7 +320,7 @@ static int pcie_list_devices_sysfs(llist_t *dev_list) {
   if (dev_list == NULL)
     return -EINVAL;
 
-  ssnprintf(dir_name, sizeof(dir_name), "%s/devices", pcie_config.access_dir);
+  snprintf(dir_name, sizeof(dir_name), "%s/devices", pcie_config.access_dir);
   dir = opendir(dir_name);
   if (!dir) {
     char errbuf[PCIE_BUFF_SIZE];
@@ -376,8 +376,8 @@ static int pcie_open(pcie_device_t *dev, const char *name) {
 static int pcie_open_proc(pcie_device_t *dev) {
   char file_name[PCIE_NAME_LEN];
 
-  ssnprintf(file_name, sizeof(file_name), "%s/%02x/%02x.%d",
-            pcie_config.access_dir, dev->bus, dev->device, dev->function);
+  snprintf(file_name, sizeof(file_name), "%s/%02x/%02x.%d",
+           pcie_config.access_dir, dev->bus, dev->device, dev->function);
 
   return pcie_open(dev, file_name);
 }
@@ -385,9 +385,9 @@ static int pcie_open_proc(pcie_device_t *dev) {
 static int pcie_open_sysfs(pcie_device_t *dev) {
   char file_name[PCIE_NAME_LEN];
 
-  ssnprintf(file_name, sizeof(file_name), "%s/devices/%04x:%02x:%02x.%d/config",
-            pcie_config.access_dir, dev->domain, dev->bus, dev->device,
-            dev->function);
+  snprintf(file_name, sizeof(file_name), "%s/devices/%04x:%02x:%02x.%d/config",
+           pcie_config.access_dir, dev->domain, dev->bus, dev->device,
+           dev->function);
 
   return pcie_open(dev, file_name);
 }
@@ -443,8 +443,8 @@ static void pcie_do_dispatch_notification(notification_t *n, const char *type) {
 static void pcie_dispatch_notification(pcie_device_t *dev, notification_t *n,
                                        const char *type,
                                        const char *type_instance) {
-  ssnprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
-            dev->domain, dev->bus, dev->device, dev->function);
+  snprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
+           dev->domain, dev->bus, dev->device, dev->function);
   sstrncpy(n->type_instance, type_instance, sizeof(n->type_instance));
 
   pcie_do_dispatch_notification(n, type);
@@ -471,8 +471,8 @@ static void pcie_dispatch_correctable_errors(pcie_device_t *dev,
 
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
-      ssnprintf(n.message, sizeof(n.message), "Correctable Error set: %s",
-                err->desc);
+      snprintf(n.message, sizeof(n.message), "Correctable Error set: %s",
+               err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
 
     } else if (err->mask & dev->correctable_errors) {
@@ -480,8 +480,8 @@ static void pcie_dispatch_correctable_errors(pcie_device_t *dev,
             dev->bus, dev->device, dev->function, err->desc);
 
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message), "Correctable Error cleared: %s",
-                err->desc);
+      snprintf(n.message, sizeof(n.message), "Correctable Error cleared: %s",
+               err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
     }
   }
@@ -511,8 +511,8 @@ static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
             dev->bus, dev->device, dev->function, err->desc, type_instance);
 
       n.severity = (severity & err->mask) ? NOTIF_FAILURE : NOTIF_WARNING;
-      ssnprintf(n.message, sizeof(n.message), "Uncorrectable(%s) Error set: %s",
-                type_instance, err->desc);
+      snprintf(n.message, sizeof(n.message), "Uncorrectable(%s) Error set: %s",
+               type_instance, err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
 
     } else if (err->mask & dev->uncorrectable_errors) {
@@ -521,9 +521,8 @@ static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
             type_instance);
 
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message),
-                "Uncorrectable(%s) Error cleared: %s", type_instance,
-                err->desc);
+      snprintf(n.message, sizeof(n.message),
+               "Uncorrectable(%s) Error cleared: %s", type_instance, err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
     }
   }
@@ -615,16 +614,16 @@ static void pcie_check_dev_status(pcie_device_t *dev, int pos) {
 
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
-      ssnprintf(n.message, sizeof(n.message), "Device Status Error set: %s",
-                err->desc);
+      snprintf(n.message, sizeof(n.message), "Device Status Error set: %s",
+               err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
 
     } else if (err->mask & dev->device_status) {
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s cleared", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message), "Device Status Error cleared: %s",
-                err->desc);
+      snprintf(n.message, sizeof(n.message), "Device Status Error cleared: %s",
+               err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
     }
   }
@@ -759,8 +758,8 @@ static void pcie_parse_msg(message *msg, const char *name,
               item->name, item->value);
     }
   }
-  ssnprintf(n.message, sizeof(n.message), "%s %s error reported in log", name,
-            n.type_instance);
+  snprintf(n.message, sizeof(n.message), "%s %s error reported in log", name,
+           n.type_instance);
 
   pcie_do_dispatch_notification(&n, PCIE_ERROR);
 }

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -50,6 +50,7 @@
 
 #define PCIE_ECAP_OFFSET 0x100 /* ECAP always begin at offset 0x100 */
 
+#define PCIE_LOG_TIME "incident time"
 #define PCIE_LOG_PORT "root port"
 #define PCIE_LOG_SEVERITY "severity"
 #define PCIE_LOG_DEV "device"
@@ -153,6 +154,10 @@ static size_t pcie_parsers_len = 0;
 
 /* Default patterns for AER errors in syslog */
 static message_pattern pcie_default_patterns[] = {
+    {.name = PCIE_LOG_TIME,
+     .regex = "(... .. ..:..:..) .* pcieport.*AER",
+     .submatch_idx = 1,
+     .is_mandatory = 1},
     {.name = PCIE_LOG_PORT,
      .regex = "pcieport (.*): AER:",
      .submatch_idx = 1,
@@ -787,6 +792,8 @@ static int pcie_patterns_config(message_pattern *patterns,
       /* set default submatch index to 1 since single submatch is the most
        * common use case */
       patterns[i].submatch_idx = 1;
+      /* Mandatory pattern is the most common use case */
+      patterns[i].is_mandatory = 1;
       for (int j = 0; j < match_opt[i].children_num; j++) {
         int status = 0;
         oconfig_item_t *regex_opt = match_opt[i].children + j;

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -120,34 +120,84 @@ static const int pcie_base_errors_num = STATIC_ARRAY_SIZE(pcie_base_errors);
 
 /* Uncorrectable Error Status */
 static pcie_error_t pcie_aer_ues[] = {
+#ifdef PCI_ERR_UNC_DLP
     {PCI_ERR_UNC_DLP, "Data Link Protocol"},
+#endif
+#ifdef PCI_ERR_UNC_SURPDN
     {PCI_ERR_UNC_SURPDN, "Surprise Down"},
+#endif
+#ifdef PCI_ERR_UNC_POISON_TLP
     {PCI_ERR_UNC_POISON_TLP, "Poisoned TLP"},
+#endif
+#ifdef PCI_ERR_UNC_FCP
     {PCI_ERR_UNC_FCP, "Flow Control Protocol"},
+#endif
+#ifdef PCI_ERR_UNC_COMP_TIME
     {PCI_ERR_UNC_COMP_TIME, "Completion Timeout"},
+#endif
+#ifdef PCI_ERR_UNC_COMP_ABORT
     {PCI_ERR_UNC_COMP_ABORT, "Completer Abort"},
+#endif
+#ifdef PCI_ERR_UNC_UNX_COMP
     {PCI_ERR_UNC_UNX_COMP, "Unexpected Completion"},
+#endif
+#ifdef PCI_ERR_UNC_RX_OVER
     {PCI_ERR_UNC_RX_OVER, "Receiver Overflow"},
+#endif
+#ifdef PCI_ERR_UNC_MALF_TLP
     {PCI_ERR_UNC_MALF_TLP, "Malformed TLP"},
+#endif
+#ifdef PCI_ERR_UNC_ECRC
     {PCI_ERR_UNC_ECRC, "ECRC Error Status"},
+#endif
+#ifdef PCI_ERR_UNC_UNSUP
     {PCI_ERR_UNC_UNSUP, "Unsupported Request"},
+#endif
+#ifdef PCI_ERR_UNC_ACSV
     {PCI_ERR_UNC_ACSV, "ACS Violation"},
+#endif
+#ifdef PCI_ERR_UNC_INTN
     {PCI_ERR_UNC_INTN, "Internal"},
+#endif
+#ifdef PCI_ERR_UNC_MCBTLP
     {PCI_ERR_UNC_MCBTLP, "MC blocked TLP"},
+#endif
+#ifdef PCI_ERR_UNC_ATOMEG
     {PCI_ERR_UNC_ATOMEG, "Atomic egress blocked"},
-    {PCI_ERR_UNC_TLPPRE, "TLP prefix blocked"}};
+#endif
+#ifdef PCI_ERR_UNC_TLPPRE
+    {PCI_ERR_UNC_TLPPRE, "TLP prefix blocked"},
+#endif
+};
 static const int pcie_aer_ues_num = STATIC_ARRAY_SIZE(pcie_aer_ues);
 
 /* Correctable Error Status */
 static pcie_error_t pcie_aer_ces[] = {
+#ifdef PCI_ERR_COR_RCVR
     {PCI_ERR_COR_RCVR, "Receiver Error Status"},
+#endif
+#ifdef PCI_ERR_COR_BAD_TLP
     {PCI_ERR_COR_BAD_TLP, "Bad TLP Status"},
+#endif
+#ifdef PCI_ERR_COR_BAD_DLLP
     {PCI_ERR_COR_BAD_DLLP, "Bad DLLP Status"},
+#endif
+#ifdef PCI_ERR_COR_REP_ROLL
     {PCI_ERR_COR_REP_ROLL, "REPLAY_NUM Rollover"},
+#endif
+#ifdef PCI_ERR_COR_REP_TIMER
     {PCI_ERR_COR_REP_TIMER, "Replay Timer Timeout"},
+#endif
+#ifdef PCI_ERR_COR_ADV_NFAT
     {PCI_ERR_COR_ADV_NFAT, "Advisory Non-Fatal"},
+#endif
+#ifdef PCI_ERR_COR_INTERNAL
     {PCI_ERR_COR_INTERNAL, "Corrected Internal"},
-    {PCI_ERR_COR_LOG_OVER, "Header Log Overflow"}};
+#endif
+#ifdef PCI_ERR_COR_LOG_OVER
+    {PCI_ERR_COR_LOG_OVER, "Header Log Overflow"},
+#endif
+};
 static const int pcie_aer_ces_num = STATIC_ARRAY_SIZE(pcie_aer_ces);
 
 static pcie_msg_parser_t *pcie_parsers = NULL;

--- a/src/tail.c
+++ b/src/tail.c
@@ -291,7 +291,7 @@ static int ctail_config(oconfig_item_t *ci) {
 static int ctail_read(user_data_t *ud) {
   int status;
 
-  status = tail_match_read((cu_tail_match_t *)ud->data);
+  status = tail_match_read((cu_tail_match_t *)ud->data, 0);
   if (status != 0) {
     ERROR("tail plugin: tail_match_read failed.");
     return (-1);

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -221,7 +221,7 @@ static int tcsv_read(user_data_t *ud) {
     size_t buffer_len;
     int status;
 
-    status = cu_tail_readline(id->tail, buffer, (int)sizeof(buffer));
+    status = cu_tail_readline(id->tail, buffer, (int)sizeof(buffer), 0);
     if (status != 0) {
       ERROR("tail_csv plugin: File \"%s\": cu_tail_readline failed "
             "with status %i.",

--- a/src/types.db
+++ b/src/types.db
@@ -164,6 +164,7 @@ objects                 value:GAUGE:0:U
 operations              value:DERIVE:0:U
 operations_per_second   value:GAUGE:0:U
 packets                 value:DERIVE:0:U
+pcie_error              value:GAUGE:U:U
 pending_operations      value:GAUGE:0:U
 percent                 value:GAUGE:0:100.1
 percent_bytes           value:GAUGE:0:100.1

--- a/src/utils_message_parser.c
+++ b/src/utils_message_parser.c
@@ -1,0 +1,320 @@
+/*
+ * collectd - src/utils_message_parser.c
+ * MIT License
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Krzysztof Matczak <krzysztofx.matczak@intel.com>
+ */
+
+#include "collectd.h"
+
+#include "common.h"
+#include "plugin.h"
+
+#include "utils_message_parser.h"
+
+#define UTIL_NAME "utils_message_parser"
+
+#define MSG_STOR_INIT_LEN 64
+#define MSG_STOR_INC_STEP 10
+
+typedef struct checked_match_t {
+  parser_job_data *parser_job;
+  message_pattern msg_pattern;
+  int msg_pattern_idx;
+} checked_match;
+
+struct parser_job_data_t {
+  const char *filename;
+  unsigned int start_idx;
+  unsigned int stop_idx;
+  cu_tail_match_t *tm;
+  message *messages_storage;
+  size_t messages_max_len;
+  int message_idx;
+  unsigned int message_item_idx;
+  unsigned int messages_completed;
+  message_pattern *message_patterns;
+  size_t message_patterns_len;
+  int (*resize_message_buffer)(parser_job_data *self, size_t);
+  int (*start_message_assembly)(parser_job_data *self);
+  void (*end_message_assembly)(parser_job_data *self);
+  void (*message_item_assembly)(parser_job_data *self, checked_match *cm,
+                                char *const *matches);
+};
+
+static void message_item_assembly(parser_job_data *self, checked_match *cm,
+                                  char *const *matches) {
+  message_item *msg_it = &(self->messages_storage[self->message_idx]
+                               .message_items[self->message_item_idx]);
+  sstrncpy(msg_it->name, (cm->msg_pattern).name, sizeof(msg_it->name));
+  sstrncpy(msg_it->value, matches[cm->msg_pattern.submatch_idx],
+           sizeof(msg_it->value));
+  self->messages_storage[self->message_idx]
+      .matched_patterns_check[cm->msg_pattern_idx] = 1;
+  ++(self->message_item_idx);
+}
+
+static int start_message_assembly(parser_job_data *self) {
+  /* Remove previous message assembly if unfinished */
+  if (self->message_idx >= 0 &&
+      self->messages_storage[self->message_idx].started == 1 &&
+      self->messages_storage[self->message_idx].completed == 0) {
+    DEBUG(UTIL_NAME ": Removing unfinished assembly of previous message");
+    self->messages_storage[self->message_idx] = (message){0};
+    self->message_item_idx = 0;
+  } else
+    ++(self->message_idx);
+
+  /* Resize messages buffer if needed */
+  if (self->message_idx >= self->messages_max_len) {
+    INFO(UTIL_NAME ": Exceeded message buffer size: %lu", self->messages_max_len);
+    if (self->resize_message_buffer(self, self->messages_max_len +
+                                              MSG_STOR_INC_STEP) != 0) {
+      ERROR(UTIL_NAME ": Insufficient message buffer size: %lu. Remaining "
+                      "messages for this read will be skipped",
+            self->messages_max_len);
+      self->message_idx = self->messages_max_len;
+      return -1;
+    }
+  }
+  self->messages_storage[self->message_idx] = (message){0};
+  self->message_item_idx = 0;
+  self->messages_storage[self->message_idx].started = 1;
+  self->messages_storage[self->message_idx].completed = 0;
+  return 0;
+}
+
+static int resize_message_buffer(parser_job_data *self, size_t new_size) {
+  INFO(UTIL_NAME ": Resizing message buffer size to %lu", new_size);
+  void *new_storage = realloc(self->messages_storage,
+                              new_size * sizeof(*(self->messages_storage)));
+  if (new_storage == NULL) {
+    ERROR(UTIL_NAME ": Error while reallocating message buffer");
+    return -1;
+  }
+  self->messages_storage = new_storage;
+  self->messages_max_len = new_size;
+  /* Fill unused memory with 0 */
+  memset(self->messages_storage + self->message_idx, 0,
+         (self->messages_max_len - self->message_idx) *
+             sizeof(*(self->messages_storage)));
+  return 0;
+}
+
+static void end_message_assembly(parser_job_data *self) {
+  /* Checking mandatory items */
+  for (size_t i = 0; i < self->message_patterns_len; i++) {
+    if (self->message_patterns[i].is_mandatory &&
+        !(self->messages_storage[self->message_idx]
+              .matched_patterns_check[i])) {
+      WARNING(
+          UTIL_NAME
+          ": Mandatory message item pattern %s not found. Message discarded",
+          self->message_patterns[i].regex);
+      self->messages_storage[self->message_idx] = (message){0};
+      self->message_item_idx = 0;
+      if (self->message_idx > 0)
+        --(self->message_idx);
+      return;
+    }
+  }
+  self->messages_storage[self->message_idx].completed = 1;
+  self->message_item_idx = 0;
+}
+
+static int message_assembler(const char *row, char *const *matches,
+                             size_t matches_num, void *user_data) {
+  if (user_data == NULL) {
+    ERROR(UTIL_NAME ": Invalid user_data pointer");
+    return -1;
+  }
+  checked_match *cm = (checked_match *)user_data;
+  parser_job_data *parser_job = cm->parser_job;
+
+  if (cm->msg_pattern.submatch_idx < 0 ||
+      cm->msg_pattern.submatch_idx >= matches_num) {
+    ERROR(UTIL_NAME ": Invalid target submatch index: %d",
+          cm->msg_pattern.submatch_idx);
+    return -1;
+  }
+  if (parser_job->message_item_idx >=
+      STATIC_ARRAY_SIZE(parser_job->messages_storage[parser_job->message_idx]
+                            .message_items)) {
+    ERROR(UTIL_NAME ": Message items number exceeded. Forced message end.");
+    parser_job->end_message_assembly(parser_job);
+    return -1;
+  }
+
+  /* Every matched start pattern resets current message items and starts
+   * assembling new messages */
+  if (strcmp((cm->msg_pattern).regex,
+             parser_job->message_patterns[parser_job->start_idx].regex) == 0) {
+    DEBUG(UTIL_NAME ": Found beginning pattern");
+    if (parser_job->start_message_assembly(parser_job) != 0)
+      return -1;
+  }
+  /* Ignoring message items without corresponding start item */
+  if (parser_job->message_idx < 0 ||
+      parser_job->messages_storage[parser_job->message_idx].started == 0) {
+    DEBUG(UTIL_NAME ": Dropping item with no corresponding start element");
+    return 0;
+  }
+  /* Populate message items */
+  parser_job->message_item_assembly(parser_job, cm, matches);
+
+  /* Handle message ending */
+  if (strcmp((cm->msg_pattern).regex,
+             parser_job->message_patterns[parser_job->stop_idx].regex) == 0) {
+    DEBUG(UTIL_NAME ": Found ending pattern");
+    parser_job->end_message_assembly(parser_job);
+  }
+  return 0;
+}
+
+parser_job_data *message_parser_init(const char *filename,
+                                     unsigned int start_idx,
+                                     unsigned int stop_idx,
+                                     message_pattern message_patterns[],
+                                     size_t message_patterns_len) {
+  parser_job_data *parser_job = calloc(1, sizeof(*parser_job));
+  if (parser_job == NULL) {
+    ERROR(UTIL_NAME ": Error allocating parser_job");
+    return NULL;
+  }
+  parser_job->resize_message_buffer = resize_message_buffer;
+  parser_job->start_message_assembly = start_message_assembly;
+  parser_job->end_message_assembly = end_message_assembly;
+  parser_job->message_item_assembly = message_item_assembly;
+  parser_job->messages_max_len = MSG_STOR_INIT_LEN;
+  parser_job->filename = filename;
+  parser_job->start_idx = start_idx;
+  parser_job->stop_idx = stop_idx;
+  parser_job->message_idx = -1;
+  parser_job->message_patterns =
+      calloc(message_patterns_len, sizeof(*(parser_job->message_patterns)));
+  if (parser_job->message_patterns == NULL) {
+    ERROR(UTIL_NAME ": Error allocating message_patterns");
+    return NULL;
+  }
+  parser_job->messages_storage = calloc(
+      parser_job->messages_max_len, sizeof(*(parser_job->messages_storage)));
+  if (parser_job->messages_storage == NULL) {
+    ERROR(UTIL_NAME ": Error allocating messages_storage");
+    return NULL;
+  }
+  /* Crete own copy of regex patterns */
+  memcpy(parser_job->message_patterns, message_patterns,
+         sizeof(*(parser_job->message_patterns)) * message_patterns_len);
+  parser_job->message_patterns_len = message_patterns_len;
+  /* Init tail match */
+  parser_job->tm = tail_match_create(parser_job->filename);
+  if (parser_job->tm == NULL) {
+    ERROR(UTIL_NAME ": Error creating tail match");
+    return NULL;
+  }
+
+  for (size_t i = 0; i < message_patterns_len; i++) {
+    /* Create current_match container for passing regex info
+     * to callback function */
+    checked_match *current_match = calloc(1, sizeof(*current_match));
+    if (current_match == NULL) {
+      ERROR(UTIL_NAME ": Error allocating current_match");
+      return NULL;
+    }
+    current_match->parser_job = parser_job;
+    current_match->msg_pattern = message_patterns[i];
+    current_match->msg_pattern_idx = i;
+    /* Create callback */
+    cu_match_t *m = match_create_callback(
+        message_patterns[i].regex, message_patterns[i].excluderegex,
+        message_assembler, current_match, free);
+    if (m == NULL) {
+      ERROR(UTIL_NAME ": Error creating match callback");
+      return NULL;
+    }
+    if (tail_match_add_match(parser_job->tm, m, 0, 0, 0) != 0) {
+      ERROR(UTIL_NAME ": Error adding match callback");
+      return NULL;
+    }
+  }
+
+  return parser_job;
+}
+
+int message_parser_read(parser_job_data *parser_job, message **messages_storage,
+                        _Bool force_rewind) {
+  if (parser_job == NULL) {
+    ERROR(UTIL_NAME ": Invalid parser_job pointer");
+    return -1;
+  }
+
+  /* Finish incomplete message assembly in this read */
+  if (parser_job->message_idx >= 0 &&
+      parser_job->messages_storage[parser_job->message_idx].started &&
+      !(parser_job->messages_storage[parser_job->message_idx].completed)) {
+    INFO(UTIL_NAME ": Found incomplete message from previous read.");
+    message tmp_message = parser_job->messages_storage[parser_job->message_idx];
+    int tmp_message_item_idx = parser_job->message_item_idx;
+    memset(parser_job->messages_storage, 0,
+           parser_job->messages_max_len *
+               sizeof(*(parser_job->messages_storage)));
+    memcpy(parser_job->messages_storage, &tmp_message,
+           sizeof(*(parser_job->messages_storage)));
+    parser_job->message_item_idx = tmp_message_item_idx;
+    parser_job->message_idx = 0;
+  } else {
+    memset(parser_job->messages_storage, 0,
+           parser_job->messages_max_len *
+               sizeof(*(parser_job->messages_storage)));
+    parser_job->message_item_idx = 0;
+    parser_job->message_idx = -1;
+  }
+
+  int status = tail_match_read(parser_job->tm, force_rewind);
+  if (status != 0) {
+    ERROR(UTIL_NAME ": Error while parser read. Status: %d", status);
+    return -1;
+  }
+
+  /* Get no of messagess completed in this read */
+  int messages_completed = 0;
+  for (size_t i = 0; i < parser_job->messages_max_len; i++) {
+    if (parser_job->messages_storage[i].completed)
+      ++messages_completed;
+  }
+  *messages_storage = parser_job->messages_storage;
+  return messages_completed;
+}
+
+void message_parser_cleanup(parser_job_data *parser_job) {
+  if (parser_job == NULL) {
+    ERROR(UTIL_NAME ": Invalid parser_job pointer");
+    return;
+  }
+  sfree(parser_job->messages_storage);
+  sfree(parser_job->message_patterns);
+  if (parser_job->tm)
+    tail_match_destroy(parser_job->tm);
+  sfree(parser_job);
+}

--- a/src/utils_message_parser.c
+++ b/src/utils_message_parser.c
@@ -174,9 +174,11 @@ static int message_assembler(const char *row, char *const *matches,
     if (parser_job->start_message_assembly(parser_job) != 0)
       return -1;
   }
-  /* Ignoring message items without corresponding start item */
+  /* Ignoring message items without corresponding start item or
+   * after completion */
   if (parser_job->message_idx < 0 ||
-      parser_job->messages_storage[parser_job->message_idx].started == 0) {
+      parser_job->messages_storage[parser_job->message_idx].started == 0 ||
+      parser_job->messages_storage[parser_job->message_idx].completed == 1) {
     DEBUG(UTIL_NAME ": Dropping item with no corresponding start element");
     return 0;
   }

--- a/src/utils_message_parser.c
+++ b/src/utils_message_parser.c
@@ -86,11 +86,11 @@ static int start_message_assembly(parser_job_data *self) {
 
   /* Resize messages buffer if needed */
   if (self->message_idx >= self->messages_max_len) {
-    INFO(UTIL_NAME ": Exceeded message buffer size: %lu",
+    INFO(UTIL_NAME ": Exceeded message buffer size: %zu",
          self->messages_max_len);
     if (self->resize_message_buffer(self, self->messages_max_len +
                                               MSG_STOR_INC_STEP) != 0) {
-      ERROR(UTIL_NAME ": Insufficient message buffer size: %lu. Remaining "
+      ERROR(UTIL_NAME ": Insufficient message buffer size: %zu. Remaining "
                       "messages for this read will be skipped",
             self->messages_max_len);
       self->message_idx = self->messages_max_len;
@@ -105,7 +105,7 @@ static int start_message_assembly(parser_job_data *self) {
 }
 
 static int resize_message_buffer(parser_job_data *self, size_t new_size) {
-  INFO(UTIL_NAME ": Resizing message buffer size to %lu", new_size);
+  INFO(UTIL_NAME ": Resizing message buffer size to %zu", new_size);
   void *new_storage = realloc(self->messages_storage,
                               new_size * sizeof(*(self->messages_storage)));
   if (new_storage == NULL) {

--- a/src/utils_message_parser.c
+++ b/src/utils_message_parser.c
@@ -79,7 +79,7 @@ static int start_message_assembly(parser_job_data *self) {
       self->messages_storage[self->message_idx].started == 1 &&
       self->messages_storage[self->message_idx].completed == 0) {
     DEBUG(UTIL_NAME ": Removing unfinished assembly of previous message");
-    self->messages_storage[self->message_idx] = (message){0};
+    self->messages_storage[self->message_idx] = (message){{{{0}}}};
     self->message_item_idx = 0;
   } else
     ++(self->message_idx);
@@ -97,7 +97,7 @@ static int start_message_assembly(parser_job_data *self) {
       return -1;
     }
   }
-  self->messages_storage[self->message_idx] = (message){0};
+  self->messages_storage[self->message_idx] = (message){{{{0}}}};
   self->message_item_idx = 0;
   self->messages_storage[self->message_idx].started = 1;
   self->messages_storage[self->message_idx].completed = 0;
@@ -132,7 +132,7 @@ static void end_message_assembly(parser_job_data *self) {
           UTIL_NAME
           ": Mandatory message item pattern %s not found. Message discarded",
           self->message_patterns[i].regex);
-      self->messages_storage[self->message_idx] = (message){0};
+      self->messages_storage[self->message_idx] = (message){{{{0}}}};
       self->message_item_idx = 0;
       if (self->message_idx > 0)
         --(self->message_idx);

--- a/src/utils_message_parser.h
+++ b/src/utils_message_parser.h
@@ -1,0 +1,146 @@
+/*
+ * collectd - src/utils_message_parser.h
+ * MIT License
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Krzysztof Matczak <krzysztofx.matczak@intel.com>
+ */
+
+#ifndef UTILS_MESSAGE_PARSER_H
+#define UTILS_MESSAGE_PARSER_H 1
+
+#include "utils_tail_match.h"
+
+typedef struct message_item_pattern_t {
+  /* User defined name for message item */
+  char *name;
+  /* Regular expression for finding out specific message item. The match result
+   * is taken only from submatch pointed by submatch_idx variable, so multiple
+   * submatches are supported. Example syntax:
+   * "(STRING1|STRING2)(.*)"
+   * For this example (STRING1|STRING2) is the first submatch and (.*) second
+   * so user can choose which one to store by setting submatch_idx argument.
+   */
+  char *regex;
+  /* Index of regex submatch that is stored as result. Value 0 takes whole
+   * match result */
+  int submatch_idx;
+  /* Regular expression that excludes string from further processing */
+  char *excluderegex;
+  /* Flag indicating if this item is mandatory for message validation */
+  _Bool is_mandatory;
+} message_pattern;
+
+typedef struct message_item_t {
+  char name[32];
+  char value[64];
+} message_item;
+
+typedef struct message_t {
+  message_item message_items[32];
+  int matched_patterns_check[32];
+  _Bool started;
+  _Bool completed;
+} message;
+
+typedef struct parser_job_data_t parser_job_data;
+
+/*
+ * NAME
+ *   message_parser_init
+ *
+ * DESCRIPTION
+ *   Configures unique message parser job. Performs necessary buffer
+ *   allocations. If there's need to create multiple parser jobs with different
+ *   parameters, this function may be called many times accordingly.
+ *
+ * PARAMETERS
+ *   `filename'   The name of the file to be parsed.
+ *   `start_idx'  Index of regular expression that indicates beginning of
+ *                message.
+ *                This index refers to 'message_patterns' array.
+ *   `stop_idx'   Index of the regular expression that indicates the end of
+ *                message. This index refers to 'message_patterns' array.
+ *   `message_patterns' Array of regular expression patterns for populating
+ *                      message items. Example:
+ *    message_pattern message_patterns[]= {
+ *      {.name = "START", .regex = "(Running trigger.*)", submatch_idx = 1,
+ *       .excluderegex = "kernel", .is_mandatory = 1},
+ *      {.name = "BANK", .regex = "BANK ([0-9]*)", submatch_idx = 1,
+ *       .excluderegex = "kernel", .is_mandatory = 1},
+ *      {.name = "TSC", .regex = "TSC ([a-z0-9]*)", submatch_idx = 1,
+ *       .excluderegex = "kernel", .is_mandatory = 1},
+ *      {.name = "MCA", .regex = "MCA: (.*)", submatch_idx = 1,
+ *       .excluderegex = "kernel", .is_mandatory = 0},
+ *      {.name = "END", .regex = "(CPUID Vendor.*)", submatch_idx = 1,
+ *       .excluderegex = "kernel", .is_mandatory = 1}
+ *    };
+ *
+ *   `message_patterns_len' Length of message_patterns array.
+ *
+ * RETURN VALUE
+ *   Returns NULL upon failure, pointer to new parser job otherwise.
+ */
+parser_job_data *message_parser_init(const char *filename,
+                                     unsigned int start_idx,
+                                     unsigned int stop_idx,
+                                     message_pattern message_patterns[],
+                                     size_t message_patterns_len);
+
+/*
+ * NAME
+ *   message_parser_read
+ *
+ * DESCRIPTION
+ *   Collects all new messages matching criteria set in 'message_parser_init'.
+ *   New messages means those reported or finished after previous call for this
+ *   function.
+ *
+ * PARAMETERS
+ *   `parser_job' Pointer to parser job to read.
+ *   `messages_storage' Pointer to be set to internally allocated messages
+ *                      storage.
+ *   `force_rewind' If value set to non zero, file will be parsed from
+ *                  beginning, otherwise tailing end of file.
+ *
+ * RETURN VALUE
+ *   Returns -1 upon failure, number of messages collected from last read
+ *   otherwise.
+ */
+int message_parser_read(parser_job_data *parser_job, message **messages_storage,
+                        _Bool force_rewind);
+
+/*
+ * NAME
+ *   message_parser_cleanup
+ *
+ * DESCRIPTION
+ *   Performs parser job resource deallocation and cleanup.
+ *
+ * PARAMETERS
+ *   `parser_job' Pointer to parser job to be cleaned up.
+ *
+ */
+void message_parser_cleanup(parser_job_data *parser_job);
+
+#endif /* UTILS_MESSAGE_PARSER_H */

--- a/src/utils_message_parser.h
+++ b/src/utils_message_parser.h
@@ -43,7 +43,7 @@ typedef struct message_item_pattern_t {
    */
   char *regex;
   /* Index of regex submatch that is stored as result. Value 0 takes whole
-   * match result */
+   * match result. Value -1 does not add result to message item. */
   int submatch_idx;
   /* Regular expression that excludes string from further processing */
   char *excluderegex;

--- a/src/utils_tail.c
+++ b/src/utils_tail.c
@@ -41,7 +41,7 @@ struct cu_tail_s {
   struct stat stat;
 };
 
-static int cu_tail_reopen(cu_tail_t *obj) {
+static int cu_tail_reopen(cu_tail_t *obj, _Bool force_rewind) {
   int seek_end = 0;
   FILE *fh;
   struct stat stat_buf = {0};
@@ -74,10 +74,11 @@ static int cu_tail_reopen(cu_tail_t *obj) {
     return (1);
   }
 
-  /* Seek to the end if we re-open the same file again or the file opened
-   * is the first at all or the first after an error */
+  /* Unless flag for rewinding to the start is set, seek to the end
+   * if we re-open the same file again or the file opened is the first at all
+   * or the first after an error */
   if ((obj->stat.st_ino == 0) || (obj->stat.st_ino == stat_buf.st_ino))
-    seek_end = 1;
+    seek_end = force_rewind ? 0 : 1;
 
   fh = fopen(obj->file, "r");
   if (fh == NULL) {
@@ -133,7 +134,7 @@ int cu_tail_destroy(cu_tail_t *obj) {
   return (0);
 } /* int cu_tail_destroy */
 
-int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen) {
+int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen, _Bool force_rewind) {
   int status;
 
   if (buflen < 1) {
@@ -142,7 +143,7 @@ int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen) {
   }
 
   if (obj->fh == NULL) {
-    status = cu_tail_reopen(obj);
+    status = cu_tail_reopen(obj, force_rewind);
     if (status < 0)
       return (status);
   }
@@ -165,7 +166,7 @@ int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen) {
   /* else: eof -> check if the file was moved away and reopen the new file if
    * so.. */
 
-  status = cu_tail_reopen(obj);
+  status = cu_tail_reopen(obj, force_rewind);
   /* error -> return with error */
   if (status < 0)
     return (status);
@@ -197,13 +198,13 @@ int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen) {
 } /* int cu_tail_readline */
 
 int cu_tail_read(cu_tail_t *obj, char *buf, int buflen, tailfunc_t *callback,
-                 void *data) {
+                 void *data, _Bool force_rewind) {
   int status;
 
   while (42) {
     size_t len;
 
-    status = cu_tail_readline(obj, buf, buflen);
+    status = cu_tail_readline(obj, buf, buflen, force_rewind);
     if (status != 0) {
       ERROR("utils_tail: cu_tail_read: cu_tail_readline "
             "failed.");

--- a/src/utils_tail.h
+++ b/src/utils_tail.h
@@ -73,7 +73,7 @@ int cu_tail_destroy(cu_tail_t *obj);
  *
  * Returns 0 when successful and non-zero otherwise.
  */
-int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen);
+int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen, _Bool force_rewind);
 
 /*
  * cu_tail_readline
@@ -83,6 +83,6 @@ int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen);
  * Returns 0 when successful and non-zero otherwise.
  */
 int cu_tail_read(cu_tail_t *obj, char *buf, int buflen, tailfunc_t *callback,
-                 void *data);
+                 void *data, _Bool force_rewind);
 
 #endif /* UTILS_TAIL_H */

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -245,8 +245,6 @@ int tail_match_add_match(cu_tail_match_t *obj, cu_match_t *match,
   obj->matches = temp;
   obj->matches_num++;
 
-  DEBUG("tail_match_add_match interval %lf",
-        CDTIME_T_TO_DOUBLE(((cu_tail_match_simple_t *)user_data)->interval));
   temp = obj->matches + (obj->matches_num - 1);
 
   temp->match = match;
@@ -314,12 +312,12 @@ out:
   return (status);
 } /* int tail_match_add_match_simple */
 
-int tail_match_read(cu_tail_match_t *obj) {
+int tail_match_read(cu_tail_match_t *obj, _Bool force_rewind) {
   char buffer[4096];
   int status;
 
   status = cu_tail_read(obj->tail, buffer, sizeof(buffer), tail_callback,
-                        (void *)obj);
+                        (void *)obj, force_rewind);
   if (status != 0) {
     ERROR("tail_match: cu_tail_read failed.");
     return (status);

--- a/src/utils_tail_match.h
+++ b/src/utils_tail_match.h
@@ -136,4 +136,4 @@ int tail_match_add_match_simple(cu_tail_match_t *obj, const char *regex,
  * RETURN VALUE
  *   Zero on success, nonzero on failure.
 */
-int tail_match_read(cu_tail_match_t *obj);
+int tail_match_read(cu_tail_match_t *obj, _Bool force_rewind);


### PR DESCRIPTION
The pcie_errors plugin collects PCI Express errors from Device Status in Capability
structure and from Advanced Error Reporting Extended Capability where available.
At every read it polls config space of PCI Express devices and dispatches
notification for every error that is set. It can be configured to parse log file
for system reported AER errors.
This plugin uses message log parser util so it depends on pull request #2154 .