### PR TITLE
configure.ac: dpdk: tolerate no pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2361,7 +2361,7 @@ AC_ARG_WITH([libdpdk],
 
 if test "x$with_libdpdk" != "xno"; then
   PKG_CHECK_MODULES([DPDK], [libdpdk], [],
-		    [AC_MSG_NOTICE([no DPDK pkg-config, using defaults])])
+                    [AC_MSG_NOTICE([no DPDK pkg-config, using defaults])])
   if test "x$LIBDPDK_CPPFLAGS" = "x"; then
     LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -2361,7 +2361,7 @@ AC_ARG_WITH([libdpdk],
 
 if test "x$with_libdpdk" != "xno"; then
   PKG_CHECK_MODULES([DPDK], [libdpdk], [],
-                    [AC_MSG_NOTICE([no DPDK pkg-config, using defaults])])
+    [AC_MSG_NOTICE([no DPDK pkg-config, using defaults])])
   if test "x$LIBDPDK_CPPFLAGS" = "x"; then
     LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -2360,7 +2360,8 @@ AC_ARG_WITH([libdpdk],
 )
 
 if test "x$with_libdpdk" != "xno"; then
-  PKG_CHECK_MODULES([DPDK], [libdpdk])
+  PKG_CHECK_MODULES([DPDK], [libdpdk], [],
+		    [AC_MSG_NOTICE([no DPDK pkg-config, using defaults])])
   if test "x$LIBDPDK_CPPFLAGS" = "x"; then
     LIBDPDK_CPPFLAGS="-I/usr/include/dpdk"
   fi


### PR DESCRIPTION
Since pull request #2400 pkg-config works great for dpdk, but not if
there is no pkg-config around at all.
To fix that the PKG_CHECK_MODULES macro needs to define a valid fourth
argument, otherwise it will error out.

This closes 2404

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>