### PR TITLE
[WiP] Convert network to host endian in a platform-independent way.

### DIFF
--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -308,7 +308,7 @@ static int parse_values(void *payload, size_t payload_size,
   for (uint16_t i = 0; i < n; i++) {
     char buf[8];
     if (buffer_next(b, &buf, sizeof(buf)))
-        return EINVAL;
+      return EINVAL;
     uint64_t tmp = *(uint64_t *)buf;
     if (state->values_types[i] == LCC_TYPE_GAUGE) {
       union {

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -38,13 +38,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* for be{16,64}toh */
-#if HAVE_ENDIAN_H
-#include <endian.h>
-#elif HAVE_SYS_ENDIAN_H
-#include <sys/endian.h>
-#endif
-
 #if HAVE_GCRYPT_H
 #define GCRYPT_NO_DEPRECATED
 #include <gcrypt.h>
@@ -114,11 +107,11 @@ static int buffer_next(buffer_t *b, void *out, size_t n) {
 }
 
 static int buffer_uint16(buffer_t *b, uint16_t *out) {
-  uint16_t tmp;
+  char tmp[2];
   if (buffer_next(b, &tmp, sizeof(tmp)) != 0)
     return -1;
 
-  *out = be16toh(tmp);
+  *out = *(uint16_t *)tmp;
   return 0;
 }
 
@@ -136,13 +129,13 @@ static int buffer_uint16(buffer_t *b, uint16_t *out) {
 #define TYPE_ENCR_AES256 0x0210
 
 static int parse_int(void *payload, size_t payload_size, uint64_t *out) {
-  uint64_t tmp;
+  char tmp[8];
 
   if (payload_size != sizeof(tmp))
     return EINVAL;
 
   memmove(&tmp, payload, sizeof(tmp));
-  *out = be64toh(tmp);
+  *out = *(uint64_t *)tmp;
   return 0;
 }
 
@@ -313,10 +306,10 @@ static int parse_values(void *payload, size_t payload_size,
   }
 
   for (uint16_t i = 0; i < n; i++) {
-    uint64_t tmp;
-    if (buffer_next(b, &tmp, sizeof(tmp)))
-      return EINVAL;
-
+    char buf[8];
+    if (buffer_next(b, &buf, sizeof(buf)))
+        return EINVAL;
+    uint64_t tmp = *(uint64_t *)buf;
     if (state->values_types[i] == LCC_TYPE_GAUGE) {
       union {
         uint64_t i;
@@ -326,7 +319,6 @@ static int parse_values(void *payload, size_t payload_size,
       continue;
     }
 
-    tmp = be64toh(tmp);
     switch (state->values_types[i]) {
     case LCC_TYPE_COUNTER:
       state->values[i].counter = (counter_t)tmp;


### PR DESCRIPTION
Based on the technique in Rob Pike's [article](https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html).