### PR TITLE
varnish-cache-5.2 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5718,20 +5718,25 @@ if test "x$with_libvarnish" = "xyes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
 
-  AC_CHECK_HEADERS([vapi/vsc.h],
-    [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
-    [
-      AC_CHECK_HEADERS([vsc.h],
-        [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
-        [
-          AC_CHECK_HEADERS([varnishapi.h],
-            [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
-            [with_libvarnish="no (found none of the varnish header files)"]
-          )
-        ]
-      )
-    ]
-  )
+  $PKG_CONFIG --atleast-version=5.2 'varnishapi' 2>/dev/null
+  if test $? -eq 0; then
+    AC_DEFINE([HAVE_VARNISH_V5], [1], [Varnish 5 API support])
+  else
+    AC_CHECK_HEADERS([vapi/vsc.h],
+      [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
+      [
+        AC_CHECK_HEADERS([vsc.h],
+          [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
+          [
+            AC_CHECK_HEADERS([varnishapi.h],
+              [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
+              [with_libvarnish="no (found none of the varnish header files)"]
+            )
+          ]
+        )
+      ]
+    )
+  fi
 
   CPPFLAGS="$SAVE_CPPFLAGS"
 fi

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -1390,7 +1390,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #endif
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   if (!ok) {
-    VSM_Destroy(&vd);
+    VSM_Delete(vd);
     ERROR("varnish plugin: Unable to open connection.");
     return -1;
   }
@@ -1403,7 +1403,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #endif
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   if (!stats) {
-    VSM_Destroy(&vd);
+    VSM_Delete(vd);
     ERROR("varnish plugin: Unable to get statistics.");
     return -1;
   }

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -157,7 +157,7 @@ static int varnish_monitor(void *priv,
   char *c;
 
   c = rindex(pt->name, '.');
-  strcpy(namebuff, c+1);
+  strcpy(namebuff, c + 1);
   name = namebuff;
 
   (void)class;
@@ -460,7 +460,6 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "bans_tests_tested") == 0)
       return varnish_submit_derive(conf->instance, "ban", "total_operations",
                                    "tests_tested", val);
-
   }
 #endif
 
@@ -501,7 +500,8 @@ static int varnish_monitor(void *priv,
                                    "total_operations", "closed_err", val);
     else if (strcmp(name, "sess_dropped") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                   "total_operations", "dropped_for_thread", val);
+                                   "total_operations", "dropped_for_thread",
+                                   val);
 #endif
   }
 
@@ -679,7 +679,7 @@ static int varnish_monitor(void *priv,
                                    "dropped", val);
     else if (strcmp(name, "thread_queue_len") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "queue_length",
-                                   "threads", val);
+                                  "threads", val);
     else if (strcmp(name, "n_wrk") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "threads",
                                   "worker", val);
@@ -709,8 +709,8 @@ static int varnish_monitor(void *priv,
                                    "queue_length", val);
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "pools") == 0)
-      return varnish_submit_gauge(conf->instance, "workers", "pools",
-                                  "pools", val);
+      return varnish_submit_gauge(conf->instance, "workers", "pools", "pools",
+                                  val);
     else if (strcmp(name, "busy_killed") == 0)
       return varnish_submit_derive(conf->instance, "workers", "http_requests",
                                    "busy_killed", val);
