### PR TITLE
Add ipv6 to ipvs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -510,15 +510,16 @@ if test "x$ac_system" = "xLinux"; then
 
   # For ipvs module
   AC_CHECK_HEADERS_ONCE([linux/ip_vs.h])
-  PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
-  PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes])
-  if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
-        SAVE_CFLAGS="$CFLAGS"
-	SAVE_LIBS="$LIBS"
-	CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS"
-        LIBS="$LIBS $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+  if test "x$ac_cv_header_linux_ip_vs_h" = "xyes"; then
+    PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes],[have_libnl_genl3=no])
+    PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes], [have_libnl3=no])
+    if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
+          SAVE_CFLAGS="$CFLAGS"
+          SAVE_LIBS="$LIBS"
+          CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS"
+          LIBS="$LIBS $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+    fi
   fi
-
   # For the email plugin
   AC_CHECK_HEADERS([linux/un.h], [], [],
     [[

--- a/configure.ac
+++ b/configure.ac
@@ -510,6 +510,14 @@ if test "x$ac_system" = "xLinux"; then
 
   # For ipvs module
   AC_CHECK_HEADERS_ONCE([linux/ip_vs.h])
+  PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
+  PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes])
+  if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
+        SAVE_CFLAGS="$CFLAGS"
+	SAVE_LIBS="$LIBS"
+	CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS"
+        LIBS="$LIBS $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+  fi
 
   # For the email plugin
   AC_CHECK_HEADERS([linux/un.h], [], [],
@@ -580,31 +588,6 @@ else
   have_linux_wireless_h="no"
 fi
 
-AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
-
-
-#for ipvs
-
-
-AM_CONDITIONAL([IP_VS_H_NEEDS_KERNEL_CFLAGS], [test "x$ip_vs_h_needs_kernel_cflags" = "xyes"])
-PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
-PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes],
-    [PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
-	    [PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
-        ])
-	])
-
-if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
-        CFLAGS+=" $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS -DLIBIPVS_USE_NL"
-        LIBS+=" $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
-#LIBS+=" $"
-elif (test "${have_libnl2}" = "yes"); then
-    CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
-	LIBS+="$LIBNL2_LIBS"
-elif  (test "${have_libnl1}" = "yes"); then
-    CFLAGS+="$LIBNL1_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
-    LIBS+="$LIBNL1_LIBS"
-fi
 AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
 
 # For the swap module
@@ -6227,7 +6210,7 @@ if test "x$ac_system" = "xLinux"; then
   plugin_wireless="yes"
   plugin_zfs_arc="yes"
 
-  if test "x$ac_cv_header_linux_ip_vs_h" = "xyes"; then
+  if test "x$ac_cv_header_linux_ip_vs_h" = "xyes" && test "${have_libnl3}" = "yes" && test "${have_libnl_genl3}" == yes; then
     plugin_ipvs="yes"
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -582,6 +582,31 @@ fi
 
 AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
 
+
+#for ipvs
+
+
+AM_CONDITIONAL([IP_VS_H_NEEDS_KERNEL_CFLAGS], [test "x$ip_vs_h_needs_kernel_cflags" = "xyes"])
+PKG_CHECK_MODULES(LIBNL_GENL3, libnl-genl-3.0, [have_libnl_genl3=yes], [have_libnl_genl3=no])
+PKG_CHECK_MODULES(LIBNL3, libnl-3.0 >= 3.1, [have_libnl3=yes],
+    [PKG_CHECK_MODULES(LIBNL2, libnl-2.0 >= 2.0, [have_libnl2=yes],
+	    [PKG_CHECK_MODULES(LIBNL1, libnl-1 >= 1, [have_libnl1=yes], [have_libnl1=no])
+        ])
+	])
+
+if ((test "${have_libnl3}" = "yes") &&(test "${have_libnl_genl3}" == yes)); then
+        CFLAGS+=" $LIBNL3_CFLAGS $LIBNL_GENL3_CFLAGS -DLIBIPVS_USE_NL"
+        LIBS+=" $LIBNL3_LIBS $LIBNL_GENL3_LIBS"
+#LIBS+=" $"
+elif (test "${have_libnl2}" = "yes"); then
+    CFLAGS+="$LIBNL2_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+	LIBS+="$LIBNL2_LIBS"
+elif  (test "${have_libnl1}" = "yes"); then
+    CFLAGS+="$LIBNL1_CFLAGS -DLIBIPVS_USE_NL -DFALLBACK_LIBNL1"
+    LIBS+="$LIBNL1_LIBS"
+fi
+AM_CONDITIONAL([BUILD_WITH_CAPABILITY], [test "x$have_capability" = "xyes"])
+
 # For the swap module
 have_sys_swap_h="yes"
 AC_CHECK_HEADERS([sys/swap.h vm/anon.h],

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -44,17 +44,11 @@
 
 #include <ip_vs.h>
 
-
-
-//add our structures
+// add our structures
 #include <ipvs.h>
 
 #define log_err(...) ERROR("ipvs: " __VA_ARGS__)
 #define log_info(...) INFO("ipvs: " __VA_ARGS__)
-
-//#define nl_sock nl_handle
-//#define nl_socket_alloc nl_handle_alloc
-//#define nl_socket_free nl_handle_destroy
 
 #include <libnl3/netlink/genl/ctrl.h>
 #include <libnl3/netlink/genl/genl.h>
@@ -62,15 +56,12 @@
 #include <libnl3/netlink/netlink.h>
 #include <libnl3/netlink/socket.h>
 
-
-
 static struct nl_sock *sock = NULL;
 static int family;
 
 /*
  * private variables
  */
-//static int sockfd = -1;
 struct ip_vs_getinfo ipvs_info;
 
 /*
@@ -203,14 +194,13 @@ static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg) {
   return NL_OK;
 }
 
-
 static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
   struct nlmsghdr *nlh = nlmsg_hdr(msg);
   struct nlattr *attrs[IPVS_CMD_ATTR_MAX + 1];
   struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
   struct ip_vs_get_services_nl **getp = (struct ip_vs_get_services_nl **)arg;
   struct ip_vs_get_services_nl *get = (struct ip_vs_get_services_nl *)*getp;
-  struct ip_vs_flags flags;
+//  struct ip_vs_flags flags;
   int i = get->num_services;
 
   if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
@@ -253,12 +243,12 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
   if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
     strncpy(get->entrytable[i].pe_name,
             nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
-         IP_VS_PENAME_MAXLEN);
+            IP_VS_PENAME_MAXLEN);
 
-  get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
-  get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
-  nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
-  get->entrytable[i].flags = flags.flags & flags.mask;
+//  get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
+  //get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
+//  nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
+ // get->entrytable[i].flags = flags.flags & flags.mask;
 
   if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
     if (ipvs_parse_stats64(&get->entrytable[i].stats64,
@@ -275,36 +265,37 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
   i++;
 
   get->num_services = i;
-  get = realloc(get, sizeof(*get) +
-                         sizeof(struct ip_vs_service_entry_nl) *
-                             (get->num_services + 1));
+  get = realloc(get, sizeof(*get) + sizeof(struct ip_vs_service_entry_nl) *
+                                        (get->num_services + 1));
   *getp = get;
-  
-return 0;
+
+  return 0;
 }
+
 /*
- *  * libipvs API
- *   */
+ * libipvs API
+ */
 static struct ip_vs_get_services_nl *ipvs_get_services(void) {
-          // struct ip_vs_getinfo ipvs_info;
-           struct ip_vs_get_services_nl *services;
+  // struct ip_vs_getinfo ipvs_info;
+  struct ip_vs_get_services_nl *services;
 
-        socklen_t len;
+  socklen_t len;
 
- struct nl_msg *msg;
-    len = sizeof(*services) + sizeof(struct ip_vs_service_entry_nl);
-    if (!(services = malloc(len)))
-      return NULL;
-
-    services->num_services = 0;
-
-    msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
-
-    if (msg && (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &services) == 0)) {
-      return services; //todo: check we free this elsewhere
-    }
-    free(services);
+  struct nl_msg *msg;
+  len = sizeof(*services) + sizeof(struct ip_vs_service_entry_nl);
+  if (!(services = malloc(len)))
     return NULL;
+
+  services->num_services = 0;
+
+  msg = ipvs_nl_message(IPVS_CMD_GET_SERVICE, NLM_F_DUMP);
+
+  if (msg &&
+      (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &services) == 0)) {
+    return services; // todo: check we free this elsewhere
+  }
+  free(services);
+  return NULL;
 } /* ipvs_get_services */
 
 static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
@@ -341,8 +332,8 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
   memcpy(&(d->entrytable[i].addr), nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
          sizeof(d->entrytable[i].addr));
   d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
