### PR TITLE
Correction of tracing from child process and new EAL params support

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -561,6 +561,8 @@
 #    Coremask "0x2"
 #    MemoryChannels "4"
 #    FilePrefix "rte"
+#    LogLevel "7"
+#    RteDriverLibPath "/usr/lib/dpdk-pmd"
 #  </EAL>
 #  SharedMemObj "dpdk_collectd_stats_0"
 #  EnabledPortMask 0xffff

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2572,6 +2572,8 @@ B<Synopsis:>
      MemoryChannels "4"
      FilePrefix "rte"
      SocketMemory "1024"
+     LogLevel "7"
+     RteDriverLibPath "/usr/lib/dpdk-pmd"
    </EAL>
    SharedMemObj "dpdk_collectd_stats_0"
    EnabledPortMask 0xffff
@@ -2603,6 +2605,20 @@ The prefix text used for hugepage filenames. The filename will be set to
 
 A string containing amount of Memory to allocate from hugepages on specific
 sockets in MB. This is an optional value.
+
+=item B<LogLevel> I<LogLevel_number>
+
+A string containing log level number. This parameter is optional.
+If parameter is not present then default value "7" - (INFO) is used.
+Value "8" - (DEBUG) can be set to enable debug traces.
+
+=item B<RteDriverLibPath> I<Path>
+
+A string containing path to shared pmd driver lib or path to directory,
+where shared pmd driver libs are available. This parameter is optional.
+This parameter enable loading of shared pmd driver libs from defined path.
+E.g.: "/usr/lib/dpdk-pmd/librte_pmd_i40e.so"
+or    "/usr/lib/dpdk-pmd"
 
 =back
 

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -45,7 +45,9 @@
 
 #define DPDK_DEFAULT_RTE_CONFIG "/var/run/.rte_config"
 #define DPDK_EAL_ARGC 10
-// Complete trace should fit into 1024 chars
+// Complete trace should fit into 1024 chars. Trace contain some headers
+// and text together with traced data from pipe. This is the reason why
+// we need to limit DPDK_MAX_BUFFER_SIZE value.
 #define DPDK_MAX_BUFFER_SIZE 896
 #define DPDK_CDM_DEFAULT_TIMEOUT 10000
 
@@ -731,7 +733,7 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
     DEBUG("%s:dpdk_helper_check_pipe: read nbytes=%d", phc->shm_name, nbytes);
     if (nbytes <= 0)
       break;
-    buf[nbytes] = '\n';
+    buf[nbytes] = '\0';
     sstrncpy(out, buf, (nbytes + 1));
     DEBUG("%s: helper process:\n%s", phc->shm_name, out);
   }

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -45,7 +45,7 @@
 
 #define DPDK_DEFAULT_RTE_CONFIG "/var/run/.rte_config"
 #define DPDK_EAL_ARGC 10
-//Complete trace should fit into 1024 chars
+// Complete trace should fit into 1024 chars
 #define DPDK_MAX_BUFFER_SIZE 896
 #define DPDK_CDM_DEFAULT_TIMEOUT 10000
 
