### PR TITLE
Add support for ceph version luminous

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -532,6 +532,8 @@ static int parse_keys(char *buffer, size_t buffer_size, const char *key_str) {
       cut_suffix(tmp, tmp_size, key_str, ".sum");
     } else if (has_suffix(key_str, ".avgtime")) {
       cut_suffix(tmp, tmp_size, key_str, ".avgtime");
+    } else {
+      sstrncpy(tmp, key_str, sizeof(tmp));
     }
   } else {
     sstrncpy(tmp, key_str, sizeof(tmp));

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -518,6 +518,12 @@ static int parse_keys(char *buffer, size_t buffer_size, const char *key_str) {
   size_t tmp_size = sizeof(tmp);
   const char *cut_suffixes[] = {".type", ".avgcount", ".sum", ".avgtime"};
 
+  /* The "avgtime" metric reports ("sum" / "avgcount"), i.e. the average time
+   * per request since the start of the Ceph daemon. Report this only when the
+   * user has configured "long running average". Otherwise, use the rate of
+   * "sum" and "avgcount" to calculate the current latency.
+   */
+
   if (buffer == NULL || buffer_size == 0 || key_str == NULL ||
       strlen(key_str) == 0)
     return EINVAL;

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -486,7 +486,7 @@ static _Bool has_suffix(char const *str, char const *suffix) {
 }
 
 static void cut_suffix(char *buffer, size_t buffer_size, char const *str,
-                      char const *suffix) {
+                       char const *suffix) {
 
   size_t str_len = strlen(str);
   size_t suffix_len = strlen(suffix);
@@ -516,25 +516,22 @@ static size_t count_parts(char const *key) {
 static int parse_keys(char *buffer, size_t buffer_size, const char *key_str) {
   char tmp[2 * buffer_size];
   size_t tmp_size = sizeof(tmp);
+  const char *cut_suffixes[] = {".type", ".avgcount", ".sum", ".avgtime"};
 
   if (buffer == NULL || buffer_size == 0 || key_str == NULL ||
       strlen(key_str) == 0)
     return EINVAL;
+
+  sstrncpy(tmp, key_str, tmp_size);
+
   /* Strip suffix if it is ".type" or one of latency metric suffix. */
   if (count_parts(key_str) > 2) {
-    if (has_suffix(key_str, ".type")) {
-      cut_suffix(tmp, tmp_size, key_str, ".type");
-    } else if (has_suffix(key_str, ".avgcount")) {
-      cut_suffix(tmp, tmp_size, key_str, ".avgcount");
-    } else if (has_suffix(key_str, ".sum")) {
-      cut_suffix(tmp, tmp_size, key_str, ".sum");
-    } else if (has_suffix(key_str, ".avgtime")) {
-      cut_suffix(tmp, tmp_size, key_str, ".avgtime");
-    } else {
-      sstrncpy(tmp, key_str, sizeof(tmp));
+    for (size_t i = 0; i < STATIC_ARRAY_SIZE(cut_suffixes); i++) {
+      if (has_suffix(key_str, cut_suffixes[i])) {
+        cut_suffix(tmp, tmp_size, key_str, cut_suffixes[i]);
+        break;
+      }
     }
-  } else {
-    sstrncpy(tmp, key_str, sizeof(tmp));
   }
 
   return compact_ds_name(buffer, buffer_size, tmp);

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -485,7 +485,7 @@ static _Bool has_suffix(char const *str, char const *suffix) {
   return 0;
 }
 
-static int cut_suffix(char new_str[], size_t new_str_len, char const *str,
+static void cut_suffix(char *buffer, size_t buffer_size, char const *str,
                       char const *suffix) {
 
   size_t str_len = strlen(str);
@@ -493,13 +493,11 @@ static int cut_suffix(char new_str[], size_t new_str_len, char const *str,
 
   size_t offset = str_len - suffix_len + 1;
 
-  if (offset > new_str_len) {
-    offset = new_str_len;
+  if (offset > buffer_size) {
+    offset = buffer_size;
   }
 
-  sstrncpy(new_str, str, offset);
-
-  return 0;
+  sstrncpy(buffer, str, offset);
 }
 
 /* count_parts returns the number of elements a "foo.bar.baz" style key has. */

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -485,10 +485,11 @@ static _Bool has_suffix(char const *str, char const *suffix) {
   return 0;
 }
 
-static int cut_suffix(char new_str[], size_t new_str_len, char const *str, char const *suffix) {
+static int cut_suffix(char new_str[], size_t new_str_len, char const *str,
+                      char const *suffix) {
 
-  size_t str_len = strlen (str);
-  size_t suffix_len = strlen (suffix);
+  size_t str_len = strlen(str);
+  size_t suffix_len = strlen(suffix);
 
   size_t offset = str_len - suffix_len + 1;
 
@@ -496,7 +497,7 @@ static int cut_suffix(char new_str[], size_t new_str_len, char const *str, char 
     offset = new_str_len;
   }
 
-  sstrncpy(new_str,str,offset);
+  sstrncpy(new_str, str, offset);
 
   return 0;
 }
@@ -521,7 +522,7 @@ static int parse_keys(char *buffer, size_t buffer_size, const char *key_str) {
   if (buffer == NULL || buffer_size == 0 || key_str == NULL ||
       strlen(key_str) == 0)
     return EINVAL;
-/* Strip suffix if it is ".type" or one of latency metric suffix. */
+  /* Strip suffix if it is ".type" or one of latency metric suffix. */
   if (count_parts(key_str) > 2) {
     if (has_suffix(key_str, ".type")) {
       cut_suffix(tmp, tmp_size, key_str, ".type");

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -518,12 +518,6 @@ static int parse_keys(char *buffer, size_t buffer_size, const char *key_str) {
   size_t tmp_size = sizeof(tmp);
   const char *cut_suffixes[] = {".type", ".avgcount", ".sum", ".avgtime"};
 
-  /* The "avgtime" metric reports ("sum" / "avgcount"), i.e. the average time
-   * per request since the start of the Ceph daemon. Report this only when the
-   * user has configured "long running average". Otherwise, use the rate of
-   * "sum" and "avgcount" to calculate the current latency.
-   */
-
   if (buffer == NULL || buffer_size == 0 || key_str == NULL ||
       strlen(key_str) == 0)
     return EINVAL;
@@ -933,7 +927,13 @@ static int node_handler_fetch_data(void *arg, const char *val,
       uv.gauge = result;
       vtmp->latency_index = (vtmp->latency_index + 1);
     } else if (has_suffix(key, ".avgtime")) {
-      // skip this step if no need in long run latency
+
+      /* The "avgtime" metric reports ("sum" / "avgcount"), i.e. the average
+       * time per request since the start of the Ceph daemon. Report this only
+       * when the user has configured "long running average". Otherwise, use the
+       * rate of "sum" and "avgcount" to calculate the current latency.
+       */
+
       if (!long_run_latency_avg) {
         return 0;
       }

--- a/src/ceph_test.c
+++ b/src/ceph_test.c
@@ -123,7 +123,7 @@ DEF_TEST(traverse_json) {
       {"WBThrottle.ios_wb.type", "2"},
       {"WBThrottle.inodes_dirtied.type", "2"},
       {"WBThrottle.inodes_wb.type", "10"},
-      {"filestore.journal_wr_bytes", "3117"},
+      {"filestore.journal_wr_bytes.sum", "3117"},
       {"filestore.example_latency.avgcount", "42"},
       {"filestore.example_latency.sum", "4711"},
   };


### PR DESCRIPTION
This patch is not backward compatible with previous ceph versions.
It adds support for [this](https://github.com/ceph/ceph/commit/767502e26ac0cfff5f060fe2ff9eca88de31258d#diff-b6cb32f55d238418c321e793d17d0da3) commit.