### PR TITLE
Implementation of "Prefix" option for write_http plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,6 +116,9 @@ Dan Ryder <daryder at cisco.com>
 David Bacher <drbacher at gmail.com>
  - serial plugin.
 
+Denis Pompilio <denis.pompilio at gmail.com>
+ - Improvements to the write_http plugin.
+
 Doug MacEachern <dougm at hyperic.com>
  - The `-T' option (config testing mode).
  - OpenVPN plugin.

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1636,6 +1636,7 @@
 #		Header "X-Custom-Header: custom_value"
 #		SSLVersion "TLSv1"
 #		Format "Command"
+#		Prefix "collectd"  # metric prefix, only available for KAIROSDB format
 #		Attribute "key" "value"     # only available for KAIROSDB format
 #		TTL 0   # data ttl, only available for KAIROSDB format
 #		Metrics true

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9270,6 +9270,12 @@ Sets the Cassandra ttl for the data points.
 
 Please refer to L<http://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html?highlight=ttl>
 
+=item B<Prefix> I<String>
+
+Only available for the KAIROSDB output format.
+
+Sets the metrics prefix I<string>. Defaults to I<collectd>.
+
 =item B<Metrics> B<true>|B<false>
 
 Controls whether I<metrics> are POSTed to this location. Defaults to B<true>.

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -184,7 +184,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
                                   int store_rates,
                                   char const *const *http_attrs,
                                   size_t http_attrs_num, int data_ttl,
-                                  char *metrics_prefix) {
+                                  char const *metrics_prefix) {
   char temp[512];
   size_t offset = 0;
   int status;
@@ -265,7 +265,7 @@ static int format_kairosdb_value_list_nocheck(
     size_t *ret_buffer_fill, size_t *ret_buffer_free, const data_set_t *ds,
     const value_list_t *vl, int store_rates, size_t temp_size,
     char const *const *http_attrs, size_t http_attrs_num, int data_ttl,
-    char *metrics_prefix) {
+    char const *metrics_prefix) {
   char temp[temp_size];
   int status;
 
@@ -341,7 +341,7 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
                                const data_set_t *ds, const value_list_t *vl,
                                int store_rates, char const *const *http_attrs,
                                size_t http_attrs_num, int data_ttl,
-                               char *metrics_prefix) {
+                               char const *metrics_prefix) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
     return -EINVAL;

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -183,7 +183,8 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
                                   const data_set_t *ds, const value_list_t *vl,
                                   int store_rates,
                                   char const *const *http_attrs,
-                                  size_t http_attrs_num, int data_ttl) {
+                                  size_t http_attrs_num, int data_ttl,
+                                  char *metrics_prefix) {
   char temp[512];
   size_t offset = 0;
   int status;
@@ -214,7 +215,7 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
      * a square bracket in `format_kairosdb_finalize'. */
     BUFFER_ADD(",{");
 
-    BUFFER_ADD("\"name\":\"collectd");
+    BUFFER_ADD("\"name\":\"%s", metrics_prefix);
 
     BUFFER_ADD(".%s", vl->plugin);
 
@@ -263,12 +264,14 @@ static int format_kairosdb_value_list_nocheck(
     char *buffer, /* {{{ */
     size_t *ret_buffer_fill, size_t *ret_buffer_free, const data_set_t *ds,
     const value_list_t *vl, int store_rates, size_t temp_size,
-    char const *const *http_attrs, size_t http_attrs_num, int data_ttl) {
+    char const *const *http_attrs, size_t http_attrs_num, int data_ttl,
+    char *metrics_prefix) {
   char temp[temp_size];
   int status;
 
   status = value_list_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates,
-                                  http_attrs, http_attrs_num, data_ttl);
+                                  http_attrs, http_attrs_num, data_ttl,
+                                  metrics_prefix);
   if (status != 0)
     return status;
   temp_size = strlen(temp);
