### PR TITLE
Treewide: Don't set value_list_t.host to hostname_g.

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -623,7 +623,7 @@ static int cc_read_page(web_page_t *wp) /* {{{ */
   if (wp->response_time)
     cc_submit_response_time(wp, CDTIME_T_TO_DOUBLE(cdtime() - start));
   if (wp->stats != NULL)
-    curl_stats_dispatch(wp->stats, wp->curl, hostname_g, "curl", wp->instance);
+    curl_stats_dispatch(wp->stats, wp->curl, NULL, "curl", wp->instance);
 
   if (wp->response_code) {
     long response_code = 0;

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -488,7 +488,6 @@ static void dpdk_events_gauge_submit(const char *plugin_instance,
                      .plugin = DPDK_EVENTS_PLUGIN,
                      .type = "gauge",
                      .meta = NULL};
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
   plugin_dispatch_values(&vl);

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -373,7 +373,6 @@ static void dpdk_stats_counter_submit(const char *plugin_instance,
   vl.values = &(value_t){.derive = value};
   vl.values_len = 1;
   vl.time = port_read_time;
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, DPDK_STATS_PLUGIN, sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
   dpdk_stats_resolve_cnt_type(vl.type, sizeof(vl.type), cnt_name);

--- a/src/mic.c
+++ b/src/mic.c
@@ -163,7 +163,6 @@ static void mic_submit_temp(int micnumber, const char *type, gauge_t value) {
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
 
-  strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
   snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, "temperature", sizeof(vl.type));
@@ -205,7 +204,6 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
   vl.values = &(value_t){.derive = value};
   vl.values_len = 1;
 
-  strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
   if (core < 0) /* global aggregation */
     snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
@@ -259,7 +257,6 @@ static void mic_submit_power(int micnumber, const char *type,
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
 
-  strncpy(vl.host, hostname_g, sizeof(vl.host));
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
   snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, type, sizeof(vl.type));

--- a/src/nut.c
+++ b/src/nut.c
@@ -96,13 +96,13 @@ static int nut_add_ups(const char *name) {
   cb_name = ssnprintf_alloc("nut/%s", name);
 
   status = plugin_register_complex_read(
-    /* group = */ "nut",
-    /* name      = */ cb_name,
-    /* callback  = */ nut_read,
-    /* interval  = */ 0,
-    /* user_data = */ &(user_data_t){
-                        .data = ups, .free_func = free_nut_ups_t,
-                      });
+      /* group     = */ "nut",
+      /* name      = */ cb_name,
+      /* callback  = */ nut_read,
+      /* interval  = */ 0,
+      /* user_data = */ &(user_data_t){
+          .data = ups, .free_func = free_nut_ups_t,
+      });
 
   sfree(cb_name);
 
@@ -191,10 +191,8 @@ static void nut_submit(nut_ups_t *ups, const char *type,
 
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
-  sstrncpy(vl.host,
-           (strcasecmp(ups->hostname, "localhost") == 0) ? hostname_g
-                                                         : ups->hostname,
-           sizeof(vl.host));
+  if (strcasecmp(ups->hostname, "localhost") != 0)
+    sstrncpy(vl.host, ups->hostname, sizeof(vl.host));
   sstrncpy(vl.plugin, "nut", sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, ups->upsname, sizeof(vl.plugin_instance));
   sstrncpy(vl.type, type, sizeof(vl.type));
@@ -211,8 +209,8 @@ static int nut_connect(nut_ups_t *ups) {
   tv.tv_sec = connect_timeout / 1000;
   tv.tv_usec = connect_timeout % 1000;
 
-  status = upscli_tryconnect(ups->conn, ups->hostname, ups->port, ssl_flags,
-                             &tv);
+  status =
+      upscli_tryconnect(ups->conn, ups->hostname, ups->port, ssl_flags, &tv);
 #else /* #if HAVE_UPSCLI_TRYCONNECT */
   status = upscli_connect(ups->conn, ups->hostname, ups->port, ssl_flags);
 #endif

--- a/src/perl.c
+++ b/src/perl.c
@@ -424,8 +424,6 @@ static int hv2value_list(pTHX_ HV *hash, value_list_t *vl) {
 
   if (NULL != (tmp = hv_fetch(hash, "host", 4, 0)))
     sstrncpy(vl->host, SvPV_nolen(*tmp), sizeof(vl->host));
-  else
-    sstrncpy(vl->host, hostname_g, sizeof(vl->host));
 
   if (NULL != (tmp = hv_fetch(hash, "plugin", 6, 0)))
     sstrncpy(vl->plugin, SvPV_nolen(*tmp), sizeof(vl->plugin));
@@ -2351,25 +2349,14 @@ static int g_interval_set(pTHX_ SV *var, MAGIC *mg) {
   return 0;
 } /* static int g_interval_set (pTHX_ SV *, MAGIC *) */
 
-static MGVTBL g_pv_vtbl = {g_pv_get,
-                           g_pv_set,
-                           NULL,
-                           NULL,
-                           NULL,
-                           NULL,
-                           NULL
+static MGVTBL g_pv_vtbl = {g_pv_get, g_pv_set, NULL, NULL, NULL, NULL, NULL
 #if HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL
                            ,
                            NULL
 #endif
 };
-static MGVTBL g_interval_vtbl = {g_interval_get,
-                                 g_interval_set,
-                                 NULL,
-                                 NULL,
-                                 NULL,
-                                 NULL,
-                                 NULL
+static MGVTBL g_interval_vtbl = {g_interval_get, g_interval_set, NULL, NULL,
+                                 NULL, NULL, NULL
 #if HAVE_PERL_STRUCT_MGVTBL_SVT_LOCAL
                                  ,
                                  NULL

--- a/src/utils_curl_stats.c
+++ b/src/utils_curl_stats.c
@@ -218,15 +218,15 @@ int curl_stats_dispatch(curl_stats_t *s, CURL *curl, const char *hostname,
 
   if (s == NULL)
     return 0;
-  if ((curl == NULL) || (hostname == NULL) || (plugin == NULL)) {
+  if ((curl == NULL) || (plugin == NULL)) {
     ERROR("curl stats: dispatch() called with missing arguments "
-          "(curl=%p; hostname=%s; plugin=%s)",
-          curl, hostname == NULL ? "<NULL>" : hostname,
-          plugin == NULL ? "<NULL>" : plugin);
+          "(curl=%p; plugin=%s)",
+          curl, plugin == NULL ? "<NULL>" : plugin);
     return -1;
   }
 
-  sstrncpy(vl.host, hostname, sizeof(vl.host));
+  if (hostname != NULL)
+    sstrncpy(vl.host, hostname, sizeof(vl.host));
   sstrncpy(vl.plugin, plugin, sizeof(vl.plugin));
   if (plugin_instance != NULL)
     sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -108,7 +108,6 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   if (match_value == NULL)
     return -1;
 
-  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
   sstrncpy(vl.plugin, data->plugin, sizeof(vl.plugin));
   sstrncpy(vl.plugin_instance, data->plugin_instance,
            sizeof(vl.plugin_instance));


### PR DESCRIPTION
`plugin_dispatch_values()` will automatically fill that value in. We should probably have a similar cleanup in the notification code, which still heavily uses `hostname_g`.