-  d->entrytable[i].conn_flags =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
+  //d->entrytable[i].conn_flags =
+    //  nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
   d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
   d->entrytable[i].u_threshold =
       nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
@@ -379,7 +370,8 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
   return 0;
 }
 
-static struct ip_vs_get_dests_nl *ipvs_get_dests(struct ip_vs_service_entry_nl *se) {
+static struct ip_vs_get_dests_nl *
+ipvs_get_dests(struct ip_vs_service_entry_nl *se) {
   struct ip_vs_get_dests_nl *ret;
   socklen_t len;
 
@@ -390,47 +382,47 @@ static struct ip_vs_get_dests_nl *ipvs_get_dests(struct ip_vs_service_entry_nl *
     exit(3);
   }
 
-    struct nl_msg *msg;
-    struct nlattr *nl_service;
-    if (se->num_dests == 0)
-      ret = realloc(ret, sizeof(*ret) + sizeof(struct ip_vs_dest_entry_nl));
+  struct nl_msg *msg;
+  struct nlattr *nl_service;
+  if (se->num_dests == 0)
+    ret = realloc(ret, sizeof(*ret) + sizeof(struct ip_vs_dest_entry_nl));
 
-    ret->fwmark = se->fwmark;
-    ret->protocol = se->protocol;
-    ret->addr = se->addr;
-    ret->port = se->port;
-    ret->num_dests = se->num_dests;
-    ret->af = se->af;
+  ret->fwmark = se->fwmark;
+  ret->protocol = se->protocol;
+  ret->addr = se->addr;
+  ret->port = se->port;
+  ret->num_dests = se->num_dests;
+  ret->af = se->af;
 
-    msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
-    if (!msg)
-      goto ipvs_nl_dest_failure;
+  msg = ipvs_nl_message(IPVS_CMD_GET_DEST, NLM_F_DUMP);
+  if (!msg)
+    goto ipvs_nl_dest_failure;
 
-    nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
-    if (!nl_service)
-      goto nla_put_failure;
+  nl_service = nla_nest_start(msg, IPVS_CMD_ATTR_SERVICE);
+  if (!nl_service)
+    goto nla_put_failure;
 
-    NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
+  NLA_PUT_U16(msg, IPVS_SVC_ATTR_AF, se->af);
 
-    if (se->fwmark) {
-      NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
-    } else {
-      NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
-      NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr), &se->addr);
-      NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
-    }
+  if (se->fwmark) {
+    NLA_PUT_U32(msg, IPVS_SVC_ATTR_FWMARK, se->fwmark);
+  } else {
+    NLA_PUT_U16(msg, IPVS_SVC_ATTR_PROTOCOL, se->protocol);
+    NLA_PUT(msg, IPVS_SVC_ATTR_ADDR, sizeof(se->addr), &se->addr);
+    NLA_PUT_U16(msg, IPVS_SVC_ATTR_PORT, se->port);
+  }
 
-    nla_nest_end(msg, nl_service);
-    if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
-      goto ipvs_nl_dest_failure;
+  nla_nest_end(msg, nl_service);
+  if (ipvs_nl_send_message(msg, ipvs_dests_parse_cb, &ret))
+    goto ipvs_nl_dest_failure;
 
-    return ret;
+  return ret;
 
-  nla_put_failure:
-    nlmsg_free(msg);
-  ipvs_nl_dest_failure:
-    free(ret);
-    return NULL;
+nla_put_failure:
+  nlmsg_free(msg);
+ipvs_nl_dest_failure:
+  free(ret);
+  return NULL;
 } /* ip_vs_get_dests */
 
 /*
@@ -439,20 +431,20 @@ static struct ip_vs_get_dests_nl *ipvs_get_dests(struct ip_vs_service_entry_nl *
 static int cipvs_init(void) {
 
   /*Test we can use netlink*/
-  if (ipvs_nl_send_message(NULL, NULL, NULL) != 0 ) {
-	log_err("Netlink test failed");
-	return -1;
+  if (ipvs_nl_send_message(NULL, NULL, NULL) != 0) {
+    log_err("Netlink test failed");
+    return -1;
   }
-    //TODO: error here
-    struct nl_msg *msg;
-    msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
-    if (msg) {
-      ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb, NULL);
-    } else {
-      return -1;
-    }
+  // TODO: error here
+  struct nl_msg *msg;
+  msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
+  if (msg) {
+    ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb, NULL);
+  } else {
+    return -1;
+  }
 
-/* we need IPVS >= 1.1.4 */
+  /* we need IPVS >= 1.1.4 */
   if (ipvs_info.version < ((1 << 16) + (1 << 8) + 4)) {
     log_err("cipvs_init: IPVS version too old (%d.%d.%d < %d.%d.%d)",
             NVERSION(ipvs_info.version), 1, 1, 4);
@@ -479,18 +471,18 @@ static int get_pi(struct ip_vs_service_entry_nl *se, char *pi, size_t size) {
   if ((NULL == se) || (NULL == pi))
     return 0;
 
-/* inet_ntoa() returns a pointer to a statically allocated buffer
- *  * I hope non-glibc systems behave the same */
+  /* inet_ntoa() returns a pointer to a statically allocated buffer
+   *  * I hope non-glibc systems behave the same */
   addr = se->addr;
   if (se->af == AF_INET6) {
     len = snprintf(pi, size, "%s_%s%u",
-                    inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
-                    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-                    ntohs(se->port));
+                   inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
+                   (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+                   ntohs(se->port));
   } else {
     len = snprintf(pi, size, "%s_%s%u", inet_ntoa(addr.in),
-                    (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
-                    ntohs(se->port));
+                   (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
+                   ntohs(se->port));
   }
   if ((0 > len) || (size <= ((size_t)len))) {
     log_err("plugin instance truncated: %s", pi);
@@ -513,8 +505,8 @@ static int get_ti(struct ip_vs_dest_entry_nl *de, char *ti, size_t size) {
  *     I hope non-glibc systems behave the same */
   if (de->af == AF_INET6) {
     len = snprintf(ti, size, "%s_%u",
-                    inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
-                    ntohs(de->port));
+                   inet_ntop(AF_INET6, &addr, straddr, sizeof(straddr)),
+                   ntohs(de->port));
   } else {
     len = snprintf(ti, size, "%s_%u", inet_ntoa(addr.in), ntohs(de->port));
   }
@@ -530,7 +522,7 @@ static void cipvs_submit_connections(const char *pi, const char *ti,
                                      derive_t value) {
   value_list_t vl = VALUE_LIST_INIT;
 
-  vl.values = &(value_t){.derive = value};
+  vl.values = &(value_t) { .derive = value };
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, "ipvs", sizeof(vl.plugin));
@@ -545,9 +537,7 @@ static void cipvs_submit_connections(const char *pi, const char *ti,
 
 static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
                             derive_t rx, derive_t tx) {
-  value_t values[] = {
-      {.derive = rx}, {.derive = tx},
-  };
+  value_t values[] = { { .derive = rx }, { .derive = tx }, };
   value_list_t vl = VALUE_LIST_INIT;
 
   vl.values = values;
@@ -577,7 +567,6 @@ static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry_nl *de) {
   return;
 } /* cipvs_submit_dest */
 
-
 static void cipvs_submit_service(struct ip_vs_service_entry_nl *se) {
   struct ip_vs_stats64 stats = se->stats64;
   struct ip_vs_get_dests_nl *dests = ipvs_get_dests(se);
@@ -602,21 +591,21 @@ static void cipvs_submit_service(struct ip_vs_service_entry_nl *se) {
 } /* cipvs_submit_service */
 
 static int cipvs_read(void) {
-   struct ip_vs_get_services_nl *services = ipvs_get_services();
-   if (services == NULL)
-     return -1;
+  struct ip_vs_get_services_nl *services = ipvs_get_services();
+  if (services == NULL)
+    return -1;
 
-   for (size_t i = 0; i < services->num_services; ++i)
-     cipvs_submit_service(&services->entrytable[i]);
+  for (size_t i = 0; i < services->num_services; ++i)
+    cipvs_submit_service(&services->entrytable[i]);
 
   free(services);
   return 0;
 } /* cipvs_read */
 
 static int cipvs_shutdown(void) {
- // if (sock != NULL)
-   // nl_socket_free(sock);
-//  sockfd = -1;
+  // if (sock != NULL)
+  // nl_socket_free(sock);
+  //  sockfd = -1;
   return 0;
 } /* cipvs_shutdown */
 

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -144,40 +144,10 @@ static int ipvs_parse_stats64(struct ip_vs_stats64 *stats, struct nlattr *nla) {
   stats->outpkts = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPKTS]);
   stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
   stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
-  stats->cps = nla_get_u64(attrs[IPVS_STATS_ATTR_CPS]);
-  stats->inpps = nla_get_u64(attrs[IPVS_STATS_ATTR_INPPS]);
-  stats->outpps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTPPS]);
-  stats->inbps = nla_get_u64(attrs[IPVS_STATS_ATTR_INBPS]);
-  stats->outbps = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBPS]);
 
   return 0;
 }
