### PR TITLE
powerdns plugin: Ensure powerdns_get_data() returns a non-NULL buffer.

### DIFF
--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -575,19 +575,6 @@ static int powerdns_get_data(list_item_t *item, char **ret_buffer,
 
 static int powerdns_read_server(list_item_t *item) /* {{{ */
 {
-  char *buffer = NULL;
-  size_t buffer_size = 0;
-  int status;
-
-  char *dummy;
-  char *saveptr;
-
-  char *key;
-  char *value;
-
-  const char *const *fields;
-  int fields_num;
-
   if (item->command == NULL)
     item->command = strdup(SERVER_COMMAND);
   if (item->command == NULL) {
@@ -595,19 +582,20 @@ static int powerdns_read_server(list_item_t *item) /* {{{ */
     return (-1);
   }
 
-  status = powerdns_get_data(item, &buffer, &buffer_size);
+  char *buffer = NULL;
+  size_t buffer_size = 0;
+  int status = powerdns_get_data(item, &buffer, &buffer_size);
   if (status != 0)
     return (-1);
   if ((buffer == NULL) || (buffer_size == 0)) {
     return EINVAL;
   }
 
+  const char *const *fields = default_server_fields;
+  int fields_num = default_server_fields_num;
   if (item->fields_num != 0) {
     fields = (const char *const *)item->fields;
     fields_num = item->fields_num;
-  } else {
-    fields = default_server_fields;
-    fields_num = default_server_fields_num;
   }
 
   assert(fields != NULL);
@@ -615,12 +603,13 @@ static int powerdns_read_server(list_item_t *item) /* {{{ */
 
   /* corrupt-packets=0,deferred-cache-inserts=0,deferred-cache-lookup=0,latency=0,packetcache-hit=0,packetcache-miss=0,packetcache-size=0,qsize-q=0,query-cache-hit=0,query-cache-miss=0,recursing-answers=0,recursing-questions=0,servfail-packets=0,tcp-answers=0,tcp-queries=0,timedout-packets=0,udp-answers=0,udp-queries=0,udp4-answers=0,udp4-queries=0,udp6-answers=0,udp6-queries=0,
    */
-  dummy = buffer;
-  saveptr = NULL;
+  char *dummy = buffer;
+  char *saveptr = NULL;
+  char *key;
   while ((key = strtok_r(dummy, ",", &saveptr)) != NULL) {
     dummy = NULL;
 
-    value = strchr(key, '=');
+    char *value = strchr(key, '=');
     if (value == NULL)
       break;
 

--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -598,6 +598,9 @@ static int powerdns_read_server(list_item_t *item) /* {{{ */
   status = powerdns_get_data(item, &buffer, &buffer_size);
   if (status != 0)
     return (-1);
+  if ((buffer == NULL) || (buffer_size == 0)) {
+    return EINVAL;
+  }
 
   if (item->fields_num != 0) {
     fields = (const char *const *)item->fields;


### PR DESCRIPTION
Coverity is concerned that if buffer is `NULL`, `strtok_r()` is called with two `NULL` arguments, causing a `NULL` pointer dereference.

CID: 37968