### PR TITLE
turbostat: better support for mutliple packages

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8223,9 +8223,9 @@ collections. The different bits of this bit mask accepted by this plugin are:
 
 Boolean enabling the use of logical core numbering for per core statistics.
 When enabled, C<cpuE<lt>nE<gt>> is used as plugin instance, where I<n> is a
-sequential number assigned by the kernel. Otherwise, C<coreE<lt>nE<gt>> is used
-where I<n> is the n-th core of the socket, causing name conflicts when there is
-more than one socket.
+dynamic number assigned by the kernel. Otherwise, C<coreE<lt>nE<gt>> is used
+if there is only one package and C<pkgE<lt>nE<gt>-coreE<lt>mE<gt>> if there is
+more than one, where I<n> is the n-th core of package I<m>.
 
 =back
 

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -585,7 +585,10 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
 
   /* If not using logical core numbering, set core id */
   if (!config_lcn) {
-    snprintf(name, sizeof(name), "core%02d", c->core_id);
+    if (topology.num_packages > 1)
+      snprintf(name, sizeof(name), "pkg%02d-core%02d", p->package_id, c->core_id);
+    else
+      snprintf(name, sizeof(name), "core%02d", c->core_id);
   }
 
   if (do_core_cstate & (1 << 3))


### PR DESCRIPTION
If multiple packages are defined, support non-logical core enumeration by prefixing each core id by its package id

Completes https://github.com/collectd/collectd/pull/2056 fix for https://github.com/collectd/collectd/issues/1974