### PR TITLE
docs: update dpdkstats documentation

### DIFF
--- a/docs/BUILD.dpdkstat.md
+++ b/docs/BUILD.dpdkstat.md
@@ -1,5 +1,8 @@
 # The dpdkstat plugin
 
+This plugin is optional and only has a specific use case: monitoring DPDK applications
+that don't expose stats in any other way than the DPDK xstats API.
+
 **Data Plane Development Kit** (DPDK) is a set of drivers and libraries for fast
 packet processing. Please note that this plugin is a polling based plugin rather
 than an events based plugin (using it will drive up core utilization on a system).

--- a/docs/BUILD.dpdkstat.md
+++ b/docs/BUILD.dpdkstat.md
@@ -1,7 +1,14 @@
 # The dpdkstat plugin
 
 **Data Plane Development Kit** (DPDK) is a set of drivers and libraries for fast
-packet processing.
+packet processing. Please note that this plugin is a polling based plugin rather
+than an events based plugin (using it will drive up core utilization on a system).
+
+**PLEASE DO NOT USE THIS PLUGIN FOR OVS-DPDK**. dpdkstat is really for DPDK
+applications that have no other way of exposing stats. For OVS or OVS-with-DPDK the
+Open vSwitch plugins available in collectd Version 5.8.0 should be used for
+collecting stats and events. In addition the OVS plugin is events based rather
+than polling based and will have a smaller footprint on the system.
 
 ## Summary
 

--- a/docs/BUILD.dpdkstat.md
+++ b/docs/BUILD.dpdkstat.md
@@ -9,7 +9,7 @@ than an events based plugin (using it will drive up core utilization on a system
 
 **PLEASE DO NOT USE THIS PLUGIN FOR OVS-DPDK**. dpdkstat is really for DPDK
 applications that have no other way of exposing stats. For OVS or OVS-with-DPDK the
-Open vSwitch plugins available in collectd Version 5.8.0 should be used for
+Open vSwitch plugins available in collectd 5.8.0 should be used for
 collecting stats and events. In addition the OVS plugin is events based rather
 than polling based and will have a smaller footprint on the system.
 


### PR DESCRIPTION
Update the dpdkstats documentation to state that it shouldn't be used with
OVS-with-DPDK. The Open vSwitch plugins is what should be used.

Signed-off-by: Maryam Tahhan <maryam.tahhan@intel.com>