### PR TITLE
Add Redis mem_fragmentation_ratio metric

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -441,6 +441,8 @@ static int redis_read(void) /* {{{ */
                       DS_TYPE_GAUGE);
     redis_handle_info(rn->name, rr->str, "memory_lua", NULL, "used_memory_lua",
                       DS_TYPE_GAUGE);
+    redis_handle_info(rn->name, rr->str, "memory_fragmentation_ratio", NULL,
+                      "mem_fragmentation_ratio", DS_TYPE_GAUGE);
     /* changes_since_last_save: Deprecated in redis version 2.6 and above */
     redis_handle_info(rn->name, rr->str, "volatile_changes", NULL,
                       "changes_since_last_save", DS_TYPE_GAUGE);

--- a/src/types.db
+++ b/src/types.db
@@ -1,280 +1,281 @@
-absolute                value:ABSOLUTE:0:U
-apache_bytes            value:DERIVE:0:U
-apache_connections      value:GAUGE:0:65535
-apache_idle_workers     value:GAUGE:0:65535
-apache_requests         value:DERIVE:0:U
-apache_scoreboard       value:GAUGE:0:65535
-ath_nodes               value:GAUGE:0:65535
-ath_stat                value:DERIVE:0:U
-backends                value:GAUGE:0:65535
-bitrate                 value:GAUGE:0:4294967295
-blocked_clients         value:GAUGE:0:U
-bucket                  value:GAUGE:0:U
-bytes                   value:GAUGE:0:U
-cache_eviction          value:DERIVE:0:U
-cache_operation         value:DERIVE:0:U
-cache_ratio             value:GAUGE:0:100
-cache_result            value:DERIVE:0:U
-cache_size              value:GAUGE:0:1125899906842623
-capacity                value:GAUGE:0:U
-ceph_bytes              value:GAUGE:U:U
-ceph_latency            value:GAUGE:U:U
-ceph_rate               value:DERIVE:0:U
-changes_since_last_save value:GAUGE:0:U
-charge                  value:GAUGE:0:U
-clock_last_meas         value:GAUGE:0:U
-clock_last_update       value:GAUGE:U:U
-clock_mode              value:GAUGE:0:U
-clock_reachability      value:GAUGE:0:U
-clock_skew_ppm          value:GAUGE:0:1000000
-clock_state             value:GAUGE:0:U
-clock_stratum           value:GAUGE:0:U
-compression             uncompressed:DERIVE:0:U, compressed:DERIVE:0:U
-compression_ratio       value:GAUGE:0:2
-connections             value:DERIVE:0:U
-conntrack               value:GAUGE:0:4294967295
-contextswitch           value:DERIVE:0:U
-count                   value:GAUGE:0:U
-counter                 value:COUNTER:U:U
-cpu                     value:DERIVE:0:U
-cpu_affinity            value:GAUGE:0:1
-cpufreq                 value:GAUGE:0:U
-current                 value:GAUGE:U:U
-current_connections     value:GAUGE:0:U
-current_sessions        value:GAUGE:0:U
-delay                   value:GAUGE:-1000000:1000000
-derive                  value:DERIVE:0:U
-df                      used:GAUGE:0:1125899906842623, free:GAUGE:0:1125899906842623
-df_complex              value:GAUGE:0:U
-df_inodes               value:GAUGE:0:U
-dilution_of_precision   value:GAUGE:0:U
-disk_error              value:GAUGE:0:U
-disk_io_time            io_time:DERIVE:0:U, weighted_io_time:DERIVE:0:U
-disk_latency            read:GAUGE:0:U, write:GAUGE:0:U
-disk_merged             read:DERIVE:0:U, write:DERIVE:0:U
-disk_octets             read:DERIVE:0:U, write:DERIVE:0:U
-disk_ops                read:DERIVE:0:U, write:DERIVE:0:U
-disk_ops_complex        value:DERIVE:0:U
-disk_time               read:DERIVE:0:U, write:DERIVE:0:U
-dns_answer              value:DERIVE:0:U
-dns_notify              value:DERIVE:0:U
-dns_octets              queries:DERIVE:0:U, responses:DERIVE:0:U
-dns_opcode              value:DERIVE:0:U
-dns_qtype               value:DERIVE:0:U
-dns_qtype_cached        value:GAUGE:0:4294967295
-dns_query               value:DERIVE:0:U
-dns_question            value:DERIVE:0:U
-dns_rcode               value:DERIVE:0:U
-dns_reject              value:DERIVE:0:U
-dns_request             value:DERIVE:0:U
-dns_resolver            value:DERIVE:0:U
-dns_response            value:DERIVE:0:U
-dns_transfer            value:DERIVE:0:U
-dns_update              value:DERIVE:0:U
-dns_zops                value:DERIVE:0:U
-domain_state            state:GAUGE:0:U, reason:GAUGE:0:U
-drbd_resource           value:DERIVE:0:U
-duration                seconds:GAUGE:0:U
-email_check             value:GAUGE:0:U
-email_count             value:GAUGE:0:U
-email_size              value:GAUGE:0:U
-energy                  value:GAUGE:U:U
-energy_wh               value:GAUGE:U:U
-entropy                 value:GAUGE:0:4294967295
-errors                  value:DERIVE:0:U
-evicted_keys            value:DERIVE:0:U
-expired_keys            value:DERIVE:0:U
-fanspeed                value:GAUGE:0:U
-file_handles            value:GAUGE:0:U
-file_size               value:GAUGE:0:U
-files                   value:GAUGE:0:U
-filter_result           value:DERIVE:0:U
-flow                    value:GAUGE:0:U
-fork_rate               value:DERIVE:0:U
-frequency               value:GAUGE:0:U
-frequency_error         value:GAUGE:-1000000:1000000
-frequency_offset        value:GAUGE:-1000000:1000000
-fscache_stat            value:DERIVE:0:U
-gauge                   value:GAUGE:U:U
-hash_collisions         value:DERIVE:0:U
-http_request_methods    value:DERIVE:0:U
-http_requests           value:DERIVE:0:U
-http_response_codes     value:DERIVE:0:U
-humidity                value:GAUGE:0:100
-if_collisions           value:DERIVE:0:U
-if_dropped              rx:DERIVE:0:U, tx:DERIVE:0:U
-if_errors               rx:DERIVE:0:U, tx:DERIVE:0:U
-if_multicast            value:DERIVE:0:U
-if_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
-if_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
-if_rx_dropped           value:DERIVE:0:U
-if_rx_errors            value:DERIVE:0:U
-if_rx_octets            value:DERIVE:0:U
-if_rx_packets           value:DERIVE:0:U
-if_tx_dropped           value:DERIVE:0:U
-if_tx_errors            value:DERIVE:0:U
-if_tx_octets            value:DERIVE:0:U
-if_tx_packets           value:DERIVE:0:U
-invocations             value:DERIVE:0:U
-io_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
-io_ops                  read:DERIVE:0:U, write:DERIVE:0:U
-io_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
-ipc                     value:GAUGE:0:U
-ipt_bytes               value:DERIVE:0:U
-ipt_packets             value:DERIVE:0:U
-irq                     value:DERIVE:0:U
-job_stats               value:DERIVE:0:U
-latency                 value:GAUGE:0:U
-links                   value:GAUGE:0:U
-load                    shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
-memory_bandwidth        value:DERIVE:0:U
-md_disks                value:GAUGE:0:U
-memcached_command       value:DERIVE:0:U
-memcached_connections   value:GAUGE:0:U
-memcached_items         value:GAUGE:0:U
-memcached_octets        rx:DERIVE:0:U, tx:DERIVE:0:U
-memcached_ops           value:DERIVE:0:U
-memory                  value:GAUGE:0:281474976710656
-memory_lua              value:GAUGE:0:281474976710656
-memory_throttle_count   value:DERIVE:0:U
-multimeter              value:GAUGE:U:U
-mutex_operations        value:DERIVE:0:U
-mysql_bpool_bytes       value:GAUGE:0:U
-mysql_bpool_counters    value:DERIVE:0:U
-mysql_bpool_pages       value:GAUGE:0:U
-mysql_commands          value:DERIVE:0:U
-mysql_handler           value:DERIVE:0:U
-mysql_innodb_data       value:DERIVE:0:U
-mysql_innodb_dblwr      value:DERIVE:0:U
-mysql_innodb_log        value:DERIVE:0:U
-mysql_innodb_pages      value:DERIVE:0:U
-mysql_innodb_row_lock   value:DERIVE:0:U
-mysql_innodb_rows       value:DERIVE:0:U
-mysql_locks             value:DERIVE:0:U
-mysql_log_position      value:DERIVE:0:U
-mysql_octets            rx:DERIVE:0:U, tx:DERIVE:0:U
-mysql_select            value:DERIVE:0:U
-mysql_sort              value:DERIVE:0:U
-mysql_sort_merge_passes value:DERIVE:0:U
-mysql_sort_rows         value:DERIVE:0:U
-mysql_slow_queries      value:DERIVE:0:U
-nfs_procedure           value:DERIVE:0:U
-nginx_connections       value:GAUGE:0:U
-nginx_requests          value:DERIVE:0:U
-node_octets             rx:DERIVE:0:U, tx:DERIVE:0:U
-node_rssi               value:GAUGE:0:255
-node_stat               value:DERIVE:0:U
-node_tx_rate            value:GAUGE:0:127
-objects                 value:GAUGE:0:U
-operations              value:DERIVE:0:U
-operations_per_second   value:GAUGE:0:U
-packets                 value:DERIVE:0:U
-pending_operations      value:GAUGE:0:U
-percent                 value:GAUGE:0:100.1
-percent_bytes           value:GAUGE:0:100.1
-percent_inodes          value:GAUGE:0:100.1
-perf                    value:DERIVE:0:U
-pf_counters             value:DERIVE:0:U
-pf_limits               value:DERIVE:0:U
-pf_source               value:DERIVE:0:U
-pf_state                value:DERIVE:0:U
-pf_states               value:GAUGE:0:U
-pg_blks                 value:DERIVE:0:U
-pg_db_size              value:GAUGE:0:U
-pg_n_tup_c              value:DERIVE:0:U
-pg_n_tup_g              value:GAUGE:0:U
-pg_numbackends          value:GAUGE:0:U
-pg_scan                 value:DERIVE:0:U
-pg_xact                 value:DERIVE:0:U
-ping                    value:GAUGE:0:65535
-ping_droprate           value:GAUGE:0:100
-ping_stddev             value:GAUGE:0:65535
-players                 value:GAUGE:0:1000000
-power                   value:GAUGE:U:U
-pressure                value:GAUGE:0:U
-protocol_counter        value:DERIVE:0:U
-ps_code                 value:GAUGE:0:9223372036854775807
-ps_count                processes:GAUGE:0:1000000, threads:GAUGE:0:1000000
-ps_cputime              user:DERIVE:0:U, syst:DERIVE:0:U
-ps_data                 value:GAUGE:0:9223372036854775807
-ps_disk_octets          read:DERIVE:0:U, write:DERIVE:0:U
-ps_disk_ops             read:DERIVE:0:U, write:DERIVE:0:U
-ps_pagefaults           minflt:DERIVE:0:U, majflt:DERIVE:0:U
-ps_rss                  value:GAUGE:0:9223372036854775807
-ps_stacksize            value:GAUGE:0:9223372036854775807
-ps_state                value:GAUGE:0:65535
-ps_vm                   value:GAUGE:0:9223372036854775807
-pubsub                  value:GAUGE:0:U
-queue_length            value:GAUGE:0:U
-records                 value:GAUGE:0:U
-requests                value:GAUGE:0:U
-response_code           value:GAUGE:0:U
-response_time           value:GAUGE:0:U
-root_delay              value:GAUGE:U:U
-root_dispersion         value:GAUGE:U:U
-route_etx               value:GAUGE:0:U
-route_metric            value:GAUGE:0:U
-routes                  value:GAUGE:0:U
-satellites              value:GAUGE:0:U
-segments                value:GAUGE:0:65535
-serial_octets           rx:DERIVE:0:U, tx:DERIVE:0:U
-signal_noise            value:GAUGE:U:0
-signal_power            value:GAUGE:U:0
-signal_quality          value:GAUGE:0:U
-smart_attribute         current:GAUGE:0:255, worst:GAUGE:0:255, threshold:GAUGE:0:255, pretty:GAUGE:0:U
-smart_badsectors        value:GAUGE:0:U
-smart_powercycles       value:GAUGE:0:U
-smart_poweron           value:GAUGE:0:U
-smart_temperature       value:GAUGE:-300:300
-snr                     value:GAUGE:0:U
-spam_check              value:GAUGE:0:U
-spam_score              value:GAUGE:U:U
-spl                     value:GAUGE:U:U
-swap                    value:GAUGE:0:1099511627776
-swap_io                 value:DERIVE:0:U
-tcp_connections         value:GAUGE:0:4294967295
-temperature             value:GAUGE:U:U
-threads                 value:GAUGE:0:U
-time_dispersion         value:GAUGE:-1000000:1000000
-time_offset             value:GAUGE:-1000000:1000000
-time_offset_ntp         value:GAUGE:-1000000:1000000
-time_offset_rms         value:GAUGE:-1000000:1000000
-time_ref                value:GAUGE:0:U
-timeleft                value:GAUGE:0:U
-total_bytes             value:DERIVE:0:U
-total_connections       value:DERIVE:0:U
-total_objects           value:DERIVE:0:U
-total_operations        value:DERIVE:0:U
-total_requests          value:DERIVE:0:U
-total_sessions          value:DERIVE:0:U
-total_threads           value:DERIVE:0:U
-total_time_in_ms        value:DERIVE:0:U
-total_values            value:DERIVE:0:U
-uptime                  value:GAUGE:0:4294967295
-users                   value:GAUGE:0:65535
-vcl                     value:GAUGE:0:65535
-vcpu                    value:GAUGE:0:U
-virt_cpu_total          value:DERIVE:0:U
-virt_vcpu               value:DERIVE:0:U
-vmpage_action           value:DERIVE:0:U
-vmpage_faults           minflt:DERIVE:0:U, majflt:DERIVE:0:U
-vmpage_io               in:DERIVE:0:U, out:DERIVE:0:U
-vmpage_number           value:GAUGE:0:4294967295
-volatile_changes        value:GAUGE:0:U
-voltage                 value:GAUGE:U:U
-voltage_threshold       value:GAUGE:U:U, threshold:GAUGE:U:U
-vs_memory               value:GAUGE:0:9223372036854775807
-vs_processes            value:GAUGE:0:65535
-vs_threads              value:GAUGE:0:65535
+absolute                   value:ABSOLUTE:0:U
+apache_bytes               value:DERIVE:0:U
+apache_connections         value:GAUGE:0:65535
+apache_idle_workers        value:GAUGE:0:65535
+apache_requests            value:DERIVE:0:U
+apache_scoreboard          value:GAUGE:0:65535
+ath_nodes                  value:GAUGE:0:65535
+ath_stat                   value:DERIVE:0:U
+backends                   value:GAUGE:0:65535
+bitrate                    value:GAUGE:0:4294967295
+blocked_clients            value:GAUGE:0:U
+bucket                     value:GAUGE:0:U
+bytes                      value:GAUGE:0:U
+cache_eviction             value:DERIVE:0:U
+cache_operation            value:DERIVE:0:U
+cache_ratio                value:GAUGE:0:100
+cache_result               value:DERIVE:0:U
+cache_size                 value:GAUGE:0:1125899906842623
+capacity                   value:GAUGE:0:U
+ceph_bytes                 value:GAUGE:U:U
+ceph_latency               value:GAUGE:U:U
+ceph_rate                  value:DERIVE:0:U
+changes_since_last_save    value:GAUGE:0:U
+charge                     value:GAUGE:0:U
+clock_last_meas            value:GAUGE:0:U
+clock_last_update          value:GAUGE:U:U
+clock_mode                 value:GAUGE:0:U
+clock_reachability         value:GAUGE:0:U
+clock_skew_ppm             value:GAUGE:0:1000000
+clock_state                value:GAUGE:0:U
+clock_stratum              value:GAUGE:0:U
+compression                uncompressed:DERIVE:0:U, compressed:DERIVE:0:U
+compression_ratio          value:GAUGE:0:2
+connections                value:DERIVE:0:U
+conntrack                  value:GAUGE:0:4294967295
+contextswitch              value:DERIVE:0:U
+count                      value:GAUGE:0:U
+counter                    value:COUNTER:U:U
+cpu                        value:DERIVE:0:U
+cpu_affinity               value:GAUGE:0:1
+cpufreq                    value:GAUGE:0:U
+current                    value:GAUGE:U:U
+current_connections        value:GAUGE:0:U
+current_sessions           value:GAUGE:0:U
+delay                      value:GAUGE:-1000000:1000000
+derive                     value:DERIVE:0:U
+df                         used:GAUGE:0:1125899906842623, free:GAUGE:0:1125899906842623
+df_complex                 value:GAUGE:0:U
+df_inodes                  value:GAUGE:0:U
+dilution_of_precision      value:GAUGE:0:U
+disk_error                 value:GAUGE:0:U
+disk_io_time               io_time:DERIVE:0:U, weighted_io_time:DERIVE:0:U
+disk_latency               read:GAUGE:0:U, write:GAUGE:0:U
+disk_merged                read:DERIVE:0:U, write:DERIVE:0:U
+disk_octets                read:DERIVE:0:U, write:DERIVE:0:U
+disk_ops                   read:DERIVE:0:U, write:DERIVE:0:U
+disk_ops_complex           value:DERIVE:0:U
+disk_time                  read:DERIVE:0:U, write:DERIVE:0:U
+dns_answer                 value:DERIVE:0:U
+dns_notify                 value:DERIVE:0:U
+dns_octets                 queries:DERIVE:0:U, responses:DERIVE:0:U
+dns_opcode                 value:DERIVE:0:U
+dns_qtype                  value:DERIVE:0:U
+dns_qtype_cached           value:GAUGE:0:4294967295
+dns_query                  value:DERIVE:0:U
+dns_question               value:DERIVE:0:U
+dns_rcode                  value:DERIVE:0:U
+dns_reject                 value:DERIVE:0:U
+dns_request                value:DERIVE:0:U
+dns_resolver               value:DERIVE:0:U
+dns_response               value:DERIVE:0:U
+dns_transfer               value:DERIVE:0:U
+dns_update                 value:DERIVE:0:U
+dns_zops                   value:DERIVE:0:U
+domain_state               state:GAUGE:0:U, reason:GAUGE:0:U
+drbd_resource              value:DERIVE:0:U
+duration                   seconds:GAUGE:0:U
+email_check                value:GAUGE:0:U
+email_count                value:GAUGE:0:U
+email_size                 value:GAUGE:0:U
+energy                     value:GAUGE:U:U
+energy_wh                  value:GAUGE:U:U
+entropy                    value:GAUGE:0:4294967295
+errors                     value:DERIVE:0:U
+evicted_keys               value:DERIVE:0:U
+expired_keys               value:DERIVE:0:U
+fanspeed                   value:GAUGE:0:U
+file_handles               value:GAUGE:0:U
+file_size                  value:GAUGE:0:U
+files                      value:GAUGE:0:U
+filter_result              value:DERIVE:0:U
+flow                       value:GAUGE:0:U
+fork_rate                  value:DERIVE:0:U
+frequency                  value:GAUGE:0:U
+frequency_error            value:GAUGE:-1000000:1000000
+frequency_offset           value:GAUGE:-1000000:1000000
+fscache_stat               value:DERIVE:0:U
+gauge                      value:GAUGE:U:U
+hash_collisions            value:DERIVE:0:U
+http_request_methods       value:DERIVE:0:U
+http_requests              value:DERIVE:0:U
+http_response_codes        value:DERIVE:0:U
+humidity                   value:GAUGE:0:100
+if_collisions              value:DERIVE:0:U
+if_dropped                 rx:DERIVE:0:U, tx:DERIVE:0:U
+if_errors                  rx:DERIVE:0:U, tx:DERIVE:0:U
+if_multicast               value:DERIVE:0:U
+if_octets                  rx:DERIVE:0:U, tx:DERIVE:0:U
+if_packets                 rx:DERIVE:0:U, tx:DERIVE:0:U
+if_rx_dropped              value:DERIVE:0:U
+if_rx_errors               value:DERIVE:0:U
+if_rx_octets               value:DERIVE:0:U
+if_rx_packets              value:DERIVE:0:U
+if_tx_dropped              value:DERIVE:0:U
+if_tx_errors               value:DERIVE:0:U
+if_tx_octets               value:DERIVE:0:U
+if_tx_packets              value:DERIVE:0:U
+invocations                value:DERIVE:0:U
+io_octets                  rx:DERIVE:0:U, tx:DERIVE:0:U
+io_ops                     read:DERIVE:0:U, write:DERIVE:0:U
+io_packets                 rx:DERIVE:0:U, tx:DERIVE:0:U
+ipc                        value:GAUGE:0:U
+ipt_bytes                  value:DERIVE:0:U
+ipt_packets                value:DERIVE:0:U
+irq                        value:DERIVE:0:U
+job_stats                  value:DERIVE:0:U
+latency                    value:GAUGE:0:U
+links                      value:GAUGE:0:U
+load                       shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
+memory_bandwidth           value:DERIVE:0:U
+md_disks                   value:GAUGE:0:U
+memcached_command          value:DERIVE:0:U
+memcached_connections      value:GAUGE:0:U
+memcached_items            value:GAUGE:0:U
+memcached_octets           rx:DERIVE:0:U, tx:DERIVE:0:U
+memcached_ops              value:DERIVE:0:U
+memory                     value:GAUGE:0:281474976710656
+memory_fragmentation_ratio value:GAUGE:0:U
+memory_lua                 value:GAUGE:0:281474976710656
+memory_throttle_count      value:DERIVE:0:U
+multimeter                 value:GAUGE:U:U
+mutex_operations           value:DERIVE:0:U
+mysql_bpool_bytes          value:GAUGE:0:U
+mysql_bpool_counters       value:DERIVE:0:U
+mysql_bpool_pages          value:GAUGE:0:U
+mysql_commands             value:DERIVE:0:U
+mysql_handler              value:DERIVE:0:U
+mysql_innodb_data          value:DERIVE:0:U
+mysql_innodb_dblwr         value:DERIVE:0:U
+mysql_innodb_log           value:DERIVE:0:U
+mysql_innodb_pages         value:DERIVE:0:U
+mysql_innodb_row_lock      value:DERIVE:0:U
+mysql_innodb_rows          value:DERIVE:0:U
+mysql_locks                value:DERIVE:0:U
+mysql_log_position         value:DERIVE:0:U
+mysql_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
+mysql_select               value:DERIVE:0:U
+mysql_sort                 value:DERIVE:0:U
+mysql_sort_merge_passes    value:DERIVE:0:U
+mysql_sort_rows            value:DERIVE:0:U
+mysql_slow_queries         value:DERIVE:0:U
+nfs_procedure              value:DERIVE:0:U
+nginx_connections          value:GAUGE:0:U
+nginx_requests             value:DERIVE:0:U
+node_octets                rx:DERIVE:0:U, tx:DERIVE:0:U
+node_rssi                  value:GAUGE:0:255
+node_stat                  value:DERIVE:0:U
+node_tx_rate               value:GAUGE:0:127
+objects                    value:GAUGE:0:U
+operations                 value:DERIVE:0:U
+operations_per_second      value:GAUGE:0:U
+packets                    value:DERIVE:0:U
+pending_operations         value:GAUGE:0:U
+percent                    value:GAUGE:0:100.1
+percent_bytes              value:GAUGE:0:100.1
+percent_inodes             value:GAUGE:0:100.1
+perf                       value:DERIVE:0:U
+pf_counters                value:DERIVE:0:U
+pf_limits                  value:DERIVE:0:U
+pf_source                  value:DERIVE:0:U
+pf_state                   value:DERIVE:0:U
+pf_states                  value:GAUGE:0:U
+pg_blks                    value:DERIVE:0:U
+pg_db_size                 value:GAUGE:0:U
+pg_n_tup_c                 value:DERIVE:0:U
+pg_n_tup_g                 value:GAUGE:0:U
+pg_numbackends             value:GAUGE:0:U
+pg_scan                    value:DERIVE:0:U
+pg_xact                    value:DERIVE:0:U
+ping                       value:GAUGE:0:65535
+ping_droprate              value:GAUGE:0:100
+ping_stddev                value:GAUGE:0:65535
+players                    value:GAUGE:0:1000000
+power                      value:GAUGE:U:U
+pressure                   value:GAUGE:0:U
+protocol_counter           value:DERIVE:0:U
+ps_code                    value:GAUGE:0:9223372036854775807
+ps_count                   processes:GAUGE:0:1000000, threads:GAUGE:0:1000000
+ps_cputime                 user:DERIVE:0:U, syst:DERIVE:0:U
+ps_data                    value:GAUGE:0:9223372036854775807
+ps_disk_octets             read:DERIVE:0:U, write:DERIVE:0:U
+ps_disk_ops                read:DERIVE:0:U, write:DERIVE:0:U
+ps_pagefaults              minflt:DERIVE:0:U, majflt:DERIVE:0:U
+ps_rss                     value:GAUGE:0:9223372036854775807
+ps_stacksize               value:GAUGE:0:9223372036854775807
+ps_state                   value:GAUGE:0:65535
+ps_vm                      value:GAUGE:0:9223372036854775807
+pubsub                     value:GAUGE:0:U
+queue_length               value:GAUGE:0:U
+records                    value:GAUGE:0:U
+requests                   value:GAUGE:0:U
+response_code              value:GAUGE:0:U
+response_time              value:GAUGE:0:U
+root_delay                 value:GAUGE:U:U
+root_dispersion            value:GAUGE:U:U
+route_etx                  value:GAUGE:0:U
+route_metric               value:GAUGE:0:U
+routes                     value:GAUGE:0:U
+satellites                 value:GAUGE:0:U
+segments                   value:GAUGE:0:65535
+serial_octets              rx:DERIVE:0:U, tx:DERIVE:0:U
+signal_noise               value:GAUGE:U:0
+signal_power               value:GAUGE:U:0
+signal_quality             value:GAUGE:0:U
+smart_attribute            current:GAUGE:0:255, worst:GAUGE:0:255, threshold:GAUGE:0:255, pretty:GAUGE:0:U
+smart_badsectors           value:GAUGE:0:U
+smart_powercycles          value:GAUGE:0:U
+smart_poweron              value:GAUGE:0:U
+smart_temperature          value:GAUGE:-300:300
+snr                        value:GAUGE:0:U
+spam_check                 value:GAUGE:0:U
+spam_score                 value:GAUGE:U:U
+spl                        value:GAUGE:U:U
+swap                       value:GAUGE:0:1099511627776
+swap_io                    value:DERIVE:0:U
+tcp_connections            value:GAUGE:0:4294967295
+temperature                value:GAUGE:U:U
+threads                    value:GAUGE:0:U
+time_dispersion            value:GAUGE:-1000000:1000000
+time_offset                value:GAUGE:-1000000:1000000
+time_offset_ntp            value:GAUGE:-1000000:1000000
+time_offset_rms            value:GAUGE:-1000000:1000000
+time_ref                   value:GAUGE:0:U
+timeleft                   value:GAUGE:0:U
+total_bytes                value:DERIVE:0:U
+total_connections          value:DERIVE:0:U
+total_objects              value:DERIVE:0:U
+total_operations           value:DERIVE:0:U
+total_requests             value:DERIVE:0:U
+total_sessions             value:DERIVE:0:U
+total_threads              value:DERIVE:0:U
+total_time_in_ms           value:DERIVE:0:U
+total_values               value:DERIVE:0:U
+uptime                     value:GAUGE:0:4294967295
+users                      value:GAUGE:0:65535
+vcl                        value:GAUGE:0:65535
+vcpu                       value:GAUGE:0:U
+virt_cpu_total             value:DERIVE:0:U
+virt_vcpu                  value:DERIVE:0:U
+vmpage_action              value:DERIVE:0:U
+vmpage_faults              minflt:DERIVE:0:U, majflt:DERIVE:0:U
+vmpage_io                  in:DERIVE:0:U, out:DERIVE:0:U
+vmpage_number              value:GAUGE:0:4294967295
+volatile_changes           value:GAUGE:0:U
+voltage                    value:GAUGE:U:U
+voltage_threshold          value:GAUGE:U:U, threshold:GAUGE:U:U
+vs_memory                  value:GAUGE:0:9223372036854775807
+vs_processes               value:GAUGE:0:65535
+vs_threads                 value:GAUGE:0:65535
 
 #
 # Legacy types
 # (required for the v5 upgrade target)
 #
