### PR TITLE
Replace zu with PRIsz and llu with PRIu64.

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -507,7 +507,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
 
 static int camqp_shutdown(void) /* {{{ */
 {
-  DEBUG("amqp plugin: Shutting down %zu subscriber threads.",
+  DEBUG("amqp plugin: Shutting down %" PRIsz " subscriber threads.",
         subscriber_threads_num);
 
   subscriber_threads_running = 0;
@@ -982,10 +982,11 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
     char cbname[128];
     snprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
-    status = plugin_register_write(
-        cbname, camqp_write, &(user_data_t){
-                                 .data = conf, .free_func = camqp_config_free,
-                             });
+    status =
+        plugin_register_write(cbname, camqp_write,
+                              &(user_data_t){
+                                  .data = conf, .free_func = camqp_config_free,
+                              });
     if (status != 0) {
       camqp_config_free(conf);
       return status;

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -412,16 +412,16 @@ static int get_reference_temperature(double *result) {
         continue;
       }
 
-      DEBUG(
-          "barometer: get_reference_temperature - initialize \"%s\", %zu vals",
-          list->sensor_name, values_num);
+      DEBUG("barometer: get_reference_temperature - initialize \"%s\", %" PRIsz
+            " vals",
+            list->sensor_name, values_num);
 
       list->initialized = 1;
       list->num_values = values_num;
 
       for (size_t i = 0; i < values_num; ++i) {
-        DEBUG("barometer: get_reference_temperature - rate %zu: %lf **", i,
-              values[i]);
+        DEBUG("barometer: get_reference_temperature - rate %" PRIsz ": %lf **",
+              i, values[i]);
         if (!isnan(values[i])) {
           avg_sum += values[i];
           ++avg_num;
@@ -444,7 +444,7 @@ static int get_reference_temperature(double *result) {
     }
 
     for (size_t i = 0; i < REF_TEMP_AVG_NUM * list->num_values; ++i) {
-      DEBUG("barometer: get_reference_temperature - history %zu: %lf", i,
+      DEBUG("barometer: get_reference_temperature - history %" PRIsz ": %lf", i,
             values_history[i]);
       if (!isnan(values_history[i])) {
         avg_sum += values_history[i];
@@ -464,8 +464,9 @@ static int get_reference_temperature(double *result) {
       }
 
       for (size_t i = 0; i < values_num; ++i) {
-        DEBUG("barometer: get_reference_temperature - rate last %zu: %lf **", i,
-              values[i]);
+        DEBUG("barometer: get_reference_temperature - rate last %" PRIsz
+              ": %lf **",
+              i, values[i]);
         if (!isnan(values[i])) {
           avg_sum += values[i];
           ++avg_num;

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1341,7 +1341,7 @@ static int cconn_main_loop(uint32_t request_type) {
       struct cconn *io = io_array + i;
       ret = cconn_prepare(io, fds + nfds);
       if (ret < 0) {
-        WARNING("ceph plugin: cconn_prepare(name=%s,i=%zu,st=%d)=%d",
+        WARNING("ceph plugin: cconn_prepare(name=%s,i=%" PRIsz ",st=%d)=%d",
                 io->d->name, i, io->state, ret);
         cconn_close(io);
         io->request_type = ASOK_REQ_NONE;

--- a/src/csv.c
+++ b/src/csv.c
@@ -74,8 +74,8 @@ static int value_list_to_string(char *buffer, int buffer_len,
       }
       status = snprintf(buffer + offset, buffer_len - offset, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER) {
-      status = snprintf(buffer + offset, buffer_len - offset, ",%llu",
-                        vl->values[i].counter);
+      status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIu64,
+                        (uint64_t)vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
       status = snprintf(buffer + offset, buffer_len - offset, ",%" PRIi64,
                         vl->values[i].derive);

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -240,8 +240,8 @@ static int cx_check_type(const data_set_t *ds, cx_xpath_t *xpath) /* {{{ */
   }
 
   if (ds->ds_num != xpath->values_len) {
-    WARNING("curl_xml plugin: DataSet `%s' requires %zu values, but config "
-            "talks about %zu",
+    WARNING("curl_xml plugin: DataSet `%s' requires %" PRIsz
+            " values, but config talks about %" PRIsz,
             xpath->type, ds->ds_num, xpath->values_len);
     return -1;
   }

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -893,7 +893,7 @@ int format_values(char *ret, size_t ret_len, /* {{{ */
       }
       BUFFER_ADD(":" GAUGE_FORMAT, rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      BUFFER_ADD(":%llu", vl->values[i].counter);
+      BUFFER_ADD(":%" PRIu64, (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       BUFFER_ADD(":%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)

--- a/src/daemon/globals.h
+++ b/src/daemon/globals.h
@@ -30,6 +30,10 @@
 #define DATA_MAX_NAME_LEN 128
 #endif
 
+#ifndef PRIsz
+#define PRIsz "zu"
+#endif /* PRIsz */
+
 /* Type for time as used by "utils_time.h" */
 typedef uint64_t cdtime_t;
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -646,7 +646,7 @@ static void start_read_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    snprintf(name, sizeof(name), "reader#%zu", read_threads_num);
+    snprintf(name, sizeof(name), "reader#%" PRIsz, read_threads_num);
     set_thread_name(read_threads[read_threads_num], name);
 
     read_threads_num++;
@@ -657,7 +657,7 @@ static void stop_read_threads(void) {
   if (read_threads == NULL)
     return;
 
-  INFO("collectd: Stopping %zu read threads.", read_threads_num);
+  INFO("collectd: Stopping %" PRIsz " read threads.", read_threads_num);
 
   pthread_mutex_lock(&read_lock);
   read_loop = 0;
@@ -853,7 +853,7 @@ static void start_write_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    snprintf(name, sizeof(name), "writer#%zu", write_threads_num);
+    snprintf(name, sizeof(name), "writer#%" PRIsz, write_threads_num);
     set_thread_name(write_threads[write_threads_num], name);
 
     write_threads_num++;
@@ -868,7 +868,7 @@ static void stop_write_threads(void) /* {{{ */
   if (write_threads == NULL)
     return;
 
-  INFO("collectd: Stopping %zu write threads.", write_threads_num);
+  INFO("collectd: Stopping %" PRIsz " write threads.", write_threads_num);
 
   pthread_mutex_lock(&write_lock);
   write_loop = 0;
@@ -900,7 +900,7 @@ static void stop_write_threads(void) /* {{{ */
   pthread_mutex_unlock(&write_lock);
 
   if (i > 0) {
-    WARNING("plugin: %zu value list%s left after shutting down "
+    WARNING("plugin: %" PRIsz " value list%s left after shutting down "
             "the write threads.",
             i, (i == 1) ? " was" : "s were");
   }
@@ -1970,8 +1970,8 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
 #else
   if (ds->ds_num != vl->values_len) {
     ERROR("plugin_dispatch_values: ds->type = %s: "
-          "(ds->ds_num = %zu) != "
-          "(vl->values_len = %zu)",
+          "(ds->ds_num = %" PRIsz ") != "
+          "(vl->values_len = %" PRIsz ")",
           ds->type, ds->ds_num, vl->values_len);
     return -1;
   }

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -39,7 +39,7 @@ static int parse_ds(data_source_t *dsrc, char *buf, size_t buf_len) {
   int fields_num;
 
   if (buf_len < 11) {
-    ERROR("parse_ds: (buf_len = %zu) < 11", buf_len);
+    ERROR("parse_ds: (buf_len = %" PRIsz ") < 11", buf_len);
     return -1;
   }
 
@@ -121,8 +121,8 @@ static void parse_line(char *buf) {
 
   for (size_t i = 0; i < ds->ds_num; i++)
     if (parse_ds(ds->ds + i, fields[i + 1], strlen(fields[i + 1])) != 0) {
-      ERROR("types_list: parse_line: Cannot parse data source #%zu "
-            "of data set %s",
+      ERROR("types_list: parse_line: Cannot parse data source #%" PRIsz
+            " of data set %s",
             i, ds->type);
       sfree(ds->ds);
       sfree(ds);

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -154,7 +154,7 @@ static int uc_insert(const data_set_t *ds, const value_list_t *vl,
   ce = cache_alloc(ds->ds_num);
   if (ce == NULL) {
     sfree(key_copy);
-    ERROR("uc_insert: cache_alloc (%zu) failed.", ds->ds_num);
+    ERROR("uc_insert: cache_alloc (%" PRIsz ") failed.", ds->ds_num);
     return -1;
   }
 
@@ -381,7 +381,7 @@ int uc_update(const data_set_t *ds, const value_list_t *vl) {
       return -1;
     } /* switch (ds->ds[i].type) */
 
-    DEBUG("uc_update: %s: ds[%zu] = %lf", name, i, ce->values_gauge[i]);
+    DEBUG("uc_update: %s: ds[%" PRIsz "] = %lf", name, i, ce->values_gauge[i]);
   } /* for (i) */
 
   /* Update the history if it exists. */
@@ -469,8 +469,8 @@ gauge_t *uc_get_rate(const data_set_t *ds, const value_list_t *vl) {
   /* This is important - the caller has no other way of knowing how many
    * values are returned. */
   if (ret_num != ds->ds_num) {
-    ERROR("utils_cache: uc_get_rate: ds[%s] has %zu values, "
-          "but uc_get_rate_by_name returned %zu.",
+    ERROR("utils_cache: uc_get_rate: ds[%s] has %" PRIsz " values, "
+          "but uc_get_rate_by_name returned %" PRIsz ".",
           ds->type, ds->ds_num, ret_num);
     sfree(ret);
     return NULL;
@@ -488,7 +488,7 @@ int uc_get_value_by_name(const char *name, value_t **ret_values,
 
   pthread_mutex_lock(&cache_lock);
 
-  if (c_avl_get(cache_tree, name, (void *) &ce) == 0) {
+  if (c_avl_get(cache_tree, name, (void *)&ce) == 0) {
     assert(ce != NULL);
 
     /* remove missing values from getval */
@@ -504,8 +504,7 @@ int uc_get_value_by_name(const char *name, value_t **ret_values,
         memcpy(ret, ce->values_raw, ret_num * sizeof(value_t));
       }
     }
-  }
-  else {
+  } else {
     DEBUG("utils_cache: uc_get_value_by_name: No such value: %s", name);
     status = -1;
   }
@@ -537,10 +536,10 @@ value_t *uc_get_value(const data_set_t *ds, const value_list_t *vl) {
 
   /* This is important - the caller has no other way of knowing how many
    * values are returned. */
-  if (ret_num != (size_t) ds->ds_num) {
-    ERROR("utils_cache: uc_get_value: ds[%s] has %zu values, "
-          "but uc_get_value_by_name returned %zu.", ds->type, ds->ds_num,
-          ret_num);
+  if (ret_num != (size_t)ds->ds_num) {
+    ERROR("utils_cache: uc_get_value: ds[%s] has %" PRIsz " values, "
+          "but uc_get_value_by_name returned %" PRIsz ".",
+          ds->type, ds->ds_num, ret_num);
     sfree(ret);
     return (NULL);
   }

--- a/src/daemon/utils_subst.c
+++ b/src/daemon/utils_subst.c
@@ -152,7 +152,7 @@ char *subst_string(char *buf, size_t buflen, const char *string,
   }
 
   if (i >= buflen) {
-    WARNING("subst_string: Loop exited after %zu iterations: "
+    WARNING("subst_string: Loop exited after %" PRIsz " iterations: "
             "string = %s; needle = %s; replacement = %s;",
             i, string, needle, replacement);
   }

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -497,8 +497,8 @@ static int cdbi_read_database_query(cdbi_database_t *db, /* {{{ */
     }
 
     column_num = (size_t)db_status;
-    DEBUG("cdbi_read_database_query (%s, %s): There are %zu columns.", db->name,
-          udb_query_get_name(q), column_num);
+    DEBUG("cdbi_read_database_query (%s, %s): There are %" PRIsz " columns.",
+          db->name, udb_query_get_name(q), column_num);
   }
 
   /* Allocate `column_names' and `column_values'. {{{ */
@@ -539,7 +539,7 @@ static int cdbi_read_database_query(cdbi_database_t *db, /* {{{ */
     column_name = dbi_result_get_field_name(res, (unsigned int)(i + 1));
     if (column_name == NULL) {
       ERROR("dbi plugin: cdbi_read_database_query (%s, %s): "
-            "Cannot retrieve name of field %zu.",
+            "Cannot retrieve name of field %" PRIsz ".",
             db->name, udb_query_get_name(q), i + 1);
       BAIL_OUT(-1);
     }
@@ -579,7 +579,7 @@ static int cdbi_read_database_query(cdbi_database_t *db, /* {{{ */
 
       if (status != 0) {
         ERROR("dbi plugin: cdbi_read_database_query (%s, %s): "
-              "cdbi_result_get_field (%zu) failed.",
+              "cdbi_result_get_field (%" PRIsz ") failed.",
               db->name, udb_query_get_name(q), i + 1);
         status = -1;
         break;

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -430,7 +430,7 @@ static int dpdk_stats_reinit_helper() {
   size_t data_size = sizeof(dpdk_stats_ctx_t) +
                      (ctx->stats_count * DPDK_STATS_CTX_GET_XSTAT_SIZE);
 
-  DEBUG("%s:%d helper reinit (new_size=%zu)", __FUNCTION__, __LINE__,
+  DEBUG("%s:%d helper reinit (new_size=%" PRIsz ")", __FUNCTION__, __LINE__,
         data_size);
 
   dpdk_stats_ctx_t tmp_ctx;

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -72,7 +72,7 @@ static int drbd_submit_fields(long int resource, char **fields,
 
   if (fields_num != drbd_names_num) {
     WARNING("drbd plugin: Wrong number of fields for "
-            "r%ld statistics. Expected %zu, got %zu.",
+            "r%ld statistics. Expected %" PRIsz ", got %" PRIsz ".",
             resource, drbd_names_num, fields_num);
     return EINVAL;
   }

--- a/src/email.c
+++ b/src/email.c
@@ -276,7 +276,7 @@ static void *collect(void *arg) {
 
       len = strlen(line);
       if ((line[len - 1] != '\n') && (line[len - 1] != '\r')) {
-        log_warn("collect: line too long (> %zu characters): "
+        log_warn("collect: line too long (> %" PRIsz " characters): "
                  "'%s' (truncated)",
                  sizeof(line) - 1, line);
 
@@ -373,14 +373,13 @@ static void *open_connection(void __attribute__((unused)) * arg) {
     pthread_exit((void *)1);
   }
 
-  struct sockaddr_un addr = {
-    .sun_family = AF_UNIX
-  };
+  struct sockaddr_un addr = {.sun_family = AF_UNIX};
   sstrncpy(addr.sun_path, path, (size_t)(UNIX_PATH_MAX - 1));
 
   errno = 0;
   if (bind(connector_socket, (struct sockaddr *)&addr,
-           offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path)) == -1) {
+           offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path)) ==
+      -1) {
     char errbuf[1024];
     disabled = 1;
     close(connector_socket);

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -472,7 +472,8 @@ static int staging_entry_update(const char *host, const char *name, /* {{{ */
   }
 
   if (ds->ds_num <= ds_index) {
-    ERROR("gmond plugin: Invalid index %zu: %s has only %zu data source(s).",
+    ERROR("gmond plugin: Invalid index %" PRIsz ": %s has only %" PRIsz
+          " data source(s).",
           ds_index, ds->type, ds->ds_num);
     return -1;
   }

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -192,7 +192,8 @@ static void pmu_dump_config(void) {
   DEBUG(PMU_PLUGIN ":   software_events   : %d", g_ctx.sw_events);
 
   for (size_t i = 0; i < g_ctx.hw_events_count; i++) {
-    DEBUG(PMU_PLUGIN ":   hardware_events[%zu]: %s", i, g_ctx.hw_events[i]);
+    DEBUG(PMU_PLUGIN ":   hardware_events[%" PRIsz "]: %s", i,
+          g_ctx.hw_events[i]);
   }
 }
 

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -25,8 +25,8 @@
  *   Serhiy Pshyk <serhiyx.pshyk@intel.com>
  **/
 
-#include "common.h"
 #include "collectd.h"
+#include "common.h"
 
 #include <pqos.h>
 
@@ -308,7 +308,7 @@ static void rdt_dump_cgroups(void) {
     return;
 
   DEBUG(RDT_PLUGIN ": Core Groups Dump");
-  DEBUG(RDT_PLUGIN ":  groups count: %zu", g_rdt->num_groups);
+  DEBUG(RDT_PLUGIN ":  groups count: %" PRIsz, g_rdt->num_groups);
 
   for (int i = 0; i < g_rdt->num_groups; i++) {
 
@@ -426,8 +426,8 @@ static int rdt_config_cgroups(oconfig_item_t *item) {
          core_idx++) {
       if (!rdt_is_core_id_valid(g_rdt->cgroups[group_idx].cores[core_idx])) {
         ERROR(RDT_PLUGIN ": Core group '%s' contains invalid core id '%d'",
-                g_rdt->cgroups[group_idx].desc,
-                (int)g_rdt->cgroups[group_idx].cores[core_idx]);
+              g_rdt->cgroups[group_idx].desc,
+              (int)g_rdt->cgroups[group_idx].cores[core_idx]);
         rdt_free_cgroups();
         return -EINVAL;
       }

--- a/src/java.c
+++ b/src/java.c
@@ -1840,7 +1840,8 @@ static int cjni_create_jvm(void) /* {{{ */
   vm_args.nOptions = (jint)jvm_argc;
 
   for (size_t i = 0; i < jvm_argc; i++) {
-    DEBUG("java plugin: cjni_create_jvm: jvm_argv[%zu] = %s", i, jvm_argv[i]);
+    DEBUG("java plugin: cjni_create_jvm: jvm_argv[%" PRIsz "] = %s", i,
+          jvm_argv[i]);
     vm_args.options[i].optionString = jvm_argv[i];
   }
 
@@ -2183,8 +2184,9 @@ static int cjni_config_perform(oconfig_item_t *ci) /* {{{ */
     }
   }
 
-  DEBUG("java plugin: jvm_argc = %zu;", jvm_argc);
-  DEBUG("java plugin: java_classes_list_len = %zu;", java_classes_list_len);
+  DEBUG("java plugin: jvm_argc = %" PRIsz ";", jvm_argc);
+  DEBUG("java plugin: java_classes_list_len = %" PRIsz ";",
+        java_classes_list_len);
 
   if ((success == 0) && (errors > 0)) {
     ERROR("java plugin: All statements failed.");

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -31,6 +31,7 @@
 
 #include "collectd/lcc_features.h"
 #include "collectd/network_parse.h"
+#include "globals.h"
 
 #include <errno.h>
 #include <math.h>
@@ -432,7 +433,7 @@ static int decrypt_aes256(buffer_t *b, void *iv, size_t iv_size,
   uint8_t pwhash[32] = {0};
   gcry_md_hash_buffer(GCRY_MD_SHA256, pwhash, password, strlen(password));
 
-  fprintf(stderr, "sizeof(iv) = %zu\n", sizeof(iv));
+  fprintf(stderr, "sizeof(iv) = %" PRIsz "\n", sizeof(iv));
   if (gcry_cipher_setkey(cipher, pwhash, sizeof(pwhash)) ||
       gcry_cipher_setiv(cipher, iv, iv_size) ||
       gcry_cipher_decrypt(cipher, b->data, b->len, /* in = */ NULL,
@@ -517,7 +518,7 @@ static int network_parse(void *data, size_t data_size, lcc_security_level_t sl,
 
     if ((sz < 5) || (((size_t)sz - 4) > b->len)) {
       DEBUG("lcc_network_parse(): invalid 'sz' field: sz = %" PRIu16
-            ", b->len = %zu\n",
+            ", b->len = %" PRIsz "\n",
             sz, b->len);
       return EINVAL;
     }

--- a/src/libcollectdclient/network_parse_test.c
+++ b/src/libcollectdclient/network_parse_test.c
@@ -245,10 +245,9 @@ static int test_network_parse() {
     uint8_t buffer[LCC_NETWORK_BUFFER_SIZE_DEFAULT];
     size_t buffer_size = sizeof(buffer);
     if (decode_string(raw_packet_data[i], buffer, &buffer_size)) {
-      fprintf(
-          stderr,
-          "lcc_network_parse(raw_packet_data[%zu]): decoding string failed\n",
-          i);
+      fprintf(stderr, "lcc_network_parse(raw_packet_data[%" PRIsz "]):"
+                      " decoding string failed\n",
+              i);
       return -1;
     }
 
@@ -257,12 +256,13 @@ static int test_network_parse() {
                                                    .writer = nop_writer,
                                                });
     if (status != 0) {
-      fprintf(stderr, "lcc_network_parse(raw_packet_data[%zu]) = %d, want 0\n",
+      fprintf(stderr,
+              "lcc_network_parse(raw_packet_data[%" PRIsz "]) = %d, want 0\n",
               i, status);
       ret = status;
     }
 
-    printf("ok - lcc_network_parse(raw_packet_data[%zu])\n", i);
+    printf("ok - lcc_network_parse(raw_packet_data[%" PRIsz "])\n", i);
   }
 
   return ret;
@@ -376,7 +376,7 @@ static int test_parse_values() {
   }
 
   if (vl.values_len != 3) {
-    fprintf(stderr, "parse_values(): vl.values_len = %zu, want 3\n",
+    fprintf(stderr, "parse_values(): vl.values_len = %" PRIsz ", want 3\n",
             vl.values_len);
     return -1;
   }
@@ -384,7 +384,8 @@ static int test_parse_values() {
   int want_types[] = {LCC_TYPE_GAUGE, LCC_TYPE_DERIVE, LCC_TYPE_GAUGE};
   for (size_t i = 0; i < sizeof(want_types) / sizeof(want_types[0]); i++) {
     if (vl.values_types[i] != want_types[i]) {
-      fprintf(stderr, "parse_values(): vl.values_types[%zu] = %d, want %d\n", i,
+      fprintf(stderr,
+              "parse_values(): vl.values_types[%" PRIsz "] = %d, want %d\n", i,
               vl.values_types[i], want_types[i]);
       ret = -1;
     }

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -417,7 +417,7 @@ static int mb_read_data(mb_host_t *host, mb_slave_t *slave, /* {{{ */
   }
 
   if (ds->ds_num != 1) {
-    ERROR("Modbus plugin: The type \"%s\" has %zu data sources. "
+    ERROR("Modbus plugin: The type \"%s\" has %" PRIsz " data sources. "
           "I can only handle data sets with only one data source.",
           data->type, ds->ds_num);
     return -1;

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -458,7 +458,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
   if ((tm->tcm_ifindex >= 0) && ((size_t)tm->tcm_ifindex >= iflist_len)) {
     ERROR("netlink plugin: qos_filter_cb: tm->tcm_ifindex = %i "
-          ">= iflist_len = %zu",
+          ">= iflist_len = %" PRIsz,
           tm->tcm_ifindex, iflist_len);
     return MNL_CB_ERROR;
   }
@@ -707,7 +707,7 @@ static int ir_read(void) {
         continue;
       }
 
-      DEBUG("netlink plugin: ir_read: querying %s from %s (%zu).",
+      DEBUG("netlink plugin: ir_read: querying %s from %s (%" PRIsz ").",
             type_name[type_index], iflist[ifindex], ifindex);
 
       nlh = mnl_nlmsg_put_header(buf);

--- a/src/network.c
+++ b/src/network.c
@@ -753,7 +753,7 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
 
   if (buffer_len < 15) {
     NOTICE("network plugin: packet is too short: "
-           "buffer_len = %zu",
+           "buffer_len = %" PRIsz,
            buffer_len);
     return -1;
   }
@@ -777,8 +777,8 @@ static int parse_part_values(void **ret_buffer, size_t *ret_buffer_len,
   if (buffer_len < exp_size) {
     WARNING("network plugin: parse_part_values: "
             "Packet too short: "
-            "Chunk of size %zu expected, "
-            "but buffer has only %zu bytes left.",
+            "Chunk of size %" PRIsz " expected, "
+            "but buffer has only %" PRIsz " bytes left.",
             exp_size, buffer_len);
     return -1;
   }
@@ -857,8 +857,8 @@ static int parse_part_number(void **ret_buffer, size_t *ret_buffer_len,
   if (buffer_len < exp_size) {
     WARNING("network plugin: parse_part_number: "
             "Packet too short: "
-            "Chunk of size %zu expected, "
-            "but buffer has only %zu bytes left.",
+            "Chunk of size %" PRIsz " expected, "
+            "but buffer has only %" PRIsz " bytes left.",
             exp_size, buffer_len);
     return -1;
   }
@@ -898,8 +898,8 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
   if (buffer_len < header_size) {
     WARNING("network plugin: parse_part_string: "
             "Packet too short: "
-            "Chunk of at least size %zu expected, "
-            "but buffer has only %zu bytes left.",
+            "Chunk of at least size %" PRIsz " expected, "
+            "but buffer has only %" PRIsz " bytes left.",
             header_size, buffer_len);
     return -1;
   }
@@ -918,7 +918,7 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
     WARNING("network plugin: parse_part_string: "
             "Packet too big: "
             "Chunk of size %" PRIu16 " received, "
-            "but buffer has only %zu bytes left.",
+            "but buffer has only %" PRIsz " bytes left.",
             pkg_length, buffer_len);
     return -1;
   }
@@ -939,9 +939,9 @@ static int parse_part_string(void **ret_buffer, size_t *ret_buffer_len,
   if (output_len < payload_size) {
     WARNING("network plugin: parse_part_string: "
             "Buffer too small: "
-            "Output buffer holds %zu bytes, "
+            "Output buffer holds %" PRIsz " bytes, "
             "which is too small to hold the received "
-            "%zu byte string.",
+            "%" PRIsz " byte string.",
             output_len, payload_size);
     return -1;
   }
@@ -2480,7 +2480,7 @@ static void network_send_buffer_encrypted(sockent_t *se, /* {{{ */
 
   assert(buffer_size <= sizeof(buffer));
   DEBUG("network plugin: network_send_buffer_encrypted: "
-        "buffer_size = %zu;",
+        "buffer_size = %" PRIsz ";",
         buffer_size);
 
   pea.head.length = htons(
@@ -2531,7 +2531,8 @@ static void network_send_buffer_encrypted(sockent_t *se, /* {{{ */
 
 static void network_send_buffer(char *buffer, size_t buffer_len) /* {{{ */
 {
-  DEBUG("network plugin: network_send_buffer: buffer_len = %zu", buffer_len);
+  DEBUG("network plugin: network_send_buffer: buffer_len = %" PRIsz,
+        buffer_len);
 
   for (sockent_t *se = sending_sockets; se != NULL; se = se->next) {
 #if HAVE_GCRYPT_H
@@ -2650,10 +2651,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
 
   pthread_mutex_lock(&send_buffer_lock);
 
-  status =
-      add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                         (send_buffer_fill + BUFF_SIG_SIZE),
-                    &send_buffer_vl, ds, vl);
+  status = add_to_buffer(send_buffer_ptr,
+                         network_config_packet_size -
+                             (send_buffer_fill + BUFF_SIG_SIZE),
+                         &send_buffer_vl, ds, vl);
   if (status >= 0) {
     /* status == bytes added to the buffer */
     send_buffer_fill += status;
@@ -2664,10 +2665,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
   } else {
     flush_buffer();
 
-    status =
-        add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                           (send_buffer_fill + BUFF_SIG_SIZE),
-                      &send_buffer_vl, ds, vl);
+    status = add_to_buffer(send_buffer_ptr,
+                           network_config_packet_size -
+                               (send_buffer_fill + BUFF_SIG_SIZE),
+                           &send_buffer_vl, ds, vl);
 
     if (status >= 0) {
       send_buffer_fill += status;

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -397,7 +397,7 @@ static int nfs_submit_fields_safe(int nfs_version, const char *instance,
                                   size_t proc_names_num) {
   if (fields_num != proc_names_num) {
     WARNING("nfs plugin: Wrong number of fields for "
-            "NFSv%i %s statistics. Expected %zu, got %zu.",
+            "NFSv%i %s statistics. Expected %" PRIsz ", got %" PRIsz ".",
             nfs_version, instance, proc_names_num, fields_num);
     return EINVAL;
   }
@@ -421,7 +421,7 @@ static int nfs_submit_nfs4_server(const char *instance, char **fields,
   default:
     if (!suppress_warning) {
       WARNING("nfs plugin: Unexpected number of fields for "
-              "NFSv4 %s statistics: %zu. ",
+              "NFSv4 %s statistics: %" PRIsz ". ",
               instance, fields_num);
     }
 
@@ -486,9 +486,8 @@ static int nfs_submit_nfs4_client(const char *instance, char **fields,
     break;
   default:
     if (!suppress_warning) {
-      WARNING("nfs plugin: Unexpected number of "
-              "fields for NFSv4 %s "
-              "statistics: %zu. ",
+      WARNING("nfs plugin: Unexpected number of fields for NFSv4 %s "
+              "statistics: %" PRIsz ". ",
               instance, fields_num);
     }
 

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -593,7 +593,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
      * Enough with the checks. Copy the data now.
      * We start by allocating some more memory.
      */
-    DEBUG("realloc (%p, %zu)", (void *)*res_data,
+    DEBUG("realloc (%p, %" PRIsz ")", (void *)*res_data,
           (items_num + pkt_item_num) * res_item_size);
     items = realloc(*res_data, (items_num + pkt_item_num) * res_item_size);
     if (items == NULL) {

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -308,10 +308,10 @@ static int o_config(oconfig_item_t *ci) /* {{{ */
     }
 
     if (queries_num > 0) {
-      DEBUG("oracle plugin: o_config: queries_num = %zu; queries[0] = %p; "
-            "udb_query_get_user_data (queries[0]) = %p;",
-            queries_num, (void *)queries[0],
-            udb_query_get_user_data(queries[0]));
+      DEBUG(
+          "oracle plugin: o_config: queries_num = %" PRIsz "; queries[0] = %p; "
+          "udb_query_get_user_data (queries[0]) = %p;",
+          queries_num, (void *)queries[0], udb_query_get_user_data(queries[0]));
     }
   } /* for (ci->children) */
 
@@ -532,8 +532,8 @@ static int o_read_database_query(o_database_t *db, /* {{{ */
     memcpy(column_names[i], column_name, column_name_length);
     column_names[i][column_name_length] = 0;
 
-    DEBUG("oracle plugin: o_read_database_query: column_names[%zu] = %s; "
-          "column_name_length = %" PRIu32 ";",
+    DEBUG("oracle plugin: o_read_database_query: column_names[%" PRIsz "] = %s;"
+          " column_name_length = %" PRIu32 ";",
           i, column_names[i], (uint32_t)column_name_length);
 
     status = OCIDefineByPos(oci_statement, &oci_defines[i], oci_error,

--- a/src/perl.c
+++ b/src/perl.c
@@ -331,12 +331,12 @@ static size_t av2value(pTHX_ char *name, AV *array, value_t *value,
 
   if (array_len < ds->ds_num) {
     log_warn("av2value: array does not contain enough elements for type "
-             "\"%s\": got %zu, want %zu",
+             "\"%s\": got %" PRIsz ", want %" PRIsz,
              name, array_len, ds->ds_num);
     return 0;
   } else if (array_len > ds->ds_num) {
     log_warn("av2value: array contains excess elements for type \"%s\": got "
-             "%zu, want %zu",
+             "%" PRIsz ", want %" PRIsz,
              name, array_len, ds->ds_num);
   }
 

--- a/src/ping.c
+++ b/src/ping.c
@@ -532,7 +532,7 @@ static int ping_config(const char *key, const char *value) /* {{{ */
       } /* }}} for (i = 0; i < size; i++) */
       ping_data[size] = 0;
     } else
-      WARNING("ping plugin: Ignoring invalid Size %zu.", size);
+      WARNING("ping plugin: Ignoring invalid Size %" PRIsz ".", size);
   } else if (strcasecmp(key, "Timeout") == 0) {
     double tmp;
 

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -742,7 +742,8 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
 
       status = snprintf(str_ptr, str_len, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = snprintf(str_ptr, str_len, ",%llu", vl->values[i].counter);
+      status = snprintf(str_ptr, str_len, ",%" PRIu64,
+                        (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       status = snprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -355,7 +355,7 @@ static void submit(const char *plugin_instance, /* {{{ */
   }
 
   if (ds->ds_num != 1) {
-    ERROR("powerdns plugin: type `%s' has %zu data sources, "
+    ERROR("powerdns plugin: type `%s' has %" PRIsz " data sources, "
           "but I can only handle one.",
           type, ds->ds_num);
     return;

--- a/src/processes.c
+++ b/src/processes.c
@@ -602,7 +602,8 @@ static int ps_config(oconfig_item_t *ci) {
 
 #if KERNEL_LINUX || KERNEL_SOLARIS || KERNEL_FREEBSD
       if (strlen(c->values[0].value.string) > max_procname_len) {
-        WARNING("processes plugin: this platform has a %zu character limit "
+        WARNING("processes plugin: this platform has a %" PRIsz
+                " character limit "
                 "to process names. The `Process \"%s\"' option will "
                 "not work as expected.",
                 max_procname_len, c->values[0].value.string);
@@ -1153,7 +1154,8 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   /* Either '(' or ')' is not found or they are in the wrong order.
    * Anyway, something weird that shouldn't happen ever. */
   if (name_start_pos >= name_end_pos) {
-    ERROR("processes plugin: name_start_pos = %zu >= name_end_pos = %zu",
+    ERROR("processes plugin: name_start_pos = %" PRIsz
+          " >= name_end_pos = %" PRIsz,
           name_start_pos, name_end_pos);
     return -1;
   }
@@ -1392,7 +1394,7 @@ static char *ps_get_cmdline(long pid,
   if ((status < 0) || (((size_t)status) != sizeof(info))) {
     ERROR("processes plugin: Unexpected return value "
           "while reading \"%s\": "
-          "Returned %zd but expected %zu.",
+          "Returned %zd but expected %" PRIsz ".",
           path, status, buffer_size);
     return NULL;
   }

--- a/src/pyvalues.c
+++ b/src/pyvalues.c
@@ -641,7 +641,8 @@ static PyObject *Values_dispatch(Values *self, PyObject *args, PyObject *kwds) {
   }
   size = (size_t)PySequence_Length(values);
   if (size != ds->ds_num) {
-    PyErr_Format(PyExc_RuntimeError, "type %s needs %zu values, got %zu",
+    PyErr_Format(PyExc_RuntimeError,
+                 "type %s needs %" PRIsz " values, got %" PRIsz,
                  value_list.type, ds->ds_num, size);
     return NULL;
   }
@@ -765,7 +766,8 @@ static PyObject *Values_write(Values *self, PyObject *args, PyObject *kwds) {
   }
   size = (size_t)PySequence_Length(values);
   if (size != ds->ds_num) {
-    PyErr_Format(PyExc_RuntimeError, "type %s needs %zu values, got %zu",
+    PyErr_Format(PyExc_RuntimeError,
+                 "type %s needs %" PRIsz " values, got %" PRIsz,
                  value_list.type, ds->ds_num, size);
     return NULL;
   }

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -88,8 +88,8 @@ static int value_list_to_string(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
-      status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
-                        vl->values[i].counter);
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+                        (uint64_t)vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_GAUGE) {
       status = snprintf(buffer + offset, buffer_len - offset, ":%f",
                         vl->values[i].gauge);

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -186,8 +186,8 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = snprintf(buffer + offset, buffer_len - offset, ":%llu",
-                        vl->values[i].counter);
+      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+                        (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)
       status = snprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
                         vl->values[i].gauge);
@@ -226,8 +226,8 @@ static int value_list_to_string(char *buffer, int buffer_len,
                       vl->values[0].gauge);
     break;
   case DS_TYPE_COUNTER:
-    status = snprintf(buffer, buffer_len, "%u:%llu", (unsigned)tt,
-                      vl->values[0].counter);
+    status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
+                      (uint64_t)vl->values[0].counter);
     break;
   case DS_TYPE_ABSOLUTE:
     status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -398,7 +398,7 @@ static int csnmp_config_add_data(oconfig_item_t *ci) {
   }
 
   DEBUG("snmp plugin: dd = { name = %s, type = %s, is_table = %s, values_len = "
-        "%zu }",
+        "%" PRIsz " }",
         dd->name, dd->type, (dd->is_table != 0) ? "true" : "false",
         dd->values_len);
 
@@ -1093,7 +1093,8 @@ static int csnmp_instance_list_add(csnmp_list_instances_t **head,
     value_t val = csnmp_value_list_to_value(
         vb, DS_TYPE_COUNTER,
         /* scale = */ 1.0, /* shift = */ 0.0, hd->name, dd->name);
-    snprintf(il->instance, sizeof(il->instance), "%llu", val.counter);
+    snprintf(il->instance, sizeof(il->instance), "%" PRIu64,
+             (uint64_t)val.counter);
   }
 
   /* TODO: Debugging output */
@@ -1296,8 +1297,9 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   }
 
   if (ds->ds_num != data->values_len) {
-    ERROR("snmp plugin: DataSet `%s' requires %zu values, but config talks "
-          "about %zu",
+    ERROR("snmp plugin: DataSet `%s' requires %" PRIsz
+          " values, but config talks "
+          "about %" PRIsz,
           data->type, ds->ds_num, data->values_len);
     return -1;
   }
@@ -1470,7 +1472,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
          * suffix is increasing. This also checks if we left the subtree */
         ret = csnmp_oid_suffix(&suffix, &vb_name, data->values + i);
         if (ret != 0) {
-          DEBUG("snmp plugin: host = %s; data = %s; i = %zu; "
+          DEBUG("snmp plugin: host = %s; data = %s; i = %" PRIsz "; "
                 "Value probably left its subtree.",
                 host->name, data->name, i);
           oid_list_todo[i] = 0;
@@ -1482,7 +1484,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
          * table matching algorithm will get confused. */
         if ((value_list_tail[i] != NULL) &&
             (csnmp_oid_compare(&suffix, &value_list_tail[i]->suffix) <= 0)) {
-          DEBUG("snmp plugin: host = %s; data = %s; i = %zu; "
+          DEBUG("snmp plugin: host = %s; data = %s; i = %" PRIsz "; "
                 "Suffix is not increasing.",
                 host->name, data->name, i);
           oid_list_todo[i] = 0;
@@ -1574,8 +1576,9 @@ static int csnmp_read_value(host_definition_t *host, data_definition_t *data) {
   }
 
   if (ds->ds_num != data->values_len) {
-    ERROR("snmp plugin: DataSet `%s' requires %zu values, but config talks "
-          "about %zu",
+    ERROR("snmp plugin: DataSet `%s' requires %" PRIsz
+          " values, but config talks "
+          "about %" PRIsz,
           data->type, ds->ds_num, data->values_len);
     return -1;
   }

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -166,7 +166,7 @@ static void snmp_agent_dump_data(void) {
         DEBUG(PLUGIN_NAME ":     TypeInstance: %s", dd->type_instance);
       for (size_t i = 0; i < dd->oids_len; i++) {
         snmp_agent_oid_to_string(oid_str, sizeof(oid_str), &dd->oids[i]);
-        DEBUG(PLUGIN_NAME ":     OID[%zu]: %s", i, oid_str);
+        DEBUG(PLUGIN_NAME ":     OID[%" PRIsz "]: %s", i, oid_str);
       }
       DEBUG(PLUGIN_NAME ":   Scale: %g", dd->scale);
       DEBUG(PLUGIN_NAME ":   Shift: %g", dd->shift);
@@ -190,7 +190,7 @@ static void snmp_agent_dump_data(void) {
       DEBUG(PLUGIN_NAME ":   TypeInstance: %s", dd->type_instance);
     for (size_t i = 0; i < dd->oids_len; i++) {
       snmp_agent_oid_to_string(oid_str, sizeof(oid_str), &dd->oids[i]);
-      DEBUG(PLUGIN_NAME ":   OID[%zu]: %s", i, oid_str);
+      DEBUG(PLUGIN_NAME ":   OID[%" PRIsz "]: %s", i, oid_str);
     }
     DEBUG(PLUGIN_NAME ":   Scale: %g", dd->scale);
     DEBUG(PLUGIN_NAME ":   Shift: %g", dd->shift);

--- a/src/table.c
+++ b/src/table.c
@@ -335,8 +335,8 @@ static int tbl_prepare(tbl_t *tbl) {
     }
 
     if (res->values_num != res->ds->ds_num) {
-      log_err("Invalid type \"%s\". Expected %zu data source%s, "
-              "got %zu.",
+      log_err("Invalid type \"%s\". Expected %" PRIsz " data source%s, "
+              "got %" PRIsz ".",
               res->type, res->values_num, (1 == res->values_num) ? "" : "s",
               res->ds->ds_num);
       return -1;
@@ -429,7 +429,7 @@ static int tbl_parse_line(tbl_t *tbl, char *line, size_t len) {
 
   if (i <= tbl->max_colnum) {
     log_warn("Not enough columns in line "
-             "(expected at least %zu, got %zu).",
+             "(expected at least %" PRIsz ", got %" PRIsz ").",
              tbl->max_colnum + 1, i);
     return -1;
   }

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -128,7 +128,7 @@ static _Bool tcsv_check_index(ssize_t index, size_t fields_num,
     return 1;
 
   ERROR("tail_csv plugin: Metric \"%s\": Request for index %zd when "
-        "only %zu fields are available.",
+        "only %" PRIsz " fields are available.",
         name, index, fields_num);
   return 0;
 }
@@ -532,7 +532,7 @@ static int tcsv_init(void) { /* {{{ */
             md->type, md->name);
       continue;
     } else if (ds->ds_num != 1) {
-      ERROR("tail_csv plugin: The type \"%s\" has %zu data sources. "
+      ERROR("tail_csv plugin: The type \"%s\" has %" PRIsz " data sources. "
             "Only types with a single data source are supported.",
             ds->type, ds->ds_num);
       continue;

--- a/src/target_replace.c
+++ b/src/target_replace.c
@@ -294,7 +294,8 @@ static int tr_action_invoke(tr_action_t *act_head, /* {{{ */
     subst_status = subst(temp, sizeof(temp), buffer, (size_t)matches[0].rm_so,
                          (size_t)matches[0].rm_eo, act->replacement);
     if (subst_status == NULL) {
-      ERROR("Target `replace': subst (buffer = %s, start = %zu, end = %zu, "
+      ERROR("Target `replace': subst (buffer = %s, start = %" PRIsz
+            ", end = %" PRIsz ", "
             "replacement = %s) failed.",
             buffer, (size_t)matches[0].rm_so, (size_t)matches[0].rm_eo,
             act->replacement);
@@ -386,7 +387,8 @@ static int tr_meta_data_action_invoke(/* {{{ */
     subst_status = subst(temp, sizeof(temp), value, (size_t)matches[0].rm_so,
                          (size_t)matches[0].rm_eo, act->replacement);
     if (subst_status == NULL) {
-      ERROR("Target `replace': subst (value = %s, start = %zu, end = %zu, "
+      ERROR("Target `replace': subst (value = %s, start = %" PRIsz
+            ", end = %" PRIsz ", "
             "replacement = %s) failed.",
             value, (size_t)matches[0].rm_so, (size_t)matches[0].rm_eo,
             act->replacement);

--- a/src/utils_cmd_getthreshold.c
+++ b/src/utils_cmd_getthreshold.c
@@ -152,7 +152,7 @@ int handle_getthreshold(FILE *fh, char *buffer) {
     i++;
 
   /* Print the response */
-  print_to_socket(fh, "%zu Threshold found\n", i);
+  print_to_socket(fh, "%" PRIsz " Threshold found\n", i);
 
   if (threshold.host[0] != 0)
     print_to_socket(fh, "Host: %s\n", threshold.host);

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -132,8 +132,8 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
   }
 
   if (ds->ds_num != values_num) {
-    ERROR("ds[%s]->ds_num = %zu, "
-          "but uc_get_rate_by_name returned %zu values.",
+    ERROR("ds[%s]->ds_num = %" PRIsz ", "
+          "but uc_get_rate_by_name returned %" PRIsz " values.",
           ds->type, ds->ds_num, values_num);
     cmd_error(CMD_ERROR, &err, "Error reading value from cache.");
     sfree(values);
@@ -141,7 +141,7 @@ cmd_status_t cmd_handle_getval(FILE *fh, char *buffer) {
     return CMD_ERROR;
   }
 
-  print_to_socket(fh, "%zu Value%s found\n", values_num,
+  print_to_socket(fh, "%" PRIsz " Value%s found\n", values_num,
                   (values_num == 1) ? "" : "s");
   for (size_t i = 0; i < values_num; i++) {
     print_to_socket(fh, "%s=", ds->ds[i].name);

--- a/src/utils_db_query.c
+++ b/src/utils_db_query.c
@@ -363,7 +363,8 @@ static int udb_result_prepare_result(udb_result_t const *r, /* {{{ */
 
   if (prep_area->ds->ds_num != r->values_num) {
     ERROR("db query utils: udb_result_prepare_result: The type `%s' "
-          "requires exactly %zu value%s, but the configuration specifies %zu.",
+          "requires exactly %" PRIsz
+          " value%s, but the configuration specifies %" PRIsz ".",
           r->type, prep_area->ds->ds_num,
           (prep_area->ds->ds_num == 1) ? "" : "s", r->values_num);
     BAIL_OUT(-1);
@@ -892,7 +893,7 @@ int udb_query_handle_result(udb_query_t const *q, /* {{{ */
   do {
     for (size_t i = 0; i < prep_area->column_num; i++) {
       DEBUG("db query utils: udb_query_handle_result (%s, %s): "
-            "column[%zu] = %s;",
+            "column[%" PRIsz "] = %s;",
             prep_area->db_name, q->name, i, column_values[i]);
     }
   } while (0);
@@ -949,7 +950,7 @@ int udb_query_prepare_result(udb_query_t const *q, /* {{{ */
   do {
     for (size_t i = 0; i < column_num; i++) {
       DEBUG("db query utils: udb_query_prepare_result: "
-            "query = %s; column[%zu] = %s;",
+            "query = %s; column[%" PRIsz "] = %s;",
             q->name, i, column_names[i]);
     }
   } while (0);

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -60,7 +60,7 @@ static int gr_format_values(char *ret, size_t ret_len, int ds_num,
   else if (rates != NULL)
     BUFFER_ADD("%f", rates[ds_num]);
   else if (ds->ds[ds_num].type == DS_TYPE_COUNTER)
-    BUFFER_ADD("%llu", vl->values[ds_num].counter);
+    BUFFER_ADD("%" PRIu64, (uint64_t)vl->values[ds_num].counter);
   else if (ds->ds[ds_num].type == DS_TYPE_DERIVE)
     BUFFER_ADD("%" PRIi64, vl->values[ds_num].derive);
   else if (ds->ds[ds_num].type == DS_TYPE_ABSOLUTE)
@@ -223,7 +223,7 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
                          (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
     if (message_len >= sizeof(message)) {
       ERROR("format_graphite: message buffer too small: "
-            "Need %zu bytes.",
+            "Need %" PRIsz " bytes.",
             message_len + 1);
       sfree(rates);
       return -ENOMEM;

--- a/src/utils_format_json.c
+++ b/src/utils_format_json.c
@@ -130,7 +130,7 @@ static int values_to_json(char *buffer, size_t buffer_size, /* {{{ */
       else
         BUFFER_ADD("null");
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      BUFFER_ADD("%llu", vl->values[i].counter);
+      BUFFER_ADD("%" PRIu64, (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       BUFFER_ADD("%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)

--- a/src/utils_format_kairosdb.c
+++ b/src/utils_format_kairosdb.c
@@ -154,7 +154,7 @@ static int values_to_kairosdb(char *buffer, size_t buffer_size, /* {{{ */
     BUFFER_ADD("[[");
     BUFFER_ADD("%" PRIu64, CDTIME_T_TO_MS(vl->time));
     BUFFER_ADD(",");
-    BUFFER_ADD("%llu", vl->values[ds_idx].counter);
+    BUFFER_ADD("%" PRIu64, (uint64_t)vl->values[ds_idx].counter);
   } else if (ds->ds[ds_idx].type == DS_TYPE_DERIVE) {
     BUFFER_ADD("[[");
     BUFFER_ADD("%" PRIu64, CDTIME_T_TO_MS(vl->time));

--- a/src/utils_latency_test.c
+++ b/src/utils_latency_test.c
@@ -26,8 +26,8 @@
 
 #define DBL_PRECISION 1e-6
 
-#include "common.h" /* for STATIC_ARRAY_SIZE */
 #include "collectd.h"
+#include "common.h" /* for STATIC_ARRAY_SIZE */
 
 #include "testing.h"
 #include "utils_latency.h"
@@ -52,7 +52,7 @@ DEF_TEST(simple) {
   CHECK_NOT_NULL(l = latency_counter_create());
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
-    printf("# case %zu: DOUBLE_TO_CDTIME_T(%g) = %" PRIu64 "\n", i,
+    printf("# case %" PRIsz ": DOUBLE_TO_CDTIME_T(%g) = %" PRIu64 "\n", i,
            cases[i].val, DOUBLE_TO_CDTIME_T(cases[i].val));
     latency_counter_add(l, DOUBLE_TO_CDTIME_T(cases[i].val));
 

--- a/src/utils_lua.c
+++ b/src/utils_lua.c
@@ -28,8 +28,8 @@
  * GCC will complain about the macro definition. */
 #define DONT_POISON_SPRINTF_YET
 
-#include "utils_lua.h"
 #include "common.h"
+#include "utils_lua.h"
 
 static int ltoc_values(lua_State *L, /* {{{ */
                        const data_set_t *ds, value_t *ret_values) {
@@ -57,8 +57,8 @@ static int ltoc_values(lua_State *L, /* {{{ */
   } /* while (lua_next) */
 
   if (i != ds->ds_num) {
-    WARNING("ltoc_values: invalid size for datasource \"%s\": expected %zu, "
-            "got %zu",
+    WARNING("ltoc_values: invalid size for datasource \"%s\": expected %" PRIsz
+            ", got %" PRIsz,
             ds->type, ds->ds_num, i);
     return -1;
   }

--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -560,7 +560,7 @@ static int ovs_db_json_data_process(ovs_db_t *pdb, const char *data,
     return -1;
 
   sstrncpy(sjson, data, len + 1);
-  OVS_DEBUG("[len=%zu] %s", len, sjson);
+  OVS_DEBUG("[len=%" PRIsz "] %s", len, sjson);
 
   /* parse json data */
   jnode = yajl_tree_parse(sjson, yajl_errbuf, sizeof(yajl_errbuf));

--- a/src/virt.c
+++ b/src/virt.c
@@ -699,10 +699,11 @@ static double cpu_ns_to_percent(unsigned int node_cpus,
               (time_diff_sec * node_cpus * NANOSEC_IN_SEC);
   }
 
-  DEBUG(PLUGIN_NAME ": node_cpus=%u cpu_time_old=%llu cpu_time_new=%llu"
-                    "cpu_time_diff=%llu time_diff_sec=%f percent=%f",
-        node_cpus, cpu_time_old, cpu_time_new, cpu_time_diff, time_diff_sec,
-        percent);
+  DEBUG(PLUGIN_NAME ": node_cpus=%u cpu_time_old=%" PRIu64
+                    " cpu_time_new=%" PRIu64 "cpu_time_diff=%" PRIu64
+                    " time_diff_sec=%f percent=%f",
+        node_cpus, (uint64_t)cpu_time_old, (uint64_t)cpu_time_new,
+        (uint64_t)cpu_time_diff, time_diff_sec, percent);
 
   return percent;
 }
@@ -1660,7 +1661,7 @@ static int lv_init_instance(size_t i, plugin_read_cb callback) {
 
   memset(lv_ud, 0, sizeof(*lv_ud));
 
-  snprintf(inst->tag, sizeof(inst->tag), "%s-%zu", PLUGIN_NAME, i);
+  snprintf(inst->tag, sizeof(inst->tag), "%s-%" PRIsz, PLUGIN_NAME, i);
   inst->id = i;
 
   user_data_t *ud = &(lv_ud->ud);

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -177,7 +177,7 @@ static int wg_flush_nolock(cdtime_t timeout, struct wg_callback *cb) {
   int status;
 
   DEBUG("write_graphite plugin: wg_flush_nolock: timeout = %.3f; "
-        "send_buf_fill = %zu;",
+        "send_buf_fill = %" PRIsz ";",
         (double)timeout, cb->send_buf_fill);
 
   /* timeout == 0  => flush unconditionally */
@@ -381,7 +381,8 @@ static int wg_send_message(char const *message, struct wg_callback *cb) {
   cb->send_buf_fill += message_len;
   cb->send_buf_free -= message_len;
 
-  DEBUG("write_graphite plugin: [%s]:%s (%s) buf %zu/%zu (%.1f %%) \"%s\"",
+  DEBUG("write_graphite plugin: [%s]:%s (%s) buf %" PRIsz "/%" PRIsz
+        " (%.1f %%) \"%s\"",
         cb->node, cb->service, cb->protocol, cb->send_buf_fill,
         sizeof(cb->send_buf),
         100.0 * ((double)cb->send_buf_fill) / ((double)sizeof(cb->send_buf)),

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -228,7 +228,7 @@ static int wh_flush_nolock(cdtime_t timeout, wh_callback_t *cb) /* {{{ */
   int status;
 
   DEBUG("write_http plugin: wh_flush_nolock: timeout = %.3f; "
-        "send_buffer_fill = %zu;",
+        "send_buffer_fill = %" PRIsz ";",
         CDTIME_T_TO_DOUBLE(timeout), cb->send_buffer_fill);
 
   /* timeout == 0  => flush unconditionally */
@@ -380,7 +380,7 @@ static int wh_write_command(const data_set_t *ds,
                                  CDTIME_T_TO_DOUBLE(vl->interval), values);
   if (command_len >= sizeof(command)) {
     ERROR("write_http plugin: Command buffer too small: "
-          "Need %zu bytes.",
+          "Need %" PRIsz " bytes.",
           command_len + 1);
     return -1;
   }
@@ -410,8 +410,8 @@ static int wh_write_command(const data_set_t *ds,
   cb->send_buffer_fill += command_len;
   cb->send_buffer_free -= command_len;
 
-  DEBUG("write_http plugin: <%s> buffer %zu/%zu (%g%%) \"%s\"", cb->location,
-        cb->send_buffer_fill, cb->send_buffer_size,
+  DEBUG("write_http plugin: <%s> buffer %" PRIsz "/%" PRIsz " (%g%%) \"%s\"",
+        cb->location, cb->send_buffer_fill, cb->send_buffer_size,
         100.0 * ((double)cb->send_buffer_fill) / ((double)cb->send_buffer_size),
         command);
 
@@ -452,8 +452,8 @@ static int wh_write_json(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     return status;
   }
 
-  DEBUG("write_http plugin: <%s> buffer %zu/%zu (%g%%)", cb->location,
-        cb->send_buffer_fill, cb->send_buffer_size,
+  DEBUG("write_http plugin: <%s> buffer %" PRIsz "/%" PRIsz " (%g%%)",
+        cb->location, cb->send_buffer_fill, cb->send_buffer_size,
         100.0 * ((double)cb->send_buffer_fill) /
             ((double)cb->send_buffer_size));
 
@@ -501,8 +501,8 @@ static int wh_write_kairosdb(const data_set_t *ds,
     return status;
   }
 
-  DEBUG("write_http plugin: <%s> buffer %zu/%zu (%g%%)", cb->location,
-        cb->send_buffer_fill, cb->send_buffer_size,
+  DEBUG("write_http plugin: <%s> buffer %" PRIsz "/%" PRIsz " (%g%%)",
+        cb->location, cb->send_buffer_fill, cb->send_buffer_size,
         100.0 * ((double)cb->send_buffer_fill) /
             ((double)cb->send_buffer_size));
 
@@ -802,7 +802,8 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   /* Allocate the buffer. */
   cb->send_buffer = malloc(cb->send_buffer_size);
   if (cb->send_buffer == NULL) {
-    ERROR("write_http plugin: malloc(%zu) failed.", cb->send_buffer_size);
+    ERROR("write_http plugin: malloc(%" PRIsz ") failed.",
+          cb->send_buffer_size);
     wh_callback_free(cb);
     return -1;
   }

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -96,7 +96,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%zu", i);
+    snprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       BSON_APPEND_DOUBLE(&subarray, key, vl->values[i].gauge);
@@ -109,7 +109,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)
       BSON_APPEND_INT64(&subarray, key, vl->values[i].absolute);
     else {
-      ERROR("write_mongodb plugin: Unknown ds_type %d for index %zu",
+      ERROR("write_mongodb plugin: Unknown ds_type %d for index %" PRIsz,
             ds->ds[i].type, i);
       bson_destroy(ret);
       return NULL;
@@ -121,7 +121,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%zu", i);
+    snprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (store_rates)
       BSON_APPEND_UTF8(&subarray, key, "gauge");
@@ -134,7 +134,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%zu", i);
+    snprintf(key, sizeof(key), "%" PRIsz, i);
     BSON_APPEND_UTF8(&subarray, key, ds->ds[i].name);
   }
   bson_append_array_end(ret, &subarray); /* }}} dsnames */
@@ -144,7 +144,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   size_t error_location;
   if (!bson_validate(ret, BSON_VALIDATE_UTF8, &error_location)) {
     ERROR("write_mongodb plugin: Error in generated BSON document "
-          "at byte %zu",
+          "at byte %" PRIsz,
           error_location);
     bson_destroy(ret);
     return NULL;

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -362,7 +362,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   {
     char ds_index[DATA_MAX_NAME_LEN];
 
-    snprintf(ds_index, sizeof(ds_index), "%zu", index);
+    snprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
     riemann_event_string_attribute_add(event, "ds_index", ds_index);
   }
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -28,14 +28,14 @@
 
 #include "collectd.h"
 
+#include "common.h"
+#include "plugin.h"
+#include "utils_cache.h"
 #include <arpa/inet.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <netdb.h>
 #include <stddef.h>
-#include "common.h"
-#include "plugin.h"
-#include "utils_cache.h"
 
 #include <stdlib.h>
 #define SENSU_HOST "localhost"
@@ -454,7 +454,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   // incorporate the data source index
   {
     char ds_index[DATA_MAX_NAME_LEN];
-    snprintf(ds_index, sizeof(ds_index), "%zu", index);
+    snprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_index\": %s",
                       ret_str, ds_index);
     free(ret_str);
@@ -519,7 +519,8 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
         return NULL;
       }
     } else {
-      res = my_asprintf(&value_str, "%llu", vl->values[index].counter);
+      res = my_asprintf(&value_str, "%" PRIu64,
+                        (uint64_t)vl->values[index].counter);
       if (res == -1) {
         free(ret_str);
         ERROR("write_sensu plugin: Unable to alloc memory");

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -130,7 +130,7 @@ static int wt_flush_nolock(cdtime_t timeout, struct wt_callback *cb) {
   int status;
 
   DEBUG("write_tsdb plugin: wt_flush_nolock: timeout = %.3f; "
-        "send_buf_fill = %zu;",
+        "send_buf_fill = %" PRIsz ";",
         (double)timeout, cb->send_buf_fill);
 
   /* timeout == 0  => flush unconditionally */
@@ -348,7 +348,7 @@ static int wt_format_values(char *ret, size_t ret_len, int ds_num,
     }
     BUFFER_ADD(GAUGE_FORMAT, rates[ds_num]);
   } else if (ds->ds[ds_num].type == DS_TYPE_COUNTER)
-    BUFFER_ADD("%llu", vl->values[ds_num].counter);
+    BUFFER_ADD("%" PRIu64, (uint64_t)vl->values[ds_num].counter);
   else if (ds->ds[ds_num].type == DS_TYPE_DERIVE)
     BUFFER_ADD("%" PRIi64, vl->values[ds_num].derive);
   else if (ds->ds[ds_num].type == DS_TYPE_ABSOLUTE)
@@ -465,7 +465,7 @@ static int wt_send_message(const char *key, const char *value, cdtime_t time,
 
   if (message_len >= sizeof(message)) {
     ERROR("write_tsdb plugin: message buffer too small: "
-          "Need %zu bytes.",
+          "Need %" PRIsz " bytes.",
           message_len + 1);
     return -1;
   }
@@ -498,8 +498,8 @@ static int wt_send_message(const char *key, const char *value, cdtime_t time,
   cb->send_buf_fill += message_len;
   cb->send_buf_free -= message_len;
 
-  DEBUG("write_tsdb plugin: [%s]:%s buf %zu/%zu (%.1f %%) \"%s\"", cb->node,
-        cb->service, cb->send_buf_fill, sizeof(cb->send_buf),
+  DEBUG("write_tsdb plugin: [%s]:%s buf %" PRIsz "/%" PRIsz " (%.1f %%) \"%s\"",
+        cb->node, cb->service, cb->send_buf_fill, sizeof(cb->send_buf),
         100.0 * ((double)cb->send_buf_fill) / ((double)sizeof(cb->send_buf)),
         message);
 


### PR DESCRIPTION
The new macro, PRIsz, can be defined differently on systems that don't support PRIu64, zu, and llu, which will make the code easier to port.