### PR TITLE
libcollectdclient: add defines for AIX

### DIFF
--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -43,10 +43,23 @@
 #include <endian.h>
 #elif HAVE_SYS_ENDIAN_H
 #include <sys/endian.h>
-#elif defined(_AIX) && defined(__GNUC__)
-/* AIX is always big endian */
-#define be16toh(x) (x)
-#define be64toh(x) (x)
+#else /* fallback */
+__attribute__((const)) static uint16_t be16toh(uint16_t n) {
+  uint8_t tmp[2];
+  memmove(tmp, &n, sizeof(tmp));
+
+  return ((uint16_t)tmp[0] << 8) | ((uint16_t)tmp[1] << 0);
+}
+
+__attribute__((const)) static uint64_t be64toh(uint64_t n) {
+  uint8_t tmp[8];
+  memmove(tmp, &n, sizeof(tmp));
+
+  return ((uint64_t)tmp[0] << 56) | ((uint64_t)tmp[1] << 48) |
+         ((uint64_t)tmp[2] << 40) | ((uint64_t)tmp[3] << 32) |
+         ((uint64_t)tmp[4] << 24) | ((uint64_t)tmp[5] << 16) |
+         ((uint64_t)tmp[6] << 8) | ((uint64_t)tmp[7] << 0);
+}
 #endif
 
 #if HAVE_GCRYPT_H

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -43,6 +43,10 @@
 #include <endian.h>
 #elif HAVE_SYS_ENDIAN_H
 #include <sys/endian.h>
+#elif defined(_AIX) && defined(__GNUC__)
+/* AIX is always big endian */
+#define be16toh(x) (x)
+#define be64toh(x) (x)
 #endif
 
 #if HAVE_GCRYPT_H


### PR DESCRIPTION
This adds two defines that are missing on AIX because they don't have
the endian.h header file. AIX is always big endian, so no further check
is required for that. As I have no access to IBMs XLC compiler, this
patch limits the definitions to GNU GCC.