@@ -337,7 +340,8 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
                                size_t *ret_buffer_fill, size_t *ret_buffer_free,
                                const data_set_t *ds, const value_list_t *vl,
                                int store_rates, char const *const *http_attrs,
-                               size_t http_attrs_num, int data_ttl) {
+                               size_t http_attrs_num, int data_ttl,
+                               char *metrics_prefix) {
   if ((buffer == NULL) || (ret_buffer_fill == NULL) ||
       (ret_buffer_free == NULL) || (ds == NULL) || (vl == NULL))
     return -EINVAL;
@@ -347,7 +351,8 @@ int format_kairosdb_value_list(char *buffer, /* {{{ */
 
   return format_kairosdb_value_list_nocheck(
       buffer, ret_buffer_fill, ret_buffer_free, ds, vl, store_rates,
-      (*ret_buffer_free) - 2, http_attrs, http_attrs_num, data_ttl);
+      (*ret_buffer_free) - 2, http_attrs, http_attrs_num, data_ttl,
+      metrics_prefix);
 } /* }}} int format_kairosdb_value_list */
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -213,11 +213,13 @@ static int value_list_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     /* All value lists have a leading comma. The first one will be replaced with
      * a square bracket in `format_kairosdb_finalize'. */
-    BUFFER_ADD(",{");
+    BUFFER_ADD(",{\"name\":\"");
 
-    BUFFER_ADD("\"name\":\"%s", metrics_prefix);
+    if (metrics_prefix != NULL) {
+      BUFFER_ADD("%s.", metrics_prefix);
+    }
 
-    BUFFER_ADD(".%s", vl->plugin);
+    BUFFER_ADD("%s", vl->plugin);
 
     status = values_to_kairosdb(temp, sizeof(temp), ds, vl, store_rates, i);
     if (status != 0)

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -41,7 +41,8 @@ int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,
                                size_t *ret_buffer_free, const data_set_t *ds,
                                const value_list_t *vl, int store_rates,
                                char const *const *http_attrs,
-                               size_t http_attrs_num, int data_ttl);
+                               size_t http_attrs_num, int data_ttl,
+                               char *metrics_prefix);
 int format_kairosdb_finalize(char *buffer, size_t *ret_buffer_fill,
                              size_t *ret_buffer_free);
 

--- a/src/utils_format_kairosdb.h
+++ b/src/utils_format_kairosdb.h
@@ -42,7 +42,7 @@ int format_kairosdb_value_list(char *buffer, size_t *ret_buffer_fill,
                                const value_list_t *vl, int store_rates,
                                char const *const *http_attrs,
                                size_t http_attrs_num, int data_ttl,
-                               char *metrics_prefix);
+                               char const *metrics_prefix);
 int format_kairosdb_finalize(char *buffer, size_t *ret_buffer_fill,
                              size_t *ret_buffer_free);
 

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -637,6 +637,12 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   cb->data_ttl = 0;
   cb->metrics_prefix = strdup(WRITE_HTTP_DEFAULT_PREFIX);
 
+  if (cb->metrics_prefix == NULL) {
+    ERROR("write_http plugin: strdup failed.");
+    sfree(cb);
+    return -1;
+  }
+
   pthread_mutex_init(&cb->send_lock, /* attr = */ NULL);
 
   cf_util_get_string(ci, &cb->name);

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -785,6 +785,9 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
     return -1;
   }
 
+  if (strlen(cb->metrics_prefix) == 0)
+    sfree(cb->metrics_prefix);
+
   if (cb->low_speed_limit > 0)
     cb->low_speed_time = CDTIME_T_TO_TIME_T(plugin_get_interval());
 


### PR DESCRIPTION
I needed to be able to override the standard "collectd" prefix applied to metrics send to KairosDB.

A new option "Prefix" is now available when using the KAIROSDB format with the write_http plugin.
If not specified, this option defaults to "collectd".