### PR TITLE
Remove recv() call to make code more portable.

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -262,10 +262,7 @@ int swrite(int fd, const void *buf, size_t count) {
   pfd.events = POLLIN | POLLHUP;
   pfd.revents = 0;
   if (poll(&pfd, 1, 0) > 0) {
-    char buffer[32];
-    if (recv(fd, buffer, sizeof(buffer), MSG_PEEK | MSG_DONTWAIT) == 0) {
-      /* if recv returns zero (even though poll() said there is data to be
-       * read), that means the connection has been closed */
+    if (pfd.revents & POLLHUP) {
       errno = ECONNRESET;
       return -1;
     }


### PR DESCRIPTION
Based on discussion in Stackdriver/collectd [windows-fixes branch](https://github.com/Stackdriver/collectd/commit/bee5e168175e3078b681585fa0fe3f7361d90055).