### PR TITLE
ceph plugin: Fix #2572

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -280,7 +280,7 @@ static int ceph_cb_number(void *ctx, const char *number_val,
    * the same type of other "Bytes". Instead of keeping an "average" or
    * "rate", use the "sum" in the pair and assign that to the derive
    * value. */
-  if (convert_special_metrics && (state->depth >= 2) &&
+  if (convert_special_metrics && (state->depth > 2) &&
       (strcmp("filestore", state->stack[state->depth - 2]) == 0) &&
       (strcmp("journal_wr_bytes", state->stack[state->depth - 1]) == 0) &&
       (strcmp("avgcount", state->key) == 0)) {


### PR DESCRIPTION
It looks like `state->depth` must be greater than 2.
I've tested this on luminous with collectd-5.8 from ci.collectd.org repo.
I can't test this on jewel right now, unfortunately.