### PR TITLE
snmp_agent plugin: Fix memory leak.

### DIFF
--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -1117,12 +1117,6 @@ static int snmp_agent_config_table(oconfig_item_t *ci) {
     }
   }
 
-  llentry_t *entry = llentry_create(td->name, td);
-  if (entry == NULL) {
-    snmp_agent_free_table(&td);
-    return -ENOMEM;
-  }
-
   td->instance_index =
       c_avl_create((int (*)(const void *, const void *))strcmp);
   if (td->instance_index == NULL) {
@@ -1137,6 +1131,11 @@ static int snmp_agent_config_table(oconfig_item_t *ci) {
     return -ENOMEM;
   }
 
+  llentry_t *entry = llentry_create(td->name, td);
+  if (entry == NULL) {
+    snmp_agent_free_table(&td);
+    return -ENOMEM;
+  }
   llist_append(g_agent->tables, entry);
 
   return 0;


### PR DESCRIPTION
Allocate "entry" later so that the error handling blocks don't leak it.

CID: 179244