### PR TITLE
Add the STRERROR() and STRERRNO macros.

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -441,10 +441,8 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
 
   status = amqp_socket_open(socket, CONF(conf, host), conf->port);
   if (status < 0) {
-    char errbuf[1024];
     status *= -1;
-    ERROR("amqp plugin: amqp_socket_open failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("amqp plugin: amqp_socket_open failed: %s", STRERROR(status));
     amqp_destroy_connection(conf->connection);
     conf->connection = NULL;
     return status;
@@ -454,10 +452,8 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
   /* this interface is deprecated as of rabbitmq-c 0.4 */
   sockfd = amqp_open_socket(CONF(conf, host), conf->port);
   if (sockfd < 0) {
-    char errbuf[1024];
     status = (-1) * sockfd;
-    ERROR("amqp plugin: amqp_open_socket failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("amqp plugin: amqp_open_socket failed: %s", STRERROR(status));
     amqp_destroy_connection(conf->connection);
     conf->connection = NULL;
     return status;
@@ -545,10 +541,8 @@ static int camqp_read_body(camqp_config_t *conf, /* {{{ */
   while (received < body_size) {
     status = amqp_simple_wait_frame(conf->connection, &frame);
     if (status < 0) {
-      char errbuf[1024];
       status = (-1) * status;
-      ERROR("amqp plugin: amqp_simple_wait_frame failed: %s",
-            sstrerror(status, errbuf, sizeof(errbuf)));
+      ERROR("amqp plugin: amqp_simple_wait_frame failed: %s", STRERROR(status));
       camqp_close_connection(conf);
       return status;
     }
@@ -597,10 +591,8 @@ static int camqp_read_header(camqp_config_t *conf) /* {{{ */
 
   status = amqp_simple_wait_frame(conf->connection, &frame);
   if (status < 0) {
-    char errbuf[1024];
     status = (-1) * status;
-    ERROR("amqp plugin: amqp_simple_wait_frame failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("amqp plugin: amqp_simple_wait_frame failed: %s", STRERROR(status));
     camqp_close_connection(conf);
     return status;
   }
@@ -693,9 +685,7 @@ static int camqp_subscribe_init(camqp_config_t *conf) /* {{{ */
   status = plugin_thread_create(tmp, /* attr = */ NULL, camqp_subscribe_thread,
                                 conf, "amqp subscribe");
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("amqp plugin: pthread_create failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("amqp plugin: pthread_create failed: %s", STRERROR(status));
     return status;
   }
 

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -972,10 +972,11 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
     char cbname[128];
     snprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
-    status = plugin_register_write(
-        cbname, camqp_write, &(user_data_t){
-                                 .data = conf, .free_func = camqp_config_free,
-                             });
+    status =
+        plugin_register_write(cbname, camqp_write,
+                              &(user_data_t){
+                                  .data = conf, .free_func = camqp_config_free,
+                              });
     if (status != 0) {
       camqp_config_free(conf);
       return status;

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -119,10 +119,8 @@ static int net_open(char const *node, char const *service) {
 
   status = getaddrinfo(node, service, &ai_hints, &ai_return);
   if (status != 0) {
-    char errbuf[1024];
     INFO("apcups plugin: getaddrinfo failed: %s",
-         (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                : gai_strerror(status));
+         (status == EAI_SYSTEM) ? STRERRNO : gai_strerror(status));
     return -1;
   }
 
@@ -147,9 +145,7 @@ static int net_open(char const *node, char const *service) {
 
   if (status != 0) /* `connect(2)' failed */
   {
-    char errbuf[1024];
-    INFO("apcups plugin: connect failed: %s",
-         sstrerror(errno, errbuf, sizeof(errbuf)));
+    INFO("apcups plugin: connect failed: %s", STRERRNO);
     close(sd);
     return -1;
   }
@@ -424,8 +420,8 @@ static int apcups_read(void) {
   int status = apc_query_server(conf_node, conf_service, &apcups_detail);
 
   if (status != 0) {
-    DEBUG("apcups plugin: apc_query_server (\"%s\", \"%s\") = %d",
-          conf_node, conf_service, status);
+    DEBUG("apcups plugin: apc_query_server (\"%s\", \"%s\") = %d", conf_node,
+          conf_service, status);
     return status;
   }
 

--- a/src/apcups.c
+++ b/src/apcups.c
@@ -236,7 +236,8 @@ static int apc_query_server(char const *node, char const *service,
   char recvline[1024];
   char *tokptr;
   char *toksaveptr;
-  int try = 0;
+  int try
+    = 0;
   int status;
 
 #if APCMAIN
@@ -261,7 +262,8 @@ static int apc_query_server(char const *node, char const *service,
       /* net_send closes the socket on error. */
       assert(global_sockfd < 0);
       if (try == 0) {
-        try++;
+        try
+          ++;
         count_retries++;
         continue;
       }
@@ -337,9 +339,7 @@ static int apc_query_server(char const *node, char const *service,
     net_shutdown(&global_sockfd);
 
   if (n < 0) {
-    char errbuf[1024];
-    ERROR("apcups plugin: Reading from socket failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("apcups plugin: Reading from socket failed: %s", STRERROR(status));
     return -1;
   }
 

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -94,19 +94,15 @@ static int aquaero_read(void) {
   char type_instance[DATA_MAX_NAME_LEN];
 
   if (libaquaero5_poll(conf_device, &aq_data, &err_msg) < 0) {
-    char errbuf[1024];
     ERROR("aquaero plugin: Failed to poll device \"%s\": %s (%s)",
-          conf_device ? conf_device : "default", err_msg,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          conf_device ? conf_device : "default", err_msg, STRERRNO);
     return -1;
   }
 
   if (libaquaero5_getsettings(conf_device, &aq_sett, &err_msg) < 0) {
-    char errbuf[1024];
     ERROR("aquaero plugin: Failed to get settings "
           "for device \"%s\": %s (%s)",
-          conf_device ? conf_device : "default", err_msg,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          conf_device ? conf_device : "default", err_msg, STRERRNO);
     return -1;
   }
 

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -547,7 +547,6 @@ static int MPL115_read_coeffs(void) {
   int8_t sic12MSB, sic12LSB, sic11MSB, sic11LSB, sic22MSB, sic22LSB;
   int16_t sia0, sib1, sib2, sic12, sic11, sic22;
 
-
   res = i2c_smbus_read_i2c_block_data(i2c_bus_fd, MPL115_ADDR_COEFFS,
                                       STATIC_ARRAY_SIZE(mpl115_coeffs),
                                       mpl115_coeffs);
@@ -1126,7 +1125,6 @@ static int BMP085_read(double *pressure, double *temperature) {
 
   long adc_pressure;
   long adc_temperature;
-
 
   /* start conversion of temperature */
   res = i2c_smbus_write_byte_data(i2c_bus_fd, BMP085_ADDR_CTRL_REG,

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -514,12 +514,11 @@ static int get_reference_temperature(double *result) {
  */
 static int MPL115_detect(void) {
   __s32 res;
-  char errbuf[1024];
 
   if (ioctl(i2c_bus_fd, I2C_SLAVE_FORCE, MPL115_I2C_ADDRESS) < 0) {
     ERROR("barometer: MPL115_detect problem setting i2c slave address to "
           "0x%02X: %s",
-          MPL115_I2C_ADDRESS, sstrerror(errno, errbuf, sizeof(errbuf)));
+          MPL115_I2C_ADDRESS, STRERRNO);
     return 0;
   }
 
@@ -548,14 +547,12 @@ static int MPL115_read_coeffs(void) {
   int8_t sic12MSB, sic12LSB, sic11MSB, sic11LSB, sic22MSB, sic22LSB;
   int16_t sia0, sib1, sib2, sic12, sic11, sic22;
 
-  char errbuf[1024];
 
   res = i2c_smbus_read_i2c_block_data(i2c_bus_fd, MPL115_ADDR_COEFFS,
                                       STATIC_ARRAY_SIZE(mpl115_coeffs),
                                       mpl115_coeffs);
   if (res < 0) {
-    ERROR("barometer: MPL115_read_coeffs - problem reading data: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("barometer: MPL115_read_coeffs - problem reading data: %s", STRERRNO);
     return -1;
   }
 
@@ -657,7 +654,6 @@ static int MPL115_read_averaged(double *pressure, double *temperature) {
   int conv_temperature;
   double adc_pressure;
   double adc_temperature;
-  char errbuf[1024];
 
   *pressure = 0.0;
   *temperature = 0.0;
@@ -674,11 +670,11 @@ static int MPL115_read_averaged(double *pressure, double *temperature) {
     if (retries > 0) {
       ERROR("barometer: MPL115_read_averaged - requesting conversion: %s, "
             "will retry at most %d more times",
-            sstrerror(errno, errbuf, sizeof(errbuf)), retries);
+            STRERRNO, retries);
     } else {
       ERROR("barometer: MPL115_read_averaged - requesting conversion: %s, "
             "too many failed retries",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return -1;
     }
   }
@@ -697,11 +693,11 @@ static int MPL115_read_averaged(double *pressure, double *temperature) {
     if (retries > 0) {
       ERROR("barometer: MPL115_read_averaged - reading conversion: %s, "
             "will retry at most %d more times",
-            sstrerror(errno, errbuf, sizeof(errbuf)), retries);
+            STRERRNO, retries);
     } else {
       ERROR("barometer: MPL115_read_averaged - reading conversion: %s, "
             "too many failed retries",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return -1;
     }
   }
@@ -738,12 +734,11 @@ static int MPL115_read_averaged(double *pressure, double *temperature) {
  */
 static int MPL3115_detect(void) {
   __s32 res;
-  char errbuf[1024];
 
   if (ioctl(i2c_bus_fd, I2C_SLAVE_FORCE, MPL3115_I2C_ADDRESS) < 0) {
     ERROR("barometer: MPL3115_detect problem setting i2c slave address to "
           "0x%02X: %s",
-          MPL3115_I2C_ADDRESS, sstrerror(errno, errbuf, sizeof(errbuf)));
+          MPL3115_I2C_ADDRESS, STRERRNO);
     return 0;
   }
 
@@ -810,21 +805,18 @@ static int MPL3115_read(double *pressure, double *temperature) {
   __s32 ctrl;
   __u8 data[MPL3115_NUM_CONV_VALS];
   long int tmp_value = 0;
-  char errbuf[1024];
 
   /* Set Active - activate the device from standby */
   res = i2c_smbus_read_byte_data(i2c_bus_fd, MPL3115_REG_CTRL_REG1);
   if (res < 0) {
-    ERROR("barometer: MPL3115_read - cannot read CTRL_REG1: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("barometer: MPL3115_read - cannot read CTRL_REG1: %s", STRERRNO);
     return 1;
   }
   ctrl = res;
   res = i2c_smbus_write_byte_data(i2c_bus_fd, MPL3115_REG_CTRL_REG1,
                                   ctrl | MPL3115_CTRL_REG1_SBYB);
   if (res < 0) {
-    ERROR("barometer: MPL3115_read - problem activating: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("barometer: MPL3115_read - problem activating: %s", STRERRNO);
     return 1;
   }
 
@@ -835,7 +827,7 @@ static int MPL3115_read(double *pressure, double *temperature) {
   res = i2c_smbus_read_byte_data(i2c_bus_fd, MPL3115_REG_STATUS);
   if (res < 0) {
     ERROR("barometer: MPL3115_read - cannot read status register: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
@@ -848,7 +840,7 @@ static int MPL3115_read(double *pressure, double *temperature) {
     res = i2c_smbus_read_byte_data(i2c_bus_fd, MPL3115_REG_STATUS);
     if (res < 0) {
       ERROR("barometer: MPL3115_read - cannot read status register: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return 1;
     }
   }
@@ -857,8 +849,7 @@ static int MPL3115_read(double *pressure, double *temperature) {
   res = i2c_smbus_read_i2c_block_data(i2c_bus_fd, MPL3115_REG_OUT_P_MSB,
                                       MPL3115_NUM_CONV_VALS, data);
   if (res < 0) {
-    ERROR("barometer: MPL3115_read - cannot read data registers: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("barometer: MPL3115_read - cannot read data registers: %s", STRERRNO);
     return 1;
   }
 
@@ -888,7 +879,6 @@ static int MPL3115_read(double *pressure, double *temperature) {
 static int MPL3115_init_sensor(void) {
   __s32 res;
   __s8 offset;
-  char errbuf[1024];
 
   /* Reset the sensor. It will reset immediately without ACKing */
   /* the transaction, so no error handling here. */
@@ -906,7 +896,7 @@ static int MPL3115_init_sensor(void) {
   res = i2c_smbus_write_byte_data(i2c_bus_fd, MPL3115_REG_OFF_T, offset);
   if (res < 0) {
     ERROR("barometer: MPL3115_init_sensor - problem setting temp offset: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -917,7 +907,7 @@ static int MPL3115_init_sensor(void) {
   if (res < 0) {
     ERROR(
         "barometer: MPL3115_init_sensor - problem setting pressure offset: %s",
-        sstrerror(errno, errbuf, sizeof(errbuf)));
+        STRERRNO);
     return -1;
   }
 
@@ -927,7 +917,7 @@ static int MPL3115_init_sensor(void) {
                                       MPL3115_PT_DATA_TDEF);
   if (res < 0) {
     ERROR("barometer: MPL3115_init_sensor - problem setting PT_DATA_CFG: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -936,7 +926,7 @@ static int MPL3115_init_sensor(void) {
                                   mpl3115_oversample);
   if (res < 0) {
     ERROR("barometer: MPL3115_init_sensor - problem configuring CTRL_REG1: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -954,12 +944,11 @@ static int MPL3115_init_sensor(void) {
  */
 static int BMP085_detect(void) {
   __s32 res;
-  char errbuf[1024];
 
   if (ioctl(i2c_bus_fd, I2C_SLAVE_FORCE, BMP085_I2C_ADDRESS) < 0) {
     ERROR("barometer: BMP085_detect - problem setting i2c slave address to "
           "0x%02X: %s",
-          BMP085_I2C_ADDRESS, sstrerror(errno, errbuf, sizeof(errbuf)));
+          BMP085_I2C_ADDRESS, STRERRNO);
     return 0;
   }
 
@@ -971,7 +960,7 @@ static int BMP085_detect(void) {
     res = i2c_smbus_read_byte_data(i2c_bus_fd, BMP085_ADDR_VERSION);
     if (res < 0) {
       ERROR("barometer: BMP085_detect - problem checking chip version: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return 0;
     }
     DEBUG("barometer: BMP085_detect - chip version ML:0x%02X AL:0x%02X",
@@ -1033,13 +1022,11 @@ static void BMP085_adjust_oversampling(void) {
 static int BMP085_read_coeffs(void) {
   __s32 res;
   __u8 coeffs[BMP085_NUM_COEFFS];
-  char errbuf[1024];
 
   res = i2c_smbus_read_i2c_block_data(i2c_bus_fd, BMP085_ADDR_COEFFS,
                                       BMP085_NUM_COEFFS, coeffs);
   if (res < 0) {
-    ERROR("barometer: BMP085_read_coeffs - problem reading data: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("barometer: BMP085_read_coeffs - problem reading data: %s", STRERRNO);
     return -1;
   }
 
@@ -1140,7 +1127,6 @@ static int BMP085_read(double *pressure, double *temperature) {
   long adc_pressure;
   long adc_temperature;
 
-  char errbuf[1024];
 
   /* start conversion of temperature */
   res = i2c_smbus_write_byte_data(i2c_bus_fd, BMP085_ADDR_CTRL_REG,
@@ -1148,7 +1134,7 @@ static int BMP085_read(double *pressure, double *temperature) {
   if (res < 0) {
     ERROR("barometer: BMP085_read - problem requesting temperature conversion: "
           "%s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
@@ -1158,7 +1144,7 @@ static int BMP085_read(double *pressure, double *temperature) {
       i2c_smbus_read_i2c_block_data(i2c_bus_fd, BMP085_ADDR_CONV, 2, measBuff);
   if (res < 0) {
     ERROR("barometer: BMP085_read - problem reading temperature data: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
@@ -1169,7 +1155,7 @@ static int BMP085_read(double *pressure, double *temperature) {
                                   bmp085_cmdCnvPress);
   if (res < 0) {
     ERROR("barometer: BMP085_read - problem requesting pressure conversion: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
@@ -1179,7 +1165,7 @@ static int BMP085_read(double *pressure, double *temperature) {
       i2c_smbus_read_i2c_block_data(i2c_bus_fd, BMP085_ADDR_CONV, 3, measBuff);
   if (res < 0) {
     ERROR("barometer: BMP085_read - problem reading pressure data: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
@@ -1571,7 +1557,6 @@ static int BMP085_collectd_barometer_read(void) {
  * @return Zero when successful.
  */
 static int collectd_barometer_init(void) {
-  char errbuf[1024];
 
   DEBUG("barometer: collectd_barometer_init");
 
@@ -1596,7 +1581,7 @@ static int collectd_barometer_init(void) {
   if (i2c_bus_fd < 0) {
     ERROR("barometer: collectd_barometer_init problem opening I2C bus device "
           "\"%s\": %s (is loaded mod i2c-dev?)",
-          config_device, sstrerror(errno, errbuf, sizeof(errbuf)));
+          config_device, STRERRNO);
     return -1;
   }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -440,18 +440,14 @@ static int bind_xml_read_timestamp(const char *xpath_expression, /* {{{ */
 #if HAVE_TIMEGM
   time_t t = timegm(&tm);
   if (t == ((time_t)-1)) {
-    char errbuf[1024];
-    ERROR("bind plugin: timegm() failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("bind plugin: timegm() failed: %s", STRERRNO);
     return -1;
   }
   *ret_value = t;
 #else
   time_t t = mktime(&tm);
   if (t == ((time_t)-1)) {
-    char errbuf[1024];
-    ERROR("bind plugin: mktime() failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("bind plugin: mktime() failed: %s", STRERRNO);
     return -1;
   }
   /* mktime assumes that tm is local time. Luckily, it also sets timezone to

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -79,9 +79,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
            cgroup_name);
   fh = fopen(abs_path, "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    ERROR("cgroups plugin: fopen (\"%s\") failed: %s", abs_path,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("cgroups plugin: fopen (\"%s\") failed: %s", abs_path, STRERRNO);
     return -1;
   }
 

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -85,8 +85,7 @@ static int cs_read(void) {
 
   fh = fopen("/proc/stat", "r");
   if (fh == NULL) {
-    ERROR("contextswitch plugin: unable to open /proc/stat: %s",
-          sstrerror(errno, buffer, sizeof(buffer)));
+    ERROR("contextswitch plugin: unable to open /proc/stat: %s", STRERRNO);
     return -1;
   }
 
@@ -126,9 +125,7 @@ static int cs_read(void) {
   status =
       perfstat_cpu_total(NULL, &perfcputotal, sizeof(perfstat_cpu_total_t), 1);
   if (status < 0) {
-    char errbuf[1024];
-    ERROR("contextswitch plugin: perfstat_cpu_total: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("contextswitch plugin: perfstat_cpu_total: %s", STRERRNO);
     return -1;
   }
 

--- a/src/csv.c
+++ b/src/csv.c
@@ -161,9 +161,7 @@ static int csv_create_file(const char *filename, const data_set_t *ds) {
 
   csv = fopen(filename, "w");
   if (csv == NULL) {
-    char errbuf[1024];
-    ERROR("csv plugin: fopen (%s) failed: %s", filename,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("csv plugin: fopen (%s) failed: %s", filename, STRERRNO);
     return -1;
   }
 
@@ -258,9 +256,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
       if (csv_create_file(filename, ds))
         return -1;
     } else {
-      char errbuf[1024];
-      ERROR("stat(%s) failed: %s", filename,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("stat(%s) failed: %s", filename, STRERRNO);
       return -1;
     }
   } else if (!S_ISREG(statbuf.st_mode)) {
@@ -270,9 +266,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
 
   csv = fopen(filename, "a");
   if (csv == NULL) {
-    char errbuf[1024];
-    ERROR("csv plugin: fopen (%s) failed: %s", filename,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("csv plugin: fopen (%s) failed: %s", filename, STRERRNO);
     return -1;
   }
   csv_fd = fileno(csv);
@@ -283,9 +277,7 @@ static int csv_write(const data_set_t *ds, const value_list_t *vl,
 
   status = fcntl(csv_fd, F_SETLK, &fl);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("csv plugin: flock (%s) failed: %s", filename,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("csv plugin: flock (%s) failed: %s", filename, STRERRNO);
     fclose(csv);
     return -1;
   }

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -824,7 +824,6 @@ static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
 
 static int cj_sock_perform(cj_t *db) /* {{{ */
 {
-  char errbuf[1024];
   struct sockaddr_un sa_unix = {
       .sun_family = AF_UNIX,
   };
@@ -835,8 +834,7 @@ static int cj_sock_perform(cj_t *db) /* {{{ */
     return -1;
   if (connect(fd, (struct sockaddr *)&sa_unix, sizeof(sa_unix)) < 0) {
     ERROR("curl_json plugin: connect(%s) failed: %s",
-          (db->sock != NULL) ? db->sock : "<null>",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          (db->sock != NULL) ? db->sock : "<null>", STRERRNO);
     close(fd);
     return -1;
   }
@@ -847,8 +845,7 @@ static int cj_sock_perform(cj_t *db) /* {{{ */
     red = read(fd, buffer, sizeof(buffer));
     if (red < 0) {
       ERROR("curl_json plugin: read(%s) failed: %s",
-            (db->sock != NULL) ? db->sock : "<null>",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            (db->sock != NULL) ? db->sock : "<null>", STRERRNO);
       close(fd);
       return -1;
     }

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -159,8 +159,7 @@ static int change_basedir(const char *orig_dir, _Bool create) {
 
   dir = strdup(orig_dir);
   if (dir == NULL) {
-    char errbuf[1024];
-    ERROR("strdup failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("strdup failed: %s", STRERRNO);
     return -1;
   }
 
@@ -178,27 +177,21 @@ static int change_basedir(const char *orig_dir, _Bool create) {
     free(dir);
     return 0;
   } else if (!create || (errno != ENOENT)) {
-    char errbuf[1024];
-    ERROR("change_basedir: chdir (%s): %s", dir,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("change_basedir: chdir (%s): %s", dir, STRERRNO);
     free(dir);
     return -1;
   }
 
   status = mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("change_basedir: mkdir (%s): %s", dir,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("change_basedir: mkdir (%s): %s", dir, STRERRNO);
     free(dir);
     return -1;
   }
 
   status = chdir(dir);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("change_basedir: chdir (%s): %s", dir,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("change_basedir: chdir (%s): %s", dir, STRERRNO);
     free(dir);
     return -1;
   }
@@ -322,8 +315,7 @@ static int do_loop(void) {
 
     while ((loop == 0) && (nanosleep(&ts_wait, &ts_wait) != 0)) {
       if (errno != EINTR) {
-        char errbuf[1024];
-        ERROR("nanosleep failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("nanosleep failed: %s", STRERRNO);
         return -1;
       }
     }
@@ -342,8 +334,7 @@ static int pidfile_create(void) {
   const char *file = global_option_get("PIDFile");
 
   if ((fh = fopen(file, "w")) == NULL) {
-    char errbuf[1024];
-    ERROR("fopen (%s): %s", file, sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("fopen (%s): %s", file, STRERRNO);
     return 1;
   }
 
@@ -411,9 +402,7 @@ static int notify_systemd(void) {
   fd = socket(AF_UNIX, SOCK_DGRAM, /* protocol = */ 0);
 #endif
   if (fd < 0) {
-    char errbuf[1024];
-    ERROR("creating UNIX socket failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("creating UNIX socket failed: %s", STRERRNO);
     return 0;
   }
 
@@ -436,9 +425,7 @@ static int notify_systemd(void) {
 
   if (sendto(fd, buffer, strlen(buffer), MSG_NOSIGNAL, (void *)&su,
              (socklen_t)su_size) < 0) {
-    char errbuf[1024];
-    ERROR("sendto(\"%s\") failed: %s", notifysocket,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("sendto(\"%s\") failed: %s", notifysocket, STRERRNO);
     close(fd);
     return 0;
   }
@@ -588,8 +575,7 @@ int main(int argc, char **argv) {
 
     if ((pid = fork()) == -1) {
       /* error */
-      char errbuf[1024];
-      fprintf(stderr, "fork: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+      fprintf(stderr, "fork: %s", STRERRNO);
       return 1;
     } else if (pid != 0) {
       /* parent */
@@ -642,27 +628,24 @@ int main(int argc, char **argv) {
   struct sigaction sig_int_action = {.sa_handler = sig_int_handler};
 
   if (0 != sigaction(SIGINT, &sig_int_action, NULL)) {
-    char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal INT: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
   struct sigaction sig_term_action = {.sa_handler = sig_term_handler};
 
   if (0 != sigaction(SIGTERM, &sig_term_action, NULL)) {
-    char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal TERM: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 
   struct sigaction sig_usr1_action = {.sa_handler = sig_usr1_handler};
 
   if (0 != sigaction(SIGUSR1, &sig_usr1_action, NULL)) {
-    char errbuf[1024];
     ERROR("Error: Failed to install a signal handler for signal USR1: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return 1;
   }
 

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -629,14 +629,10 @@ int check_create_dir(const char *file_orig) {
           if (EEXIST == errno)
             continue;
 
-          char errbuf[1024];
-          ERROR("check_create_dir: mkdir (%s): %s", dir,
-                sstrerror(errno, errbuf, sizeof(errbuf)));
+          ERROR("check_create_dir: mkdir (%s): %s", dir, STRERRNO);
           return -1;
         } else {
-          char errbuf[1024];
-          ERROR("check_create_dir: stat (%s): %s", dir,
-                sstrerror(errno, errbuf, sizeof(errbuf)));
+          ERROR("check_create_dir: stat (%s): %s", dir, STRERRNO);
           return -1;
         }
       } else if (!S_ISDIR(statbuf.st_mode)) {
@@ -1210,9 +1206,7 @@ int walk_directory(const char *dir, dirwalk_callback_f callback,
   failure = 0;
 
   if ((dh = opendir(dir)) == NULL) {
-    char errbuf[1024];
-    ERROR("walk_directory: Cannot open '%s': %s", dir,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("walk_directory: Cannot open '%s': %s", dir, STRERRNO);
     return -1;
   }
 

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -73,6 +73,13 @@ char *sstrdup(const char *s);
 void *smalloc(size_t size);
 char *sstrerror(int errnum, char *buf, size_t buflen);
 
+#ifndef ERRBUF_SIZE
+#define ERRBUF_SIZE 256
+#endif
+
+#define STRERROR(e) sstrerror((e), (char[ERRBUF_SIZE]){0}, ERRBUF_SIZE)
+#define STRERRNO STRERROR(errno)
+
 /*
  * NAME
  *   sread

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -461,9 +461,9 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
     return 0;
   }
 
-  temp = realloc(dst->children,
-                 sizeof(oconfig_item_t) *
-                     (dst->children_num + src->children_num - 1));
+  temp =
+      realloc(dst->children, sizeof(oconfig_item_t) *
+                                 (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -502,9 +502,8 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   if ((src == NULL) || (src->children_num == 0))
     return 0;
 
-  temp =
-      realloc(dst->children,
-              sizeof(oconfig_item_t) * (dst->children_num + src->children_num));
+  temp = realloc(dst->children, sizeof(oconfig_item_t) *
+                                    (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -634,9 +633,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
 
   dh = opendir(dir);
   if (dh == NULL) {
-    char errbuf[1024];
-    ERROR("configfile: opendir failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("configfile: opendir failed: %s", STRERRNO);
     return NULL;
   }
 
@@ -765,9 +762,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
     status = stat(path_ptr, &statbuf);
     if (status != 0) {
-      char errbuf[1024];
-      WARNING("configfile: stat (%s) failed: %s", path_ptr,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("configfile: stat (%s) failed: %s", path_ptr, STRERRNO);
       continue;
     }
 
@@ -813,9 +808,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
   status = stat(path, &statbuf);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("configfile: stat (%s) failed: %s", path,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("configfile: stat (%s) failed: %s", path, STRERRNO);
     return NULL;
   }
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -461,9 +461,9 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
     return 0;
   }
 
-  temp =
-      realloc(dst->children, sizeof(oconfig_item_t) *
-                                 (dst->children_num + src->children_num - 1));
+  temp = realloc(dst->children,
+                 sizeof(oconfig_item_t) *
+                     (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -502,8 +502,9 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   if ((src == NULL) || (src->children_num == 0))
     return 0;
 
-  temp = realloc(dst->children, sizeof(oconfig_item_t) *
-                                    (dst->children_num + src->children_num));
+  temp =
+      realloc(dst->children,
+              sizeof(oconfig_item_t) * (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1009,9 +1009,7 @@ int plugin_load(char const *plugin_name, _Bool global) {
   }
 
   if ((dh = opendir(dir)) == NULL) {
-    char errbuf[1024];
-    ERROR("plugin_load: opendir (%s) failed: %s", dir,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("plugin_load: opendir (%s) failed: %s", dir, STRERRNO);
     return -1;
   }
 
@@ -1026,9 +1024,7 @@ int plugin_load(char const *plugin_name, _Bool global) {
     }
 
     if (lstat(filename, &statbuf) == -1) {
-      char errbuf[1024];
-      WARNING("plugin_load: stat (\"%s\") failed: %s", filename,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("plugin_load: stat (\"%s\") failed: %s", filename, STRERRNO);
       continue;
     } else if (!S_ISREG(statbuf.st_mode)) {
       /* don't follow symlinks */
@@ -2462,9 +2458,7 @@ static plugin_ctx_t *plugin_ctx_create(void) {
 
   ctx = malloc(sizeof(*ctx));
   if (ctx == NULL) {
-    char errbuf[1024];
-    ERROR("Failed to allocate plugin context: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("Failed to allocate plugin context: %s", STRERRNO);
     return NULL;
   }
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -610,9 +610,7 @@ static void set_thread_name(pthread_t tid, char const *name) {
 #if defined(HAVE_PTHREAD_SETNAME_NP)
   int status = pthread_setname_np(tid, n);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("set_thread_name(\"%s\"): %s", n,
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("set_thread_name(\"%s\"): %s", n, STRERROR(status));
   }
 #else /* if defined(HAVE_PTHREAD_SET_NAME_NP) */
   pthread_set_name_np(tid, n);
@@ -638,10 +636,9 @@ static void start_read_threads(size_t num) /* {{{ */
                                 /* attr = */ NULL, plugin_read_thread,
                                 /* arg = */ NULL);
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("plugin: start_read_threads: pthread_create failed "
-            "with status %i (%s).",
-            status, sstrerror(status, errbuf, sizeof(errbuf)));
+      ERROR("plugin: start_read_threads: pthread_create failed with status %i "
+            "(%s).",
+            status, STRERROR(status));
       return;
     }
 
@@ -845,10 +842,9 @@ static void start_write_threads(size_t num) /* {{{ */
                                 /* attr = */ NULL, plugin_write_thread,
                                 /* arg = */ NULL);
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("plugin: start_write_threads: pthread_create failed "
-            "with status %i (%s).",
-            status, sstrerror(status, errbuf, sizeof(errbuf)));
+      ERROR("plugin: start_write_threads: pthread_create failed with status %i "
+            "(%s).",
+            status, STRERROR(status));
       return;
     }
 
@@ -2088,10 +2084,9 @@ int plugin_dispatch_values(value_list_t const *vl) {
 
   status = plugin_write_enqueue(vl);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("plugin_dispatch_values: plugin_write_enqueue failed "
-          "with status %i (%s).",
-          status, sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("plugin_dispatch_values: plugin_write_enqueue failed with status %i "
+          "(%s).",
+          status, STRERROR(status));
     return status;
   }
 

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -174,11 +174,9 @@ int read_types_list(const char *file) {
 
   fh = fopen(file, "r");
   if (fh == NULL) {
-    char errbuf[1024];
     fprintf(stderr, "Failed to open types database `%s': %s.\n", file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
-    ERROR("Failed to open types database `%s': %s", file,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
+    ERROR("Failed to open types database `%s': %s", file, STRERRNO);
     return -1;
   }
 

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -47,9 +47,7 @@ cdtime_t cdtime(void) /* {{{ */
 
   status = clock_gettime(CLOCK_REALTIME, &ts);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("cdtime: clock_gettime failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("cdtime: clock_gettime failed: %s", STRERRNO);
     return 0;
   }
 
@@ -64,9 +62,7 @@ cdtime_t cdtime(void) /* {{{ */
 
   status = gettimeofday(&tv, /* struct timezone = */ NULL);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("cdtime: gettimeofday failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("cdtime: gettimeofday failed: %s", STRERRNO);
     return 0;
   }
 
@@ -85,10 +81,8 @@ static int get_utc_time(cdtime_t t, struct tm *t_tm, long *nsec) /* {{{ */
   NORMALIZE_TIMESPEC(t_spec);
 
   if (gmtime_r(&t_spec.tv_sec, t_tm) == NULL) {
-    char errbuf[1024];
     int status = errno;
-    ERROR("get_utc_time: gmtime_r failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("get_utc_time: gmtime_r failed: %s", STRERRNO);
     return status;
   }
 
@@ -102,10 +96,8 @@ static int get_local_time(cdtime_t t, struct tm *t_tm, long *nsec) /* {{{ */
   NORMALIZE_TIMESPEC(t_spec);
 
   if (localtime_r(&t_spec.tv_sec, t_tm) == NULL) {
-    char errbuf[1024];
     int status = errno;
-    ERROR("get_local_time: localtime_r failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("get_local_time: localtime_r failed: %s", STRERRNO);
     return status;
   }
 

--- a/src/df.c
+++ b/src/df.c
@@ -202,9 +202,7 @@ static int df_read(void) {
       continue;
 
     if (STATANYFS(mnt_ptr->dir, &statbuf) < 0) {
-      char errbuf[1024];
-      ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir, STRERRNO);
       continue;
     }
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -973,9 +973,7 @@ static int disk_read(void) {
   int rnumdisk;
 
   if ((numdisk = perfstat_disk(NULL, NULL, sizeof(perfstat_disk_t), 0)) < 0) {
-    char errbuf[1024];
-    WARNING("disk plugin: perfstat_disk: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("disk plugin: perfstat_disk: %s", STRERRNO);
     return -1;
   }
 
@@ -989,9 +987,7 @@ static int disk_read(void) {
   firstpath.name[0] = '\0';
   if ((rnumdisk = perfstat_disk(&firstpath, stat_disk, sizeof(perfstat_disk_t),
                                 numdisk)) < 0) {
-    char errbuf[1024];
-    WARNING("disk plugin: perfstat_disk : %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("disk plugin: perfstat_disk : %s", STRERRNO);
     return -1;
   }
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -29,8 +29,8 @@
 #include "common.h"
 #include "plugin.h"
 
-#include <poll.h>
 #include "utils_dns.h"
+#include <poll.h>
 
 #include <pcap.h>
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -287,9 +287,7 @@ static int dns_init(void) {
   status = plugin_thread_create(&listen_thread, NULL, dns_child_loop, (void *)0,
                                 "dns listen");
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("dns plugin: pthread_create failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("dns plugin: pthread_create failed: %s", STRERRNO);
     return -1;
   }
 

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -129,12 +129,11 @@ static int dpdk_event_keep_alive_shm_open(void) {
             shm_name);
   }
 
-  char errbuf[ERR_BUF_SIZE];
   int fd = shm_open(shm_name, O_RDONLY, 0);
   if (fd < 0) {
     ERROR(DPDK_EVENTS_PLUGIN ": Failed to open %s as SHM:%s. Is DPDK KA "
                              "primary application running?",
-          shm_name, sstrerror(errno, errbuf, sizeof(errbuf)));
+          shm_name, STRERRNO);
     return errno;
   }
 
@@ -166,8 +165,7 @@ static int dpdk_event_keep_alive_shm_open(void) {
   ec->config.keep_alive.shm = (dpdk_keepalive_shm_t *)mmap(
       0, sizeof(*(ec->config.keep_alive.shm)), PROT_READ, MAP_SHARED, fd, 0);
   if (ec->config.keep_alive.shm == MAP_FAILED) {
-    ERROR(DPDK_EVENTS_PLUGIN ": Failed to mmap KA SHM:%s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR(DPDK_EVENTS_PLUGIN ": Failed to mmap KA SHM:%s", STRERRNO);
     close(fd);
     return errno;
   }

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -127,7 +127,7 @@ static int dpdk_stats_preinit(void) {
   if (ret != 0) {
     char errbuf[ERR_BUF_SIZE];
     ERROR("%s: failed to initialize %s helper(error: %s)", DPDK_STATS_PLUGIN,
-          g_shm_name, sstrerror(errno, errbuf, sizeof(errbuf)));
+          g_shm_name, STRERRNO);
     return ret;
   }
 
@@ -448,7 +448,7 @@ static int dpdk_stats_reinit_helper() {
   if (ret != 0) {
     char errbuf[ERR_BUF_SIZE];
     ERROR("%s: failed to initialize %s helper(error: %s)", DPDK_STATS_PLUGIN,
-          g_shm_name, sstrerror(errno, errbuf, sizeof(errbuf)));
+          g_shm_name, STRERRNO);
     return ret;
   }
 

--- a/src/email.c
+++ b/src/email.c
@@ -408,9 +408,7 @@ static void *open_connection(void __attribute__((unused)) * arg) {
     grp = NULL;
     status = getgrnam_r(group, &sg, grbuf, sizeof(grbuf), &grp);
     if (status != 0) {
-      char errbuf[1024];
-      log_warn("getgrnam_r (%s) failed: %s", group,
-               sstrerror(status, errbuf, sizeof(errbuf)));
+      log_warn("getgrnam_r (%s) failed: %s", group, STRERROR(status));
     } else if (grp == NULL) {
       log_warn("No such group: `%s'", group);
     } else {

--- a/src/ethstat.c
+++ b/src/ethstat.c
@@ -204,9 +204,7 @@ static int ethstat_read_interface(char *device) {
 
   fd = socket(AF_INET, SOCK_DGRAM, /* protocol = */ 0);
   if (fd < 0) {
-    char errbuf[1024];
-    ERROR("ethstat plugin: Failed to open control socket: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("ethstat plugin: Failed to open control socket: %s", STRERRNO);
     return 1;
   }
 
@@ -218,11 +216,10 @@ static int ethstat_read_interface(char *device) {
 
   status = ioctl(fd, SIOCETHTOOL, &req);
   if (status < 0) {
-    char errbuf[1024];
     close(fd);
     ERROR("ethstat plugin: Failed to get driver information "
           "from %s: %s",
-          device, sstrerror(errno, errbuf, sizeof(errbuf)));
+          device, STRERRNO);
     return -1;
   }
 
@@ -252,12 +249,10 @@ static int ethstat_read_interface(char *device) {
   req.ifr_data = (void *)strings;
   status = ioctl(fd, SIOCETHTOOL, &req);
   if (status < 0) {
-    char errbuf[1024];
     close(fd);
     free(strings);
     free(stats);
-    ERROR("ethstat plugin: Cannot get strings from %s: %s", device,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("ethstat plugin: Cannot get strings from %s: %s", device, STRERRNO);
     return -1;
   }
 
@@ -266,12 +261,11 @@ static int ethstat_read_interface(char *device) {
   req.ifr_data = (void *)stats;
   status = ioctl(fd, SIOCETHTOOL, &req);
   if (status < 0) {
-    char errbuf[1024];
     close(fd);
     free(strings);
     free(stats);
     ERROR("ethstat plugin: Reading statistics from %s failed: %s", device,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -265,7 +265,6 @@ __attribute__((noreturn)) static void exec_child(program_list_t *pl, int uid,
                                                  int gid, int egid) /* {{{ */
 {
   int status;
-  char errbuf[1024];
 
 #if HAVE_SETGROUPS
   if (getuid() == 0) {
@@ -286,31 +285,27 @@ __attribute__((noreturn)) static void exec_child(program_list_t *pl, int uid,
 
   status = setgid(gid);
   if (status != 0) {
-    ERROR("exec plugin: setgid (%i) failed: %s", gid,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("exec plugin: setgid (%i) failed: %s", gid, STRERRNO);
     exit(-1);
   }
 
   if (egid != -1) {
     status = setegid(egid);
     if (status != 0) {
-      ERROR("exec plugin: setegid (%i) failed: %s", egid,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("exec plugin: setegid (%i) failed: %s", egid, STRERRNO);
       exit(-1);
     }
   }
 
   status = setuid(uid);
   if (status != 0) {
-    ERROR("exec plugin: setuid (%i) failed: %s", uid,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("exec plugin: setuid (%i) failed: %s", uid, STRERRNO);
     exit(-1);
   }
 
   execvp(pl->exec, pl->argv);
 
-  ERROR("exec plugin: Failed to execute ``%s'': %s", pl->exec,
-        sstrerror(errno, errbuf, sizeof(errbuf)));
+  ERROR("exec plugin: Failed to execute ``%s'': %s", pl->exec, STRERRNO);
   exit(-1);
 } /* void exec_child }}} */
 
@@ -324,13 +319,11 @@ static void reset_signal_mask(void) /* {{{ */
 
 static int create_pipe(int fd_pipe[2]) /* {{{ */
 {
-  char errbuf[1024];
   int status;
 
   status = pipe(fd_pipe);
   if (status != 0) {
-    ERROR("exec plugin: pipe failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("exec plugin: pipe failed: %s", STRERRNO);
     return -1;
   }
 
@@ -438,8 +431,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
 
   pid = fork();
   if (pid < 0) {
-    ERROR("exec plugin: fork failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("exec plugin: fork failed: %s", STRERRNO);
     goto failed;
   } else if (pid == 0) {
     int fd_num;
@@ -688,9 +680,7 @@ static void *exec_notification_one(void *arg) /* {{{ */
 
   fh = fdopen(fd, "w");
   if (fh == NULL) {
-    char errbuf[1024];
-    ERROR("exec plugin: fdopen (%i) failed: %s", fd,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("exec plugin: fdopen (%i) failed: %s", fd, STRERRNO);
     kill(pid, SIGTERM);
     close(fd);
     sfree(arg);

--- a/src/exec.c
+++ b/src/exec.c
@@ -351,7 +351,6 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   int fd_pipe_in[2] = {-1, -1};
   int fd_pipe_out[2] = {-1, -1};
   int fd_pipe_err[2] = {-1, -1};
-  char errbuf[1024];
   int status;
   int pid;
 
@@ -380,7 +379,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   status = getpwnam_r(pl->user, &sp, nambuf, sizeof(nambuf), &sp_ptr);
   if (status != 0) {
     ERROR("exec plugin: Failed to get user information for user ``%s'': %s",
-          pl->user, sstrerror(status, errbuf, sizeof(errbuf)));
+          pl->user, STRERROR(status));
     goto failed;
   }
 
@@ -415,7 +414,7 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
       if (status != 0) {
         ERROR("exec plugin: Failed to get group information "
               "for group ``%s'': %s",
-              pl->group, sstrerror(status, errbuf, sizeof(errbuf)));
+              pl->group, STRERROR(status));
         goto failed;
       }
       if (gr_ptr == NULL) {

--- a/src/fhcount.c
+++ b/src/fhcount.c
@@ -75,17 +75,16 @@ static int fhcount_read(void) {
   int prc_used, prc_unused;
   char *fields[3];
   char buffer[buffer_len];
-  char errbuf[1024];
   FILE *fp;
 
   // Open file
   fp = fopen("/proc/sys/fs/file-nr", "r");
   if (fp == NULL) {
-    ERROR("fhcount: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("fhcount: fopen: %s", STRERRNO);
     return EXIT_FAILURE;
   }
   if (fgets(buffer, buffer_len, fp) == NULL) {
-    ERROR("fhcount: fgets: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("fhcount: fgets: %s", STRERRNO);
     fclose(fp);
     return EXIT_FAILURE;
   }

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -108,10 +108,8 @@ static char *hddtemp_query_daemon(void) {
                               .ai_socktype = SOCK_STREAM};
 
   if ((ai_return = getaddrinfo(host, port, &ai_hints, &ai_list)) != 0) {
-    char errbuf[1024];
     ERROR("hddtemp plugin: getaddrinfo (%s, %s): %s", host, port,
-          (ai_return == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                    : gai_strerror(ai_return));
+          (ai_return == EAI_SYSTEM) ? STRERRNO : gai_strerror(ai_return));
     return NULL;
   }
 
@@ -121,17 +119,13 @@ static char *hddtemp_query_daemon(void) {
     /* create our socket descriptor */
     fd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (fd < 0) {
-      char errbuf[1024];
-      ERROR("hddtemp plugin: socket: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("hddtemp plugin: socket: %s", STRERRNO);
       continue;
     }
 
     /* connect to the hddtemp daemon */
     if (connect(fd, (struct sockaddr *)ai_ptr->ai_addr, ai_ptr->ai_addrlen)) {
-      char errbuf[1024];
-      INFO("hddtemp plugin: connect (%s, %s) failed: %s", host, port,
-           sstrerror(errno, errbuf, sizeof(errbuf)));
+      INFO("hddtemp plugin: connect (%s, %s) failed: %s", host, port, STRERRNO);
       close(fd);
       fd = -1;
       continue;
@@ -177,13 +171,11 @@ static char *hddtemp_query_daemon(void) {
     if (status == 0) {
       break;
     } else if (status == -1) {
-      char errbuf[1024];
 
       if ((errno == EAGAIN) || (errno == EINTR))
         continue;
 
-      ERROR("hddtemp plugin: Error reading from socket: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("hddtemp plugin: Error reading from socket: %s", STRERRNO);
       close(fd);
       free(buffer);
       return NULL;

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -185,10 +185,8 @@ static int read_syshugepages(const char *path, const char *node) {
     long page_size = strtol(result->d_name + strlen(hugepages_dir),
                             /* endptr = */ NULL, /* base = */ 10);
     if (errno != 0) {
-      char errbuf[1024];
       ERROR("%s: failed to determine page size from directory name \"%s\": %s",
-            g_plugin_name, result->d_name,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            g_plugin_name, result->d_name, STRERRNO);
       continue;
     }
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -236,9 +236,7 @@ static int interface_read(void) {
   int numfields;
 
   if ((fh = fopen("/proc/net/dev", "r")) == NULL) {
-    char errbuf[1024];
-    WARNING("interface plugin: fopen: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("interface plugin: fopen: %s", STRERRNO);
     return -1;
   }
 
@@ -352,9 +350,7 @@ static int interface_read(void) {
 
   if ((nif = perfstat_netinterface(NULL, NULL, sizeof(perfstat_netinterface_t),
                                    0)) < 0) {
-    char errbuf[1024];
-    WARNING("interface plugin: perfstat_netinterface: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("interface plugin: perfstat_netinterface: %s", STRERRNO);
     return -1;
   }
 
@@ -367,9 +363,8 @@ static int interface_read(void) {
   id.name[0] = '\0';
   if ((ifs = perfstat_netinterface(&id, ifstat, sizeof(perfstat_netinterface_t),
                                    nif)) < 0) {
-    char errbuf[1024];
     WARNING("interface plugin: perfstat_netinterface (interfaces=%d): %s", nif,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
     return -1;
   }
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -119,10 +119,9 @@ static int ipc_read_sem(void) /* {{{ */
 
   status = semctl(/* id = */ 0, /* num = */ 0, SEM_INFO, arg);
   if (status == -1) {
-    char errbuf[1024];
     ERROR("ipc plugin: semctl(2) failed: %s. "
           "Maybe the kernel is not configured for semaphores?",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -139,10 +138,9 @@ static int ipc_read_shm(void) /* {{{ */
 
   status = shmctl(/* id = */ 0, SHM_INFO, (void *)&shm_info);
   if (status == -1) {
-    char errbuf[1024];
     ERROR("ipc plugin: shmctl(2) failed: %s. "
           "Maybe the kernel is not configured for shared memory?",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -187,9 +185,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
 
   if (get_ipc_info(cid, cmd, version, buff, &size) < 0) {
     if (errno != ENOSPC) {
-      char errbuf[1024];
-      WARNING("ipc plugin: get_ipc_info: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("ipc plugin: get_ipc_info: %s", STRERRNO);
       return NULL;
     }
   }
@@ -211,9 +207,7 @@ static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,
   }
 
   if (get_ipc_info(cid, cmd, version, buff, &size) < 0) {
-    char errbuf[1024];
-    WARNING("ipc plugin: get_ipc_info: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("ipc plugin: get_ipc_info: %s", STRERRNO);
     free(buff);
     return NULL;
   }

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -101,7 +101,7 @@ static int iptables_config(const char *key, const char *value) {
     return 1;
 
   ip_chain_t temp = {0};
-  ip_chain_t *final, **list;
+  ip_chain_t * final, **list;
   char *table;
   int table_len;
   char *chain;
@@ -113,8 +113,7 @@ static int iptables_config(const char *key, const char *value) {
 
   value_copy = strdup(value);
   if (value_copy == NULL) {
-    char errbuf[1024];
-    ERROR("strdup failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("strdup failed: %s", STRERRNO);
     return 1;
   }
 
@@ -182,17 +181,15 @@ static int iptables_config(const char *key, const char *value) {
 
   list = realloc(chain_list, (chain_num + 1) * sizeof(ip_chain_t *));
   if (list == NULL) {
-    char errbuf[1024];
-    ERROR("realloc failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("realloc failed: %s", STRERRNO);
     sfree(temp.rule.comment);
     return 1;
   }
 
   chain_list = list;
-  final = malloc(sizeof(*final));
+  final = malloc(sizeof(* final));
   if (final == NULL) {
-    char errbuf[1024];
-    ERROR("malloc failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("malloc failed: %s", STRERRNO);
     sfree(temp.rule.comment);
     return 1;
   }

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -101,7 +101,7 @@ static int iptables_config(const char *key, const char *value) {
     return 1;
 
   ip_chain_t temp = {0};
-  ip_chain_t * final, **list;
+  ip_chain_t *final, **list;
   char *table;
   int table_len;
   char *chain;
@@ -187,7 +187,7 @@ static int iptables_config(const char *key, const char *value) {
   }
 
   chain_list = list;
-  final = malloc(sizeof(* final));
+  final = malloc(sizeof(*final));
   if (final == NULL) {
     ERROR("malloc failed: %s", STRERRNO);
     sfree(temp.rule.comment);

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -63,9 +63,7 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
 
   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, &ipvs_info, &len) ==
       -1) {
-    char errbuf[1024];
-    log_err("ip_vs_get_services: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("ip_vs_get_services: getsockopt() failed: %s", STRERRNO);
     return NULL;
   }
 
@@ -82,9 +80,7 @@ static struct ip_vs_get_services *ipvs_get_services(void) {
 
   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_SERVICES, services, &len) ==
       -1) {
-    char errbuf[1024];
-    log_err("ipvs_get_services: getsockopt failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("ipvs_get_services: getsockopt failed: %s", STRERRNO);
 
     free(services);
     return NULL;
@@ -111,9 +107,7 @@ static struct ip_vs_get_dests *ipvs_get_dests(struct ip_vs_service_entry *se) {
   dests->num_dests = se->num_dests;
 
   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_DESTS, dests, &len) == -1) {
-    char errbuf[1024];
-    log_err("ipvs_get_dests: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("ipvs_get_dests: getsockopt() failed: %s", STRERRNO);
     free(dests);
     return NULL;
   }
@@ -127,9 +121,7 @@ static int cipvs_init(void) {
   struct ip_vs_getinfo ipvs_info;
 
   if ((sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) == -1) {
-    char errbuf[1024];
-    log_err("cipvs_init: socket() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("cipvs_init: socket() failed: %s", STRERRNO);
     return -1;
   }
 
@@ -137,9 +129,7 @@ static int cipvs_init(void) {
 
   if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO, &ipvs_info, &len) ==
       -1) {
-    char errbuf[1024];
-    log_err("cipvs_init: getsockopt() failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("cipvs_init: getsockopt() failed: %s", STRERRNO);
     close(sockfd);
     sockfd = -1;
     return -1;

--- a/src/irq.c
+++ b/src/irq.c
@@ -90,9 +90,7 @@ static int irq_read(void) {
    */
   fh = fopen("/proc/interrupts", "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    ERROR("irq plugin: fopen (/proc/interrupts): %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("irq plugin: fopen (/proc/interrupts): %s", STRERRNO);
     return -1;
   }
 

--- a/src/load.c
+++ b/src/load.c
@@ -73,13 +73,11 @@ static int load_config(const char *key, const char *value) {
 }
 static void load_submit(gauge_t snum, gauge_t mnum, gauge_t lnum) {
   int cores = 0;
-  char errbuf[1024];
 
 #ifdef _SC_NPROCESSORS_ONLN
   if (report_relative_load) {
     if ((cores = sysconf(_SC_NPROCESSORS_ONLN)) < 1) {
-      WARNING("load: sysconf failed : %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("load: sysconf failed : %s", STRERRNO);
     }
   }
 #endif
@@ -114,9 +112,7 @@ static int load_read(void) {
   if (getloadavg(load, 3) == 3)
     load_submit(load[LOADAVG_1MIN], load[LOADAVG_5MIN], load[LOADAVG_15MIN]);
   else {
-    char errbuf[1024];
-    WARNING("load: getloadavg failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("load: getloadavg failed: %s", STRERRNO);
   }
 /* #endif HAVE_GETLOADAVG */
 
@@ -129,21 +125,18 @@ static int load_read(void) {
   int numfields;
 
   if ((loadavg = fopen("/proc/loadavg", "r")) == NULL) {
-    char errbuf[1024];
-    WARNING("load: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("load: fopen: %s", STRERRNO);
     return -1;
   }
 
   if (fgets(buffer, 16, loadavg) == NULL) {
-    char errbuf[1024];
-    WARNING("load: fgets: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("load: fgets: %s", STRERRNO);
     fclose(loadavg);
     return -1;
   }
 
   if (fclose(loadavg)) {
-    char errbuf[1024];
-    WARNING("load: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("load: fclose: %s", STRERRNO);
   }
 
   numfields = strsplit(buffer, fields, 8);
@@ -177,9 +170,7 @@ static int load_read(void) {
 
   if (perfstat_cpu_total(NULL, &cputotal, sizeof(perfstat_cpu_total_t), 1) <
       0) {
-    char errbuf[1024];
-    WARNING("load: perfstat_cpu : %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("load: perfstat_cpu : %s", STRERRNO);
     return -1;
   }
 

--- a/src/log_logstash.c
+++ b/src/log_logstash.c
@@ -160,9 +160,8 @@ static void log_logstash_print(yajl_gen g, int severity,
   }
 
   if (fh == NULL) {
-    char errbuf[1024];
     fprintf(stderr, "log_logstash plugin: fopen (%s) failed: %s\n", log_file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
   } else {
     fprintf(fh, "%s\n", buf);
     if (do_close) {

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -126,9 +126,8 @@ static void logfile_print(const char *msg, int severity,
   }
 
   if (fh == NULL) {
-    char errbuf[1024];
     fprintf(stderr, "logfile plugin: fopen (%s) failed: %s\n", log_file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
   } else {
     if (print_timestamp)
       fprintf(fh, "[%s] %s%s\n", timestamp_str, level_str, msg);

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -76,9 +76,8 @@ static int lpar_init(void) {
                                     sizeof(perfstat_partition_total_t),
                                     /* number = */ 1 /* (must be 1) */);
   if (status != 1) {
-    char errbuf[1024];
-    ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)",
-          sstrerror(errno, errbuf, sizeof(errbuf)), status);
+    ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)", STRERRNO,
+          status);
     return -1;
   }
 
@@ -138,9 +137,8 @@ static int lpar_read(void) {
                                &lparstats, sizeof(perfstat_partition_total_t),
                                /* number = */ 1 /* (must be 1) */);
   if (status != 1) {
-    char errbuf[1024];
-    ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)",
-          sstrerror(errno, errbuf, sizeof(errbuf)), status);
+    ERROR("lpar plugin: perfstat_partition_total failed: %s (%i)", STRERRNO,
+          status);
     return -1;
   }
 

--- a/src/mbmon.c
+++ b/src/mbmon.c
@@ -95,10 +95,8 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
                               .ai_socktype = SOCK_STREAM};
 
   if ((ai_return = getaddrinfo(host, port, &ai_hints, &ai_list)) != 0) {
-    char errbuf[1024];
     ERROR("mbmon: getaddrinfo (%s, %s): %s", host, port,
-          (ai_return == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                    : gai_strerror(ai_return));
+          (ai_return == EAI_SYSTEM) ? STRERRNO : gai_strerror(ai_return));
     return -1;
   }
 
@@ -108,16 +106,13 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
     /* create our socket descriptor */
     if ((fd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype,
                      ai_ptr->ai_protocol)) < 0) {
-      char errbuf[1024];
-      ERROR("mbmon: socket: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("mbmon: socket: %s", STRERRNO);
       continue;
     }
 
     /* connect to the mbmon daemon */
     if (connect(fd, (struct sockaddr *)ai_ptr->ai_addr, ai_ptr->ai_addrlen)) {
-      char errbuf[1024];
-      INFO("mbmon: connect (%s, %s): %s", host, port,
-           sstrerror(errno, errbuf, sizeof(errbuf)));
+      INFO("mbmon: connect (%s, %s): %s", host, port, STRERRNO);
       close(fd);
       fd = -1;
       continue;
@@ -142,13 +137,11 @@ static int mbmon_query_daemon(char *buffer, int buffer_size) {
   while ((status = read(fd, buffer + buffer_fill, buffer_size - buffer_fill)) !=
          0) {
     if (status == -1) {
-      char errbuf[1024];
 
       if ((errno == EAGAIN) || (errno == EINTR))
         continue;
 
-      ERROR("mbmon: Error reading from socket: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("mbmon: Error reading from socket: %s", STRERRNO);
       close(fd);
       return -1;
     }

--- a/src/md.c
+++ b/src/md.c
@@ -74,7 +74,6 @@ static void md_submit(const int minor, const char *type_instance,
 } /* void md_submit */
 
 static void md_process(const int minor, const char *path) {
-  char errbuf[1024];
   int fd;
   struct stat st;
   mdu_array_info_t array;
@@ -82,13 +81,12 @@ static void md_process(const int minor, const char *path) {
 
   fd = open(path, O_RDONLY);
   if (fd < 0) {
-    WARNING("md: open(%s): %s", path, sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("md: open(%s): %s", path, STRERRNO);
     return;
   }
 
   if (fstat(fd, &st) < 0) {
-    WARNING("md: Unable to fstat file descriptor for %s: %s", path,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("md: Unable to fstat file descriptor for %s: %s", path, STRERRNO);
     close(fd);
     return;
   }
@@ -109,8 +107,7 @@ static void md_process(const int minor, const char *path) {
 
   /* Retrieve md information */
   if (ioctl(fd, GET_ARRAY_INFO, &array) < 0) {
-    WARNING("md: Unable to retrieve array info from %s: %s", path,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("md: Unable to retrieve array info from %s: %s", path, STRERRNO);
     close(fd);
     return;
   }
@@ -146,9 +143,7 @@ static int md_read(void) {
 
   fh = fopen(PROC_DISKSTATS, "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    WARNING("md: Unable to open %s: %s", PROC_DISKSTATS,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("md: Unable to open %s: %s", PROC_DISKSTATS, STRERRNO);
     return -1;
   }
 

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -99,9 +99,8 @@ static int memcached_connect_unix(memcached_t *st) {
   /* create our socket descriptor */
   int fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0) {
-    char errbuf[1024];
     ERROR("memcached plugin: memcached_connect_unix: socket(2) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -134,12 +133,10 @@ static int memcached_connect_inet(memcached_t *st) {
 
   int status = getaddrinfo(st->connhost, st->connport, &ai_hints, &ai_list);
   if (status != 0) {
-    char errbuf[1024];
     ERROR("memcached plugin: memcached_connect_inet: "
           "getaddrinfo(%s,%s) failed: %s",
           st->connhost, st->connport,
-          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                 : gai_strerror(status));
+          (status == EAI_SYSTEM) ? STRERRNO : gai_strerror(status));
     return -1;
   }
 
@@ -148,10 +145,9 @@ static int memcached_connect_inet(memcached_t *st) {
     /* create our socket descriptor */
     fd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (fd < 0) {
-      char errbuf[1024];
       WARNING("memcached plugin: memcached_connect_inet: "
               "socket(2) failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
       continue;
     }
 
@@ -246,9 +242,8 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
 
   status = (int)swrite(st->fd, "stats\r\n", strlen("stats\r\n"));
   if (status != 0) {
-    char errbuf[1024];
     ERROR("memcached plugin: Instance \"%s\": write(2) failed: %s", st->name,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     shutdown(st->fd, SHUT_RDWR);
     close(st->fd);
     st->fd = -1;
@@ -280,13 +275,12 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
 
     char const end_token[5] = {'E', 'N', 'D', '\r', '\n'};
     if (status < 0) {
-      char errbuf[1024];
 
       if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
         continue;
 
       ERROR("memcached plugin: Instance \"%s\": Error reading from socket: %s",
-            st->name, sstrerror(errno, errbuf, sizeof(errbuf)));
+            st->name, STRERRNO);
       shutdown(st->fd, SHUT_RDWR);
       close(st->fd);
       st->fd = -1;
@@ -683,10 +677,9 @@ static int memcached_add_read_callback(memcached_t *st) {
       /* group = */ "memcached",
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
-      /* interval  = */ 0,
-      &(user_data_t){
-          .data = st, .free_func = memcached_free,
-      });
+      /* interval  = */ 0, &(user_data_t){
+                               .data = st, .free_func = memcached_free,
+                           });
 } /* int memcached_add_read_callback */
 
 /* Configuration handling functiions

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -677,9 +677,10 @@ static int memcached_add_read_callback(memcached_t *st) {
       /* group = */ "memcached",
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
-      /* interval  = */ 0, &(user_data_t){
-                               .data = st, .free_func = memcached_free,
-                           });
+      /* interval  = */ 0,
+      &(user_data_t){
+          .data = st, .free_func = memcached_free,
+      });
 } /* int memcached_add_read_callback */
 
 /* Configuration handling functiions

--- a/src/memory.c
+++ b/src/memory.c
@@ -280,8 +280,7 @@ static int memory_read_internal(value_list_t *vl) {
   gauge_t mem_slab_unreclaimable = 0;
 
   if ((fh = fopen("/proc/meminfo", "r")) == NULL) {
-    char errbuf[1024];
-    WARNING("memory: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("memory: fopen: %s", STRERRNO);
     return -1;
   }
 
@@ -315,8 +314,7 @@ static int memory_read_internal(value_list_t *vl) {
   }
 
   if (fclose(fh)) {
-    char errbuf[1024];
-    WARNING("memory: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("memory: fclose: %s", STRERRNO);
   }
 
   if (mem_total < (mem_free + mem_buffered + mem_cached + mem_slab_total))
@@ -421,9 +419,7 @@ static int memory_read_internal(value_list_t *vl) {
   size = sizeof(vmtotal);
 
   if (sysctl(mib, 2, &vmtotal, &size, NULL, 0) < 0) {
-    char errbuf[1024];
-    WARNING("memory plugin: sysctl failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("memory plugin: sysctl failed: %s", STRERRNO);
     return -1;
   }
 
@@ -451,9 +447,7 @@ static int memory_read_internal(value_list_t *vl) {
   perfstat_memory_total_t pmemory = {0};
 
   if (perfstat_memory_total(NULL, &pmemory, sizeof(pmemory), 1) < 0) {
-    char errbuf[1024];
-    WARNING("memory plugin: perfstat_memory_total failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("memory plugin: perfstat_memory_total failed: %s", STRERRNO);
     return -1;
   }
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -770,10 +770,8 @@ static int mb_config_set_host_address(mb_host_t *host, /* {{{ */
 
   status = getaddrinfo(address, /* service = */ NULL, &ai_hints, &ai_list);
   if (status != 0) {
-    char errbuf[1024];
     ERROR("Modbus plugin: getaddrinfo failed: %s",
-          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                 : gai_strerror(status));
+          (status == EAI_SYSTEM) ? STRERRNO : gai_strerror(status));
     return status;
   }
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -600,9 +600,10 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
   }
 
   snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
-  plugin_register_write(cb_name, mqtt_write, &(user_data_t){
-                                                 .data = conf,
-                                             });
+  plugin_register_write(cb_name, mqtt_write,
+                        &(user_data_t){
+                            .data = conf,
+                        });
   return 0;
 } /* mqtt_config_publisher */
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -247,10 +247,8 @@ static int mqtt_reconnect(mqtt_client_conf_t *conf) {
 
   status = mosquitto_reconnect(conf->mosq);
   if (status != MOSQ_ERR_SUCCESS) {
-    char errbuf[1024];
     ERROR("mqtt_connect_broker: mosquitto_connect failed: %s",
-          (status == MOSQ_ERR_ERRNO) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                     : mosquitto_strerror(status));
+          (status == MOSQ_ERR_ERRNO) ? STRERRNO : mosquitto_strerror(status));
     return -1;
   }
 
@@ -325,11 +323,8 @@ static int mqtt_connect(mqtt_client_conf_t *conf) {
     status =
         mosquitto_username_pw_set(conf->mosq, conf->username, conf->password);
     if (status != MOSQ_ERR_SUCCESS) {
-      char errbuf[1024];
       ERROR("mqtt plugin: mosquitto_username_pw_set failed: %s",
-            (status == MOSQ_ERR_ERRNO)
-                ? sstrerror(errno, errbuf, sizeof(errbuf))
-                : mosquitto_strerror(status));
+            (status == MOSQ_ERR_ERRNO) ? STRERRNO : mosquitto_strerror(status));
 
       mosquitto_destroy(conf->mosq);
       conf->mosq = NULL;
@@ -346,10 +341,8 @@ static int mqtt_connect(mqtt_client_conf_t *conf) {
       mosquitto_connect(conf->mosq, conf->host, conf->port, MQTT_KEEPALIVE);
 #endif
   if (status != MOSQ_ERR_SUCCESS) {
-    char errbuf[1024];
     ERROR("mqtt plugin: mosquitto_connect failed: %s",
-          (status == MOSQ_ERR_ERRNO) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                     : mosquitto_strerror(status));
+          (status == MOSQ_ERR_ERRNO) ? STRERRNO : mosquitto_strerror(status));
 
     mosquitto_destroy(conf->mosq);
     conf->mosq = NULL;
@@ -438,12 +431,10 @@ static int publish(mqtt_client_conf_t *conf, char const *topic,
 #endif
                              conf->qos, conf->retain);
   if (status != MOSQ_ERR_SUCCESS) {
-    char errbuf[1024];
     c_complain(LOG_ERR, &conf->complaint_cantpublish,
                "mqtt plugin: mosquitto_publish failed: %s",
-               (status == MOSQ_ERR_ERRNO)
-                   ? sstrerror(errno, errbuf, sizeof(errbuf))
-                   : mosquitto_strerror(status));
+               (status == MOSQ_ERR_ERRNO) ? STRERRNO
+                                          : mosquitto_strerror(status));
     /* Mark our connection "down" regardless of the error as a safety
      * measure; we will try to reconnect the next time we have to publish a
      * message */
@@ -609,10 +600,9 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
   }
 
   snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
-  plugin_register_write(cb_name, mqtt_write,
-                        &(user_data_t){
-                            .data = conf,
-                        });
+  plugin_register_write(cb_name, mqtt_write, &(user_data_t){
+                                                 .data = conf,
+                                             });
   return 0;
 } /* mqtt_config_publisher */
 
@@ -758,9 +748,7 @@ static int mqtt_init(void) {
                                   /* args  = */ subscribers[i],
                                   /* name  = */ "mqtt");
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("mqtt plugin: pthread_create failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("mqtt plugin: pthread_create failed: %s", STRERRNO);
       continue;
     }
   }

--- a/src/multimeter.c
+++ b/src/multimeter.c
@@ -46,9 +46,7 @@ static int multimeter_read_value(double *value) {
     tcflush(fd, TCIFLUSH);
 
     if (gettimeofday(&time_end, NULL) < 0) {
-      char errbuf[1024];
-      ERROR("multimeter plugin: gettimeofday failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("multimeter plugin: gettimeofday failed: %s", STRERRNO);
       return -1;
     }
     time_end.tv_sec++;
@@ -71,10 +69,9 @@ static int multimeter_read_value(double *value) {
       FD_SET(fd, &rfds);
 
       if (gettimeofday(&time_now, NULL) < 0) {
-        char errbuf[1024];
         ERROR("multimeter plugin: "
               "gettimeofday failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
         return -1;
       }
       if (timeval_cmp(time_end, time_now, &timeout) < 0)
@@ -132,10 +129,9 @@ static int multimeter_read_value(double *value) {
         continue;
       } else /* status == -1 */
       {
-        char errbuf[1024];
         ERROR("multimeter plugin: "
               "select failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
         break;
       }
     }

--- a/src/network.c
+++ b/src/network.c
@@ -1578,9 +1578,7 @@ static int network_set_ttl(const sockent_t *se, const struct addrinfo *ai) {
 
     if (setsockopt(se->data.client.fd, IPPROTO_IP, optname, &network_config_ttl,
                    sizeof(network_config_ttl)) != 0) {
-      char errbuf[1024];
-      ERROR("network plugin: setsockopt (ipv4-ttl): %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: setsockopt (ipv4-ttl): %s", STRERRNO);
       return -1;
     }
   } else if (ai->ai_family == AF_INET6) {
@@ -1596,9 +1594,7 @@ static int network_set_ttl(const sockent_t *se, const struct addrinfo *ai) {
 
     if (setsockopt(se->data.client.fd, IPPROTO_IPV6, optname,
                    &network_config_ttl, sizeof(network_config_ttl)) != 0) {
-      char errbuf[1024];
-      ERROR("network plugin: setsockopt(ipv6-ttl): %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: setsockopt(ipv6-ttl): %s", STRERRNO);
       return -1;
     }
   }
@@ -1634,9 +1630,7 @@ static int network_set_interface(const sockent_t *se,
 
       if (setsockopt(se->data.client.fd, IPPROTO_IP, IP_MULTICAST_IF, &mreq,
                      sizeof(mreq)) != 0) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (ipv4-multicast-if): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (ipv4-multicast-if): %s", STRERRNO);
         return -1;
       }
 
@@ -1648,9 +1642,7 @@ static int network_set_interface(const sockent_t *se,
     if (IN6_IS_ADDR_MULTICAST(&addr->sin6_addr)) {
       if (setsockopt(se->data.client.fd, IPPROTO_IPV6, IPV6_MULTICAST_IF,
                      &se->interface, sizeof(se->interface)) != 0) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (ipv6-multicast-if): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (ipv6-multicast-if): %s", STRERRNO);
         return -1;
       }
 
@@ -1671,9 +1663,7 @@ static int network_set_interface(const sockent_t *se,
 
     if (setsockopt(se->data.client.fd, SOL_SOCKET, SO_BINDTODEVICE,
                    interface_name, sizeof(interface_name)) == -1) {
-      char errbuf[1024];
-      ERROR("network plugin: setsockopt (bind-if): %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: setsockopt (bind-if): %s", STRERRNO);
       return -1;
     }
 /* #endif HAVE_IF_INDEXTONAME && SO_BINDTODEVICE */
@@ -1704,17 +1694,14 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
 
   /* allow multiple sockets to use the same PORT number */
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) == -1) {
-    char errbuf[1024];
-    ERROR("network plugin: setsockopt (reuseaddr): %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("network plugin: setsockopt (reuseaddr): %s", STRERRNO);
     return -1;
   }
 
   DEBUG("fd = %i; calling `bind'", fd);
 
   if (bind(fd, ai->ai_addr, ai->ai_addrlen) == -1) {
-    char errbuf[1024];
-    ERROR("bind: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("bind: %s", STRERRNO);
     return -1;
   }
 
@@ -1742,17 +1729,13 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
 
       if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop)) ==
           -1) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (multicast-loop): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (multicast-loop): %s", STRERRNO);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) ==
           -1) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (add-membership): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (add-membership): %s", STRERRNO);
         return -1;
       }
 
@@ -1782,17 +1765,13 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &loop,
                      sizeof(loop)) == -1) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (ipv6-multicast-loop): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (ipv6-multicast-loop): %s", STRERRNO);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq,
                      sizeof(mreq)) == -1) {
-        char errbuf[1024];
-        ERROR("network plugin: setsockopt (ipv6-add-membership): %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: setsockopt (ipv6-add-membership): %s", STRERRNO);
         return -1;
       }
 
@@ -1815,9 +1794,7 @@ static int network_bind_socket(int fd, const struct addrinfo *ai,
 
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name,
                    sizeof(interface_name)) == -1) {
-      char errbuf[1024];
-      ERROR("network plugin: setsockopt (bind-if): %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: setsockopt (bind-if): %s", STRERRNO);
       return -1;
     }
   }
@@ -1994,9 +1971,7 @@ static int sockent_client_connect(sockent_t *se) /* {{{ */
     client->fd =
         socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (client->fd < 0) {
-      char errbuf[1024];
-      ERROR("network plugin: socket(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: socket(2) failed: %s", STRERRNO);
       continue;
     }
 
@@ -2081,9 +2056,7 @@ static int sockent_server_listen(sockent_t *se) /* {{{ */
 
     *tmp = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (*tmp < 0) {
-      char errbuf[1024];
-      ERROR("network plugin: socket(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: socket(2) failed: %s", STRERRNO);
       continue;
     }
 
@@ -2231,11 +2204,9 @@ static int network_receive(void) /* {{{ */
   while (listen_loop == 0) {
     status = poll(listen_sockets_pollfd, listen_sockets_num, -1);
     if (status <= 0) {
-      char errbuf[1024];
       if (errno == EINTR)
         continue;
-      ERROR("network plugin: poll(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network plugin: poll(2) failed: %s", STRERRNO);
       break;
     }
 
@@ -2249,10 +2220,8 @@ static int network_receive(void) /* {{{ */
       buffer_len = recv(listen_sockets_pollfd[i].fd, buffer, sizeof(buffer),
                         0 /* no flags */);
       if (buffer_len < 0) {
-        char errbuf[1024];
         status = (errno != 0) ? errno : -1;
-        ERROR("network plugin: recv(2) failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("network plugin: recv(2) failed: %s", STRERRNO);
         break;
       }
 
@@ -2362,13 +2331,11 @@ static void network_send_buffer_plain(sockent_t *se, /* {{{ */
                     /* flags = */ 0, (struct sockaddr *)se->data.client.addr,
                     se->data.client.addrlen);
     if (status < 0) {
-      char errbuf[1024];
-
       if ((errno == EINTR) || (errno == EAGAIN))
         continue;
 
       ERROR("network plugin: sendto failed: %s. Closing sending socket.",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       sockent_client_disconnect(se);
       return;
     }
@@ -3167,9 +3134,7 @@ static int network_init(void) {
                                   dispatch_thread, NULL /* no argument */,
                                   "network disp");
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("network: pthread_create failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network: pthread_create failed: %s", STRERRNO);
     } else {
       dispatch_thread_running = 1;
     }
@@ -3181,9 +3146,7 @@ static int network_init(void) {
                                   receive_thread, NULL /* no argument */,
                                   "network recv");
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("network: pthread_create failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("network: pthread_create failed: %s", STRERRNO);
     } else {
       receive_thread_running = 1;
     }

--- a/src/network.c
+++ b/src/network.c
@@ -2617,10 +2617,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
 
   pthread_mutex_lock(&send_buffer_lock);
 
-  status =
-      add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                         (send_buffer_fill + BUFF_SIG_SIZE),
-                    &send_buffer_vl, ds, vl);
+  status = add_to_buffer(send_buffer_ptr,
+                         network_config_packet_size -
+                             (send_buffer_fill + BUFF_SIG_SIZE),
+                         &send_buffer_vl, ds, vl);
   if (status >= 0) {
     /* status == bytes added to the buffer */
     send_buffer_fill += status;
@@ -2631,10 +2631,10 @@ static int network_write(const data_set_t *ds, const value_list_t *vl,
   } else {
     flush_buffer();
 
-    status =
-        add_to_buffer(send_buffer_ptr, network_config_packet_size -
-                                           (send_buffer_fill + BUFF_SIG_SIZE),
-                      &send_buffer_vl, ds, vl);
+    status = add_to_buffer(send_buffer_ptr,
+                           network_config_packet_size -
+                               (send_buffer_fill + BUFF_SIG_SIZE),
+                           &send_buffer_vl, ds, vl);
 
     if (status >= 0) {
       send_buffer_fill += status;

--- a/src/notify_nagios.c
+++ b/src/notify_nagios.c
@@ -67,10 +67,8 @@ static int nagios_print(char const *buffer) /* {{{ */
 
   fd = open(file, O_WRONLY | O_APPEND);
   if (fd < 0) {
-    char errbuf[1024];
     status = errno;
-    ERROR("notify_nagios plugin: Opening \"%s\" failed: %s", file,
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("notify_nagios plugin: Opening \"%s\" failed: %s", file, STRERRNO);
     return status;
   }
 
@@ -79,30 +77,26 @@ static int nagios_print(char const *buffer) /* {{{ */
 
   status = fcntl(fd, F_GETLK, &lock);
   if (status != 0) {
-    char errbuf[1024];
     status = errno;
     ERROR("notify_nagios plugin: Failed to acquire write lock on \"%s\": %s",
-          file, sstrerror(status, errbuf, sizeof(errbuf)));
+          file, STRERRNO);
     close(fd);
     return status;
   }
 
   status = (int)lseek(fd, 0, SEEK_END);
   if (status == -1) {
-    char errbuf[1024];
     status = errno;
     ERROR("notify_nagios plugin: Seeking to end of \"%s\" failed: %s", file,
-          sstrerror(status, errbuf, sizeof(errbuf)));
+          STRERRNO);
     close(fd);
     return status;
   }
 
   status = (int)swrite(fd, buffer, strlen(buffer));
   if (status != 0) {
-    char errbuf[1024];
     status = errno;
-    ERROR("notify_nagios plugin: Writing to \"%s\" failed: %s", file,
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("notify_nagios plugin: Writing to \"%s\" failed: %s", file, STRERRNO);
     close(fd);
     return status;
   }

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -337,10 +337,8 @@ static int ntpd_connect(void) {
                               .ai_socktype = SOCK_DGRAM};
 
   if ((status = getaddrinfo(host, port, &ai_hints, &ai_list)) != 0) {
-    char errbuf[1024];
     ERROR("ntpd plugin: getaddrinfo (%s, %s): %s", host, port,
-          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                 : gai_strerror(status));
+          (status == EAI_SYSTEM) ? STRERRNO : gai_strerror(status));
     return -1;
   }
 
@@ -409,9 +407,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
   *res_data = NULL;
 
   if (gettimeofday(&time_end, NULL) < 0) {
-    char errbuf[1024];
-    ERROR("ntpd plugin: gettimeofday failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("ntpd plugin: gettimeofday failed: %s", STRERRNO);
     return -1;
   }
   time_end.tv_sec++; /* wait for a most one second */
@@ -421,9 +417,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
     struct timeval time_left;
 
     if (gettimeofday(&time_now, NULL) < 0) {
-      char errbuf[1024];
-      ERROR("ntpd plugin: gettimeofday failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ntpd plugin: gettimeofday failed: %s", STRERRNO);
       return -1;
     }
 
@@ -447,9 +441,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       continue;
 
     if (status < 0) {
-      char errbuf[1024];
-      ERROR("ntpd plugin: poll failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ntpd plugin: poll failed: %s", STRERRNO);
       return -1;
     }
 
@@ -466,8 +458,7 @@ static int ntpd_receive_response(int *res_items, int *res_size, char **res_data,
       continue;
 
     if (status < 0) {
-      char errbuf[1024];
-      INFO("recv(2) failed: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+      INFO("recv(2) failed: %s", STRERRNO);
       DEBUG("Closing socket #%i", sd);
       close(sd);
       sock_descr = sd = -1;
@@ -763,10 +754,8 @@ static int ntpd_get_name_from_address(char *buffer, size_t buffer_size,
                        buffer_size, NULL, 0, /* No port name */
                        flags);
   if (status != 0) {
-    char errbuf[1024];
     ERROR("ntpd plugin: getnameinfo failed: %s",
-          (status == EAI_SYSTEM) ? sstrerror(errno, errbuf, sizeof(errbuf))
-                                 : gai_strerror(status));
+          (status == EAI_SYSTEM) ? STRERRNO : gai_strerror(status));
     return -1;
   }
 

--- a/src/numa.c
+++ b/src/numa.c
@@ -66,9 +66,8 @@ static int numa_read_node(int node) /* {{{ */
 
   fh = fopen(path, "r");
   if (fh == NULL) {
-    char errbuf[1024];
     ERROR("numa plugin: Reading node %i failed: open(%s): %s", node, path,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 
@@ -137,9 +136,7 @@ static int numa_init(void) /* {{{ */
       break;
     } else /* ((status != 0) && (errno != ENOENT)) */
     {
-      char errbuf[1024];
-      ERROR("numa plugin: stat(%s) failed: %s", path,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("numa plugin: stat(%s) failed: %s", path, STRERRNO);
       return -1;
     }
   }

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -162,19 +162,16 @@ static FILE *olsrd_connect(void) /* {{{ */
        ai_ptr = ai_ptr->ai_next) {
     int fd;
     int status;
-    char errbuf[1024];
 
     fd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (fd < 0) {
-      ERROR("olsrd plugin: socket failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("olsrd plugin: socket failed: %s", STRERRNO);
       continue;
     }
 
     status = connect(fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
     if (status != 0) {
-      ERROR("olsrd plugin: connect failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("olsrd plugin: connect failed: %s", STRERRNO);
       close(fd);
       continue;
     }

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -293,7 +293,6 @@ static int cow_read_values(const char *path, const char *name,
     char *buffer;
     size_t buffer_size;
     int status;
-    char errbuf[1024];
 
     char file[4096];
     char *endptr;
@@ -308,8 +307,7 @@ static int cow_read_values(const char *path, const char *name,
     status = OW_get(file, &buffer, &buffer_size);
     if (status < 0) {
       ERROR("onewire plugin: OW_get (%s/%s) failed. error = %s;", path,
-            family_info->features[i].filename,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            family_info->features[i].filename, STRERRNO);
       return -1;
     }
     DEBUG("Read onewire device %s as %s", file, buffer);
@@ -365,7 +363,6 @@ static int cow_read_bus(const char *path) {
   char *buffer;
   size_t buffer_size;
   int status;
-  char errbuf[1024];
 
   char *buffer_ptr;
   char *dummy;
@@ -374,8 +371,7 @@ static int cow_read_bus(const char *path) {
 
   status = OW_get(path, &buffer, &buffer_size);
   if (status < 0) {
-    ERROR("onewire plugin: OW_get (%s) failed. error = %s;", path,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("onewire plugin: OW_get (%s) failed. error = %s;", path, STRERRNO);
     return -1;
   }
   DEBUG("onewire plugin: OW_get (%s) returned: %s", path, buffer);
@@ -426,7 +422,6 @@ static int cow_simple_read(void) {
   char *buffer;
   size_t buffer_size;
   int status;
-  char errbuf[1024];
   char *endptr;
   direct_access_element_t *traverse;
 
@@ -438,7 +433,7 @@ static int cow_simple_read(void) {
     status = OW_get(traverse->path, &buffer, &buffer_size);
     if (status < 0) {
       ERROR("onewire plugin: OW_get (%s) failed. status = %s;", traverse->path,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return -1;
     }
     DEBUG("onewire plugin: Read onewire device %s as %s", traverse->path,
@@ -507,7 +502,6 @@ static int cow_shutdown(void) {
 
 static int cow_init(void) {
   int status;
-  char errbuf[1024];
 
   if (device_g == NULL) {
     ERROR("onewire plugin: cow_init: No device configured.");
@@ -517,8 +511,7 @@ static int cow_init(void) {
   DEBUG("onewire plugin: about to init device <%s>.", device_g);
   status = (int)OW_init(device_g);
   if (status != 0) {
-    ERROR("onewire plugin: OW_init(%s) failed: %s.", device_g,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("onewire plugin: OW_init(%s) failed: %s.", device_g, STRERRNO);
     return 1;
   }
 

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -429,9 +429,7 @@ static int openvpn_read(user_data_t *user_data) {
 
   FILE *fh = fopen(st->file, "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    WARNING("openvpn plugin: fopen(%s) failed: %s", st->file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("openvpn plugin: fopen(%s) failed: %s", st->file, STRERRNO);
 
     return -1;
   }
@@ -471,9 +469,7 @@ static int openvpn_config(const char *key, const char *value) {
 
     char *status_file = strdup(value);
     if (status_file == NULL) {
-      char errbuf[1024];
-      ERROR("openvpn plugin: strdup failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("openvpn plugin: strdup failed: %s", STRERRNO);
       return 1;
     }
 
@@ -491,9 +487,7 @@ static int openvpn_config(const char *key, const char *value) {
     /* create a new vpn element */
     vpn_status_t *instance = calloc(1, sizeof(*instance));
     if (instance == NULL) {
-      char errbuf[1024];
-      ERROR("openvpn plugin: malloc failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("openvpn plugin: malloc failed: %s", STRERRNO);
       sfree(status_file);
       return 1;
     }
@@ -506,10 +500,9 @@ static int openvpn_config(const char *key, const char *value) {
         /* group = */ "openvpn",
         /* name      = */ callback_name,
         /* callback  = */ openvpn_read,
-        /* interval  = */ 0,
-        &(user_data_t){
-            .data = instance, .free_func = openvpn_free,
-        });
+        /* interval  = */ 0, &(user_data_t){
+                                 .data = instance, .free_func = openvpn_free,
+                             });
 
     if (status == EINVAL) {
       WARNING("openvpn plugin: status filename \"%s\" "

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -500,9 +500,10 @@ static int openvpn_config(const char *key, const char *value) {
         /* group = */ "openvpn",
         /* name      = */ callback_name,
         /* callback  = */ openvpn_read,
-        /* interval  = */ 0, &(user_data_t){
-                                 .data = instance, .free_func = openvpn_free,
-                             });
+        /* interval  = */ 0,
+        &(user_data_t){
+            .data = instance, .free_func = openvpn_free,
+        });
 
     if (status == EINVAL) {
       WARNING("openvpn plugin: status filename \"%s\" "

--- a/src/pf.c
+++ b/src/pf.c
@@ -83,17 +83,13 @@ static int pf_read(void) {
 
   fd = open(pf_device, O_RDONLY);
   if (fd < 0) {
-    char errbuf[1024];
-    ERROR("pf plugin: Unable to open %s: %s", pf_device,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("pf plugin: Unable to open %s: %s", pf_device, STRERRNO);
     return -1;
   }
 
   status = ioctl(fd, DIOCGETSTATUS, &state);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("pf plugin: ioctl(DIOCGETSTATUS) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("pf plugin: ioctl(DIOCGETSTATUS) failed: %s", STRERRNO);
     close(fd);
     return -1;
   }

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -294,25 +294,19 @@ static int pb_add_socket(pinba_socket_t *s, /* {{{ */
 
   fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
   if (fd < 0) {
-    char errbuf[1024];
-    ERROR("pinba plugin: socket(2) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("pinba plugin: socket(2) failed: %s", STRERRNO);
     return 0;
   }
 
   tmp = 1;
   status = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof(tmp));
   if (status != 0) {
-    char errbuf[1024];
-    WARNING("pinba plugin: setsockopt(SO_REUSEADDR) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("pinba plugin: setsockopt(SO_REUSEADDR) failed: %s", STRERRNO);
   }
 
   status = bind(fd, ai->ai_addr, ai->ai_addrlen);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("pinba plugin: bind(2) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("pinba plugin: bind(2) failed: %s", STRERRNO);
     close(fd);
     return 0;
   }
@@ -414,7 +408,6 @@ static int pinba_udp_read_callback_fn(int sock) /* {{{ */
     status = recvfrom(sock, buffer, buffer_size - 1, MSG_DONTWAIT,
                       /* from = */ NULL, /* from len = */ 0);
     if (status < 0) {
-      char errbuf[1024];
 
       if ((errno == EINTR)
 #ifdef EWOULDBLOCK
@@ -424,8 +417,7 @@ static int pinba_udp_read_callback_fn(int sock) /* {{{ */
         continue;
       }
 
-      WARNING("pinba plugin: recvfrom(2) failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("pinba plugin: recvfrom(2) failed: %s", STRERRNO);
       return -1;
     } else if (status == 0) {
       DEBUG("pinba plugin: recvfrom(2) returned unexpected status zero.");
@@ -469,13 +461,10 @@ static int receive_loop(void) /* {{{ */
     {
       continue;
     } else if (status < 0) {
-      char errbuf[1024];
-
       if ((errno == EINTR) || (errno == EAGAIN))
         continue;
 
-      ERROR("pinba plugin: poll(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("pinba plugin: poll(2) failed: %s", STRERRNO);
       pinba_socket_free(s);
       return -1;
     }
@@ -593,9 +582,7 @@ static int plugin_init(void) /* {{{ */
                                 /* attrs = */ NULL, collector_thread,
                                 /* args = */ NULL, "pinba collector");
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("pinba plugin: pthread_create(3) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("pinba plugin: pthread_create(3) failed: %s", STRERRNO);
     return -1;
   }
   collector_thread_running = 1;

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -600,9 +600,7 @@ static int plugin_shutdown(void) /* {{{ */
 
     status = pthread_join(collector_thread_id, /* retval = */ NULL);
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("pinba plugin: pthread_join(3) failed: %s",
-            sstrerror(status, errbuf, sizeof(errbuf)));
+      ERROR("pinba plugin: pthread_join(3) failed: %s", STRERROR(status));
     }
 
     collector_thread_running = 0;

--- a/src/ping.c
+++ b/src/ping.c
@@ -296,9 +296,7 @@ static void *ping_thread(void *arg) /* {{{ */
     _Bool send_successful = 0;
 
     if (gettimeofday(&tv_begin, NULL) < 0) {
-      char errbuf[1024];
-      ERROR("ping plugin: gettimeofday failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ping plugin: gettimeofday failed: %s", STRERRNO);
       ping_thread_error = 1;
       break;
     }
@@ -323,9 +321,7 @@ static void *ping_thread(void *arg) /* {{{ */
       (void)ping_dispatch_all(pingobj);
 
     if (gettimeofday(&tv_end, NULL) < 0) {
-      char errbuf[1024];
-      ERROR("ping plugin: gettimeofday failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ping plugin: gettimeofday failed: %s", STRERRNO);
       ping_thread_error = 1;
       break;
     }
@@ -436,9 +432,8 @@ static int config_set_string(const char *name, /* {{{ */
 
   tmp = strdup(value);
   if (tmp == NULL) {
-    char errbuf[1024];
     ERROR("ping plugin: Setting `%s' to `%s' failed: strdup failed: %s", name,
-          value, sstrerror(errno, errbuf, sizeof(errbuf)));
+          value, STRERRNO);
     return 1;
   }
 
@@ -456,18 +451,14 @@ static int ping_config(const char *key, const char *value) /* {{{ */
 
     hl = malloc(sizeof(*hl));
     if (hl == NULL) {
-      char errbuf[1024];
-      ERROR("ping plugin: malloc failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ping plugin: malloc failed: %s", STRERRNO);
       return 1;
     }
 
     host = strdup(value);
     if (host == NULL) {
-      char errbuf[1024];
       sfree(hl);
-      ERROR("ping plugin: strdup failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ping plugin: strdup failed: %s", STRERRNO);
       return 1;
     }
 

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -44,15 +44,12 @@
 #endif
 #define FUNC_ERROR(func)                                                       \
   do {                                                                         \
-    char errbuf[1024];                                                         \
-    ERROR("powerdns plugin: %s failed: %s", func,                              \
-          sstrerror(errno, errbuf, sizeof(errbuf)));                           \
+    ERROR("powerdns plugin: %s failed: %s", func, STRERRNO);                   \
   } while (0)
 #define SOCK_ERROR(func, sockpath)                                             \
   do {                                                                         \
-    char errbuf[1024];                                                         \
     ERROR("powerdns plugin: Socket `%s` %s failed: %s", sockpath, func,        \
-          sstrerror(errno, errbuf, sizeof(errbuf)));                           \
+          STRERRNO);                                                           \
   } while (0)
 
 #define SERVER_SOCKET LOCALSTATEDIR "/run/pdns.controlsocket"

--- a/src/processes.c
+++ b/src/processes.c
@@ -904,9 +904,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
     } /* while (fgets) */
 
     if (fclose(fh)) {
-      char errbuf[1024];
-      WARNING("processes: fclose: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("processes: fclose: %s", STRERRNO);
     }
   }
   closedir(dh);
@@ -962,8 +960,7 @@ static int ps_read_status(long pid, process_entry_t *ps) {
   } /* while (fgets) */
 
   if (fclose(fh)) {
-    char errbuf[1024];
-    WARNING("processes: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("processes: fclose: %s", STRERRNO);
   }
 
   ps->vmem_data = data * 1024;
@@ -1023,8 +1020,7 @@ static int ps_read_io(process_entry_t *ps) {
   } /* while (fgets) */
 
   if (fclose(fh)) {
-    char errbuf[1024];
-    WARNING("processes: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("processes: fclose: %s", STRERRNO);
   }
   return 0;
 } /* int ps_read_io (...) */
@@ -1048,8 +1044,7 @@ static int ps_count_maps(pid_t pid) {
   } /* while (fgets) */
 
   if (fclose(fh)) {
-    char errbuf[1024];
-    WARNING("processes: fclose: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("processes: fclose: %s", STRERRNO);
   }
   return count;
 } /* int ps_count_maps (...) */
@@ -1260,12 +1255,10 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
   errno = 0;
   fd = open(file, O_RDONLY);
   if (fd < 0) {
-    char errbuf[4096];
     /* ENOENT means the process exited while we were handling it.
      * Don't complain about this, it only fills the logs. */
     if (errno != ENOENT)
-      WARNING("processes plugin: Failed to open `%s': %s.", file,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("processes plugin: Failed to open `%s': %s.", file, STRERRNO);
     return NULL;
   }
 
@@ -1280,13 +1273,12 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
     status = read(fd, (void *)buf_ptr, len);
 
     if (status < 0) {
-      char errbuf[1024];
 
       if ((EAGAIN == errno) || (EINTR == errno))
         continue;
 
       WARNING("processes plugin: Failed to read from `%s': %s.", file,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
       close(fd);
       return NULL;
     }
@@ -1344,9 +1336,7 @@ static int read_fork_rate(void) {
 
   proc_stat = fopen("/proc/stat", "r");
   if (proc_stat == NULL) {
-    char errbuf[1024];
-    ERROR("processes plugin: fopen (/proc/stat) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("processes plugin: fopen (/proc/stat) failed: %s", STRERRNO);
     return -1;
   }
 
@@ -1858,8 +1848,7 @@ static int ps_read(void) {
   ps_list_reset();
 
   if ((proc = opendir("/proc")) == NULL) {
-    char errbuf[1024];
-    ERROR("Cannot open `/proc': %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("Cannot open `/proc': %s", STRERRNO);
     return -1;
   }
 

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -87,8 +87,7 @@ static int read_file(const char *path) {
 
   fh = fopen(path, "r");
   if (fh == NULL) {
-    ERROR("protocols plugin: fopen (%s) failed: %s.", path,
-          sstrerror(errno, key_buffer, sizeof(key_buffer)));
+    ERROR("protocols plugin: fopen (%s) failed: %s.", path, STRERRNO);
     return -1;
   }
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -89,8 +89,7 @@ static void submit_interface(cr_data_t *rd, /* {{{ */
 
 static int handle_interface(__attribute__((unused))
                             ros_connection_t *c, /* {{{ */
-                            const ros_interface_t *i,
-                            void *user_data) {
+                            const ros_interface_t *i, void *user_data) {
   if ((i == NULL) || (user_data == NULL))
     return EINVAL;
 
@@ -171,8 +170,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
 static int handle_regtable(__attribute__((unused))
                            ros_connection_t *c, /* {{{ */
-                           const ros_registration_table_t *r,
-                           void *user_data) {
+                           const ros_registration_table_t *r, void *user_data) {
   if ((r == NULL) || (user_data == NULL))
     return EINVAL;
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -242,9 +242,7 @@ static int cr_read(user_data_t *user_data) /* {{{ */
     status = ros_interface(rd->connection, handle_interface,
                            /* user data = */ rd);
     if (status != 0) {
-      char errbuf[128];
-      ERROR("routeros plugin: ros_interface failed: %s",
-            sstrerror(status, errbuf, sizeof(errbuf)));
+      ERROR("routeros plugin: ros_interface failed: %s", STRERROR(status));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
       return -1;
@@ -255,9 +253,8 @@ static int cr_read(user_data_t *user_data) /* {{{ */
     status = ros_registration_table(rd->connection, handle_regtable,
                                     /* user data = */ rd);
     if (status != 0) {
-      char errbuf[128];
       ERROR("routeros plugin: ros_registration_table failed: %s",
-            sstrerror(status, errbuf, sizeof(errbuf)));
+            STRERROR(status));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
       return -1;
@@ -270,9 +267,8 @@ static int cr_read(user_data_t *user_data) /* {{{ */
     status = ros_system_resource(rd->connection, handle_system_resource,
                                  /* user data = */ rd);
     if (status != 0) {
-      char errbuf[128];
       ERROR("routeros plugin: ros_system_resource failed: %s",
-            sstrerror(status, errbuf, sizeof(errbuf)));
+            STRERROR(status));
       ros_disconnect(rd->connection);
       rd->connection = NULL;
       return -1;

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -89,7 +89,8 @@ static void submit_interface(cr_data_t *rd, /* {{{ */
 
 static int handle_interface(__attribute__((unused))
                             ros_connection_t *c, /* {{{ */
-                            const ros_interface_t *i, void *user_data) {
+                            const ros_interface_t *i,
+                            void *user_data) {
   if ((i == NULL) || (user_data == NULL))
     return EINVAL;
 
@@ -170,7 +171,8 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
 static int handle_regtable(__attribute__((unused))
                            ros_connection_t *c, /* {{{ */
-                           const ros_registration_table_t *r, void *user_data) {
+                           const ros_registration_table_t *r,
+                           void *user_data) {
   if ((r == NULL) || (user_data == NULL))
     return EINVAL;
 
@@ -230,9 +232,7 @@ static int cr_read(user_data_t *user_data) /* {{{ */
     rd->connection =
         ros_connect(rd->node, rd->service, rd->username, rd->password);
     if (rd->connection == NULL) {
-      char errbuf[128];
-      ERROR("routeros plugin: ros_connect failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("routeros plugin: ros_connect failed: %s", STRERRNO);
       return -1;
     }
   }

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -424,9 +424,7 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
     status = stat(filename, &statbuf);
     if (status != 0) {
       if (errno != ENOENT) {
-        char errbuf[1024];
-        ERROR("rrdcached plugin: stat (%s) failed: %s", filename,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("rrdcached plugin: stat (%s) failed: %s", filename, STRERRNO);
         return -1;
       }
 

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -520,10 +520,7 @@ static void rrd_cache_flush(cdtime_t timeout) {
     {
       char **tmp = realloc(keys, (keys_num + 1) * sizeof(char *));
       if (tmp == NULL) {
-        char errbuf[1024];
-        ERROR("rrdtool plugin: "
-              "realloc failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("rrdtool plugin: realloc failed: %s", STRERRNO);
         c_avl_iterator_destroy(iter);
         sfree(keys);
         return;
@@ -652,15 +649,12 @@ static int rrd_cache_insert(const char *filename, const char *value,
   values_new =
       realloc((void *)rc->values, (rc->values_num + 1) * sizeof(char *));
   if (values_new == NULL) {
-    char errbuf[1024];
     void *cache_key = NULL;
-
-    sstrerror(errno, errbuf, sizeof(errbuf));
 
     c_avl_remove(cache, filename, &cache_key, NULL);
     pthread_mutex_unlock(&cache_lock);
 
-    ERROR("rrdtool plugin: realloc failed: %s", errbuf);
+    ERROR("rrdtool plugin: realloc failed: %s", STRERRNO);
 
     sfree(cache_key);
     sfree(rc->values);
@@ -682,12 +676,9 @@ static int rrd_cache_insert(const char *filename, const char *value,
     void *cache_key = strdup(filename);
 
     if (cache_key == NULL) {
-      char errbuf[1024];
-      sstrerror(errno, errbuf, sizeof(errbuf));
-
       pthread_mutex_unlock(&cache_lock);
 
-      ERROR("rrdtool plugin: strdup failed: %s", errbuf);
+      ERROR("rrdtool plugin: strdup failed: %s", STRERRNO);
 
       sfree(rc->values[0]);
       sfree(rc->values);
@@ -816,9 +807,7 @@ static int rrd_write(const data_set_t *ds, const value_list_t *vl,
         return 0;
       }
     } else {
-      char errbuf[1024];
-      ERROR("rrdtool plugin: stat(%s) failed: %s", filename,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("rrdtool plugin: stat(%s) failed: %s", filename, STRERRNO);
       return -1;
     }
   } else if (!S_ISREG(statbuf.st_mode)) {

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -269,9 +269,7 @@ static int sensors_load_conf(void) {
   if (conffile != NULL) {
     fh = fopen(conffile, "r");
     if (fh == NULL) {
-      char errbuf[1024];
-      ERROR("sensors plugin: fopen(%s) failed: %s", conffile,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("sensors plugin: fopen(%s) failed: %s", conffile, STRERRNO);
       return -1;
     }
   }

--- a/src/serial.c
+++ b/src/serial.c
@@ -52,8 +52,7 @@ static int serial_read(void) {
   /* there are a variety of names for the serial device */
   if ((fh = fopen("/proc/tty/driver/serial", "r")) == NULL &&
       (fh = fopen("/proc/tty/driver/ttyS", "r")) == NULL) {
-    char errbuf[1024];
-    WARNING("serial: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("serial: fopen: %s", STRERRNO);
     return -1;
   }
 

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -340,9 +340,7 @@ static int sigrok_init(void) {
   status = plugin_thread_create(&sr_thread, NULL, sigrok_read_thread, NULL,
                                 "sigrok read");
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("sigrok plugin: Failed to create thread: %s.",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("sigrok plugin: Failed to create thread: %s.", STRERRNO);
     return -1;
   }
   sr_thread_running = TRUE;

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -597,8 +597,9 @@ static int statsd_config_timer_percentile(oconfig_item_t *ci) /* {{{ */
     return ERANGE;
   }
 
-  tmp = realloc(conf_timer_percentile, sizeof(*conf_timer_percentile) *
-                                           (conf_timer_percentile_num + 1));
+  tmp =
+      realloc(conf_timer_percentile,
+              sizeof(*conf_timer_percentile) * (conf_timer_percentile_num + 1));
   if (tmp == NULL) {
     ERROR("statsd plugin: realloc failed.");
     return ENOMEM;

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -446,13 +446,11 @@ static void statsd_network_read(int fd) /* {{{ */
 
   status = recv(fd, buffer, sizeof(buffer), /* flags = */ MSG_DONTWAIT);
   if (status < 0) {
-    char errbuf[1024];
 
     if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
       return;
 
-    ERROR("statsd plugin: recv(2) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("statsd plugin: recv(2) failed: %s", STRERRNO);
     return;
   }
 
@@ -497,9 +495,7 @@ static int statsd_network_init(struct pollfd **ret_fds, /* {{{ */
 
     fd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (fd < 0) {
-      char errbuf[1024];
-      ERROR("statsd plugin: socket(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("statsd plugin: socket(2) failed: %s", STRERRNO);
       continue;
     }
 
@@ -511,9 +507,7 @@ static int statsd_network_init(struct pollfd **ret_fds, /* {{{ */
 
     status = bind(fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("statsd plugin: bind(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("statsd plugin: bind(2) failed: %s", STRERRNO);
       close(fd);
       continue;
     }
@@ -561,13 +555,11 @@ static void *statsd_network_thread(void *args) /* {{{ */
   while (!network_thread_shutdown) {
     status = poll(fds, (nfds_t)fds_num, /* timeout = */ -1);
     if (status < 0) {
-      char errbuf[1024];
 
       if ((errno == EINTR) || (errno == EAGAIN))
         continue;
 
-      ERROR("statsd plugin: poll(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("statsd plugin: poll(2) failed: %s", STRERRNO);
       break;
     }
 
@@ -605,9 +597,8 @@ static int statsd_config_timer_percentile(oconfig_item_t *ci) /* {{{ */
     return ERANGE;
   }
 
-  tmp =
-      realloc(conf_timer_percentile,
-              sizeof(*conf_timer_percentile) * (conf_timer_percentile_num + 1));
+  tmp = realloc(conf_timer_percentile, sizeof(*conf_timer_percentile) *
+                                           (conf_timer_percentile_num + 1));
   if (tmp == NULL) {
     ERROR("statsd plugin: realloc failed.");
     return ENOMEM;
@@ -669,10 +660,8 @@ static int statsd_init(void) /* {{{ */
                             /* attr = */ NULL, statsd_network_thread,
                             /* args = */ NULL);
     if (status != 0) {
-      char errbuf[1024];
       pthread_mutex_unlock(&metrics_lock);
-      ERROR("statsd plugin: pthread_create failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("statsd plugin: pthread_create failed: %s", STRERRNO);
       return status;
     }
   }

--- a/src/swap.c
+++ b/src/swap.c
@@ -234,9 +234,7 @@ static int swap_read_separate(void) /* {{{ */
 
   fh = fopen("/proc/swaps", "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    WARNING("swap plugin: fopen (/proc/swaps) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("swap plugin: fopen (/proc/swaps) failed: %s", STRERRNO);
     return -1;
   }
 
@@ -291,9 +289,7 @@ static int swap_read_combined(void) /* {{{ */
 
   fh = fopen("/proc/meminfo", "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    WARNING("swap plugin: fopen (/proc/meminfo) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("swap plugin: fopen (/proc/meminfo) failed: %s", STRERRNO);
     return -1;
   }
 
@@ -350,8 +346,7 @@ static int swap_read_io(void) /* {{{ */
     /* /proc/vmstat does not exist in kernels <2.6 */
     fh = fopen("/proc/stat", "r");
     if (fh == NULL) {
-      char errbuf[1024];
-      WARNING("swap: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("swap: fopen: %s", STRERRNO);
       return -1;
     } else
       old_kernel = 1;
@@ -414,7 +409,7 @@ static int swap_read(void) /* {{{ */
 
   return 0;
 } /* }}} int swap_read */
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 /*
  * Under Solaris, two mechanisms can be used to read swap statistics, swapctl
@@ -436,9 +431,7 @@ static int swap_read_kstat(void) /* {{{ */
   struct anoninfo ai;
 
   if (swapctl(SC_AINFO, &ai) == -1) {
-    char errbuf[1024];
-    ERROR("swap plugin: swapctl failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("swap plugin: swapctl failed: %s", STRERRNO);
     return -1;
   }
 
@@ -513,9 +506,7 @@ static int swap_read(void) /* {{{ */
 
   status = swapctl(SC_LIST, s);
   if (status < 0) {
-    char errbuf[1024];
-    ERROR("swap plugin: swapctl (SC_LIST) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("swap plugin: swapctl (SC_LIST) failed: %s", STRERRNO);
     sfree(s_paths);
     sfree(s);
     return -1;
@@ -719,9 +710,7 @@ static int swap_read(void) /* {{{ */
   status =
       perfstat_memory_total(NULL, &pmemory, sizeof(perfstat_memory_total_t), 1);
   if (status < 0) {
-    char errbuf[1024];
-    WARNING("swap plugin: perfstat_memory_total failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("swap plugin: perfstat_memory_total failed: %s", STRERRNO);
     return -1;
   }
 

--- a/src/swap.c
+++ b/src/swap.c
@@ -409,7 +409,7 @@ static int swap_read(void) /* {{{ */
 
   return 0;
 } /* }}} int swap_read */
-  /* #endif KERNEL_LINUX */
+/* #endif KERNEL_LINUX */
 
 /*
  * Under Solaris, two mechanisms can be used to read swap statistics, swapctl

--- a/src/table.c
+++ b/src/table.c
@@ -154,8 +154,7 @@ static int tbl_config_append_array_i(char *name, size_t **var, size_t *len,
 
   tmp = realloc(*var, ((*len) + num) * sizeof(**var));
   if (NULL == tmp) {
-    char errbuf[1024];
-    log_err("realloc failed: %s.", sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("realloc failed: %s.", STRERRNO);
     return -1;
   }
   *var = tmp;
@@ -180,8 +179,7 @@ static int tbl_config_result(tbl_t *tbl, oconfig_item_t *ci) {
 
   res = realloc(tbl->results, (tbl->results_num + 1) * sizeof(*tbl->results));
   if (res == NULL) {
-    char errbuf[1024];
-    log_err("realloc failed: %s.", sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("realloc failed: %s.", STRERRNO);
     return -1;
   }
 
@@ -243,8 +241,7 @@ static int tbl_config_table(oconfig_item_t *ci) {
 
   tbl = realloc(tables, (tables_num + 1) * sizeof(*tables));
   if (NULL == tbl) {
-    char errbuf[1024];
-    log_err("realloc failed: %s.", sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("realloc failed: %s.", STRERRNO);
     return -1;
   }
 
@@ -449,9 +446,7 @@ static int tbl_read_table(tbl_t *tbl) {
 
   fh = fopen(tbl->file, "r");
   if (NULL == fh) {
-    char errbuf[1024];
-    log_err("Failed to open file \"%s\": %s.", tbl->file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("Failed to open file \"%s\": %s.", tbl->file, STRERRNO);
     return -1;
   }
 
@@ -469,9 +464,7 @@ static int tbl_read_table(tbl_t *tbl) {
   }
 
   if (0 != ferror(fh)) {
-    char errbuf[1024];
-    log_err("Failed to read from file \"%s\": %s.", tbl->file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+    log_err("Failed to read from file \"%s\": %s.", tbl->file, STRERRNO);
     fclose(fh);
     return -1;
   }

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -459,7 +459,7 @@ static int conn_read_netlink(void) {
   if (fd < 0) {
     ERROR("tcpconns plugin: conn_read_netlink: socket(AF_NETLINK, SOCK_RAW, "
           "NETLINK_INET_DIAG) failed: %s",
-          sstrerror(errno, buf, sizeof(buf)));
+          STRERRNO);
     return -1;
   }
 
@@ -490,7 +490,7 @@ static int conn_read_netlink(void) {
 
   if (sendmsg(fd, &msg, 0) < 0) {
     ERROR("tcpconns plugin: conn_read_netlink: sendmsg(2) failed: %s",
-          sstrerror(errno, buf, sizeof(buf)));
+          STRERRNO);
     close(fd);
     return -1;
   }
@@ -514,7 +514,7 @@ static int conn_read_netlink(void) {
         continue;
 
       ERROR("tcpconns plugin: conn_read_netlink: recvmsg(2) failed: %s",
-            sstrerror(errno, buf, sizeof(buf)));
+            STRERRNO);
       close(fd);
       return -1;
     } else if (status == 0) {

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -204,18 +204,14 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
     /* Create socket */
     sd = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (sd < 0) {
-      char errbuf[1024];
-      WARNING("teamspeak2 plugin: socket failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("teamspeak2 plugin: socket failed: %s", STRERRNO);
       continue;
     }
 
     /* Try to connect */
     status = connect(sd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
     if (status != 0) {
-      char errbuf[1024];
-      WARNING("teamspeak2 plugin: connect failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("teamspeak2 plugin: connect failed: %s", STRERRNO);
       close(sd);
       sd = -1;
       continue;
@@ -236,18 +232,14 @@ static int tss2_get_socket(FILE **ret_read_fh, FILE **ret_write_fh) {
   /* Create file objects from sockets */
   global_read_fh = fdopen(sd, "r");
   if (global_read_fh == NULL) {
-    char errbuf[1024];
-    ERROR("teamspeak2 plugin: fdopen failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("teamspeak2 plugin: fdopen failed: %s", STRERRNO);
     close(sd);
     return -1;
   }
 
   global_write_fh = fdopen(sd, "w");
   if (global_write_fh == NULL) {
-    char errbuf[1024];
-    ERROR("teamspeak2 plugin: fdopen failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("teamspeak2 plugin: fdopen failed: %s", STRERRNO);
     tss2_close_socket();
     return -1;
   }
@@ -312,9 +304,7 @@ static int tss2_receive_line(FILE *fh, char *buffer, int buffer_size) {
    */
   temp = fgets(buffer, buffer_size, fh);
   if (temp == NULL) {
-    char errbuf[1024];
-    ERROR("teamspeak2 plugin: fgets failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("teamspeak2 plugin: fgets failed: %s", STRERRNO);
     tss2_close_socket();
     return -1;
   }

--- a/src/ted.c
+++ b/src/ted.c
@@ -109,19 +109,15 @@ static int ted_read_value(double *ret_power, double *ret_voltage) {
       /* Some signal or something. Start over.. */
       continue;
     } else if (status < 0) {
-      char errbuf[1024];
-      ERROR("ted plugin: select failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ted plugin: select failed: %s", STRERRNO);
       return -1;
     }
 
     receive_buffer_length = read(fd, receive_buffer, sizeof(receive_buffer));
     if (receive_buffer_length < 0) {
-      char errbuf[1024];
       if ((errno == EAGAIN) || (errno == EINTR))
         continue;
-      ERROR("ted plugin: read(2) failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("ted plugin: read(2) failed: %s", STRERRNO);
       return -1;
     } else if (receive_buffer_length == 0) {
       /* Should we close the FD in this case? */

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -138,9 +138,8 @@ static int us_open_socket(void) {
 
     status = getgrnam_r(grpname, &sg, grbuf, sizeof(grbuf), &g);
     if (status != 0) {
-      char errbuf[1024];
       WARNING("unixsock plugin: getgrnam_r (%s) failed: %s", grpname,
-              sstrerror(status, errbuf, sizeof(errbuf)));
+              STRERROR(status));
       break;
     }
     if (g == NULL) {

--- a/src/unixsock.c
+++ b/src/unixsock.c
@@ -75,9 +75,7 @@ static int us_open_socket(void) {
 
   sock_fd = socket(PF_UNIX, SOCK_STREAM, 0);
   if (sock_fd < 0) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: socket failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: socket failed: %s", STRERRNO);
     return -1;
   }
 
@@ -91,9 +89,8 @@ static int us_open_socket(void) {
     errno = 0;
     status = unlink(sa.sun_path);
     if ((status != 0) && (errno != ENOENT)) {
-      char errbuf[1024];
       WARNING("unixsock plugin: Deleting socket file \"%s\" failed: %s",
-              sa.sun_path, sstrerror(errno, errbuf, sizeof(errbuf)));
+              sa.sun_path, STRERRNO);
     } else if (status == 0) {
       INFO("unixsock plugin: Successfully deleted socket file \"%s\".",
            sa.sun_path);
@@ -102,9 +99,7 @@ static int us_open_socket(void) {
 
   status = bind(sock_fd, (struct sockaddr *)&sa, sizeof(sa));
   if (status != 0) {
-    char errbuf[1024];
-    sstrerror(errno, errbuf, sizeof(errbuf));
-    ERROR("unixsock plugin: bind failed: %s", errbuf);
+    ERROR("unixsock plugin: bind failed: %s", STRERRNO);
     close(sock_fd);
     sock_fd = -1;
     return -1;
@@ -112,9 +107,7 @@ static int us_open_socket(void) {
 
   status = chmod(sa.sun_path, sock_perms);
   if (status == -1) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: chmod failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: chmod failed: %s", STRERRNO);
     close(sock_fd);
     sock_fd = -1;
     return -1;
@@ -122,9 +115,7 @@ static int us_open_socket(void) {
 
   status = listen(sock_fd, 8);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: listen failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: listen failed: %s", STRERRNO);
     close(sock_fd);
     sock_fd = -1;
     return -1;
@@ -159,10 +150,9 @@ static int us_open_socket(void) {
 
     if (chown((sock_file != NULL) ? sock_file : US_DEFAULT_PATH, (uid_t)-1,
               g->gr_gid) != 0) {
-      char errbuf[1024];
       WARNING("unixsock plugin: chown (%s, -1, %i) failed: %s",
               (sock_file != NULL) ? sock_file : US_DEFAULT_PATH, (int)g->gr_gid,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
     }
   } while (0);
 
@@ -182,18 +172,14 @@ static void *us_handle_client(void *arg) {
 
   fdout = dup(fdin);
   if (fdout < 0) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: dup failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: dup failed: %s", STRERRNO);
     close(fdin);
     pthread_exit((void *)1);
   }
 
   fhin = fdopen(fdin, "r");
   if (fhin == NULL) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: fdopen failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: fdopen failed: %s", STRERRNO);
     close(fdin);
     close(fdout);
     pthread_exit((void *)1);
@@ -202,9 +188,7 @@ static void *us_handle_client(void *arg) {
 
   fhout = fdopen(fdout, "w");
   if (fhout == NULL) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: fdopen failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: fdopen failed: %s", STRERRNO);
     fclose(fhin); /* this closes fdin as well */
     close(fdout);
     pthread_exit((void *)1);
@@ -213,9 +197,7 @@ static void *us_handle_client(void *arg) {
 
   /* change output buffer to line buffered mode */
   if (setvbuf(fhout, NULL, _IOLBF, 0) != 0) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: setvbuf failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: setvbuf failed: %s", STRERRNO);
     fclose(fhin);
     fclose(fhout);
     pthread_exit((void *)1);
@@ -235,9 +217,8 @@ static void *us_handle_client(void *arg) {
         continue;
 
       if (errno != 0) {
-        char errbuf[1024];
         WARNING("unixsock plugin: failed to read from socket #%i: %s",
-                fileno(fhin), sstrerror(errno, errbuf, sizeof(errbuf)));
+                fileno(fhin), STRERRNO);
       }
       break;
     }
@@ -276,9 +257,8 @@ static void *us_handle_client(void *arg) {
       cmd_handle_flush(fhout, buffer);
     } else {
       if (fprintf(fhout, "-1 Unknown command: %s\n", fields[0]) < 0) {
-        char errbuf[1024];
         WARNING("unixsock plugin: failed to write to socket #%i: %s",
-                fileno(fhout), sstrerror(errno, errbuf, sizeof(errbuf)));
+                fileno(fhout), STRERRNO);
         break;
       }
     }
@@ -308,13 +288,11 @@ static void *us_server_thread(void __attribute__((unused)) * arg) {
     DEBUG("unixsock plugin: Calling accept..");
     status = accept(sock_fd, NULL, NULL);
     if (status < 0) {
-      char errbuf[1024];
 
       if (errno == EINTR)
         continue;
 
-      ERROR("unixsock plugin: accept failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("unixsock plugin: accept failed: %s", STRERRNO);
       close(sock_fd);
       sock_fd = -1;
       pthread_attr_destroy(&th_attr);
@@ -323,9 +301,7 @@ static void *us_server_thread(void __attribute__((unused)) * arg) {
 
     remote_fd = malloc(sizeof(*remote_fd));
     if (remote_fd == NULL) {
-      char errbuf[1024];
-      WARNING("unixsock plugin: malloc failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("unixsock plugin: malloc failed: %s", STRERRNO);
       close(status);
       continue;
     }
@@ -336,9 +312,7 @@ static void *us_server_thread(void __attribute__((unused)) * arg) {
     status = plugin_thread_create(&th, &th_attr, us_handle_client,
                                   (void *)remote_fd, "unixsock conn");
     if (status != 0) {
-      char errbuf[1024];
-      WARNING("unixsock plugin: pthread_create failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("unixsock plugin: pthread_create failed: %s", STRERRNO);
       close(*remote_fd);
       free(remote_fd);
       continue;
@@ -351,10 +325,8 @@ static void *us_server_thread(void __attribute__((unused)) * arg) {
 
   status = unlink((sock_file != NULL) ? sock_file : US_DEFAULT_PATH);
   if (status != 0) {
-    char errbuf[1024];
     NOTICE("unixsock plugin: unlink (%s) failed: %s",
-           (sock_file != NULL) ? sock_file : US_DEFAULT_PATH,
-           sstrerror(errno, errbuf, sizeof(errbuf)));
+           (sock_file != NULL) ? sock_file : US_DEFAULT_PATH, STRERRNO);
   }
 
   return (void *)0;
@@ -404,9 +376,7 @@ static int us_init(void) {
   status = plugin_thread_create(&listen_thread, NULL, us_server_thread, NULL,
                                 "unixsock listen");
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("unixsock plugin: pthread_create failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("unixsock plugin: pthread_create failed: %s", STRERRNO);
     return -1;
   }
 

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -87,9 +87,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
 
   status = sysinfo(&info);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("uptime plugin: Error calling sysinfo: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("uptime plugin: Error calling sysinfo: %s", STRERRNO);
     return -1;
   }
 
@@ -148,9 +146,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
   status = sysctl(mib, STATIC_ARRAY_SIZE(mib), &boottv, &boottv_len,
                   /* new_value = */ NULL, /* new_length = */ 0);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("uptime plugin: No value read from sysctl interface: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("uptime plugin: No value read from sysctl interface: %s", STRERRNO);
     return -1;
   }
 
@@ -170,9 +166,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
 
   status = perfstat_cpu_total(NULL, &cputotal, sizeof(perfstat_cpu_total_t), 1);
   if (status < 0) {
-    char errbuf[1024];
-    ERROR("uptime plugin: perfstat_cpu_total: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("uptime plugin: perfstat_cpu_total: %s", STRERRNO);
     return -1;
   }
 

--- a/src/utils_cmd_getthreshold.c
+++ b/src/utils_cmd_getthreshold.c
@@ -36,9 +36,8 @@
 
 #define print_to_socket(fh, ...)                                               \
   if (fprintf(fh, __VA_ARGS__) < 0) {                                          \
-    char errbuf[1024];                                                         \
     WARNING("handle_getthreshold: failed to write to socket #%i: %s",          \
-            fileno(fh), sstrerror(errno, errbuf, sizeof(errbuf)));             \
+            fileno(fh), STRERRNO);                                             \
     return -1;                                                                 \
   }
 

--- a/src/utils_cmd_getval.c
+++ b/src/utils_cmd_getval.c
@@ -78,9 +78,8 @@ cmd_status_t cmd_parse_getval(size_t argc, char **argv,
 #define print_to_socket(fh, ...)                                               \
   do {                                                                         \
     if (fprintf(fh, __VA_ARGS__) < 0) {                                        \
-      char errbuf[1024];                                                       \
       WARNING("cmd_handle_getval: failed to write to socket #%i: %s",          \
-              fileno(fh), sstrerror(errno, errbuf, sizeof(errbuf)));           \
+              fileno(fh), STRERRNO);                                           \
       return -1;                                                               \
     }                                                                          \
     fflush(fh);                                                                \

--- a/src/utils_cmd_listval.c
+++ b/src/utils_cmd_listval.c
@@ -62,9 +62,8 @@ cmd_status_t cmd_parse_listval(size_t argc, char **argv,
 #define print_to_socket(fh, ...)                                               \
   do {                                                                         \
     if (fprintf(fh, __VA_ARGS__) < 0) {                                        \
-      char errbuf[1024];                                                       \
       WARNING("handle_listval: failed to write to socket #%i: %s", fileno(fh), \
-              sstrerror(errno, errbuf, sizeof(errbuf)));                       \
+              STRERRNO);                                                       \
       free_everything_and_return(CMD_ERROR);                                   \
     }                                                                          \
     fflush(fh);                                                                \

--- a/src/utils_cmd_putnotif.c
+++ b/src/utils_cmd_putnotif.c
@@ -35,9 +35,8 @@
 #define print_to_socket(fh, ...)                                               \
   do {                                                                         \
     if (fprintf(fh, __VA_ARGS__) < 0) {                                        \
-      char errbuf[1024];                                                       \
       WARNING("handle_putnotif: failed to write to socket #%i: %s",            \
-              fileno(fh), sstrerror(errno, errbuf, sizeof(errbuf)));           \
+              fileno(fh), STRERRNO);                                           \
       return -1;                                                               \
     }                                                                          \
     fflush(fh);                                                                \

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -26,12 +26,12 @@
  *   Sebastian 'tokkee' Harl <sh at tokkee.org>
  **/
 
-#include "utils_cmds.h"
 #include "daemon/common.h"
 #include "utils_cmd_flush.h"
 #include "utils_cmd_getval.h"
 #include "utils_cmd_listval.h"
 #include "utils_cmd_putval.h"
+#include "utils_cmds.h"
 #include "utils_parse_option.h"
 
 #include <stdbool.h>

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -301,9 +301,8 @@ void cmd_error_fh(void *ud, cmd_status_t status, const char *format,
   vsnprintf(buf, sizeof(buf), format, ap);
   buf[sizeof(buf) - 1] = '\0';
   if (fprintf(fh, "%i %s\n", code, buf) < 0) {
-    char errbuf[1024];
     WARNING("utils_cmds: failed to write to file-handle #%i: %s", fileno(fh),
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
     return;
   }
 

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -519,7 +519,6 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
 
   return first;
 } /* static cu_mount_t *cu_mount_gen_getmntent (void) */
-/* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
 
 #elif HAVE_SEQ_GETMNTENT
 #warn "This version of `getmntent' hat not yet been implemented!"

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -361,9 +361,7 @@ static cu_mount_t *cu_mount_listmntent(void) {
   struct tabmntent *mntlist;
   if (listmntent(&mntlist, COLLECTD_MNTTAB, NULL, NULL) < 0) {
 #if COLLECT_DEBUG
-    char errbuf[1024];
-    DEBUG("utils_mount: calling listmntent() failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    DEBUG("utils_mount: calling listmntent() failed: %s", STRERRNO);
 #endif /* COLLECT_DEBUG */
   }
 
@@ -431,9 +429,7 @@ static cu_mount_t *cu_mount_getfsstat(void) {
   /* Get the number of mounted file systems */
   if ((bufsize = CMD_STATFS(NULL, 0, FLAGS_STATFS)) < 1) {
 #if COLLECT_DEBUG
-    char errbuf[1024];
-    DEBUG("utils_mount: getv?fsstat failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    DEBUG("utils_mount: getv?fsstat failed: %s", STRERRNO);
 #endif /* COLLECT_DEBUG */
     return NULL;
   }
@@ -446,9 +442,7 @@ static cu_mount_t *cu_mount_getfsstat(void) {
   if ((num = CMD_STATFS(buf, bufsize * sizeof(STRUCT_STATFS), FLAGS_STATFS)) <
       1) {
 #if COLLECT_DEBUG
-    char errbuf[1024];
-    DEBUG("utils_mount: getv?fsstat failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    DEBUG("utils_mount: getv?fsstat failed: %s", STRERRNO);
 #endif /* COLLECT_DEBUG */
     free(buf);
     return NULL;
@@ -495,9 +489,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
   DEBUG("utils_mount: (void); COLLECTD_MNTTAB = %s", COLLECTD_MNTTAB);
 
   if ((fp = fopen(COLLECTD_MNTTAB, "r")) == NULL) {
-    char errbuf[1024];
-    ERROR("fopen (%s): %s", COLLECTD_MNTTAB,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("fopen (%s): %s", COLLECTD_MNTTAB, STRERRNO);
     return NULL;
   }
 
@@ -527,7 +519,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
 
   return first;
 } /* static cu_mount_t *cu_mount_gen_getmntent (void) */
-  /* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
+/* #endif HAVE_TWO_GETMNTENT || HAVE_GEN_GETMNTENT || HAVE_SUN_GETMNTENT */
 
 #elif HAVE_SEQ_GETMNTENT
 #warn "This version of `getmntent' hat not yet been implemented!"
@@ -546,9 +538,7 @@ static cu_mount_t *cu_mount_getmntent(void) {
   DEBUG("utils_mount: (void); COLLECTD_MNTTAB = %s", COLLECTD_MNTTAB);
 
   if ((fp = setmntent(COLLECTD_MNTTAB, "r")) == NULL) {
-    char errbuf[1024];
-    ERROR("setmntent (%s): %s", COLLECTD_MNTTAB,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("setmntent (%s): %s", COLLECTD_MNTTAB, STRERRNO);
     return NULL;
   }
 
@@ -597,9 +587,7 @@ static cu_mount_t *cu_mount_getmntent(void) {
   DEBUG("utils_mount: (void); COLLECTD_MNTTAB = %s", COLLECTD_MNTTAB);
 
   if ((fp = setmntent(COLLECTD_MNTTAB, "r")) == NULL) {
-    char errbuf[1024];
-    ERROR("setmntent (%s): %s", COLLECTD_MNTTAB,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("setmntent (%s): %s", COLLECTD_MNTTAB, STRERRNO);
     return NULL;
   }
 

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -285,11 +285,11 @@ static int ds_get(char ***ret, /* {{{ */
     } else
       snprintf(max, sizeof(max), "%f", d->max);
 
-    status = snprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
-                      type, (cfg->heartbeat > 0)
-                                ? cfg->heartbeat
-                                : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
-                      min, max);
+    status = snprintf(
+        buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name, type,
+        (cfg->heartbeat > 0) ? cfg->heartbeat
+                             : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
+        min, max);
     if ((status < 1) || ((size_t)status >= sizeof(buffer)))
       break;
 

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -556,9 +556,7 @@ static int srrd_create_async(const char *filename, /* {{{ */
 
   status = pthread_create(&thread, &attr, srrd_create_thread, args);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("srrd_create_async: pthread_create failed: %s",
-          sstrerror(status, errbuf, sizeof(errbuf)));
+    ERROR("srrd_create_async: pthread_create failed: %s", STRERROR(status));
     pthread_attr_destroy(&attr);
     srrd_create_args_destroy(args);
     return status;

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -251,9 +251,7 @@ static int ds_get(char ***ret, /* {{{ */
 
   ds_def = calloc(ds->ds_num, sizeof(*ds_def));
   if (ds_def == NULL) {
-    char errbuf[1024];
-    ERROR("rrdtool plugin: calloc failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("rrdtool plugin: calloc failed: %s", STRERRNO);
     return -1;
   }
 
@@ -287,11 +285,11 @@ static int ds_get(char ***ret, /* {{{ */
     } else
       snprintf(max, sizeof(max), "%f", d->max);
 
-    status = snprintf(
-        buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name, type,
-        (cfg->heartbeat > 0) ? cfg->heartbeat
-                             : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
-        min, max);
+    status = snprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
+                      type, (cfg->heartbeat > 0)
+                                ? cfg->heartbeat
+                                : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
+                      min, max);
     if ((status < 1) || ((size_t)status >= sizeof(buffer)))
       break;
 
@@ -512,9 +510,8 @@ static void *srrd_create_thread(void *targs) /* {{{ */
 
   status = rename(tmpfile, args->filename);
   if (status != 0) {
-    char errbuf[1024];
     ERROR("srrd_create_thread: rename (\"%s\", \"%s\") failed: %s", tmpfile,
-          args->filename, sstrerror(errno, errbuf, sizeof(errbuf)));
+          args->filename, STRERRNO);
     unlink(tmpfile);
     unlock_file(args->filename);
     srrd_create_args_destroy(args);
@@ -605,9 +602,7 @@ int cu_rrd_create_file(const char *filename, /* {{{ */
   argc = ds_num + rra_num;
 
   if ((argv = malloc(sizeof(*argv) * (argc + 1))) == NULL) {
-    char errbuf[1024];
-    ERROR("cu_rrd_create_file failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("cu_rrd_create_file failed: %s", STRERRNO);
     rra_free(rra_num, rra_def);
     ds_free(ds_num, ds_def);
     return -1;

--- a/src/utils_tail.c
+++ b/src/utils_tail.c
@@ -49,9 +49,7 @@ static int cu_tail_reopen(cu_tail_t *obj) {
 
   status = stat(obj->file, &stat_buf);
   if (status != 0) {
-    char errbuf[1024];
-    ERROR("utils_tail: stat (%s) failed: %s", obj->file,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("utils_tail: stat (%s) failed: %s", obj->file, STRERRNO);
     return -1;
   }
 
@@ -62,9 +60,7 @@ static int cu_tail_reopen(cu_tail_t *obj) {
       INFO("utils_tail: File `%s' was truncated.", obj->file);
       status = fseek(obj->fh, 0, SEEK_SET);
       if (status != 0) {
-        char errbuf[1024];
-        ERROR("utils_tail: fseek (%s) failed: %s", obj->file,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+        ERROR("utils_tail: fseek (%s) failed: %s", obj->file, STRERRNO);
         fclose(obj->fh);
         obj->fh = NULL;
         return -1;
@@ -81,18 +77,14 @@ static int cu_tail_reopen(cu_tail_t *obj) {
 
   fh = fopen(obj->file, "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    ERROR("utils_tail: fopen (%s) failed: %s", obj->file,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("utils_tail: fopen (%s) failed: %s", obj->file, STRERRNO);
     return -1;
   }
 
   if (seek_end != 0) {
     status = fseek(fh, 0, SEEK_END);
     if (status != 0) {
-      char errbuf[1024];
-      ERROR("utils_tail: fseek (%s) failed: %s", obj->file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("utils_tail: fseek (%s) failed: %s", obj->file, STRERRNO);
       fclose(fh);
       return -1;
     }
@@ -183,9 +175,8 @@ int cu_tail_readline(cu_tail_t *obj, char *buf, int buflen) {
   }
 
   if (ferror(obj->fh) != 0) {
-    char errbuf[1024];
     WARNING("utils_tail: fgets (%s) returned an error: %s", obj->file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
     fclose(obj->fh);
     obj->fh = NULL;
     return -1;

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -104,9 +104,7 @@ static int vmem_read(void) {
 
   fh = fopen("/proc/vmstat", "r");
   if (fh == NULL) {
-    char errbuf[1024];
-    ERROR("vmem plugin: fopen (/proc/vmstat) failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("vmem plugin: fopen (/proc/vmstat) failed: %s", STRERRNO);
     return -1;
   }
 

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -124,9 +124,7 @@ static int vserver_read(void) {
   errno = 0;
   proc = opendir(PROCDIR);
   if (proc == NULL) {
-    char errbuf[1024];
-    ERROR("vserver plugin: fopen (%s): %s", PROCDIR,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("vserver plugin: fopen (%s): %s", PROCDIR, STRERRNO);
     return -1;
   }
 
@@ -146,13 +144,11 @@ static int vserver_read(void) {
     errno = 0;
     dent = readdir(proc);
     if (dent == NULL) {
-      char errbuf[4096];
-
       if (errno == 0) /* end of directory */
         break;
 
       ERROR("vserver plugin: failed to read directory %s: %s", PROCDIR,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       closedir(proc);
       return -1;
     }
@@ -166,9 +162,7 @@ static int vserver_read(void) {
 
     status = stat(file, &statbuf);
     if (status != 0) {
-      char errbuf[4096];
-      WARNING("vserver plugin: stat (%s) failed: %s", file,
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+      WARNING("vserver plugin: stat (%s) failed: %s", file, STRERRNO);
       continue;
     }
 
@@ -181,9 +175,7 @@ static int vserver_read(void) {
       continue;
 
     if (NULL == (fh = fopen(file, "r"))) {
-      char errbuf[1024];
-      ERROR("Cannot open '%s': %s", file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("Cannot open '%s': %s", file, STRERRNO);
     }
 
     while ((fh != NULL) && (NULL != fgets(buffer, BUFSIZE, fh))) {
@@ -225,9 +217,7 @@ static int vserver_read(void) {
       continue;
 
     if (NULL == (fh = fopen(file, "r"))) {
-      char errbuf[1024];
-      ERROR("Cannot open '%s': %s", file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("Cannot open '%s': %s", file, STRERRNO);
     }
 
     while ((fh != NULL) && (NULL != fgets(buffer, BUFSIZE, fh))) {
@@ -271,9 +261,7 @@ static int vserver_read(void) {
       continue;
 
     if (NULL == (fh = fopen(file, "r"))) {
-      char errbuf[1024];
-      ERROR("Cannot open '%s': %s", file,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+      ERROR("Cannot open '%s': %s", file, STRERRNO);
     }
 
     while ((fh != NULL) && (NULL != fgets(buffer, BUFSIZE, fh))) {

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -90,8 +90,7 @@ static int wireless_read(void) {
 
   /* there are a variety of names for the wireless device */
   if ((fh = fopen(WIRELESS_PROC_FILE, "r")) == NULL) {
-    char errbuf[1024];
-    WARNING("wireless: fopen: %s", sstrerror(errno, errbuf, sizeof(errbuf)));
+    WARNING("wireless: fopen: %s", STRERRNO);
     return -1;
   }
 

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -156,11 +156,9 @@ static int wg_send_buffer(struct wg_callback *cb) {
   status = swrite(cb->sock_fd, cb->send_buf, strlen(cb->send_buf));
   if (status != 0) {
     if (cb->log_send_errors) {
-      char errbuf[1024];
       ERROR("write_graphite plugin: send to %s:%s (%s) failed with status %zi "
             "(%s)",
-            cb->node, cb->service, cb->protocol, status,
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            cb->node, cb->service, cb->protocol, status, STRERRNO);
     }
 
     close(cb->sock_fd);
@@ -238,9 +236,7 @@ static int wg_callback_init(struct wg_callback *cb) {
     cb->sock_fd =
         socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (cb->sock_fd < 0) {
-      char errbuf[1024];
-      snprintf(connerr, sizeof(connerr), "failed to open socket: %s",
-               sstrerror(errno, errbuf, sizeof(errbuf)));
+      snprintf(connerr, sizeof(connerr), "failed to open socket: %s", STRERRNO);
       continue;
     }
 
@@ -248,10 +244,8 @@ static int wg_callback_init(struct wg_callback *cb) {
 
     status = connect(cb->sock_fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
     if (status != 0) {
-      char errbuf[1024];
-      snprintf(connerr, sizeof(connerr), "failed to connect to remote "
-                                         "host: %s",
-               sstrerror(errno, errbuf, sizeof(errbuf)));
+      snprintf(connerr, sizeof(connerr), "failed to connect to remote host: %s",
+               STRERRNO);
       close(cb->sock_fd);
       cb->sock_fd = -1;
       continue;
@@ -263,9 +257,6 @@ static int wg_callback_init(struct wg_callback *cb) {
   freeaddrinfo(ai_list);
 
   if (cb->sock_fd < 0) {
-    if (connerr[0] == '\0')
-      /* this should not happen but try to get a message anyway */
-      sstrerror(errno, connerr, sizeof(connerr));
     c_complain(LOG_ERR, &cb->init_complaint,
                "write_graphite plugin: Connecting to %s:%s via %s failed. "
                "The last error was: %s",

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -879,11 +879,9 @@ static int sensu_send_msg(struct sensu_host *host, const char *msg) /* {{{ */
   sensu_close_socket(host);
 
   if (status != 0) {
-    char errbuf[1024];
     ERROR("write_sensu plugin: Sending to Sensu at %s:%s failed: %s",
           (host->node != NULL) ? host->node : SENSU_HOST,
-          (host->service != NULL) ? host->service : SENSU_PORT,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          (host->service != NULL) ? host->service : SENSU_PORT, STRERRNO);
     return -1;
   }
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -28,14 +28,14 @@
 
 #include "collectd.h"
 
+#include "common.h"
+#include "plugin.h"
+#include "utils_cache.h"
 #include <arpa/inet.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <netdb.h>
 #include <stddef.h>
-#include "common.h"
-#include "plugin.h"
-#include "utils_cache.h"
 
 #include <stdlib.h>
 #define SENSU_HOST "localhost"

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -112,9 +112,8 @@ static int wt_send_buffer(struct wt_callback *cb) {
 
   status = swrite(cb->sock_fd, cb->send_buf, strlen(cb->send_buf));
   if (status != 0) {
-    char errbuf[1024];
     ERROR("write_tsdb plugin: send failed with status %zi (%s)", status,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
 
     close(cb->sock_fd);
     cb->sock_fd = -1;
@@ -242,10 +241,9 @@ static int wt_callback_init(struct wt_callback *cb) {
   }
 
   if (cb->sock_fd < 0) {
-    char errbuf[1024];
     ERROR("write_tsdb plugin: Connecting to %s:%s failed. "
           "The last error was: %s",
-          node, service, sstrerror(errno, errbuf, sizeof(errbuf)));
+          node, service, STRERRNO);
     return -1;
   }
 

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -202,9 +202,8 @@ static int za_read(void) {
 
   fh = fopen(ZOL_ARCSTATS_FILE, "r");
   if (fh == NULL) {
-    char errbuf[1024];
     ERROR("zfs_arc plugin: Opening \"%s\" failed: %s", ZOL_ARCSTATS_FILE,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+          STRERRNO);
     return -1;
   }
 

--- a/src/zone.c
+++ b/src/zone.c
@@ -68,9 +68,7 @@ static int zone_read_procfile(char const *pidstr, char const *name, void *buf,
   }
 
   if (sread(fd, buf, bufsize) != 0) {
-    char errbuf[1024];
-    ERROR("zone plugin: Reading \"%s\" failed: %s", procfile,
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("zone plugin: Reading \"%s\" failed: %s", procfile, STRERRNO);
     close(fd);
     return 1;
   }


### PR DESCRIPTION
This allows us to get rid of all the `char errbuf[1024];` that were all over the place.