### PR TITLE
cpu plugin: add linux-specific "guest" states.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -364,6 +364,9 @@
 #  ReportByCpu true
 #  ReportByState true
 #  ValuesPercentage false
+#  ReportNumCpu false
+#  ReportGuestState false
+#  SubtractGuestState true
 #</Plugin>
 #
 #<Plugin csv>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1474,6 +1474,19 @@ in the un-aggregated (per-CPU, per-state) mode as well.
 When set to B<true>, reports the number of available CPUs.
 Defaults to B<false>.
 
+=item B<ReportGuestState> B<false>|B<true>
+
+When set to B<true>, reports the "guest" and "guest_nice" CPU states.
+Defaults to B<false>.
+
+=item B<SubtractGuestState> B<false>|B<true>
+
+This option is only considered when B<ReportGuestState> is set to B<true>.
+"guest" and "guest_nice" are included in respectively "user" and "nice".
+If set to B<true>, "guest" will be subtracted from "user" and "guest_nice"
+will be subtracted from "nice".
+Defaults to B<true>.
+
 =back
 
 =head2 Plugin C<cpufreq>

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -644,7 +644,6 @@ static int cpu_read(void) {
 
   char *fields[11];
   int numfields;
-  long long user_value, nice_value, value;
 
   if ((fh = fopen("/proc/stat", "r")) == NULL) {
     char errbuf[1024];
@@ -666,8 +665,8 @@ static int cpu_read(void) {
     cpu = atoi(fields[0] + 3);
 
     /* Do not stage User and Nice immediately: we may need to alter them later: */
-    user_value = atoll(fields[1]);
-    nice_value = atoll(fields[2]);
+    long long user_value = atoll(fields[1]);
+    long long nice_value = atoll(fields[2]);
     cpu_stage(cpu, COLLECTD_CPU_STATE_SYSTEM, (derive_t)atoll(fields[3]), now);
     cpu_stage(cpu, COLLECTD_CPU_STATE_IDLE, (derive_t)atoll(fields[4]), now);
 
@@ -684,7 +683,7 @@ static int cpu_read(void) {
 
         if (numfields >= 10) { /* Guest (since Linux 2.6.24) */
           if (report_guest) {
-            value = atoll(fields[9]);
+            long long value = atoll(fields[9]);
             cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST,
                       (derive_t)value, now);
             /* Guest is included in User; optionally subtract Guest from
@@ -697,7 +696,7 @@ static int cpu_read(void) {
 
           if (numfields >= 11) { /* Guest_nice (since Linux 2.6.33) */
             if (report_guest) {
-              value = atoll(fields[10]);
+              long long value = atoll(fields[10]);
               cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST_NICE,
                         (derive_t)value, now);
               /* Guest_nice is included in Nice; optionally subtract

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -676,40 +676,37 @@ static int cpu_read(void) {
                 now);
       cpu_stage(cpu, COLLECTD_CPU_STATE_SOFTIRQ, (derive_t)atoll(fields[7]),
                 now);
+	}
 
-      if (numfields >= 9) {
-        cpu_stage(cpu, COLLECTD_CPU_STATE_STEAL, (derive_t)atoll(fields[8]),
-                  now);
+    if (numfields >= 9) { /* Steal (since Linux 2.6.11) */
+      cpu_stage(cpu, COLLECTD_CPU_STATE_STEAL, (derive_t)atoll(fields[8]), now);
+    }
 
-        if (numfields >= 10) { /* Guest (since Linux 2.6.24) */
-          if (report_guest) {
-            long long value = atoll(fields[9]);
-            cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST,
-                      (derive_t)value, now);
-            /* Guest is included in User; optionally subtract Guest from
-               User: */
-            if (subtract_guest) {
-              user_value -= value;
-              if (user_value < 0) user_value = 0;
-            }
-          }
-
-          if (numfields >= 11) { /* Guest_nice (since Linux 2.6.33) */
-            if (report_guest) {
-              long long value = atoll(fields[10]);
-              cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST_NICE,
-                        (derive_t)value, now);
-              /* Guest_nice is included in Nice; optionally subtract
-                 Guest_nice from Nice: */
-              if (subtract_guest) {
-                nice_value -= value;
-                if (nice_value < 0) nice_value = 0;
-              }
-            }
-          }
+    if (numfields >= 10) { /* Guest (since Linux 2.6.24) */
+      if (report_guest) {
+        long long value = atoll(fields[9]);
+        cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST, (derive_t)value, now);
+        /* Guest is included in User; optionally subtract Guest from User: */
+        if (subtract_guest) {
+          user_value -= value;
+          if (user_value < 0) user_value = 0;
         }
       }
     }
+
+    if (numfields >= 11) { /* Guest_nice (since Linux 2.6.33) */
+      if (report_guest) {
+        long long value = atoll(fields[10]);
+        cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST_NICE, (derive_t)value, now);
+        /* Guest_nice is included in Nice; optionally subtract Guest_nice from
+           Nice: */
+        if (subtract_guest) {
+          nice_value -= value;
+          if (nice_value < 0) nice_value = 0;
+        }
+      }
+    }
+
     /* Eventually stage User and Nice: */
     cpu_stage(cpu, COLLECTD_CPU_STATE_USER, (derive_t)user_value, now);
     cpu_stage(cpu, COLLECTD_CPU_STATE_NICE, (derive_t)nice_value, now);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -195,9 +195,12 @@ static _Bool report_by_cpu = 1;
 static _Bool report_by_state = 1;
 static _Bool report_percent = 0;
 static _Bool report_num_cpu = 0;
+static _Bool report_guest = 0;
+static _Bool subtract_guest = 1;
 
 static const char *config_keys[] = {"ReportByCpu", "ReportByState",
-                                    "ReportNumCpu", "ValuesPercentage"};
+                                    "ReportNumCpu", "ValuesPercentage",
+                                    "ReportGuestState", "SubtractGuestState"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static int cpu_config(char const *key, char const *value) /* {{{ */
@@ -210,6 +213,10 @@ static int cpu_config(char const *key, char const *value) /* {{{ */
     report_by_state = IS_TRUE(value) ? 1 : 0;
   else if (strcasecmp(key, "ReportNumCpu") == 0)
     report_num_cpu = IS_TRUE(value) ? 1 : 0;
+  else if (strcasecmp(key, "ReportGuestState") == 0)
+    report_guest = IS_TRUE(value) ? 1 : 0;
+  else if (strcasecmp(key, "SubtractGuestState") == 0)
+    subtract_guest = IS_TRUE(value) ? 1 : 0;
   else
     return -1;
 
@@ -637,6 +644,7 @@ static int cpu_read(void) {
 
   char *fields[11];
   int numfields;
+  long long user_value, nice_value, value;
 
   if ((fh = fopen("/proc/stat", "r")) == NULL) {
     char errbuf[1024];
@@ -657,8 +665,9 @@ static int cpu_read(void) {
 
     cpu = atoi(fields[0] + 3);
 
-    cpu_stage(cpu, COLLECTD_CPU_STATE_USER, (derive_t)atoll(fields[1]), now);
-    cpu_stage(cpu, COLLECTD_CPU_STATE_NICE, (derive_t)atoll(fields[2]), now);
+    /* Do not stage User and Nice immediately: we may need to alter them later: */
+    user_value = atoll(fields[1]);
+    nice_value = atoll(fields[2]);
     cpu_stage(cpu, COLLECTD_CPU_STATE_SYSTEM, (derive_t)atoll(fields[3]), now);
     cpu_stage(cpu, COLLECTD_CPU_STATE_IDLE, (derive_t)atoll(fields[4]), now);
 
@@ -673,17 +682,38 @@ static int cpu_read(void) {
         cpu_stage(cpu, COLLECTD_CPU_STATE_STEAL, (derive_t)atoll(fields[8]),
                   now);
 
-        if (numfields >= 10) {
-          cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST, (derive_t)atoll(fields[9]),
-                    now);
+        if (numfields >= 10) { /* Guest (since Linux 2.6.24) */
+          if (report_guest) {
+            value = atoll(fields[9]);
+            cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST,
+                      (derive_t)value, now);
+            /* Guest is included in User; optionally subtract Guest from
+               User: */
+            if (subtract_guest) {
+              user_value -= value;
+              if (user_value < 0) user_value = 0;
+            }
+          }
 
-          if (numfields >= 11) {
-            cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST_NICE,
-                      (derive_t)atoll(fields[10]), now);
+          if (numfields >= 11) { /* Guest_nice (since Linux 2.6.33) */
+            if (report_guest) {
+              value = atoll(fields[10]);
+              cpu_stage(cpu, COLLECTD_CPU_STATE_GUEST_NICE,
+                        (derive_t)value, now);
+              /* Guest_nice is included in Nice; optionally subtract
+                 Guest_nice from Nice: */
+              if (subtract_guest) {
+                nice_value -= value;
+                if (nice_value < 0) nice_value = 0;
+              }
+            }
           }
         }
       }
     }
+    /* Eventually stage User and Nice: */
+    cpu_stage(cpu, COLLECTD_CPU_STATE_USER, (derive_t)user_value, now);
+    cpu_stage(cpu, COLLECTD_CPU_STATE_NICE, (derive_t)nice_value, now);
   }
   fclose(fh);
 /* }}} #endif defined(KERNEL_LINUX) */


### PR DESCRIPTION
Hello,

The "cpu" plugin currently lacks two Linux-specific CPU states:

- guest (since Linux 2.6.24) Time spent running a virtual CPU for guest operating systems under the control of the Linux kernel.
- guest_nice (since Linux 2.6.33) Time spent running a niced guest (virtual CPU for guest operating systems under the control of the Linux kernel).

(excerpts from procfs(5))

This patch brings support for guest and guest_nice CPU states into collectd. It lacks testing on non-Linux systems though. Feedback on whatever can be improved would be greatly appreciated.