### PR TITLE
tail plugin: Allow to set type for "bucket" metrics

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1404,6 +1404,7 @@
 #        Bucket 0.5 1.0   # -> bucket-latency-foo-0.5_1
 #        Bucket 1.0 2.0   # -> bucket-latency-foo-1_2
 #        Bucket 2.0 0     # -> bucket-latency-foo-2_inf
+#        #BucketType "bucket"
 #      </DSType>
 #      Type "latency"
 #      Instance "foo"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7704,6 +7704,7 @@ user using (extended) regular expressions, as described in L<regex(7)>.
         <DSType "Distribution">
           Percentile 99
           Bucket 0 100
+          #BucketType "bucket"
         </DSType>
         Type "latency"
         Instance "foo"
@@ -7823,6 +7824,7 @@ B<Synopsis:>
   <DSType "Distribution">
     Percentile 99
     Bucket 0 100
+    BucketType "bucket"
   </DSType>
 
 =over 4
@@ -7859,10 +7861,16 @@ the following schema:
   Bucket  20  50
   Bucket  50   0
 
-Metrics are reported with the I<type> C<bucket> and the I<type instance>
+Metrics are reported with the I<type> set by B<BucketType> option (C<bucket> 
+by default) and the I<type instance>
 C<E<lt>TypeE<gt>[-E<lt>InstanceE<gt>]-E<lt>lower_boundE<gt>_E<lt>upper_boundE<gt>>.
 
 This option may be repeated to calculate more than one rate.
+
+=item B<BucketType> I<Type>
+
+Sets the type used to dispatch B<Bucket> metrics.
+Optional, by default C<bucket> will be used.
 
 =back
 

--- a/src/utils_latency_config.c
+++ b/src/utils_latency_config.c
@@ -105,6 +105,8 @@ int latency_config(latency_config_t *conf, oconfig_item_t *ci,
       status = latency_config_add_percentile(conf, child, plugin);
     else if (strcasecmp("Bucket", child->key) == 0)
       status = latency_config_add_bucket(conf, child, plugin);
+    else if (strcasecmp("BucketType", child->key) == 0)
+      status = cf_util_get_string(child, &conf->bucket_type);
     else
       WARNING("%s plugin: \"%s\" is not a valid option within a \"%s\" block.",
               plugin, child->key, ci->key);
@@ -137,6 +139,14 @@ int latency_config_copy(latency_config_t *dst, const latency_config_t src) {
     return ENOMEM;
   }
 
+  if (src.bucket_type != NULL) {
+    dst->bucket_type = strdup(src.bucket_type);
+    if (dst->bucket_type == NULL) {
+      latency_config_free(*dst);
+      return ENOMEM;
+    }
+  }
+
   memmove(dst->percentile, src.percentile,
           dst->percentile_num * sizeof(*dst->percentile));
   memmove(dst->buckets, src.buckets, dst->buckets_num * sizeof(*dst->buckets));
@@ -147,4 +157,5 @@ int latency_config_copy(latency_config_t *dst, const latency_config_t src) {
 void latency_config_free(latency_config_t conf) {
   sfree(conf.percentile);
   sfree(conf.buckets);
+  sfree(conf.bucket_type);
 } /* void latency_config_free */

--- a/src/utils_latency_config.h
+++ b/src/utils_latency_config.h
@@ -44,6 +44,7 @@ typedef struct {
 
   latency_bucket_t *buckets;
   size_t buckets_num;
+  char *bucket_type;
 
   /*
   _Bool lower;

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -137,7 +137,11 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   }
 
   /* Submit buckets */
-  sstrncpy(vl.type, "bucket", sizeof(vl.type));
+  if (data->latency_config.bucket_type != NULL)
+    sstrncpy(vl.type, data->latency_config.bucket_type, sizeof(vl.type));
+  else
+    sstrncpy(vl.type, "bucket", sizeof(vl.type));
+
   for (size_t i = 0; i < data->latency_config.buckets_num; i++) {
     latency_bucket_t bucket = data->latency_config.buckets[i];
 


### PR DESCRIPTION
When several distributions needs to be calculated in one 'tail' instance,
all their metrics will be reported as single 'bucket' type with the same plugin instance value.
That is confusing. This patch allows to split these metrics to their own types.

Practical example: webserver log line has reponse time and response length. 
We want to calculate distribution for both these values.