-static int ipvs_parse_stats(struct ip_vs_stats64 *stats, struct nlattr *nla) {
-  struct nlattr *attrs[IPVS_STATS_ATTR_MAX + 1];
 
-  if (nla_parse_nested(attrs, IPVS_STATS_ATTR_MAX, nla, ipvs_stats_policy))
-    return -1;
-
-  if (!(attrs[IPVS_STATS_ATTR_CONNS] && attrs[IPVS_STATS_ATTR_INPKTS] &&
-        attrs[IPVS_STATS_ATTR_OUTPKTS] && attrs[IPVS_STATS_ATTR_INBYTES] &&
-        attrs[IPVS_STATS_ATTR_OUTBYTES] && attrs[IPVS_STATS_ATTR_CPS] &&
-        attrs[IPVS_STATS_ATTR_INPPS] && attrs[IPVS_STATS_ATTR_OUTPPS] &&
-        attrs[IPVS_STATS_ATTR_INBPS] && attrs[IPVS_STATS_ATTR_OUTBPS]))
-    return -1;
-
-  stats->conns = nla_get_u32(attrs[IPVS_STATS_ATTR_CONNS]);
-  stats->inpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_INPKTS]);
-  stats->outpkts = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPKTS]);
-  stats->inbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_INBYTES]);
-  stats->outbytes = nla_get_u64(attrs[IPVS_STATS_ATTR_OUTBYTES]);
-  stats->cps = nla_get_u32(attrs[IPVS_STATS_ATTR_CPS]);
-  stats->inpps = nla_get_u32(attrs[IPVS_STATS_ATTR_INPPS]);
-  stats->outpps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTPPS]);
-  stats->inbps = nla_get_u32(attrs[IPVS_STATS_ATTR_INBPS]);
-  stats->outbps = nla_get_u32(attrs[IPVS_STATS_ATTR_OUTBPS]);
-
-  return 0;
-}
 static int ipvs_getinfo_parse_cb(struct nl_msg *msg, void *arg) {
   struct nlmsghdr *nlh = nlmsg_hdr(msg);
   struct nlattr *attrs[IPVS_INFO_ATTR_MAX + 1];
@@ -200,7 +170,6 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
   struct nlattr *svc_attrs[IPVS_SVC_ATTR_MAX + 1];
   struct ip_vs_get_services_nl **getp = (struct ip_vs_get_services_nl **)arg;
   struct ip_vs_get_services_nl *get = (struct ip_vs_get_services_nl *)*getp;
-//  struct ip_vs_flags flags;
   int i = get->num_services;
 
   if (genlmsg_parse(nlh, 0, attrs, IPVS_CMD_ATTR_MAX, ipvs_cmd_policy) != 0)
@@ -245,18 +214,10 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
             nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
             IP_VS_PENAME_MAXLEN);
 