@@ -741,38 +741,38 @@ static int varnish_monitor(void *priv,
                                    "bitmap", "happy_hprobes", val);
     */
     if (strcmp(name, "bereq_hdrbytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "bereq_hdrbytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "bereq_hdrbytes", val);
     else if (strcmp(name, "bereq_bodybytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "bereq_bodybytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "bereq_bodybytes", val);
     else if (strcmp(name, "bereq_protobytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "bereq_protobytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "bereq_protobytes", val);
     else if (strcmp(name, "beresp_hdrbytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "beresp_hdrbytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "beresp_hdrbytes", val);
     else if (strcmp(name, "beresp_bodybytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "beresp_bodybytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "beresp_bodybytes", val);
     else if (strcmp(name, "beresp_protobytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "beresp_protobytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "beresp_protobytes", val);
     else if (strcmp(name, "pipe_hdrbytes") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "pipe_hdrbytes", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "pipe_hdrbytes", val);
     else if (strcmp(name, "pipe_out") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "pipe_out", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "pipe_out", val);
     else if (strcmp(name, "pipe_in") == 0)
-      return varnish_submit_derive(conf->instance, "vbe",
-                                   "total_bytes", "pipe_in", val);
+      return varnish_submit_derive(conf->instance, "vbe", "total_bytes",
+                                   "pipe_in", val);
     else if (strcmp(name, "conn") == 0)
       return varnish_submit_derive(conf->instance, "vbe", "connections",
-                                  "c_conns", val);
+                                   "c_conns", val);
     else if (strcmp(name, "req") == 0)
       return varnish_submit_derive(conf->instance, "vbe", "http_requests",
-                                  "b_reqs", val);
+                                   "b_reqs", val);
   }
 
   /* All Stevedores support these counters */
@@ -787,20 +787,20 @@ static int varnish_monitor(void *priv,
       strncpy(category, "mse", 4);
 
     if (strcmp(name, "c_req") == 0)
-      return varnish_submit_derive(conf->instance, category,
-                                   "total_operations", "alloc_req", val);
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                   "alloc_req", val);
     else if (strcmp(name, "c_fail") == 0)
-      return varnish_submit_derive(conf->instance, category,
-                                   "total_operations", "alloc_fail", val);
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                   "alloc_fail", val);
     else if (strcmp(name, "c_bytes") == 0)
-      return varnish_submit_derive(conf->instance, category,
-                                   "total_bytes", "bytes_allocated", val);
+      return varnish_submit_derive(conf->instance, category, "total_bytes",
+                                   "bytes_allocated", val);
     else if (strcmp(name, "c_freed") == 0)
-      return varnish_submit_derive(conf->instance, category,
-                                   "total_bytes", "bytes_freed", val);
+      return varnish_submit_derive(conf->instance, category, "total_bytes",
+                                   "bytes_freed", val);
     else if (strcmp(name, "g_alloc") == 0)
-      return varnish_submit_derive(conf->instance, category,
-                                  "total_operations", "alloc_outstanding", val);
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                   "alloc_outstanding", val);
     else if (strcmp(name, "g_bytes") == 0)
       return varnish_submit_gauge(conf->instance, category, "bytes",
                                   "bytes_outstanding", val);
@@ -813,14 +813,14 @@ static int varnish_monitor(void *priv,
 
   if (conf->collect_smf) {
     if (strcmp(name, "g_smf") == 0)
-        return varnish_submit_gauge(conf->instance, "smf", "objects",
-                                    "n_struct_smf", val);
-      else if (strcmp(name, "g_smf_frag") == 0)
-        return varnish_submit_gauge(conf->instance, "smf", "objects",
-                                    "n_small_free_smf", val);
-      else if (strcmp(name, "g_smf_large") == 0)
-        return varnish_submit_gauge(conf->instance, "smf", "objects",
-                                    "n_large_free_smf", val);
+      return varnish_submit_gauge(conf->instance, "smf", "objects",
+                                  "n_struct_smf", val);
+    else if (strcmp(name, "g_smf_frag") == 0)
+      return varnish_submit_gauge(conf->instance, "smf", "objects",
+                                  "n_small_free_smf", val);
+    else if (strcmp(name, "g_smf_large") == 0)
+      return varnish_submit_gauge(conf->instance, "smf", "objects",
+                                  "n_large_free_smf", val);
   }
 
   if (conf->collect_mgt) {
@@ -828,35 +828,35 @@ static int varnish_monitor(void *priv,
       return varnish_submit_gauge(conf->instance, "mgt", "uptime",
                                   "mgt_proc_uptime", val);
     else if (strcmp(name, "child_start") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_start", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_start", val);
     else if (strcmp(name, "child_exit") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_exit", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_exit", val);
     else if (strcmp(name, "child_stop") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_stop", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_stop", val);
     else if (strcmp(name, "child_died") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_died", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_died", val);
     else if (strcmp(name, "child_dump") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_dump", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_dump", val);
     else if (strcmp(name, "child_panic") == 0)
-      return varnish_submit_derive(conf->instance, "mgt",
-                                   "total_operations", "child_panic", val);
+      return varnish_submit_derive(conf->instance, "mgt", "total_operations",
+                                   "child_panic", val);
   }
 
   if (conf->collect_lck) {
     if (strcmp(name, "creat") == 0)
-      return varnish_submit_gauge(conf->instance, "lck", "objects",
-                                  "created", val);
+      return varnish_submit_gauge(conf->instance, "lck", "objects", "created",
+                                  val);
     else if (strcmp(name, "destroy") == 0)
-      return varnish_submit_gauge(conf->instance, "lck", "objects",
-                                  "destroyed", val);
+      return varnish_submit_gauge(conf->instance, "lck", "objects", "destroyed",
+                                  val);
     else if (strcmp(name, "locks") == 0)
       return varnish_submit_derive(conf->instance, "lck", "total_operations",
-                                  "lock_ops", val);
+                                   "lock_ops", val);
   }
 
   if (conf->collect_mempool) {
@@ -879,112 +879,111 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "mempool",
                                    "total_operations", "frees", val);
     else if (strcmp(name, "recycle") == 0)
-      return varnish_submit_gauge(conf->instance, "mempool",
-                                   "objects", "recycled", val);
+      return varnish_submit_gauge(conf->instance, "mempool", "objects",
+                                  "recycled", val);
     else if (strcmp(name, "timeout") == 0)
-      return varnish_submit_gauge(conf->instance, "mempool",
-                                   "objects", "timed_out", val);
+      return varnish_submit_gauge(conf->instance, "mempool", "objects",
+                                  "timed_out", val);
     else if (strcmp(name, "toosmall") == 0)
-      return varnish_submit_gauge(conf->instance, "mempool",
-                                   "objects", "too_small", val);
+      return varnish_submit_gauge(conf->instance, "mempool", "objects",
+                                  "too_small", val);
     else if (strcmp(name, "surplus") == 0)
-      return varnish_submit_gauge(conf->instance, "mempool",
-                                   "objects", "surplus", val);
+      return varnish_submit_gauge(conf->instance, "mempool", "objects",
+                                  "surplus", val);
     else if (strcmp(name, "randry") == 0)
-      return varnish_submit_gauge(conf->instance, "mempool",
-                                   "objects", "ran_dry", val);
+      return varnish_submit_gauge(conf->instance, "mempool", "objects",
+                                  "ran_dry", val);
   }
 
   if (conf->collect_mse) {
     if (strcmp(name, "c_full") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "full_allocs", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "full_allocs", val);
     else if (strcmp(name, "c_truncated") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "truncated_allocs", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "truncated_allocs", val);
     else if (strcmp(name, "c_expanded") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "expanded_allocs", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "expanded_allocs", val);
     else if (strcmp(name, "c_failed") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "failed_allocs", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "failed_allocs", val);
     else if (strcmp(name, "c_bytes") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_bytes", "bytes_allocated", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_bytes",
+                                   "bytes_allocated", val);
     else if (strcmp(name, "c_freed") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_bytes", "bytes_freed", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_bytes",
+                                   "bytes_freed", val);
     else if (strcmp(name, "g_fo_alloc") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "fo_allocs_outstanding", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "fo_allocs_outstanding", val);
     else if (strcmp(name, "g_fo_bytes") == 0)
-      return varnish_submit_gauge(conf->instance, "mse",
-                                  "bytes", "fo_bytes_outstanding", val);
+      return varnish_submit_gauge(conf->instance, "mse", "bytes",
+                                  "fo_bytes_outstanding", val);
     else if (strcmp(name, "g_membuf_alloc") == 0)
-      return varnish_submit_gauge(conf->instance, "mse",
-                                  "objects", "membufs_allocated", val);
+      return varnish_submit_gauge(conf->instance, "mse", "objects",
+                                  "membufs_allocated", val);
     else if (strcmp(name, "g_membuf_inuse") == 0)
-      return varnish_submit_gauge(conf->instance, "mse",
-                                  "objects", "membufs_inuse", val);
+      return varnish_submit_gauge(conf->instance, "mse", "objects",
+                                  "membufs_inuse", val);
     else if (strcmp(name, "g_bans_bytes") == 0)
-      return varnish_submit_gauge(conf->instance, "mse",
-                                  "bytes", "persisted_banspace_used", val);
+      return varnish_submit_gauge(conf->instance, "mse", "bytes",
+                                  "persisted_banspace_used", val);
     else if (strcmp(name, "g_bans_space") == 0)
-      return varnish_submit_gauge(conf->instance, "mse",
-                                  "bytes", "persisted_banspace_available", val);
+      return varnish_submit_gauge(conf->instance, "mse", "bytes",
+                                  "persisted_banspace_available", val);
     else if (strcmp(name, "g_bans_persisted") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "bans_persisted", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "bans_persisted", val);
     else if (strcmp(name, "g_bans_lost") == 0)
-      return varnish_submit_derive(conf->instance, "mse",
-                                  "total_operations", "bans_lost", val);
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "bans_lost", val);
 
-     /* mse seg */
+    /* mse seg */
     else if (strcmp(name, "g_journal_bytes") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_reg",
-                                  "bytes", "journal_bytes_used", val);
+      return varnish_submit_gauge(conf->instance, "mse_reg", "bytes",
+                                  "journal_bytes_used", val);
     else if (strcmp(name, "g_journal_space") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_reg",
-                                  "bytes", "journal_bytes_free", val);
+      return varnish_submit_gauge(conf->instance, "mse_reg", "bytes",
+                                  "journal_bytes_free", val);
 
     /* mse segagg */
     else if (strcmp(name, "g_bigspace") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "bytes", "big_extents_bytes_available", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "bytes",
+                                  "big_extents_bytes_available", val);
     else if (strcmp(name, "g_extfree") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "objects", "free_extents", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "objects",
+                                  "free_extents", val);
     else if (strcmp(name, "g_sparenode") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "objects", "spare_nodes_available", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "objects",
+                                  "spare_nodes_available", val);
     else if (strcmp(name, "g_objnode") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "objects", "object_nodes_in_use", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "objects",
+                                  "object_nodes_in_use", val);
     else if (strcmp(name, "g_extnode") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "objects", "extent_nodes_in_use", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "objects",
+                                  "extent_nodes_in_use", val);
     else if (strcmp(name, "g_bigextfree") == 0)
-      return varnish_submit_gauge(conf->instance, "mse_segagg",
-                                  "objects", "free_big_extents", val);
+      return varnish_submit_gauge(conf->instance, "mse_segagg", "objects",
+                                  "free_big_extents", val);
     else if (strcmp(name, "c_pruneloop") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_operations", "prune_loops", val);
+                                   "total_operations", "prune_loops", val);
     else if (strcmp(name, "c_pruned") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_objects", "pruned_objects", val);
+                                   "total_objects", "pruned_objects", val);
     else if (strcmp(name, "c_spared") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_operations", "spared_objects", val);
+                                   "total_operations", "spared_objects", val);
     else if (strcmp(name, "c_skipped") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_operations", "missed_objects", val);
+                                   "total_operations", "missed_objects", val);
     else if (strcmp(name, "c_nuked") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_operations", "nuked_objects", val);
+                                   "total_operations", "nuked_objects", val);
     else if (strcmp(name, "c_sniped") == 0)
       return varnish_submit_derive(conf->instance, "mse_segagg",
-                                  "total_operations", "sniped_objects", val);
-
+                                   "total_operations", "sniped_objects", val);
   }
 
 #endif
