### PR TITLE
gps, write_graphite, write_tsdb plugins: Fix locking issues.

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -26,10 +26,10 @@
  *   Marc Fournier <marc.fournier at camptocamp.com>
  **/
 
+#include "collectd.h"
 #include "common.h"
 #include "plugin.h"
 #include "utils_time.h"
-#include "collectd.h"
 
 #define CGPS_TRUE 1
 #define CGPS_FALSE 0
@@ -80,7 +80,7 @@ static int cgps_thread_pause(cdtime_t pTime) {
 
   int ret = !cgps_thread_shutdown;
 
-  pthread_mutex_lock(&cgps_thread_lock);
+  pthread_mutex_unlock(&cgps_thread_lock);
   return ret;
 }
 

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -312,6 +312,7 @@ static void wg_callback_free(void *data) {
   sfree(cb->prefix);
   sfree(cb->postfix);
 
+  pthread_mutex_unlock(&cb->send_lock);
   pthread_mutex_destroy(&cb->send_lock);
 
   sfree(cb);

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -219,6 +219,7 @@ static void wt_callback_free(void *data) {
   sfree(cb->service);
   sfree(cb->host_tags);
 
+  pthread_mutex_unlock(&cb->send_lock);
   pthread_mutex_destroy(&cb->send_lock);
 
   sfree(cb);


### PR DESCRIPTION
*   gps plugin: Typo, called lock() instead of unlock(). CID: 158522
*   write_graphite plugin: Unlock mutex before destroying it. CID: 179225
*   write_tsdb plugin: Unlock mutex before destroying it. CID: 179224