-//  get->entrytable[i].netmask = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_NETMASK]);
-  //get->entrytable[i].timeout = nla_get_u32(svc_attrs[IPVS_SVC_ATTR_TIMEOUT]);
-//  nla_memcpy(&flags, svc_attrs[IPVS_SVC_ATTR_FLAGS], sizeof(flags));
- // get->entrytable[i].flags = flags.flags & flags.mask;
 
   if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
     if (ipvs_parse_stats64(&get->entrytable[i].stats64,
                            svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
-      return -1;
-  } else if (svc_attrs[IPVS_SVC_ATTR_STATS]) {
-    if (ipvs_parse_stats(&get->entrytable[i].stats64,
-                         svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
       return -1;
   }
 
@@ -276,7 +237,6 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
  * libipvs API
  */
 static struct ip_vs_get_services_nl *ipvs_get_services(void) {
-  // struct ip_vs_getinfo ipvs_info;
   struct ip_vs_get_services_nl *services;
 
   socklen_t len;
@@ -292,7 +252,7 @@ static struct ip_vs_get_services_nl *ipvs_get_services(void) {
 
   if (msg &&
       (ipvs_nl_send_message(msg, ipvs_services_parse_cb, &services) == 0)) {
-    return services; // todo: check we free this elsewhere
+    return services; 
   }
   free(services);
   return NULL;
@@ -332,13 +292,6 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
   memcpy(&(d->entrytable[i].addr), nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
          sizeof(d->entrytable[i].addr));
   d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
-  //d->entrytable[i].conn_flags =
-    //  nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
-  //d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
-  //d->entrytable[i].u_threshold =
-    //  nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
- // d->entrytable[i].l_threshold =
-   //   nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
   d->entrytable[i].activeconns =
       nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
   d->entrytable[i].inactconns =
@@ -352,12 +305,8 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
     d->entrytable[i].af = d->af;
 
   if (dest_attrs[IPVS_DEST_ATTR_STATS64]) {
-    if (ipvs_parse_stats(&d->entrytable[i].stats64,
+    if (ipvs_parse_stats64(&d->entrytable[i].stats64,
                          dest_attrs[IPVS_DEST_ATTR_STATS64]) != 0)
-      return -1;
-  } else if (dest_attrs[IPVS_DEST_ATTR_STATS]) {
-    if (ipvs_parse_stats(&d->entrytable[i].stats64,
-                         dest_attrs[IPVS_DEST_ATTR_STATS]) != 0)
       return -1;
   }
 
@@ -458,9 +407,9 @@ static int cipvs_init(void) {
 } /* cipvs_init */
 
 /*
- *  * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-total
- *   * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-<real IP>_<port>
- *    */
+ * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-total
+ * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-<real IP>_<port>
+ */
 
 /* plugin instance */
 static int get_pi(struct ip_vs_service_entry_nl *se, char *pi, size_t size) {

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -334,11 +334,11 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
   d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
   //d->entrytable[i].conn_flags =
     //  nla_get_u32(dest_attrs[IPVS_DEST_ATTR_FWD_METHOD]);
-  d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
-  d->entrytable[i].u_threshold =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
-  d->entrytable[i].l_threshold =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
+  //d->entrytable[i].weight = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_WEIGHT]);
+  //d->entrytable[i].u_threshold =
+    //  nla_get_u32(dest_attrs[IPVS_DEST_ATTR_U_THRESH]);
+ // d->entrytable[i].l_threshold =
+   //   nla_get_u32(dest_attrs[IPVS_DEST_ATTR_L_THRESH]);
   d->entrytable[i].activeconns =
       nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
   d->entrytable[i].inactconns =

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -47,246 +47,293 @@
 #define log_err(...) ERROR("ipvs: " __VA_ARGS__)
 #define log_info(...) INFO("ipvs: " __VA_ARGS__)
 
+#define nl_sock nl_handle
+#define nl_socket_alloc nl_handle_alloc
+#define nl_socket_free nl_handle_destroy
+
+#include <libnl3/netlink/genl/ctrl.h>
+#include <libnl3/netlink/genl/genl.h>
+#include <libnl3/netlink/msg.h>
+#include <libnl3/netlink/netlink.h>
+#include<libnl3/netlink/socket.h>
+
+
+
+static struct nl_sock *sock = NULL;
+static int family;
+
 /*
  * private variables
  */
-static int sockfd = -1;
+//static int sockfd = -1;
 
 /*
  * libipvs API
  */
-static struct ip_vs_get_services *ipvs_get_services(void) {
-  struct ip_vs_getinfo ipvs_info;
-  struct ip_vs_get_services *services;
+// static struct ip_vs_get_services *ipvs_get_services(void) {
+//   struct ip_vs_getinfo ipvs_info;
+//   struct ip_vs_get_services *services;
+//
+//   socklen_t len = sizeof(ipvs_info);
+//
+//   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, &ipvs_info, &len) ==
+//       -1) {
+//     char errbuf[1024];
+//     log_err("ip_vs_get_services: getsockopt() failed: %s",
+//             sstrerror(errno, errbuf, sizeof(errbuf)));
+//     return NULL;
+//   }
+//
+//   len = sizeof(*services) +
+//         sizeof(struct ip_vs_service_entry) * ipvs_info.num_services;
+//
+//   services = malloc(len);
+//   if (services == NULL) {
+//     log_err("ipvs_get_services: Out of memory.");
+//     return NULL;
+//   }
+//
+//   services->num_services = ipvs_info.num_services;
+//
+//   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_SERVICES, services, &len) ==
+//       -1) {
+//     char errbuf[1024];
+//     log_err("ipvs_get_services: getsockopt failed: %s",
+//             sstrerror(errno, errbuf, sizeof(errbuf)));
+//
+//     free(services);
+//     return NULL;
+//   }
+//   return services;
+// } /* ipvs_get_services */
+//
+// static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
+//   struct ip_vs_get_dests *dests;
+//
+//   socklen_t len =
+//       sizeof(*dests) + sizeof(struct ip_vs_dest_entry) * se->num_dests;
+//
+//   dests = malloc(len);
+//   if (dests == NULL) {
+//     log_err("ipvs_get_dests: Out of memory.");
+//     return NULL;
+//   }
+//
+//   dests->fwmark = se->fwmark;
+//   dests->protocol = se->protocol;
+//   dests->addr = se->addr;
+//   dests->port = se->port;
+//   dests->num_dests = se->num_dests;
+//
+//   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS, dests, &len) == -1) {
+//     char errbuf[1024];
+//     log_err("ipvs_get_dests: getsockopt() failed: %s",
+//             sstrerror(errno, errbuf, sizeof(errbuf)));
+//     free(dests);
+//     return NULL;
+//   }
+//   return dests;
+// } /* ip_vs_get_dests */
+//
 
-  socklen_t len = sizeof(ipvs_info);
 
-  if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, &ipvs_info, &len) ==
-      -1) {
-    char errbuf[1024];
-    log_err("ip_vs_get_services: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    return NULL;
+static int ipvs_nl_send_message(struct nl_msg *msg, nl_recvmsg_msg_cb_t func,
+                                void *arg) {
+  int err = EINVAL;
+
+  sock = nl_socket_alloc();
+  if (!sock) {
+    nlmsg_free(msg);
+    return -1;
   }
 
-  len = sizeof(*services) +
-        sizeof(struct ip_vs_service_entry) * ipvs_info.num_services;
+  if (genl_connect(sock) < 0)
+    goto fail_genl;
 
-  services = malloc(len);
-  if (services == NULL) {
-    log_err("ipvs_get_services: Out of memory.");
-    return NULL;
+  family = genl_ctrl_resolve(sock, IPVS_GENL_NAME);
+  if (family < 0)
+    goto fail_genl;
+
+  // To test connections and set the family
+  if (msg == NULL) {
+    nl_socket_free(sock);
+    sock = NULL;
+    return 0;
   }
 
-  services->num_services = ipvs_info.num_services;
+  if (nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, func, arg) != 0)
+    goto fail_genl;
 
-  if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_SERVICES, services, &len) ==
-      -1) {
-    char errbuf[1024];
-    log_err("ipvs_get_services: getsockopt failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+  if (nl_send_auto_complete(sock, msg) < 0)
+    goto fail_genl;
 
-    free(services);
-    return NULL;
-  }
-  return services;
-} /* ipvs_get_services */
+  if ((err = -nl_recvmsgs_default(sock)) > 0)
+    goto fail_genl;
 
-static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
-  struct ip_vs_get_dests *dests;
+  nlmsg_free(msg);
 
-  socklen_t len =
-      sizeof(*dests) + sizeof(struct ip_vs_dest_entry) * se->num_dests;
+  nl_socket_free(sock);
 
-  dests = malloc(len);
-  if (dests == NULL) {
-    log_err("ipvs_get_dests: Out of memory.");
-    return NULL;
-  }
+  return 0;
 
-  dests->fwmark = se->fwmark;
-  dests->protocol = se->protocol;
-  dests->addr = se->addr;
-  dests->port = se->port;
-  dests->num_dests = se->num_dests;
+fail_genl:
+  nl_socket_free(sock);
+  sock = NULL;
+  nlmsg_free(msg);
+  errno = err;
+  return -1;
+}
 
-  if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS, dests, &len) == -1) {
-    char errbuf[1024];
-    log_err("ipvs_get_dests: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    free(dests);
-    return NULL;
-  }
-  return dests;
-} /* ip_vs_get_dests */
-
-/*
- * collectd plugin API and helper functions
- */
+// /*
+//  * collectd plugin API and helper functions
+//  */
 static int cipvs_init(void) {
-  struct ip_vs_getinfo ipvs_info;
 
-  if ((sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) == -1) {
-    char errbuf[1024];
-    log_err("cipvs_init: socket() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    return -1;
-  }
+  /*Test we can use netlink*/
+  if (ipvs_nl_send_message(NULL, NULL, NULL) == 0)
+   printf("we have nl");
+	// try_nl = 1;
+    //TODO: error here
 
-  socklen_t len = sizeof(ipvs_info);
-
-  if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, &ipvs_info, &len) ==
-      -1) {
-    char errbuf[1024];
-    log_err("cipvs_init: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    close(sockfd);
-    sockfd = -1;
-    return -1;
-  }
-
-  /* we need IPVS >= 1.1.4 */
-  if (ipvs_info.version < ((1 << 16) + (1 << 8) + 4)) {
-    log_err("cipvs_init: IPVS version too old (%d.%d.%d < %d.%d.%d)",
-            NVERSION(ipvs_info.version), 1, 1, 4);
-    close(sockfd);
-    sockfd = -1;
-    return -1;
-  } else {
-    log_info("Successfully connected to IPVS %d.%d.%d",
-             NVERSION(ipvs_info.version));
-  }
+/*    struct nl_msg *msg;
+    msg = ipvs_nl_message(IPVS_CMD_GET_INFO, 0);
+    if (msg) {
+      ipvs_nl_send_message(msg, ipvs_getinfo_parse_cb, NULL);
+    } else {
+      return -1;
+    }
+*/
   return 0;
 } /* cipvs_init */
-
-/*
- * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-total
- * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-<real IP>_<port>
- */
-
-/* plugin instance */
-static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
-  if ((se == NULL) || (pi == NULL))
-    return 0;
-
-  struct in_addr addr = {.s_addr = se->addr};
-
-  int len =
-      snprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
-               (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
-
-  if ((len < 0) || (size <= ((size_t)len))) {
-    log_err("plugin instance truncated: %s", pi);
-    return -1;
-  }
-  return 0;
-} /* get_pi */
-
-/* type instance */
-static int get_ti(struct ip_vs_dest_entry *de, char *ti, size_t size) {
-  if ((de == NULL) || (ti == NULL))
-    return 0;
-
-  struct in_addr addr = {.s_addr = de->addr};
-
-  int len = snprintf(ti, size, "%s_%u", inet_ntoa(addr), ntohs(de->port));
-
-  if ((len < 0) || (size <= ((size_t)len))) {
-    log_err("type instance truncated: %s", ti);
-    return -1;
-  }
-  return 0;
-} /* get_ti */
-
-static void cipvs_submit_connections(const char *pi, const char *ti,
-                                     derive_t value) {
-  value_list_t vl = VALUE_LIST_INIT;
-
-  vl.values = &(value_t){.derive = value};
-  vl.values_len = 1;
-
-  sstrncpy(vl.plugin, "ipvs", sizeof(vl.plugin));
-  sstrncpy(vl.plugin_instance, pi, sizeof(vl.plugin_instance));
-  sstrncpy(vl.type, "connections", sizeof(vl.type));
-  sstrncpy(vl.type_instance, (ti != NULL) ? ti : "total",
-           sizeof(vl.type_instance));
-
-  plugin_dispatch_values(&vl);
-} /* cipvs_submit_connections */
-
-static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
-                            derive_t rx, derive_t tx) {
-  value_t values[] = {
-      {.derive = rx}, {.derive = tx},
-  };
-  value_list_t vl = VALUE_LIST_INIT;
-
-  vl.values = values;
-  vl.values_len = STATIC_ARRAY_SIZE(values);
-
-  sstrncpy(vl.plugin, "ipvs", sizeof(vl.plugin));
-  sstrncpy(vl.plugin_instance, pi, sizeof(vl.plugin_instance));
-  sstrncpy(vl.type, t, sizeof(vl.type));
-  sstrncpy(vl.type_instance, (ti != NULL) ? ti : "total",
-           sizeof(vl.type_instance));
-
-  plugin_dispatch_values(&vl);
-} /* cipvs_submit_if */
-
-static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
-  struct ip_vs_stats_user stats = de->stats;
-
-  char ti[DATA_MAX_NAME_LEN];
-
-  if (get_ti(de, ti, sizeof(ti)) != 0)
-    return;
-
-  cipvs_submit_connections(pi, ti, stats.conns);
-  cipvs_submit_if(pi, "if_packets", ti, stats.inpkts, stats.outpkts);
-  cipvs_submit_if(pi, "if_octets", ti, stats.inbytes, stats.outbytes);
-} /* cipvs_submit_dest */
-
-static void cipvs_submit_service(struct ip_vs_service_entry *se) {
-  struct ip_vs_stats_user stats = se->stats;
-  struct ip_vs_get_dests *dests = ipvs_get_dests(se);
-
-  char pi[DATA_MAX_NAME_LEN];
-
-  if (get_pi(se, pi, sizeof(pi)) != 0) {
-    free(dests);
-    return;
-  }
-
-  cipvs_submit_connections(pi, NULL, stats.conns);
-  cipvs_submit_if(pi, "if_packets", NULL, stats.inpkts, stats.outpkts);
-  cipvs_submit_if(pi, "if_octets", NULL, stats.inbytes, stats.outbytes);
-
-  for (size_t i = 0; i < dests->num_dests; ++i)
-    cipvs_submit_dest(pi, &dests->entrytable[i]);
-
-  free(dests);
-  return;
-} /* cipvs_submit_service */
+//
+// /*
+//  * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-total
+//  * ipvs-<virtual IP>_{UDP,TCP}<port>/<type>-<real IP>_<port>
+//  */
+//
+// /* plugin instance */
+// static int get_pi(struct ip_vs_service_entry *se, char *pi, size_t size) {
+//   if ((se == NULL) || (pi == NULL))
+//     return 0;
+//
+//   struct in_addr addr = {.s_addr = se->addr};
+//
+//   int len =
+//       snprintf(pi, size, "%s_%s%u", inet_ntoa(addr),
+//                (se->protocol == IPPROTO_TCP) ? "TCP" : "UDP", ntohs(se->port));
+//
+//   if ((len < 0) || (size <= ((size_t)len))) {
+//     log_err("plugin instance truncated: %s", pi);
+//     return -1;
+//   }
+//   return 0;
+// } /* get_pi */
+//
+// /* type instance */
+// static int get_ti(struct ip_vs_dest_entry *de, char *ti, size_t size) {
+//   if ((de == NULL) || (ti == NULL))
+//     return 0;
+//
+//   struct in_addr addr = {.s_addr = de->addr};
+//
+//   int len = snprintf(ti, size, "%s_%u", inet_ntoa(addr), ntohs(de->port));
+//
+//   if ((len < 0) || (size <= ((size_t)len))) {
+//     log_err("type instance truncated: %s", ti);
+//     return -1;
+//   }
+//   return 0;
+// } /* get_ti */
+//
+// static void cipvs_submit_connections(const char *pi, const char *ti,
+//                                      derive_t value) {
+//   value_list_t vl = VALUE_LIST_INIT;
+//
+//   vl.values = &(value_t){.derive = value};
+//   vl.values_len = 1;
+//
+//   sstrncpy(vl.plugin, "ipvs", sizeof(vl.plugin));
+//   sstrncpy(vl.plugin_instance, pi, sizeof(vl.plugin_instance));
+//   sstrncpy(vl.type, "connections", sizeof(vl.type));
+//   sstrncpy(vl.type_instance, (ti != NULL) ? ti : "total",
+//            sizeof(vl.type_instance));
+//
+//   plugin_dispatch_values(&vl);
+// } /* cipvs_submit_connections */
+//
+// static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
+//                             derive_t rx, derive_t tx) {
+//   value_t values[] = {
+//       {.derive = rx}, {.derive = tx},
+//   };
+//   value_list_t vl = VALUE_LIST_INIT;
+//
+//   vl.values = values;
+//   vl.values_len = STATIC_ARRAY_SIZE(values);
+//
+//   sstrncpy(vl.plugin, "ipvs", sizeof(vl.plugin));
+//   sstrncpy(vl.plugin_instance, pi, sizeof(vl.plugin_instance));
+//   sstrncpy(vl.type, t, sizeof(vl.type));
+//   sstrncpy(vl.type_instance, (ti != NULL) ? ti : "total",
+//            sizeof(vl.type_instance));
+//
+//   plugin_dispatch_values(&vl);
+// } /* cipvs_submit_if */
+//
+// static void cipvs_submit_dest(const char *pi, struct ip_vs_dest_entry *de) {
+//   struct ip_vs_stats_user stats = de->stats;
+//
+//   char ti[DATA_MAX_NAME_LEN];
+//
+//   if (get_ti(de, ti, sizeof(ti)) != 0)
+//     return;
+//
+//   cipvs_submit_connections(pi, ti, stats.conns);
+//   cipvs_submit_if(pi, "if_packets", ti, stats.inpkts, stats.outpkts);
+//   cipvs_submit_if(pi, "if_octets", ti, stats.inbytes, stats.outbytes);
+// } /* cipvs_submit_dest */
+//
+// static void cipvs_submit_service(struct ip_vs_service_entry *se) {
+//   struct ip_vs_stats_user stats = se->stats;
+//   struct ip_vs_get_dests *dests = ipvs_get_dests(se);
+//
+//   char pi[DATA_MAX_NAME_LEN];
+//
+//   if (get_pi(se, pi, sizeof(pi)) != 0) {
+//     free(dests);
+//     return;
+//   }
+//
+//   cipvs_submit_connections(pi, NULL, stats.conns);
+//   cipvs_submit_if(pi, "if_packets", NULL, stats.inpkts, stats.outpkts);
+//   cipvs_submit_if(pi, "if_octets", NULL, stats.inbytes, stats.outbytes);
+//
+//   for (size_t i = 0; i < dests->num_dests; ++i)
+//     cipvs_submit_dest(pi, &dests->entrytable[i]);
+//
+//   free(dests);
+//   return;
+//} /* cipvs_submit_service */
 
 static int cipvs_read(void) {
-  if (sockfd < 0)
-    return -1;
-
-  struct ip_vs_get_services *services = ipvs_get_services();
-  if (services == NULL)
-    return -1;
-
-  for (size_t i = 0; i < services->num_services; ++i)
-    cipvs_submit_service(&services->entrytable[i]);
-
-  free(services);
+// //  if (sockfd < 0)
+//   //  return -1;
+//
+//   struct ip_vs_get_services *services = ipvs_get_services();
+//   if (services == NULL)
+//     return -1;
+//
+//   for (size_t i = 0; i < services->num_services; ++i)
+//     cipvs_submit_service(&services->entrytable[i]);
+//
+//  free(services);
   return 0;
 } /* cipvs_read */
 
 static int cipvs_shutdown(void) {
-  if (sockfd >= 0)
-    close(sockfd);
-  sockfd = -1;
+  //if (sockfd >= 0)
+    //close(sockfd);
+  //sockfd = -1;
 
   return 0;
 } /* cipvs_shutdown */

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -215,11 +215,9 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg) {
             IP_VS_PENAME_MAXLEN);
 
 
-  if (svc_attrs[IPVS_SVC_ATTR_STATS64]) {
-    if (ipvs_parse_stats64(&get->entrytable[i].stats64,
+  if (ipvs_parse_stats64(&get->entrytable[i].stats64,
                            svc_attrs[IPVS_SVC_ATTR_STATS64]) != 0)
-      return -1;
-  }
+    return -1;
 
   get->entrytable[i].num_dests = 0;
 
@@ -282,22 +280,18 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg) {
   if (!(dest_attrs[IPVS_DEST_ATTR_ADDR] && dest_attrs[IPVS_DEST_ATTR_PORT] &&
         dest_attrs[IPVS_DEST_ATTR_FWD_METHOD] &&
         dest_attrs[IPVS_DEST_ATTR_WEIGHT] &&
-        dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
-        dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
-        dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS] &&
-        dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
-        dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
+    //    dest_attrs[IPVS_DEST_ATTR_U_THRESH] &&
+      //  dest_attrs[IPVS_DEST_ATTR_L_THRESH] &&
+        dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS])) 
+       // dest_attrs[IPVS_DEST_ATTR_INACT_CONNS] &&
+//        dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]))
     return -1;
 
   memcpy(&(d->entrytable[i].addr), nla_data(dest_attrs[IPVS_DEST_ATTR_ADDR]),
          sizeof(d->entrytable[i].addr));
   d->entrytable[i].port = nla_get_u16(dest_attrs[IPVS_DEST_ATTR_PORT]);
-  d->entrytable[i].activeconns =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
-  d->entrytable[i].inactconns =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
-  d->entrytable[i].persistconns =
-      nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
+ // d->entrytable[i].persistconns =
+  //    nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
   attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
   if (attr_addr_family)
     d->entrytable[i].af = nla_get_u16(attr_addr_family);

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -77,13 +77,17 @@ struct ip_vs_get_services_nl {
   unsigned int num_services;
 
   /* service table */
-  struct ip_vs_service_entry entrytable[0];
+  struct ip_vs_service_entry_nl entrytable[0];
 };
+
+
+
+
 
 extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
 extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
 //extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
-//extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
+extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
 //extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
 
@@ -118,4 +122,17 @@ struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
         [IPVS_SVC_ATTR_TIMEOUT] = {.type = NLA_U32},
         [IPVS_SVC_ATTR_NETMASK] = {.type = NLA_U32},
         [IPVS_SVC_ATTR_STATS] = {.type = NLA_NESTED},
+};
+
+struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
+        [IPVS_STATS_ATTR_CONNS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_OUTBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_CPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTBPS] = {.type = NLA_U32},
 };

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -25,30 +25,19 @@ struct ip_vs_stats64 {
   __u64 outpkts;  /* outgoing packets */
   __u64 inbytes;  /* incoming bytes */
   __u64 outbytes; /* outgoing bytes */
-
-  __u64 cps;    /* current connection rate */
-  __u64 inpps;  /* current in packet rate */
-  __u64 outpps; /* current out packet rate */
-  __u64 inbps;  /* current in byte rate */
-  __u64 outbps; /* current out byte rate */
 };
 
 /*
  * Struct used for ipv6 addreses
  */
 struct ip_vs_service_entry_nl {
-  /* which service: user fills in these */
   u_int16_t protocol;
-//not used  __be32 __addr_v4; /* virtual address - internal use only*/
   __be16 port;
   u_int32_t fwmark; /* firwall mark of service */
 
   /* service options */
   char sched_name[IP_VS_SCHEDNAME_MAXLEN];
-  //unsigned flags;   /* virtual service flags */
-//  unsigned timeout; /* persistent timeout */
-//  __be32 netmask;   /* persistent netmask */
-
+  
   /* number of real servers */
   unsigned int num_dests;
 
@@ -64,13 +53,7 @@ struct ip_vs_service_entry_nl {
 };
 
 struct ip_vs_dest_entry_nl {
-//not used  __be32 __addr_v4; /* destination address - internal use only */
   __be16 port;
-  //unsigned conn_flags; /* connection flags */
- // int weight;          /* destination weight */
-
-  //u_int32_t u_threshold; /* upper threshold */
- // u_int32_t l_threshold; /* lower threshold */
 
   u_int32_t activeconns;  /* active connections */
   u_int32_t inactconns;   /* inactive connections */
@@ -88,9 +71,8 @@ struct ip_vs_dest_entry_nl {
 struct ip_vs_get_dests_nl {
   /* which service: user fills in these */
   u_int16_t protocol;
-//not used  __be32 __addr_v4; /* virtual address - internal use only */
   __be16 port;
-  u_int32_t fwmark; /* firwall mark of service */
+  u_int32_t fwmark; /* firewall mark of service */
 
   /* number of real servers */
   unsigned int num_dests;
@@ -111,13 +93,11 @@ struct ip_vs_get_services_nl {
 };
 
 /* IPVS Netlink Policy definitions */
-
 extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
 extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
 extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
 extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
-// extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
 
 struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] =
     {[IPVS_CMD_ATTR_SERVICE] = { .type = NLA_NESTED },

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -1,5 +1,5 @@
-#include <linux/types.h>
 #include <libnl3/netlink/genl/genl.h>
+#include <linux/types.h>
 
 #include <arpa/inet.h>
 #include <linux/types.h> /* For __beXX types in userland */
@@ -35,7 +35,7 @@ struct ip_vs_service_entry_nl {
 
   /* service options */
   char sched_name[IP_VS_SCHEDNAME_MAXLEN];
-  
+
   /* number of real servers */
   unsigned int num_dests;
 
@@ -96,55 +96,60 @@ extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
 extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
 
-struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] =
-    {[IPVS_CMD_ATTR_SERVICE] = { .type = NLA_NESTED },
-     [IPVS_CMD_ATTR_DEST] = { .type = NLA_NESTED },
-     [IPVS_CMD_ATTR_DAEMON] = { .type = NLA_NESTED },
-     [IPVS_CMD_ATTR_TIMEOUT_TCP] = { .type = NLA_U32 },
-     [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = { .type = NLA_U32 },
-     [IPVS_CMD_ATTR_TIMEOUT_UDP] = { .type = NLA_U32 }, };
+struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
+        [IPVS_CMD_ATTR_SERVICE] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DEST] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DAEMON] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_UDP] = {.type = NLA_U32},
+};
 
-struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] =
-    {[IPVS_INFO_ATTR_VERSION] = { .type = NLA_U32 },
-     [IPVS_INFO_ATTR_CONN_TAB_SIZE] = { .type = NLA_U32 }, };
+struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
+        [IPVS_INFO_ATTR_VERSION] = {.type = NLA_U32},
+        [IPVS_INFO_ATTR_CONN_TAB_SIZE] = {.type = NLA_U32},
+};
 
-struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] =
-    {[IPVS_SVC_ATTR_AF] = { .type = NLA_U16 },
-     [IPVS_SVC_ATTR_PROTOCOL] = { .type = NLA_U16 },
-     [IPVS_SVC_ATTR_ADDR] = { .type = NLA_UNSPEC,
-                              .maxlen = sizeof(struct in6_addr) },
-     [IPVS_SVC_ATTR_PORT] = { .type = NLA_U16 },
-     [IPVS_SVC_ATTR_FWMARK] = { .type = NLA_U32 },
-     [IPVS_SVC_ATTR_SCHED_NAME] = { .type = NLA_STRING,
-                                    .maxlen = IP_VS_SCHEDNAME_MAXLEN },
-     [IPVS_SVC_ATTR_FLAGS] = { .type = NLA_UNSPEC,
-                               .minlen = sizeof(struct ip_vs_flags),
-                               .maxlen = sizeof(struct ip_vs_flags) },
-     [IPVS_SVC_ATTR_TIMEOUT] = { .type = NLA_U32 },
-     [IPVS_SVC_ATTR_NETMASK] = { .type = NLA_U32 },
-     [IPVS_SVC_ATTR_STATS] = { .type = NLA_NESTED }, };
+struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
+        [IPVS_SVC_ATTR_AF] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_PROTOCOL] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                .maxlen = sizeof(struct in6_addr)},
+        [IPVS_SVC_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_FWMARK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_SCHED_NAME] = {.type = NLA_STRING,
+                                      .maxlen = IP_VS_SCHEDNAME_MAXLEN},
+        [IPVS_SVC_ATTR_FLAGS] = {.type = NLA_UNSPEC,
+                                 .minlen = sizeof(struct ip_vs_flags),
+                                 .maxlen = sizeof(struct ip_vs_flags)},
+        [IPVS_SVC_ATTR_TIMEOUT] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_NETMASK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_STATS] = {.type = NLA_NESTED},
+};
 
-struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] =
-    {[IPVS_STATS_ATTR_CONNS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_INPKTS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_OUTPKTS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_INBYTES] = { .type = NLA_U64 },
-     [IPVS_STATS_ATTR_OUTBYTES] = { .type = NLA_U64 },
-     [IPVS_STATS_ATTR_CPS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_INPPS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_OUTPPS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_INBPS] = { .type = NLA_U32 },
-     [IPVS_STATS_ATTR_OUTBPS] = { .type = NLA_U32 }, };
+struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
+        [IPVS_STATS_ATTR_CONNS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPKTS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_OUTBYTES] = {.type = NLA_U64},
+        [IPVS_STATS_ATTR_CPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTPPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_INBPS] = {.type = NLA_U32},
+        [IPVS_STATS_ATTR_OUTBPS] = {.type = NLA_U32},
+};
 
-struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] =
-    {[IPVS_DEST_ATTR_ADDR] = { .type = NLA_UNSPEC,
-                               .maxlen = sizeof(struct in6_addr) },
-     [IPVS_DEST_ATTR_PORT] = { .type = NLA_U16 },
-     [IPVS_DEST_ATTR_FWD_METHOD] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_WEIGHT] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_U_THRESH] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_L_THRESH] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_ACTIVE_CONNS] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_INACT_CONNS] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_PERSIST_CONNS] = { .type = NLA_U32 },
-     [IPVS_DEST_ATTR_STATS] = { .type = NLA_NESTED }, };
+struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
+        [IPVS_DEST_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                 .maxlen = sizeof(struct in6_addr)},
+        [IPVS_DEST_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_DEST_ATTR_FWD_METHOD] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_WEIGHT] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_U_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_L_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_ACTIVE_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_INACT_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_PERSIST_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_STATS] = {.type = NLA_NESTED},
+};

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -1,6 +1,5 @@
-#include <linux/types.h> 
+#include <linux/types.h>
 #include <libnl3/netlink/genl/genl.h>
-
 
 #include <arpa/inet.h>
 #include <linux/types.h> /* For __beXX types in userland */
@@ -8,9 +7,6 @@
 #include <sys/socket.h>
 
 #define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
