### PR TITLE
write_redis_plugin: Add document for MaxSetDuration

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9323,6 +9323,7 @@ Synopsis:
         Prefix "collectd/"
         Database 1
         MaxSetSize -1
+        MaxSetDuration -1
         StoreRates true
     </Node>
   </Plugin>
@@ -9384,6 +9385,12 @@ to C<0>.
 
 The B<MaxSetSize> option limits the number of items that the I<Sorted Sets> can
 hold. Negative values for I<Items> sets no limit, which is the default behavior.
+
+=item B<MaxSetDuration> I<Seconds>
+
+The B<MaxSetDuration> option limits the duration of items that the
+I<Sorted Sets> can hold. Negative values for I<Items> sets no duration, which
+is the default behavior.
 
 =item B<StoreRates> B<true>|B<false>
 


### PR DESCRIPTION
This change adds description for MaxSetDuration, which is introduced at #2440.