### PR TITLE
memcached: Fix CPU usage reporting

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -436,9 +436,10 @@ static int memcached_read(user_data_t *user_data) {
      * CPU time consumed by the memcached process
      */
     if (FIELD_IS("rusage_user")) {
-      rusage_user = atoll(fields[2]);
+      /* Convert to useconds */
+      rusage_user = atof(fields[2]) * 1000000;
     } else if (FIELD_IS("rusage_system")) {
-      rusage_syst = atoll(fields[2]);
+      rusage_syst = atof(fields[2]) * 1000000;
     }
 
     /*


### PR DESCRIPTION
Memcached returns CPU usage as a float values, in seconds.
Example output of Memcached 'stats' command:
```
...
STAT rusage_user 2693.628341
STAT rusage_system 7624.136478
...
```

The Collectd code uses `atoll()` for these values, which leads to huge precision loss.

Before the patch:
![memcached_hourly](https://user-images.githubusercontent.com/13328211/31334297-f716a8b4-ad17-11e7-831f-4befe8f02f8a.png)

With patch applied:
![memcached_hourly_fixed](https://user-images.githubusercontent.com/13328211/31334296-f6fac16c-ad17-11e7-8ac4-894d8fcdb187.png)

This chart match CPU load of 0.3%-0.9%-1.x% which I see at 'top' output.