-
-
-
 
 union nf_inet_addr {
   __u32 all[4];
@@ -20,10 +16,9 @@ union nf_inet_addr {
   struct in6_addr in6;
 };
 
-
 /*
- *  *  *   IPVS statistics object (for user space), 64-bit
- *   *   */
+ * IPVS statistics object (for user space), 64-bit
+ */
 struct ip_vs_stats64 {
   __u64 conns;    /* connections scheduled */
   __u64 inpkts;   /* incoming packets */
@@ -38,23 +33,21 @@ struct ip_vs_stats64 {
   __u64 outbps; /* current out byte rate */
 };
 
-
-
 /*
- * Strcut used for ipv6 addreses
+ * Struct used for ipv6 addreses
  */
 struct ip_vs_service_entry_nl {
   /* which service: user fills in these */
   u_int16_t protocol;
-  __be32 __addr_v4; /* virtual address - internal use only*/
+//not used  __be32 __addr_v4; /* virtual address - internal use only*/
   __be16 port;
   u_int32_t fwmark; /* firwall mark of service */
 
   /* service options */
   char sched_name[IP_VS_SCHEDNAME_MAXLEN];
-  unsigned flags;   /* virtual service flags */
-  unsigned timeout; /* persistent timeout */
-  __be32 netmask;   /* persistent netmask */
+  //unsigned flags;   /* virtual service flags */
+//  unsigned timeout; /* persistent timeout */
+//  __be32 netmask;   /* persistent netmask */
 
   /* number of real servers */
   unsigned int num_dests;
@@ -71,9 +64,9 @@ struct ip_vs_service_entry_nl {
 };
 
 struct ip_vs_dest_entry_nl {
-  __be32 __addr_v4; /* destination address - internal use only */
+//not used  __be32 __addr_v4; /* destination address - internal use only */
   __be16 port;
-  unsigned conn_flags; /* connection flags */
+  //unsigned conn_flags; /* connection flags */
   int weight;          /* destination weight */
 
   u_int32_t u_threshold; /* upper threshold */
@@ -95,7 +88,7 @@ struct ip_vs_dest_entry_nl {
 struct ip_vs_get_dests_nl {
   /* which service: user fills in these */
   u_int16_t protocol;
-  __be32 __addr_v4; /* virtual address - internal use only */
+//not used  __be32 __addr_v4; /* virtual address - internal use only */
   __be16 port;
   u_int32_t fwmark; /* firwall mark of service */
 
@@ -117,73 +110,64 @@ struct ip_vs_get_services_nl {
   struct ip_vs_service_entry_nl entrytable[0];
 };
 
-
-
-
+/* IPVS Netlink Policy definitions */
 
 extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
 extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
 extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
 extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
-//extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
+// extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
 
-/* Policy definitions */
-struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
-        [IPVS_CMD_ATTR_SERVICE] = {.type = NLA_NESTED},
-        [IPVS_CMD_ATTR_DEST] = {.type = NLA_NESTED},
-        [IPVS_CMD_ATTR_DAEMON] = {.type = NLA_NESTED},
-        [IPVS_CMD_ATTR_TIMEOUT_TCP] = {.type = NLA_U32},
-        [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = {.type = NLA_U32},
-        [IPVS_CMD_ATTR_TIMEOUT_UDP] = {.type = NLA_U32},
-};
+struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] =
+    {[IPVS_CMD_ATTR_SERVICE] = { .type = NLA_NESTED },
+     [IPVS_CMD_ATTR_DEST] = { .type = NLA_NESTED },
+     [IPVS_CMD_ATTR_DAEMON] = { .type = NLA_NESTED },
+     [IPVS_CMD_ATTR_TIMEOUT_TCP] = { .type = NLA_U32 },
+     [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = { .type = NLA_U32 },
+     [IPVS_CMD_ATTR_TIMEOUT_UDP] = { .type = NLA_U32 }, };
 
+struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] =
+    {[IPVS_INFO_ATTR_VERSION] = { .type = NLA_U32 },
+     [IPVS_INFO_ATTR_CONN_TAB_SIZE] = { .type = NLA_U32 }, };
 
-struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
-        [IPVS_INFO_ATTR_VERSION] = {.type = NLA_U32},
-        [IPVS_INFO_ATTR_CONN_TAB_SIZE] = {.type = NLA_U32},
-};
+struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] =
+    {[IPVS_SVC_ATTR_AF] = { .type = NLA_U16 },
+     [IPVS_SVC_ATTR_PROTOCOL] = { .type = NLA_U16 },
+     [IPVS_SVC_ATTR_ADDR] = { .type = NLA_UNSPEC,
+                              .maxlen = sizeof(struct in6_addr) },
+     [IPVS_SVC_ATTR_PORT] = { .type = NLA_U16 },
+     [IPVS_SVC_ATTR_FWMARK] = { .type = NLA_U32 },
+     [IPVS_SVC_ATTR_SCHED_NAME] = { .type = NLA_STRING,
+                                    .maxlen = IP_VS_SCHEDNAME_MAXLEN },
+     [IPVS_SVC_ATTR_FLAGS] = { .type = NLA_UNSPEC,
+                               .minlen = sizeof(struct ip_vs_flags),
+                               .maxlen = sizeof(struct ip_vs_flags) },
+     [IPVS_SVC_ATTR_TIMEOUT] = { .type = NLA_U32 },
+     [IPVS_SVC_ATTR_NETMASK] = { .type = NLA_U32 },
+     [IPVS_SVC_ATTR_STATS] = { .type = NLA_NESTED }, };
 
-struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
-        [IPVS_SVC_ATTR_AF] = {.type = NLA_U16},
-        [IPVS_SVC_ATTR_PROTOCOL] = {.type = NLA_U16},
-        [IPVS_SVC_ATTR_ADDR] = {.type = NLA_UNSPEC,
-                                .maxlen = sizeof(struct in6_addr)},
-        [IPVS_SVC_ATTR_PORT] = {.type = NLA_U16},
-        [IPVS_SVC_ATTR_FWMARK] = {.type = NLA_U32},
-        [IPVS_SVC_ATTR_SCHED_NAME] = {.type = NLA_STRING,
-                                      .maxlen = IP_VS_SCHEDNAME_MAXLEN},
-        [IPVS_SVC_ATTR_FLAGS] = {.type = NLA_UNSPEC,
-                                 .minlen = sizeof(struct ip_vs_flags),
-                                 .maxlen = sizeof(struct ip_vs_flags)},
-        [IPVS_SVC_ATTR_TIMEOUT] = {.type = NLA_U32},
-        [IPVS_SVC_ATTR_NETMASK] = {.type = NLA_U32},
-        [IPVS_SVC_ATTR_STATS] = {.type = NLA_NESTED},
-};
+struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] =
+    {[IPVS_STATS_ATTR_CONNS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_INPKTS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_OUTPKTS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_INBYTES] = { .type = NLA_U64 },
+     [IPVS_STATS_ATTR_OUTBYTES] = { .type = NLA_U64 },
+     [IPVS_STATS_ATTR_CPS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_INPPS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_OUTPPS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_INBPS] = { .type = NLA_U32 },
+     [IPVS_STATS_ATTR_OUTBPS] = { .type = NLA_U32 }, };
 
-struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
-        [IPVS_STATS_ATTR_CONNS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_INPKTS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_OUTPKTS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_INBYTES] = {.type = NLA_U64},
-        [IPVS_STATS_ATTR_OUTBYTES] = {.type = NLA_U64},
-        [IPVS_STATS_ATTR_CPS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_INPPS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_OUTPPS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_INBPS] = {.type = NLA_U32},
-        [IPVS_STATS_ATTR_OUTBPS] = {.type = NLA_U32},
-};
-
-struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
-        [IPVS_DEST_ATTR_ADDR] = {.type = NLA_UNSPEC,
-                                 .maxlen = sizeof(struct in6_addr)},
-        [IPVS_DEST_ATTR_PORT] = {.type = NLA_U16},
-        [IPVS_DEST_ATTR_FWD_METHOD] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_WEIGHT] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_U_THRESH] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_L_THRESH] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_ACTIVE_CONNS] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_INACT_CONNS] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_PERSIST_CONNS] = {.type = NLA_U32},
-        [IPVS_DEST_ATTR_STATS] = {.type = NLA_NESTED},
-};
+struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] =
+    {[IPVS_DEST_ATTR_ADDR] = { .type = NLA_UNSPEC,
+                               .maxlen = sizeof(struct in6_addr) },
+     [IPVS_DEST_ATTR_PORT] = { .type = NLA_U16 },
+     [IPVS_DEST_ATTR_FWD_METHOD] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_WEIGHT] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_U_THRESH] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_L_THRESH] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_ACTIVE_CONNS] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_INACT_CONNS] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_PERSIST_CONNS] = { .type = NLA_U32 },
+     [IPVS_DEST_ATTR_STATS] = { .type = NLA_NESTED }, };

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -21,7 +21,6 @@ union nf_inet_addr {
 };
 
 
