### PR TITLE
dpdkstats: Fix compilation issue

### DIFF
--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -125,7 +125,6 @@ static int dpdk_stats_preinit(void) {
 
   int ret = dpdk_helper_init(g_shm_name, sizeof(dpdk_stats_ctx_t), &g_hc);
   if (ret != 0) {
-    char errbuf[ERR_BUF_SIZE];
     ERROR("%s: failed to initialize %s helper(error: %s)", DPDK_STATS_PLUGIN,
           g_shm_name, STRERRNO);
     return ret;
@@ -446,7 +445,6 @@ static int dpdk_stats_reinit_helper() {
   int ret;
   ret = dpdk_helper_init(g_shm_name, data_size, &g_hc);
   if (ret != 0) {
-    char errbuf[ERR_BUF_SIZE];
     ERROR("%s: failed to initialize %s helper(error: %s)", DPDK_STATS_PLUGIN,
           g_shm_name, STRERRNO);
     return ret;


### PR DESCRIPTION
Fixed dpdkstats plugin compilation issue caused by #2519 commit.

===================
  CC       src/dpdkstat_la-dpdkstat.lo
src/dpdkstat.c: In function ‘dpdk_stats_preinit’:
src/dpdkstat.c:128:10: error: unused variable ‘errbuf’ [-Werror=unused-variable]
     char errbuf[ERR_BUF_SIZE];
          ^
src/dpdkstat.c: In function ‘dpdk_stats_reinit_helper’:
src/dpdkstat.c:449:10: error: unused variable ‘errbuf’ [-Werror=unused-variable]
     char errbuf[ERR_BUF_SIZE];
          ^
cc1: all warnings being treated as errors
