### PR TITLE
src/utils_ovs.c: Assign variable only once.

### DIFF
--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -1006,6 +1006,7 @@ ovs_db_t *ovs_db_init(const char *node, const char *service,
   ovs_db_t *pdb = calloc(1, sizeof(*pdb));
   if (pdb == NULL)
     return NULL;
+  pdb->sock = -1;
 
   /* store the OVS DB address */
   sstrncpy(pdb->node, node, sizeof(pdb->node));
@@ -1047,7 +1048,6 @@ ovs_db_t *ovs_db_init(const char *node, const char *service,
   }
 
   /* init polling thread */
-  pdb->sock = -1;
   if (ovs_db_poll_thread_init(pdb) < 0) {
     ovs_db_destroy(pdb);
     return NULL;

--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -1003,7 +1003,7 @@ ovs_db_t *ovs_db_init(const char *node, const char *service,
     return NULL;
 
   /* allocate db data & fill it */
-  ovs_db_t *pdb = pdb = calloc(1, sizeof(*pdb));
+  ovs_db_t *pdb = calloc(1, sizeof(*pdb));
   if (pdb == NULL)
     return NULL;
 


### PR DESCRIPTION
CID: 179233

Additionally:

*   `src/utils_ovs.c`: Initialize `pdb->sock` to `-1` earlier.
    `ovs_db_destroy()` was called before the field was initialized, leading to `close(0)` being called.
