### PR TITLE
processes plugin: Fix compiler warning

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1249,7 +1249,8 @@ static int ps_delay(process_entry_t *ps) {
   return 0;
 }
 #else
-static int ps_delay(__attribute__((unused)) process_entry_t *unused) {
+__attribute__((unused)) static int ps_delay(__attribute__((unused))
+                                            process_entry_t *unused) {
   return -1;
 }
 #endif


### PR DESCRIPTION
- Add 'unused' attribute to ps_delay() to prevent 'defined but not used'
  warning.

Closes https://github.com/collectd/collectd/issues/2609

---

.. because `./configure && make` of master d3bd9c3 2017-12-08 failed for me:
~~~
  CC       src/processes_la-processes.lo
src/processes.c:1252:12: error: ‘ps_delay’ defined but not used [-Werror=unused-function]
 static int ps_delay(__attribute__((unused)) process_entry_t *unused) {
            ^
cc1: all warnings being treated as errors
~~~