### PR TITLE
disk: in linux, reset the disk when it disappear from /proc/diskstats

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -820,7 +820,7 @@ static int disk_read(void) {
       ds->poll_count = poll_count;
       continue;
     }
-    ds->poll_count++;
+    ds->poll_count = poll_count;
 
     if ((read_ops == 0) && (write_ops == 0)) {
       DEBUG("disk plugin: ((read_ops == 0) && "
@@ -884,14 +884,12 @@ static int disk_read(void) {
 
     /* Disk is missing, remove it */
     diskstats_t *missing_ds = ds;
-    if (pre_ds == disklist) {
-      disklist = ds->next;
-      ds = disklist;
-      pre_ds = ds;
+    if (ds == disklist) {
+      pre_ds = disklist = ds->next;
     } else {
       pre_ds->next = ds->next;
-      ds = ds->next;
     }
+    ds = ds->next;
 
     DEBUG("disk plugin: Disk %s disappeared.", missing_ds->name);
     free(missing_ds->name);


### PR DESCRIPTION
If you don't reset diskstats_t for a given diskname when it disappear and the diskname is reused later (for exemple an iSCSI disk) the "disk" plugin detect an "counter wrap around" because linux /proc/diskstats are
resetted to 0 for that diskname. Because of that the plugin send incorrect stats for the new disk.

Note1: the number of bytes written is calculated by multiplying the number of sector written by 512, which seems incorrect if those sector are 4k ones but I haven't tested that.

Note2: the patch proposed here is racy for the disk removal detection, a better way to detect it would be through udev, but I guess it will necessitate its own thread and more linux specific code.