@@ -1374,8 +1373,8 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
       VSM_Delete(vd);
 #elif HAVE_VARNISH_V5
-    VSC_Destroy(&vsc, vd);
-    VSM_Destroy(&vd);
+      VSC_Destroy(&vsc, vd);
+      VSM_Destroy(&vd);
 #endif
       ERROR("varnish plugin: VSM_Arg (\"%s\") failed "
             "with status %i.",
@@ -1411,20 +1410,20 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #endif
 
 #if HAVE_VARNISH_V5
-    if (VSM_Attach(vd, STDERR_FILENO)) {
-        ERROR("varnish plugin: Cannot attach to varnish. %s", VSM_Error(vd));
-        VSC_Destroy(&vsc, vd);
-        VSM_Destroy(&vd);
-        return -1;
-    }
+  if (VSM_Attach(vd, STDERR_FILENO)) {
+    ERROR("varnish plugin: Cannot attach to varnish. %s", VSM_Error(vd));
+    VSC_Destroy(&vsc, vd);
+    VSM_Destroy(&vd);
+    return -1;
+  }
 
-    vsm_status = VSM_Status(vd);
-    if (vsm_status & ~(VSM_MGT_RUNNING|VSM_WRK_RUNNING)) {
-        ERROR("varnish plugin: Unable to get statistics.");
-        VSC_Destroy(&vsc, vd);
-        VSM_Destroy(&vd);
-        return -1;
-    }
+  vsm_status = VSM_Status(vd);
+  if (vsm_status & ~(VSM_MGT_RUNNING | VSM_WRK_RUNNING)) {
+    ERROR("varnish plugin: Unable to get statistics.");
+    VSC_Destroy(&vsc, vd);
+    VSM_Destroy(&vd);
+    return -1;
+  }
 #endif
 
 #if HAVE_VARNISH_V3
@@ -1436,10 +1435,10 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 #endif
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
-    VSM_Delete(vd);
+  VSM_Delete(vd);
 #elif HAVE_VARNISH_V5
-    VSC_Destroy(&vsc, vd);
-    VSM_Destroy(&vd);
+  VSC_Destroy(&vsc, vd);
+  VSM_Destroy(&vd);
 #endif
 
   return 0;
@@ -1752,9 +1751,9 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 #endif
       && !conf->collect_vcl && !conf->collect_workers
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
-      && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf
-      && !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool
-      && !conf->collect_mse
+      && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf &&
+      !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
+      !conf->collect_mse
 #endif
       ) {
     WARNING("Varnish plugin: No metric has been configured for "

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -144,7 +144,6 @@ static int varnish_monitor(void *priv,
 {
   uint64_t val;
   const user_config_t *conf;
-  const char *class;
   const char *name;
 
   if (pt == NULL)
@@ -160,9 +159,9 @@ static int varnish_monitor(void *priv,
   strcpy(namebuff, c + 1);
   name = namebuff;
 
-  (void)class;
-
 #elif HAVE_VARNISH_V4
+  const char *class;
+
   class = pt->section->fantom->type;
   name = pt->desc->name;
 
@@ -170,6 +169,8 @@ static int varnish_monitor(void *priv,
     return 0;
 
 #elif HAVE_VARNISH_V3
+  const char *class;
+
   class = pt->class;
   name = pt->name;
 


### PR DESCRIPTION
- detecting varnish-cache version at least 5.2 with `pkg-config`
- setting up the variables to match the varnish-cache-5.2 - `LIBVARNISHAPI_2.0`
- the rest of the behaviour is the same as with `HAVE_VARNISH_V4`