### PR TITLE
libcollectdclient: Ensure vl->values_len is non-zero.

### DIFF
--- a/src/libcollectdclient/network_buffer.c
+++ b/src/libcollectdclient/network_buffer.c
@@ -255,6 +255,10 @@ static double htond(double val) /* {{{ */
 
 static int nb_add_values(char **ret_buffer, /* {{{ */
                          size_t *ret_buffer_len, const lcc_value_list_t *vl) {
+  if ((vl == NULL) || (vl->values_len < 1)) {
+    return EINVAL;
+  }
+
   char *packet_ptr;
   size_t packet_len;
 


### PR DESCRIPTION
That size_t is then used to declare Variable Length Arrays. Hopefully
this helps to convince Coverity that pkg_values and pkg_values_types are
actually fully initialized.

CID: 141009, 141010