### PR TITLE
write_riemann plugin: Unlock mutex before destroying it.

### DIFF
--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -601,6 +601,7 @@ static void wrr_free(void *p) /* {{{ */
 
   wrr_disconnect(host);
 
+  pthread_mutex_lock(&host->lock);
   pthread_mutex_destroy(&host->lock);
   sfree(host);
 } /* }}} void wrr_free */


### PR DESCRIPTION
CID: 179227