### PR TITLE
tail plugin, latency: Fix regressions after #2535

### DIFF
--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -118,10 +118,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   sstrncpy(vl.type, data->type, sizeof(vl.type));
   for (size_t i = 0; i < data->latency_config.percentile_num; i++) {
     if (strlen(data->type_instance) != 0)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.117s-%.2f",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%.5g",
                data->type_instance, data->latency_config.percentile[i]);
     else
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.0f",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.5g",
                data->latency_config.percentile[i]);
 
     vl.values = &(value_t){
@@ -150,11 +150,10 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
         bucket.upper_bound ? CDTIME_T_TO_DOUBLE(bucket.upper_bound) : INFINITY;
 
     if (strlen(data->type_instance) != 0)
-      snprintf(vl.type_instance, sizeof(vl.type_instance),
-               "%.54s-%.54s-%.2g_%.2g", data->type, data->type_instance,
-               lower_bound, upper_bound);
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%.50s-%g_%g",
+               data->type, data->type_instance, lower_bound, upper_bound);
     else
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.107s-%.2g_%.2g",
+      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%g_%g",
                data->type, lower_bound, upper_bound);
 
     vl.values = &(value_t){


### PR DESCRIPTION
As reported in #2587, the f46d76e976ed76d2d8fa297918ecd308680d7ae9 causes regression.

1) It adds two fixed decimal places into type instance of reported percentiles.

Before: 

```
# perl -e 'print sprintf("%.0f\n", 10.05);'
10
```
After:
```
# perl -e 'print sprintf("%.2f\n", 10.00);'
10.00
```

Also, the difference in format of percentile appeared after f46d76e976ed76d2d8fa297918ecd308680d7ae9 : the '%.0f' was in use when no type instance is configured, and '%.2f' - when type instance is set.

This was fixed by setting format to '%.4g' for all cases. 
I think it's enough to use '%.4g' to output percentile values which are in range from 0 to 100.

2) It reduces accuracy of bounds in reported buckets.

Before:
```
# perl -e 'print sprintf("%g\n", 10.05);'
10.05
```
After:
```
# perl -e 'print sprintf("%.2g\n", 100);'
1e+02
# perl -e 'print sprintf("%.2g\n", 10.05);'
10
```

This was fixed by reverting format back to '%g' as it was before f46d76e976ed76d2d8fa297918ecd308680d7ae9. 

Summary:
- Removed two fixed decimal places from type instance of percentiles
- Recovered accuracy of bounds in type instance of buckets
+ Allowed (compared to state before #2535) to report percentiles with fractional values
* Changed maximum length of reported type and type instance to 50 chars in all latency metrics

References: #2535, #2587

Have anybody any objections against merging this?

CC @taraschornyi, @mfournier, @PhantomPhreak