### PR TITLE
memcached: Check for closed connection to avoid deadloop

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -291,6 +291,12 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
       close(st->fd);
       st->fd = -1;
       return -1;
+    } else if (status == 0) {
+      ERROR("memcached plugin: Instance \"%s\": Connection closed by peer",
+            st->name);
+      close(st->fd);
+      st->fd = -1;
+      return -1;
     }
 
     buffer_fill += (size_t)status;


### PR DESCRIPTION
Check for 'recv(...) == 0' state was lost while implementing persistent connections at #2388.
That can cause a deadloop if connection was closed right after successfull send of 'stats' command.