### PR TITLE
rrd plugin: Fix writing of long values.

### DIFF
--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -794,7 +794,7 @@ static int rrd_write(const data_set_t *ds, const value_list_t *vl,
   if (value_list_to_filename(filename, sizeof(filename), vl) != 0)
     return -1;
 
-  char values[32 * ds->ds_num];
+  char values[32 * (ds->ds_num + 1)];
   if (value_list_to_string(values, sizeof(values), ds, vl) != 0)
     return -1;
 


### PR DESCRIPTION
The buffer provided for value_list_to_string() was not long enough to
fit negative values using exponent and maximum precision of the gauge
format.

It seems this was a regression from commit 291879be6c66d00ff8dad09a0e44b332db31459a.