### PR TITLE
Cleanup version-gen.sh

### DIFF
--- a/version-gen.sh
+++ b/version-gen.sh
@@ -3,7 +3,7 @@
 DEFAULT_VERSION="5.8.0.git"
 
 if [ -d .git ]; then
-	VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | grep collectd | sed -e 's/^collectd-//' -e 's/-/./g'`"
+	VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | sed -e '/^collectd-/!d' -e 's///' -e 'y/-/./'`"
 fi
 
 if test -z "$VERSION"; then


### PR DESCRIPTION
ChangeLog: build: Cleanup version-gen.sh

Existing script matches too generously.  eg, an annotated
tag 'foo-connectd-bar' will not be filtered.  Effectively,
this commit replaces 'grep collectd' with 'grep ^collectd-',
but removes the grep and does the filtering directly in sed.