@@ -183,7 +183,7 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
       status = cf_util_get_string_buffer(child, prefix, sizeof(prefix));
       if (status == 0) {
         snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
-                  "/var/run/.%s_config", prefix);
+                 "/var/run/.%s_config", prefix);
         DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
       }
     } else if (strcasecmp("LogLevel", child->key) == 0) {
@@ -191,9 +191,11 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
                                          sizeof(phc->eal_config.log_level));
       DEBUG("dpdk_common: EAL:LogLevel %s", phc->eal_config.log_level);
     } else if (strcasecmp("RteDriverLibPath", child->key) == 0) {
-      status = cf_util_get_string_buffer(child, phc->eal_config.rte_driver_lib_path,
-                                         sizeof(phc->eal_config.rte_driver_lib_path));
-      DEBUG("dpdk_common: EAL:RteDriverLibPath %s", phc->eal_config.rte_driver_lib_path);
+      status = cf_util_get_string_buffer(
+          child, phc->eal_config.rte_driver_lib_path,
+          sizeof(phc->eal_config.rte_driver_lib_path));
+      DEBUG("dpdk_common: EAL:RteDriverLibPath %s",
+            phc->eal_config.rte_driver_lib_path);
     } else {
       ERROR("dpdk_common: Invalid '%s' configuration option", child->key);
       status = -EINVAL;
@@ -507,8 +509,8 @@ static int dpdk_helper_eal_init(dpdk_helper_ctx_t *phc) {
     argp[argc++] = phc->eal_config.log_level;
   }
   if (strcasecmp(phc->eal_config.rte_driver_lib_path, "") != 0) {
-      argp[argc++] = "-d";
-      argp[argc++] = phc->eal_config.rte_driver_lib_path;
+    argp[argc++] = "-d";
+    argp[argc++] = phc->eal_config.rte_driver_lib_path;
   }
 
   assert(argc <= (DPDK_EAL_ARGC * 2 + 1));
@@ -715,7 +717,8 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
       .fd = phc->pipes[0], .events = POLLIN,
   };
   int data_avail = poll(&fds, 1, 0);
-  DEBUG("%s:dpdk_helper_check_pipe: poll data_avail=%d", phc->shm_name, data_avail);
+  DEBUG("%s:dpdk_helper_check_pipe: poll data_avail=%d", phc->shm_name,
+        data_avail);
   if (data_avail < 0) {
     if (errno != EINTR || errno != EAGAIN) {
       char errbuf[ERR_BUF_SIZE];

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -734,7 +734,7 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
     if (nbytes <= 0)
       break;
     buf[nbytes] = '\0';
-    sstrncpy(out, buf, (nbytes + 1));
+    sstrncpy(out, buf, sizeof(out));
     DEBUG("%s: helper process:\n%s", phc->shm_name, out);
   }
 }

--- a/src/utils_dpdk.h
+++ b/src/utils_dpdk.h
@@ -52,7 +52,7 @@ struct dpdk_eal_config_s {
   char socket_memory[DATA_MAX_NAME_LEN];
   char file_prefix[DATA_MAX_NAME_LEN];
   char log_level[DATA_MAX_NAME_LEN];
-  char rte_driver_lib_path[DATA_MAX_NAME_LEN];
+  char rte_driver_lib_path[PATH_MAX];
 };
 typedef struct dpdk_eal_config_s dpdk_eal_config_t;
 

--- a/src/utils_dpdk.h
+++ b/src/utils_dpdk.h
@@ -51,6 +51,8 @@ struct dpdk_eal_config_s {
   char memory_channels[DATA_MAX_NAME_LEN];
   char socket_memory[DATA_MAX_NAME_LEN];
   char file_prefix[DATA_MAX_NAME_LEN];
+  char log_level[DATA_MAX_NAME_LEN];
+  char rte_driver_lib_path[DATA_MAX_NAME_LEN];
 };
 typedef struct dpdk_eal_config_s dpdk_eal_config_t;
 


### PR DESCRIPTION
Correction of tracing from child process
- There was read 16kb from pipe but only less then 1kb was traced.
  Rest of trace data was lost.
Added support for two EAL parameters:
  LogLevel - optional EAL paramenter which enable debug traces from rte libs
             If parameter is not used default trace level = 7 (INFO) is used
             LogLevel "8" - (DEBUG) can be set to collectd.conf into dpdkstat
             EAL section
  RteDriverLibPath - optional EAL parameter which enable loading of shared
                     pmd driver libs. Param value can be full path to single
                     pmd diriver lib or directory where pmd driver libs are
                     located. E.g.: "/usr/lib/dpdk-pmd/librte_pmd_i40e.so"
                                 or "/usr/lib/dpdk-pmd"

Signed-off-by: Jiri Prokes <jirix.x.prokes@intel.com>