### PR TITLE
nut: add readout of power

### DIFF
--- a/src/nut.c
+++ b/src/nut.c
@@ -316,7 +316,7 @@ static int nut_read(user_data_t *user_data) {
       else if (strcmp("output.voltage", key) == 0)
         nut_submit(ups, "voltage", "output", value);
       else if (strcmp("output.realpower", key) == 0)
-        nut_submit(ups, "energy", "output", value);
+        nut_submit(ups, "realpower", "output", value);
       else if (strcmp("output.power", key) == 0)
         nut_submit(ups, "power", "output", value);
     } else if (strncmp("ups.", key, 4) == 0) {

--- a/src/nut.c
+++ b/src/nut.c
@@ -316,6 +316,8 @@ static int nut_read(user_data_t *user_data) {
       else if (strcmp("output.voltage", key) == 0)
         nut_submit(ups, "voltage", "output", value);
       else if (strcmp("output.realpower", key) == 0)
+        nut_submit(ups, "energy", "output", value);
+      else if (strcmp("output.power", key) == 0)
         nut_submit(ups, "power", "output", value);
     } else if (strncmp("ups.", key, 4) == 0) {
       if (strcmp("ups.load", key) == 0)

--- a/src/nut.c
+++ b/src/nut.c
@@ -315,6 +315,8 @@ static int nut_read(user_data_t *user_data) {
         nut_submit(ups, "frequency", "output", value);
       else if (strcmp("output.voltage", key) == 0)
         nut_submit(ups, "voltage", "output", value);
+      else if (strcmp("output.realpower", key) == 0)
+        nut_submit(ups, "power", "output", value);
     } else if (strncmp("ups.", key, 4) == 0) {
       if (strcmp("ups.load", key) == 0)
         nut_submit(ups, "percent", "load", value);

--- a/src/nut.c
+++ b/src/nut.c
@@ -316,9 +316,9 @@ static int nut_read(user_data_t *user_data) {
       else if (strcmp("output.voltage", key) == 0)
         nut_submit(ups, "voltage", "output", value);
       else if (strcmp("output.realpower", key) == 0)
-        nut_submit(ups, "realpower", "output", value);
+        nut_submit(ups, "power", "watt-output", value);
       else if (strcmp("output.power", key) == 0)
-        nut_submit(ups, "power", "output", value);
+        nut_submit(ups, "power", "voltampere-output", value);
     } else if (strncmp("ups.", key, 4) == 0) {
       if (strcmp("ups.load", key) == 0)
         nut_submit(ups, "percent", "load", value);

--- a/src/types.db
+++ b/src/types.db
@@ -212,7 +212,6 @@ ps_vm                   value:GAUGE:0:9223372036854775807
 pstates_enabled         value:GAUGE:0:1
 pubsub                  value:GAUGE:0:U
 queue_length            value:GAUGE:0:U
-realpower		value:GAUGE:U:U
 records                 value:GAUGE:0:U
 redis_command_cputime   value:DERIVE:0:U
 requests                value:GAUGE:0:U

--- a/src/types.db
+++ b/src/types.db
@@ -212,6 +212,7 @@ ps_vm                   value:GAUGE:0:9223372036854775807
 pstates_enabled         value:GAUGE:0:1
 pubsub                  value:GAUGE:0:U
 queue_length            value:GAUGE:0:U
+realpower		value:GAUGE:U:U
 records                 value:GAUGE:0:U
 redis_command_cputime   value:DERIVE:0:U
 requests                value:GAUGE:0:U


### PR DESCRIPTION
ChangeLog: nut: Adding support for the "output.realpower" value from the ups code.

Calculating the value from voltage and current does not work for all USV's,
so this would be a benefit to have, when the USV provides the value.