-
 /*
  *  *  *   IPVS statistics object (for user space), 64-bit
  *   *   */
@@ -38,6 +37,7 @@ struct ip_vs_stats64 {
   __u64 inbps;  /* current in byte rate */
   __u64 outbps; /* current out byte rate */
 };
+
 
 
 /*
@@ -70,6 +70,43 @@ struct ip_vs_service_entry_nl {
   struct ip_vs_stats64 stats64;
 };
 
+struct ip_vs_dest_entry_nl {
+  __be32 __addr_v4; /* destination address - internal use only */
+  __be16 port;
+  unsigned conn_flags; /* connection flags */
+  int weight;          /* destination weight */
+
+  u_int32_t u_threshold; /* upper threshold */
+  u_int32_t l_threshold; /* lower threshold */
+
+  u_int32_t activeconns;  /* active connections */
+  u_int32_t inactconns;   /* inactive connections */
+  u_int32_t persistconns; /* persistent connections */
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+  u_int16_t af;
+  union nf_inet_addr addr;
+
+  /* statistics, 64-bit */
+  struct ip_vs_stats64 stats64;
+};
+
+struct ip_vs_get_dests_nl {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 __addr_v4; /* virtual address - internal use only */
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* number of real servers */
+  unsigned int num_dests;
+  u_int16_t af;
+  union nf_inet_addr addr;
+
+  /* the real servers */
+  struct ip_vs_dest_entry_nl entrytable[0];
+};
 
 /* The argument to IP_VS_SO_GET_SERVICES */
 struct ip_vs_get_services_nl {
@@ -86,7 +123,7 @@ struct ip_vs_get_services_nl {
 
 extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
 extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
-//extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
+extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
 extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
 extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
 //extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
@@ -135,4 +172,18 @@ struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
         [IPVS_STATS_ATTR_OUTPPS] = {.type = NLA_U32},
         [IPVS_STATS_ATTR_INBPS] = {.type = NLA_U32},
         [IPVS_STATS_ATTR_OUTBPS] = {.type = NLA_U32},
+};
+
+struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
+        [IPVS_DEST_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                 .maxlen = sizeof(struct in6_addr)},
+        [IPVS_DEST_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_DEST_ATTR_FWD_METHOD] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_WEIGHT] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_U_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_L_THRESH] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_ACTIVE_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_INACT_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_PERSIST_CONNS] = {.type = NLA_U32},
+        [IPVS_DEST_ATTR_STATS] = {.type = NLA_NESTED},
 };

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -55,9 +55,9 @@ struct ip_vs_service_entry_nl {
 struct ip_vs_dest_entry_nl {
   __be16 port;
 
-  u_int32_t activeconns;  /* active connections */
+ // u_int32_t activeconns;  /* active connections */
   u_int32_t inactconns;   /* inactive connections */
-  u_int32_t persistconns; /* persistent connections */
+ // u_int32_t persistconns; /* persistent connections */
 
   /* statistics */
   struct ip_vs_stats_user stats;

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -1,0 +1,121 @@
+#include <linux/types.h> 
+#include <libnl3/netlink/genl/genl.h>
+
+
+#include <arpa/inet.h>
+#include <linux/types.h> /* For __beXX types in userland */
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
+
+
+
+
+union nf_inet_addr {
+  __u32 all[4];
+  __be32 ip;
+  __be32 ip6[4];
+  struct in_addr in;
+  struct in6_addr in6;
+};
+
+
+
+/*
+ *  *  *   IPVS statistics object (for user space), 64-bit
+ *   *   */
+struct ip_vs_stats64 {
+  __u64 conns;    /* connections scheduled */
+  __u64 inpkts;   /* incoming packets */
+  __u64 outpkts;  /* outgoing packets */
+  __u64 inbytes;  /* incoming bytes */
+  __u64 outbytes; /* outgoing bytes */
+
+  __u64 cps;    /* current connection rate */
+  __u64 inpps;  /* current in packet rate */
+  __u64 outpps; /* current out packet rate */
+  __u64 inbps;  /* current in byte rate */
+  __u64 outbps; /* current out byte rate */
+};
+
+
+/*
+ * Strcut used for ipv6 addreses
+ */
+struct ip_vs_service_entry_nl {
+  /* which service: user fills in these */
+  u_int16_t protocol;
+  __be32 __addr_v4; /* virtual address - internal use only*/
+  __be16 port;
+  u_int32_t fwmark; /* firwall mark of service */
+
+  /* service options */
+  char sched_name[IP_VS_SCHEDNAME_MAXLEN];
+  unsigned flags;   /* virtual service flags */
+  unsigned timeout; /* persistent timeout */
+  __be32 netmask;   /* persistent netmask */
+
+  /* number of real servers */
+  unsigned int num_dests;
+
+  /* statistics */
+  struct ip_vs_stats_user stats;
+
+  u_int16_t af;
+  union nf_inet_addr addr;
+  char pe_name[IP_VS_PENAME_MAXLEN];
+
+  /* statistics, 64-bit */
+  struct ip_vs_stats64 stats64;
+};
+
+
+/* The argument to IP_VS_SO_GET_SERVICES */
+struct ip_vs_get_services_nl {
+  /* number of virtual services */
+  unsigned int num_services;
+
+  /* service table */
+  struct ip_vs_service_entry entrytable[0];
+};
+
+extern struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1];
+extern struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1];
+//extern struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1];
+//extern struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1];
+extern struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1];
+//extern struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1];
+
+/* Policy definitions */
+struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
+        [IPVS_CMD_ATTR_SERVICE] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DEST] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_DAEMON] = {.type = NLA_NESTED},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_TCP_FIN] = {.type = NLA_U32},
+        [IPVS_CMD_ATTR_TIMEOUT_UDP] = {.type = NLA_U32},
+};
+
+
+struct nla_policy ipvs_info_policy[IPVS_INFO_ATTR_MAX + 1] = {
+        [IPVS_INFO_ATTR_VERSION] = {.type = NLA_U32},
+        [IPVS_INFO_ATTR_CONN_TAB_SIZE] = {.type = NLA_U32},
+};
+
+struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
+        [IPVS_SVC_ATTR_AF] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_PROTOCOL] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_ADDR] = {.type = NLA_UNSPEC,
+                                .maxlen = sizeof(struct in6_addr)},
+        [IPVS_SVC_ATTR_PORT] = {.type = NLA_U16},
+        [IPVS_SVC_ATTR_FWMARK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_SCHED_NAME] = {.type = NLA_STRING,
+                                      .maxlen = IP_VS_SCHEDNAME_MAXLEN},
+        [IPVS_SVC_ATTR_FLAGS] = {.type = NLA_UNSPEC,
+                                 .minlen = sizeof(struct ip_vs_flags),
+                                 .maxlen = sizeof(struct ip_vs_flags)},
+        [IPVS_SVC_ATTR_TIMEOUT] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_NETMASK] = {.type = NLA_U32},
+        [IPVS_SVC_ATTR_STATS] = {.type = NLA_NESTED},
+};

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -67,10 +67,10 @@ struct ip_vs_dest_entry_nl {
 //not used  __be32 __addr_v4; /* destination address - internal use only */
   __be16 port;
   //unsigned conn_flags; /* connection flags */
-  int weight;          /* destination weight */
+ // int weight;          /* destination weight */
 
-  u_int32_t u_threshold; /* upper threshold */
-  u_int32_t l_threshold; /* lower threshold */
+  //u_int32_t u_threshold; /* upper threshold */
+ // u_int32_t l_threshold; /* lower threshold */
 
   u_int32_t activeconns;  /* active connections */
   u_int32_t inactconns;   /* inactive connections */

--- a/src/ipvs.h
+++ b/src/ipvs.h
@@ -6,8 +6,6 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
-#define IPVS_INFO_ATTR_MAX (__IPVS_INFO_ATTR_MAX - 1)
-
 union nf_inet_addr {
   __u32 all[4];
   __be32 ip;
@@ -55,9 +53,8 @@ struct ip_vs_service_entry_nl {
 struct ip_vs_dest_entry_nl {
   __be16 port;
 
- // u_int32_t activeconns;  /* active connections */
-  u_int32_t inactconns;   /* inactive connections */
- // u_int32_t persistconns; /* persistent connections */
+  /* active connections */
+  u_int32_t activeconns;
 
   /* statistics */
   struct ip_vs_stats_user stats;


### PR DESCRIPTION
Adding IPV6 support to the ipvs plugin. The IPV6 stats are only available by querying ipvs through Netlink. It was decided to set a minimum requirement of libnl3 as the distos collectd is aimed at all support this. 