### PR TITLE
virt plugin: Remove `do {} while(0)` loop around macro.

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -444,12 +444,10 @@ static void init_block_info(struct lv_block_info *binfo) {
 #ifdef HAVE_BLOCK_STATS_FLAGS
 
 #define GET_BLOCK_INFO_VALUE(NAME, FIELD)                                      \
-  do {                                                                         \
-    if (!strcmp(param[i].field, NAME)) {                                       \
-      binfo->FIELD = param[i].value.l;                                         \
-      continue;                                                                \
-    }                                                                          \
-  } while (0)
+  if (!strcmp(param[i].field, NAME)) {                                         \
+    binfo->FIELD = param[i].value.l;                                           \
+    continue;                                                                  \
+  }
 
 static int get_block_info(struct lv_block_info *binfo,
                           virTypedParameterPtr param, int nparams) {


### PR DESCRIPTION
The `continue` in the macro was supposed to continue the `for` loop, but was (unexpectedly) exiting the `do…while` loop instead.

CID: 179238