### PR TITLE
Perl plugin: Remove the defunct c_ithread_destructor() callback.

### DIFF
--- a/src/perl.c
+++ b/src/perl.c
@@ -1226,31 +1226,6 @@ static void c_ithread_destroy(c_ithread_t *ithread) {
   return;
 } /* static void c_ithread_destroy (c_ithread_t *) */
 
-static void c_ithread_destructor(void *arg) {
-  c_ithread_t *ithread = (c_ithread_t *)arg;
-  c_ithread_t *t = NULL;
-
-  if (NULL == perl_threads)
-    return;
-
-  pthread_mutex_lock(&perl_threads->mutex);
-
-  for (t = perl_threads->head; NULL != t; t = t->next)
-    if (t == ithread)
-      break;
-
-  /* the ithread no longer exists */
-  if (NULL == t) {
-    pthread_mutex_unlock(&perl_threads->mutex);
-    return;
-  }
-
-  c_ithread_destroy(ithread);
-
-  pthread_mutex_unlock(&perl_threads->mutex);
-  return;
-} /* static void c_ithread_destructor (void *) */
-
 /* must be called with perl_threads->mutex locked */
 static c_ithread_t *c_ithread_create(PerlInterpreter *base) {
   c_ithread_t *t = NULL;
@@ -2420,7 +2395,7 @@ static int init_pi(int argc, char **argv) {
   }
 #endif /* COLLECT_DEBUG */
 
-  if (0 != pthread_key_create(&perl_thr_key, c_ithread_destructor)) {
+  if (0 != pthread_key_create(&perl_thr_key, NULL)) {
     log_err("init_pi: pthread_key_create failed");
 
     /* this must not happen - cowardly giving up if it does */


### PR DESCRIPTION
This callback was only implicitly called by `pthread_key_delete()` from `perl_shutdown()`. Importantly, this happens *after*:

  * All threads referenced by the linked list in `perl_threads` have been destroyed.
  * The `perl_threads->mutex` has been destroyed.

The callback therefore cannot work and likely wasn't called in the past. I think it's save to remove.