### PR TITLE
memcached: Fix hitratio reporting, add connections rate report

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -406,8 +406,11 @@ static gauge_t calculate_ratio_percent(derive_t part, derive_t total,
   *prev_part = part;
   *prev_total = total;
 
-  if (num == 0 || denom == 0)
+  if (denom == 0)
     return NAN;
+
+  if (num == 0)
+    return 0;
 
   return 100.0 * (gauge_t)num / (gauge_t)denom;
 }
@@ -426,8 +429,11 @@ static gauge_t calculate_ratio_percent2(derive_t part1, derive_t part2,
   *prev1 = part1;
   *prev2 = part2;
 
-  if (num == 0 || denom == 0)
+  if (denom == 0)
     return NAN;
+
+  if (num == 0)
+    return 0;
 
   return 100.0 * (gauge_t)num / (gauge_t)denom;
 }

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -92,13 +92,12 @@ static void memcached_free(void *arg) {
 
 static int memcached_connect_unix(memcached_t *st) {
   struct sockaddr_un serv_addr = {0};
-  int fd;
 
   serv_addr.sun_family = AF_UNIX;
   sstrncpy(serv_addr.sun_path, st->socket, sizeof(serv_addr.sun_path));
 
   /* create our socket descriptor */
-  fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0) {
     char errbuf[1024];
     ERROR("memcached plugin: memcached_connect_unix: socket(2) failed: %s",
@@ -127,14 +126,13 @@ static int memcached_connect_unix(memcached_t *st) {
 
 static int memcached_connect_inet(memcached_t *st) {
   struct addrinfo *ai_list;
-  int status;
   int fd = -1;
 
   struct addrinfo ai_hints = {.ai_family = AF_UNSPEC,
                               .ai_flags = AI_ADDRCONFIG,
                               .ai_socktype = SOCK_STREAM};
 
-  status = getaddrinfo(st->connhost, st->connport, &ai_hints, &ai_list);
+  int status = getaddrinfo(st->connhost, st->connport, &ai_hints, &ai_list);
   if (status != 0) {
     char errbuf[1024];
     ERROR("memcached plugin: memcached_connect_inet: "
@@ -437,10 +435,7 @@ static gauge_t calculate_ratio_percent2(derive_t part1, derive_t part2,
 static int memcached_read(user_data_t *user_data) {
   char buf[4096];
   char *fields[3];
-  char *ptr;
   char *line;
-  char *saveptr;
-  int fields_num;
 
   derive_t bytes_used = 0;
   derive_t bytes_total = 0;
@@ -466,18 +461,15 @@ static int memcached_read(user_data_t *user_data) {
 #define FIELD_IS(cnst)                                                         \
   (((sizeof(cnst) - 1) == name_len) && (strcmp(cnst, fields[1]) == 0))
 
-  ptr = buf;
-  saveptr = NULL;
+  char *ptr = buf;
+  char *saveptr = NULL;
   while ((line = strtok_r(ptr, "\n\r", &saveptr)) != NULL) {
-    int name_len;
-
     ptr = NULL;
 
-    fields_num = strsplit(line, fields, 3);
-    if (fields_num != 3)
+    if (strsplit(line, fields, 3) != 3)
       continue;
 
-    name_len = strlen(fields[1]);
+    int name_len = strlen(fields[1]);
     if (name_len == 0)
       continue;
 
@@ -701,13 +693,12 @@ static int memcached_add_read_callback(memcached_t *st) {
  * </Plugin>
  */
 static int config_add_instance(oconfig_item_t *ci) {
-  memcached_t *st;
   int status = 0;
 
   /* Disable automatic generation of default instance in the init callback. */
   memcached_have_instances = 1;
 
-  st = calloc(1, sizeof(*st));
+  memcached_t *st = calloc(1, sizeof(*st));
   if (st == NULL) {
     ERROR("memcached plugin: calloc failed.");
     return ENOMEM;
@@ -782,14 +773,12 @@ static int memcached_config(oconfig_item_t *ci) {
 } /* int memcached_config */
 
 static int memcached_init(void) {
-  memcached_t *st;
-  int status;
 
   if (memcached_have_instances)
     return 0;
 
   /* No instances were configured, lets start a default instance. */
-  st = calloc(1, sizeof(*st));
+  memcached_t *st = calloc(1, sizeof(*st));
   if (st == NULL)
     return ENOMEM;
   st->name = NULL;
@@ -800,7 +789,7 @@ static int memcached_init(void) {
 
   st->fd = -1;
 
-  status = memcached_add_read_callback(st);
+  int status = memcached_add_read_callback(st);
   if (status == 0)
     memcached_have_instances = 1;
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -436,9 +436,10 @@ static int memcached_read(user_data_t *user_data) {
      * CPU time consumed by the memcached process
      */
     if (FIELD_IS("rusage_user")) {
-      rusage_user = atoll(fields[2]);
+      /* Convert to useconds */
+      rusage_user = atof(fields[2]) * 1000000;
     } else if (FIELD_IS("rusage_system")) {
-      rusage_syst = atoll(fields[2]);
+      rusage_syst = atof(fields[2]) * 1000000;
     }
 
     /*


### PR DESCRIPTION
When Collectd calculates 'hitratio', it divides two continiously-grown values.
So, reported metric contains the average since 'memcached' start, which is incorrect.
Collectd should report actual hitratio, not average for weeks-months-years.

The second commit adds connections rate reporting.

![hitratio](https://user-images.githubusercontent.com/13328211/28753279-919d294c-755c-11e7-9d48-63c9e52dbda9.png)

The value of `hitratio` is calculated as `get_hits / cmd_get` , unlike the rest, `incr_hitratio` and `decr_hitratio`, which are calculated like `incr_hits / (incr_hits + incr_misses)`.

The `get_hits / (get_hits + get_misses)` formula may be used to unify the code, if use only these variables.  But new `get_*` stats was added in memcached: the `get_expired` in memcached-1.4.26 , and `get_flushed` in memcached-1.4.28, so that unification cannot be applied.