### PR TITLE
configure.ac: dpdk: use pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -784,7 +784,7 @@ pkglib_LTLIBRARIES += dpdkevents.la
 dpdkevents_la_SOURCES = src/dpdkevents.c src/utils_dpdk.c src/utils_dpdk.h
 dpdkevents_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDPDK_CPPFLAGS)
 dpdkevents_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(LIBDPDK_LDFLAGS)
-dpdkevents_la_LIBADD = -ldpdk
+dpdkevents_la_LIBADD = $(LIBDPDK_LIBS)
 endif
 
 if BUILD_PLUGIN_DPDKSTAT
@@ -792,7 +792,7 @@ pkglib_LTLIBRARIES += dpdkstat.la
 dpdkstat_la_SOURCES = src/dpdkstat.c src/utils_dpdk.c src/utils_dpdk.h
 dpdkstat_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDPDK_CPPFLAGS)
 dpdkstat_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(LIBDPDK_LDFLAGS)
-dpdkstat_la_LIBADD = -ldpdk
+dpdkstat_la_LIBADD = $(LIBDPDK_LIBS)
 endif
 
 if BUILD_PLUGIN_DRBD

--- a/Makefile.am
+++ b/Makefile.am
@@ -783,6 +783,7 @@ if BUILD_PLUGIN_DPDKEVENTS
 pkglib_LTLIBRARIES += dpdkevents.la
 dpdkevents_la_SOURCES = src/dpdkevents.c src/utils_dpdk.c src/utils_dpdk.h
 dpdkevents_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDPDK_CPPFLAGS)
+dpdkevents_la_CFLAGS = $(AM_CFLAGS) $(LIBDPDK_CFLAGS)
 dpdkevents_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(LIBDPDK_LDFLAGS)
 dpdkevents_la_LIBADD = $(LIBDPDK_LIBS)
 endif
@@ -791,6 +792,7 @@ if BUILD_PLUGIN_DPDKSTAT
 pkglib_LTLIBRARIES += dpdkstat.la
 dpdkstat_la_SOURCES = src/dpdkstat.c src/utils_dpdk.c src/utils_dpdk.h
 dpdkstat_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDPDK_CPPFLAGS)
+dpdkstat_la_CFLAGS = $(AM_CFLAGS) $(LIBDPDK_CFLAGS)
 dpdkstat_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(LIBDPDK_LDFLAGS)
 dpdkstat_la_LIBADD = $(LIBDPDK_LIBS)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -2349,6 +2349,7 @@ AC_SUBST(BUILD_WITH_LIBDBI_LIBS)
 
 # --with-libdpdk {{{
 AC_ARG_VAR([LIBDPDK_CPPFLAGS], [Preprocessor flags for libdpdk])
+AC_ARG_VAR([LIBDPDK_CFLAGS], [Compiler flags for libdpdk])
 AC_ARG_VAR([LIBDPDK_LDFLAGS], [Linker flags for libdpdk])
 AC_ARG_VAR([LIBDPDK_LIBS], [Libraries to link for libdpdk])
 
@@ -2360,12 +2361,8 @@ AC_ARG_WITH([libdpdk],
 
 if test "x$with_libdpdk" != "xno"; then
   PKG_CHECK_MODULES([DPDK], [libdpdk])
-  if test "x$LIBDPDK_CPPFLAGS" = "x"; then
-    if test "x$DPDK_CFLAGS" != "x"; then
-      LIBDPDK_CPPFLAGS="$DPDK_CFLAGS"
-    else
-      LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
-    fi
+  if test "x$LIBDPDK_CFLAGS" = "x"; then
+      LIBDPDK_CFLAGS="$DPDK_CFLAGS"
   fi
   if test "x$LIBDPDK_LIBS" = "x"; then
       if test "x$DPDK_LIBS" != "x"; then
@@ -2374,8 +2371,13 @@ if test "x$with_libdpdk" != "xno"; then
           LIBDPDK_LIBS="-ldpdk"
       fi
   fi
+  if test "x$LIBDPDK_CPPFLAGS" = "x"; then
+    LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
+  fi
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$LIBDPDK_CPPFLAGS $CPPFLAGS"
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$LIBDPDK_CFLAGS $CFLAGS"
   AC_CHECK_HEADERS([rte_config.h],
     [
       with_libdpdk="yes"
@@ -2397,6 +2399,7 @@ if test "x$with_libdpdk" != "xno"; then
     [with_libdpdk="no (rte_config.h not found)"]
   )
   CPPFLAGS="$SAVE_CPPFLAGS"
+  CFLAGS="$SAVE_CFLAGS"
 fi
 
 if test "x$with_libdpdk" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2350,6 +2350,7 @@ AC_SUBST(BUILD_WITH_LIBDBI_LIBS)
 # --with-libdpdk {{{
 AC_ARG_VAR([LIBDPDK_CPPFLAGS], [Preprocessor flags for libdpdk])
 AC_ARG_VAR([LIBDPDK_LDFLAGS], [Linker flags for libdpdk])
+AC_ARG_VAR([LIBDPDK_LIBS], [Libraries to link for libdpdk])
 
 AC_ARG_WITH([libdpdk],
   [AS_HELP_STRING([--without-libdpdk], [Disable libdpdk.])],
@@ -2358,8 +2359,20 @@ AC_ARG_WITH([libdpdk],
 )
 
 if test "x$with_libdpdk" != "xno"; then
+  PKG_CHECK_MODULES([DPDK], [libdpdk])
   if test "x$LIBDPDK_CPPFLAGS" = "x"; then
-    LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
+    if test "x$DPDK_CFLAGS" != "x"; then
+      LIBDPDK_CPPFLAGS="$DPDK_CFLAGS"
+    else
+      LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
+    fi
+  fi
+  if test "x$LIBDPDK_LIBS" = "x"; then
+      if test "x$DPDK_LIBS" != "x"; then
+          LIBDPDK_LIBS="$DPDK_LIBS"
+      else
+          LIBDPDK_LIBS="-ldpdk"
+      fi
   fi
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$LIBDPDK_CPPFLAGS $CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -2361,8 +2361,12 @@ AC_ARG_WITH([libdpdk],
 
 if test "x$with_libdpdk" != "xno"; then
   PKG_CHECK_MODULES([DPDK], [libdpdk])
+  if test "x$LIBDPDK_CPPFLAGS" = "x"; then
+    LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
+  fi
   if test "x$LIBDPDK_CFLAGS" = "x"; then
       LIBDPDK_CFLAGS="$DPDK_CFLAGS"
+      LIBDPDK_CPPFLAGS="$LIBDPDK_CPPFLAGS $DPDK_CFLAGS"
   fi
   if test "x$LIBDPDK_LIBS" = "x"; then
       if test "x$DPDK_LIBS" != "x"; then
@@ -2370,9 +2374,6 @@ if test "x$with_libdpdk" != "xno"; then
       else
           LIBDPDK_LIBS="-ldpdk"
       fi
-  fi
-  if test "x$LIBDPDK_CPPFLAGS" = "x"; then
-    LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
   fi
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$LIBDPDK_CPPFLAGS $CPPFLAGS"


### PR DESCRIPTION
To detect cflags and libs use the sometimes provided pkg-config for
libdpdk. That avoids build errors on systems where special flags are
needed and provided by dpdk via pkg-config, but not yet considered by
the collectd build system.

This closes #2399

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>