### PR TITLE
libcollectdclient: fix usage of ip_mreq

### DIFF
--- a/src/libcollectdclient/server.c
+++ b/src/libcollectdclient/server.c
@@ -82,7 +82,7 @@ static int server_multicast_join(lcc_listener_t *srv,
     };
 #else
     struct ip_mreq mreq = {
-        .imr_address.s_addr = INADDR_ANY, .imr_multiaddr.s_addr = sa->s_addr,
+        .imr_multiaddr.s_addr = sa->sin_addr.s_addr,
     };
 #endif
     status = setsockopt(srv->conn, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq,


### PR DESCRIPTION
Trying to compile latest HEAD on AIX, I noticed that the struct `ip_mreq` does not define the field `imr_address`. I checked on Gentoo Linux and the definition is the same there. But on Linux, the struct `ip_mreqn` is present and thus the failing code path is not used. 
It also fails in the assignment of `sa->s_addr`.

Note: I don't have a setup to test multicast, so this may or may not break it. It compiles on Linux (when manipulating it to think ip_mreqn is undefined) and IBM AIX 7.1 after this change.