### PR TITLE
write_kafka: ‘rd_kafka_errno2err’ is deprecated, fix failed builds

### DIFF
--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -156,7 +156,7 @@ static int kafka_handle(struct kafka_topic_context *ctx) /* {{{ */
                                          topic_conf)) == NULL) {
       ERROR("write_kafka plugin: cannot create topic : %s\n",
             rd_kafka_err2str(kafka_error()));
-      return 1;
+      return errno;
     }
 
     rd_kafka_topic_conf_destroy(ctx->conf);

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -147,8 +147,8 @@ static int kafka_handle(struct kafka_topic_context *ctx) /* {{{ */
     if ((ctx->topic = rd_kafka_topic_new(ctx->kafka, ctx->topic_name,
                                          topic_conf)) == NULL) {
       ERROR("write_kafka plugin: cannot create topic : %s\n",
-            rd_kafka_err2str(rd_kafka_errno2err(errno)));
-      return errno;
+            rd_kafka_err2str(rd_kafka_last_error()));
+      return 1;
     }
 
     rd_kafka_topic_conf_destroy(ctx->conf);

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -77,6 +77,14 @@ static void kafka_log(const rd_kafka_t *rkt, int level, const char *fac,
 }
 #endif
 
+static rd_kafka_resp_err_t kafka_error() {
+#if RD_KAFKA_VERSION >= 0x000b00ff
+  return rd_kafka_last_error();
+#else
+  return rd_kafka_errno2err(errno);
+#endif
+}
+
 static uint32_t kafka_hash(const char *keydata, size_t keylen) {
   uint32_t hash = 5381;
   for (; keylen > 0; keylen--)
@@ -147,7 +155,7 @@ static int kafka_handle(struct kafka_topic_context *ctx) /* {{{ */
     if ((ctx->topic = rd_kafka_topic_new(ctx->kafka, ctx->topic_name,
                                          topic_conf)) == NULL) {
       ERROR("write_kafka plugin: cannot create topic : %s\n",
-            rd_kafka_err2str(rd_kafka_last_error()));
+            rd_kafka_err2str(kafka_error()));
       return 1;
     }
 


### PR DESCRIPTION
rd_kafka_errno2err is deprecated. (#2607)
Applications should use rd_kafka_last_error() to retrieve the error
code from the legacy APIs.