### PR TITLE
Fix documentation typo for PostgreSQL plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1171,7 +1171,7 @@
 #	<Database bar>
 #		Interval 60
 #		Service "service_name"
-#		Query backend # predefined
+#		Query backends # predefined
 #		Query rt36_tickets
 #	</Database>
 #	<Database qux>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6258,7 +6258,7 @@ L<http://www.postgresql.org/docs/manuals/>.
     <Database bar>
       Interval 300
       Service "service_name"
-      Query backend # predefined
+      Query backends # predefined
       Query rt36_tickets
     </Database>
 


### PR DESCRIPTION
In collectd/src/postgresql_default.conf the name for the backends
query is plural, yet in the documentation it is singular. This caused
me some lost time when running this plugin.

It is also wrongly listed on the wiki:

https://collectd.org/wiki/index.php/Plugin:PostgreSQL