### PR TITLE
write_prometheus plugin: Fall back to IPv4 socket if IPv6 fails.

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -732,45 +732,54 @@ metric_family_get(data_set_t const *ds, value_list_t const *vl, size_t ds_index,
 /* }}} */
 
 #if MHD_VERSION >= 0x00090000
-static int prom_open_socket(int domain, struct sockaddr const *addr,
-                            socklen_t addrlen) {
-  int fd = socket(domain, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (fd == -1)
-    return errno;
+static int prom_open_socket(int addrfamily) {
+  /* {{{ */
+  char service[NI_MAXSERV];
+  snprintf(service, sizeof(service), "%hu", httpd_port);
 
-  if (bind(fd, addr, addrlen) != 0) {
-    close(fd);
+  struct addrinfo *res;
+  int status = getaddrinfo(NULL, service,
+                           &(struct addrinfo){
+                               .ai_flags = AI_PASSIVE | AI_ADDRCONFIG,
+                               .ai_family = addrfamily,
+                               .ai_socktype = SOCK_STREAM,
+                           },
+                           &res);
+  if (status != 0) {
     return -1;
   }
 
-  if (listen(fd, /* backlog = */ 16) != 0) {
-    close(fd);
-    return -1;
+  int fd = -1;
+  for (struct addrinfo *ai = res; ai != NULL; ai = ai->ai_next) {
+    fd = socket(ai->ai_family, ai->ai_socktype | SOCK_CLOEXEC, 0);
+    if (fd == -1)
+      continue;
+
+    if (bind(fd, ai->ai_addr, ai->ai_addrlen) != 0) {
+      close(fd);
+      fd = -1;
+      continue;
+    }
+
+    if (listen(fd, /* backlog = */ 16) != 0) {
+      close(fd);
+      fd = -1;
+      continue;
+    }
+
+    break;
   }
+
+  freeaddrinfo(res);
 
   return fd;
-}
+} /* }}} int prom_open_socket */
 
 static struct MHD_Daemon *prom_start_daemon() {
-  struct sockaddr_in6 sa6 = {
-      .sin6_family = AF_INET6,
-      .sin6_port = htons(httpd_port),
-      .sin6_addr = IN6ADDR_ANY_INIT,
-  };
-  int fd = prom_open_socket(PF_INET6, (void *)&sa6, sizeof(sa6));
-
-  if (fd == -1) {
-    struct sockaddr_in sa4 = {
-        .sin_family = AF_INET,
-        .sin_port = htons(httpd_port),
-        .sin_addr =
-            {
-                .s_addr = INADDR_ANY,
-            },
-    };
-    fd = prom_open_socket(PF_INET, (void *)&sa4, sizeof(sa4));
-  }
-
+  /* {{{ */
+  int fd = prom_open_socket(PF_INET6);
+  if (fd == -1)
+    fd = prom_open_socket(PF_INET);
   if (fd == -1) {
     ERROR("write_prometheus plugin: Opening a listening socket failed.");
     return NULL;
@@ -788,9 +797,10 @@ static struct MHD_Daemon *prom_start_daemon() {
   }
 
   return d;
-}
+} /* }}} struct MHD_Daemon *prom_start_daemon */
 #else /* if MHD_VERSION < 0x00090000 */
 static struct MHD_Daemon *prom_start_daemon() {
+  /* {{{ */
   struct MHD_Daemon *d =
       MHD_start_daemon(MHD_USE_THREAD_PER_CONNECTION, 0,
                        /* MHD_AcceptPolicyCallback = */ NULL,
@@ -802,7 +812,7 @@ static struct MHD_Daemon *prom_start_daemon() {
   }
 
   return d;
-}
+} /* }}} struct MHD_Daemon *prom_start_daemon */
 #endif
 
 /*


### PR DESCRIPTION
Unfortunately, for *libmicrohttpd* "dual stack" means "enforce IPv6 (but allow IPv4, too)". That means that on systems without IPv6, libmicrohttpd'd initialization fails (when the dual stack flag is set). To work around this limitation we open the socket ourselves and pass it to libmicrohttpd to use.

Fixes: #2149