-arc_counts              demand_data:COUNTER:0:U, demand_metadata:COUNTER:0:U, prefetch_data:COUNTER:0:U, prefetch_metadata:COUNTER:0:U
-arc_l2_bytes            read:COUNTER:0:U, write:COUNTER:0:U
-arc_l2_size             value:GAUGE:0:U
-arc_ratio               value:GAUGE:0:U
-arc_size                current:GAUGE:0:U, target:GAUGE:0:U, minlimit:GAUGE:0:U, maxlimit:GAUGE:0:U
-mysql_qcache            hits:COUNTER:0:U, inserts:COUNTER:0:U, not_cached:COUNTER:0:U, lowmem_prunes:COUNTER:0:U, queries_in_cache:GAUGE:0:U
-mysql_threads           running:GAUGE:0:U, connected:GAUGE:0:U, cached:GAUGE:0:U, created:COUNTER:0:U
+arc_counts                 demand_data:COUNTER:0:U, demand_metadata:COUNTER:0:U, prefetch_data:COUNTER:0:U, prefetch_metadata:COUNTER:0:U
+arc_l2_bytes               read:COUNTER:0:U, write:COUNTER:0:U
+arc_l2_size                value:GAUGE:0:U
+arc_ratio                  value:GAUGE:0:U
+arc_size                   current:GAUGE:0:U, target:GAUGE:0:U, minlimit:GAUGE:0:U, maxlimit:GAUGE:0:U
+mysql_qcache               hits:COUNTER:0:U, inserts:COUNTER:0:U, not_cached:COUNTER:0:U, lowmem_prunes:COUNTER:0:U, queries_in_cache:GAUGE:0:U
+mysql_threads              running:GAUGE:0:U, connected:GAUGE:0:U, cached:GAUGE:0:U, created:COUNTER:0:U


### PR DESCRIPTION
Hi,

This PR adds support for `mem_fragmentation_ratio` metric in the Redis plugin.

Let me know if this change suits to you.

Regards,
Vincent