### PR TITLE
postgresql: fix last sum() related parse errors

### DIFF
--- a/src/postgresql_default.conf
+++ b/src/postgresql_default.conf
@@ -38,9 +38,9 @@
 </Query>
 
 <Query queries>
-	Statement "SELECT sum(n_tup_ins) AS ins, \
-			sum(n_tup_upd) AS upd, \
-			sum(n_tup_del) AS del \
+	Statement "SELECT coalesce(sum(n_tup_ins), 0) AS ins, \
+			coalesce(sum(n_tup_upd), 0) AS upd, \
+			coalesce(sum(n_tup_del), 0) AS del \
 		FROM pg_stat_user_tables;"
 
 	<Result>
@@ -63,10 +63,10 @@
 </Query>
 
 <Query queries>
-	Statement "SELECT sum(n_tup_ins) AS ins, \
-			sum(n_tup_upd) AS upd, \
-			sum(n_tup_del) AS del, \
-			sum(n_tup_hot_upd) AS hot_upd \
+	Statement "SELECT coalesce(sum(n_tup_ins), 0) AS ins, \
+			coalesce(sum(n_tup_upd), 0) AS upd, \
+			coalesce(sum(n_tup_del), 0) AS del, \
+			coalesce(sum(n_tup_hot_upd), 0) AS hot_upd \
 		FROM pg_stat_user_tables;"
 
 	<Result>
@@ -188,7 +188,8 @@
 </Query>
 
 <Query table_states>
-	Statement "SELECT sum(n_live_tup) AS live, sum(n_dead_tup) AS dead \
+	Statement "SELECT coalesce(sum(n_live_tup), 0) AS live, \
+		coalesce(sum(n_dead_tup), 0) AS dead \
 		FROM pg_stat_user_tables;"
 
 	<Result>


### PR DESCRIPTION
These queries return empty values when a database doesn't have any
tables yet, which results in collectd logging this error every Interval:

```
db query utils: udb_result_submit: Parsing `' as derive failed.
```

Related to #1905