### PR TITLE
Plugin for measuring thermal throttle count

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1635,6 +1635,12 @@ thermal_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 thermal_la_LIBADD = libignorelist.la
 endif
 
+if BUILD_PLUGIN_THERMAL_THROTTLE
+pkglib_LTLIBRARIES += thermal_throttle.la
+thermal_throttle_la_SOURCES = src/thermal_throttle.c
+thermal_throttle_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+endif
+
 if BUILD_PLUGIN_THRESHOLD
 pkglib_LTLIBRARIES += threshold.la
 threshold_la_SOURCES = src/threshold.c

--- a/README
+++ b/README
@@ -408,6 +408,9 @@ Features
     - thermal
       Linux ACPI thermal zone information.
 
+    - thermal_throttle
+      Linux cpu throttle information
+
     - tokyotyrant
       Reads the number of records and file size from a running Tokyo Tyrant
       server.

--- a/configure.ac
+++ b/configure.ac
@@ -6154,6 +6154,7 @@ plugin_tape="no"
 plugin_tcpconns="no"
 plugin_ted="no"
 plugin_thermal="no"
+plugin_thermal_throttle="no"
 plugin_turbostat="no"
 plugin_uptime="no"
 plugin_users="no"
@@ -6196,6 +6197,7 @@ if test "x$ac_system" = "xLinux"; then
   plugin_swap="yes"
   plugin_tcpconns="yes"
   plugin_thermal="yes"
+  plugin_thermal_throttle="yes"
   plugin_uptime="yes"
   plugin_vmem="yes"
   plugin_vserver="yes"
@@ -6621,6 +6623,7 @@ AC_PLUGIN([tcpconns],            [$plugin_tcpconns],        [TCP connection stat
 AC_PLUGIN([teamspeak2],          [yes],                     [TeamSpeak2 server statistics])
 AC_PLUGIN([ted],                 [$plugin_ted],             [Read The Energy Detective values])
 AC_PLUGIN([thermal],             [$plugin_thermal],         [Linux ACPI thermal zone statistics])
+AC_PLUGIN([thermal_throttle],    [$plugin_thermal_throttle],[Thermal Throttling Stats])
 AC_PLUGIN([threshold],           [yes],                     [Threshold checking plugin])
 AC_PLUGIN([tokyotyrant],         [$with_libtokyotyrant],    [TokyoTyrant database statistics])
 AC_PLUGIN([turbostat],           [$plugin_turbostat],       [Advanced statistic on Intel cpu states])
@@ -7038,6 +7041,7 @@ AC_MSG_RESULT([    tcpconns  . . . . . . $enable_tcpconns])
 AC_MSG_RESULT([    teamspeak2  . . . . . $enable_teamspeak2])
 AC_MSG_RESULT([    ted . . . . . . . . . $enable_ted])
 AC_MSG_RESULT([    thermal . . . . . . . $enable_thermal])
+AC_MSG_RESULT([    thermal_throttling. . $enable_thermal_throttle])
 AC_MSG_RESULT([    threshold . . . . . . $enable_threshold])
 AC_MSG_RESULT([    tokyotyrant . . . . . $enable_tokyotyrant])
 AC_MSG_RESULT([    turbostat . . . . . . $enable_turbostat])

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -200,6 +200,7 @@
 #@BUILD_PLUGIN_TEAMSPEAK2_TRUE@LoadPlugin teamspeak2
 #@BUILD_PLUGIN_TED_TRUE@LoadPlugin ted
 #@BUILD_PLUGIN_THERMAL_TRUE@LoadPlugin thermal
+#@BUILD_PLUGIN_THERMAL_THROTTLE_TRUE@LoadPlugin thermal_throttle
 #@BUILD_PLUGIN_TOKYOTYRANT_TRUE@LoadPlugin tokyotyrant
 #@BUILD_PLUGIN_TURBOSTAT_TRUE@LoadPlugin turbostat
 #@BUILD_PLUGIN_UNIXSOCK_TRUE@LoadPlugin unixsock

--- a/src/thermal_throttle.c
+++ b/src/thermal_throttle.c
@@ -1,0 +1,100 @@
+/**
+ * collectd - src/thermal_throttle.c
+ * Copyright (C) 2017      notbaab
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; only version 2 of the License is applicable.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * Authors:
+ *   notbaab <notbaab at gmail.com>
+ **/
+
+#include "common.h"
+#include "plugin.h"
+#include "collectd.h"
+
+static int num_cpu = 0;
+
+static int thermal_throttle_init() {
+  int status;
+  char filename[256];
+  num_cpu = 0;
+
+  while (1) {
+    status = snprintf(filename, sizeof(filename),
+                      "/sys/devices/system/cpu/cpu%d/thermal_throttle/"
+                      "core_throttle_count",
+                      num_cpu);
+
+    if ((status < 1) || (unsigned int)status >= sizeof(filename)) {
+      break;
+    }
+
+    if (access(filename, R_OK)) {
+      break;
+    }
+
+    num_cpu++;
+  }
+  return 0;
+}
+
+static void thermal_throttle_submit(int cpu_num, value_t v_core,
+                                    value_t v_package) {
+  value_list_t v1 = VALUE_LIST_INIT;
+  value_t values[] = {v_core, v_package};
+  v1.values = values;
+  v1.values_len = 2;
+
+  sstrncpy(v1.plugin, "thermal_throttle", sizeof(v1.plugin));
+  sstrncpy(v1.type, "thermal_throttle", sizeof(v1.type));
+  snprintf(v1.type_instance, sizeof(v1.type_instance), "%i", cpu_num);
+
+  plugin_dispatch_values(&v1);
+}
+
+static int thermal_throttle_read(void) {
+  for (int i = 0; i < num_cpu; i++) {
+    char filename[1024];
+    snprintf(
+        filename, sizeof(filename),
+        "/sys/devices/system/cpu/cpu%d/thermal_throttle/core_throttle_count",
+        i);
+
+    value_t v_core;
+    if (parse_value_file(filename, &v_core, DS_TYPE_COUNTER) != 0) {
+      WARNING("thermal_throttle plugin: Reading \"%s\" failed.", filename);
+      continue;
+    }
+
+    snprintf(
+        filename, sizeof(filename),
+        "/sys/devices/system/cpu/cpu%d/thermal_throttle/package_throttle_count",
+        i);
+
+    value_t v_package;
+    if (parse_value_file(filename, &v_package, DS_TYPE_COUNTER) != 0) {
+      WARNING("thermal_throttle plugin: Reading \"%s\" failed.", filename);
+      continue;
+    }
+
+    thermal_throttle_submit(i, v_core, v_package);
+  }
+
+  return 0;
+}
+
+void module_register(void) {
+  plugin_register_init("thermal_throttle", thermal_throttle_init);
+  plugin_register_read("thermal_throttle", thermal_throttle_read);
+}

--- a/src/types.db
+++ b/src/types.db
@@ -235,6 +235,7 @@ swap_io                 value:DERIVE:0:U
 tcp_connections         value:GAUGE:0:4294967295
 temperature             value:GAUGE:U:U
 threads                 value:GAUGE:0:U
+thermal_throttle        core_throttle_count:COUNTER:0:U, package_throttle_count:COUNTER:0:U
 time_dispersion         value:GAUGE:-1000000:1000000
 time_offset             value:GAUGE:-1000000:1000000
 time_offset_ntp         value:GAUGE:-1000000:1000000


### PR DESCRIPTION
This plugin allows you to monitor the core and package throttle count on Linux machines by looking in the /sys/devices/system/cpu/cpuN/thermal_throttle/ directory for all N cores on the machine. 