### PR TITLE
[WIP] Knot Plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,6 +166,9 @@ Jérôme Renard <jerome.renard at gmail.com>
 Jiri Tyr <jiri.tyr at gmail.com>
  - fhcount plugin.
 
+Julian Brost <julian at 0x4a42.net>
+ - knot plugin.
+
 Julien Ammous <j.ammous at gmail.com>
  - Lua plugin.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -993,6 +993,14 @@ java_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(JAVA_LDFLAGS)
 java_la_LIBADD = $(JAVA_LIBS)
 endif
 
+if BUILD_PLUGIN_KNOT
+pkglib_LTLIBRARIES += knot.la
+knot_la_SOURCES = src/knot.c
+knot_la_CFLAGS = $(AM_CFLAGS)
+knot_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+knot_la_LIBADD = libignorelist.la -lknot
+endif
+
 if BUILD_PLUGIN_LOAD
 pkglib_LTLIBRARIES += load.la
 load_la_SOURCES = src/load.c

--- a/configure.ac
+++ b/configure.ac
@@ -5985,6 +5985,11 @@ PKG_CHECK_MODULES([LIBRIEMANN_CLIENT], [riemann-client >= 1.6.0],
  [with_libriemann_client="no (pkg-config doesn't know libriemann-client)"]
 )
 
+PKG_CHECK_MODULES([KNOT], [libknot],
+  [with_libknot="yes"],
+  [with_libknot="no (pkg-config could not find libknot)"]
+)
+
 # Check for enabled/disabled features
 #
 
@@ -6137,6 +6142,7 @@ plugin_ipc="no"
 plugin_ipmi="no"
 plugin_ipvs="no"
 plugin_irq="no"
+plugin_knot="no"
 plugin_load="no"
 plugin_log_logstash="no"
 plugin_mcelog="no"
@@ -6490,6 +6496,10 @@ if test "x$with_libdpdk" = "xyes"; then
   plugin_dpdkstat="yes"
 fi
 
+if test "x$with_libknot" = "xyes"; then
+  plugin_knot="yes"
+fi
+
 m4_divert_once([HELP_ENABLE], [
 collectd plugins:])
 
@@ -6559,7 +6569,7 @@ AC_PLUGIN([iptables],            [$with_libiptc],           [IPTables rule count
 AC_PLUGIN([ipvs],                [$plugin_ipvs],            [IPVS connection statistics])
 AC_PLUGIN([irq],                 [$plugin_irq],             [IRQ statistics])
 AC_PLUGIN([java],                [$with_java],              [Embed the Java Virtual Machine])
-AC_PLUGIN([knot],                [yes],                     [Knot DNS server statistics])
+AC_PLUGIN([knot],                [$plugin_knot],            [Knot DNS server statistics])
 AC_PLUGIN([load],                [$plugin_load],            [System load])
 AC_PLUGIN([log_logstash],        [$plugin_log_logstash],    [Logstash json_event compatible logging])
 AC_PLUGIN([logfile],             [yes],                     [File logging plugin])
@@ -6874,6 +6884,7 @@ AC_MSG_RESULT([    libiptc . . . . . . . $with_libiptc])
 AC_MSG_RESULT([    libjevents  . . . . . $with_libjevents])
 AC_MSG_RESULT([    libjvm  . . . . . . . $with_java])
 AC_MSG_RESULT([    libkstat  . . . . . . $with_kstat])
+AC_MSG_RESULT([    libknot . . . . . . . $with_libknot])
 AC_MSG_RESULT([    libkvm  . . . . . . . $with_libkvm])
 AC_MSG_RESULT([    libldap . . . . . . . $with_libldap])
 AC_MSG_RESULT([    liblua  . . . . . . . $with_liblua])
@@ -6979,6 +6990,7 @@ AC_MSG_RESULT([    iptables  . . . . . . $enable_iptables])
 AC_MSG_RESULT([    ipvs  . . . . . . . . $enable_ipvs])
 AC_MSG_RESULT([    irq . . . . . . . . . $enable_irq])
 AC_MSG_RESULT([    java  . . . . . . . . $enable_java])
+AC_MSG_RESULT([    knot  . . . . . . . . $enable_knot])
 AC_MSG_RESULT([    load  . . . . . . . . $enable_load])
 AC_MSG_RESULT([    logfile . . . . . . . $enable_logfile])
 AC_MSG_RESULT([    log_logstash  . . . . $enable_log_logstash])

--- a/configure.ac
+++ b/configure.ac
@@ -6559,6 +6559,7 @@ AC_PLUGIN([iptables],            [$with_libiptc],           [IPTables rule count
 AC_PLUGIN([ipvs],                [$plugin_ipvs],            [IPVS connection statistics])
 AC_PLUGIN([irq],                 [$plugin_irq],             [IRQ statistics])
 AC_PLUGIN([java],                [$with_java],              [Embed the Java Virtual Machine])
+AC_PLUGIN([knot],                [yes],                     [Knot DNS server statistics])
 AC_PLUGIN([load],                [$plugin_load],            [System load])
 AC_PLUGIN([log_logstash],        [$plugin_log_logstash],    [Logstash json_event compatible logging])
 AC_PLUGIN([logfile],             [yes],                     [File logging plugin])

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -138,6 +138,7 @@
 #@BUILD_PLUGIN_IPVS_TRUE@LoadPlugin ipvs
 #@BUILD_PLUGIN_IRQ_TRUE@LoadPlugin irq
 #@BUILD_PLUGIN_JAVA_TRUE@LoadPlugin java
+#@BUILD_PLUGIN_KNOT_TRUE@LoadPlugin knot
 @BUILD_PLUGIN_LOAD_TRUE@@BUILD_PLUGIN_LOAD_TRUE@LoadPlugin load
 #@BUILD_PLUGIN_LPAR_TRUE@LoadPlugin lpar
 #@BUILD_PLUGIN_LUA_TRUE@LoadPlugin lua
@@ -729,6 +730,14 @@
 #	<Plugin "org.collectd.java.Foobar">
 #	  # To be parsed by the plugin
 #	</Plugin>
+#</Plugin>
+
+#<Plugin knot>
+#        Socket "/run/knot/knot.sock"
+#        PerZoneStats false
+#        Zone "example.com"
+#        Zone "example.org"
+#        IgnoreSelected false
 #</Plugin>
 
 #<Plugin load>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3566,6 +3566,66 @@ independent from the I<JavaClass> argument passed to B<LoadPlugin>.
 
 =back
 
+=head2 Plugin C<knot>
+
+The I<Knot plugin> collects metrics from Knot, a high-performance
+authoritative-only DNS server. It requires Knot version 2.4.0 or later. To use
+this plugin, you first need to tell Knot to make this information available.
+This is done with the C<mod-stats> plugin which can be enabled on a per-zone
+basis or via a zone template:
+
+  template:
+    - id: default
+      global-module: mod-stats
+
+B<Synopsis:>
+
+  <Plugin knot>
+    Socket "/run/knot/knot.sock"
+    PerZoneStats false
+    Zone "example.com"
+    Zone "example.org"
+    IgnoreSelected false
+  </Plugin>
+
+The knot plugin accepts the following configuration options:
+
+=over 4
+
+=item B<Socket> I<Path>
+
+Connect to I<knot> using the UNIX domain socket at I<Path>.
+
+=item B<PerZoneStats> B<true>|B<false>
+
+Selects whether statistics for individual zones are collected. Defaults to
+B<false> as it can generate large amounts of data (possibly over 100 metrics
+per zone, depending on the C<mod-stats> options set in the Knot configuration
+file).
+
+=item B<Zone> I<Name>
+
+Select the zone I<Name>. Whether it is collected or ignored depends on the
+B<IgnoreSelected> setting, see below. As with other plugins that use the
+daemon's ignorelist functionality, a string that starts and ends with a slash
+is interpreted as a regular expression. Examples:
+
+  Zone "collectd.org"
+  Zone "/example\..*/"
+
+See F</"IGNORELISTS"> for details.
+
+=item B<IgnoreSelected> B<true>|B<false>
+
+Sets whether selected zones, i.E<nbsp>e. the ones matches by any of the B<Zone>
+statements, are ignored or if all other zones are ignored. The behavior
+(hopefully) is intuitive: If no B<Zone> option is configured, all zones are
+collected. If at least one B<Zone> option is given and no B<IgnoreSelected> or
+set to B<false>, B<only> matching zones will be collected. If B<IgnoreSelected>
+is set to B<true>, all zones are collected B<except> the ones matched.
+
+=back
+
 =head2 Plugin C<load>
 
 The I<Load plugin> collects the system load. These numbers give a rough overview

--- a/src/knot.c
+++ b/src/knot.c
@@ -1,0 +1,288 @@
+/**
+ * collectd - src/knot.c
+ * Copyright (C) 2018       Julian Brost
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Julian Brost <julian at 0x4a42.net>
+ **/
+
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+
+#include "collectd.h"
+#include "common.h"
+#include "plugin.h"
+#include "utils_ignorelist.h"
+
+#include <libknot/libknot.h>
+
+static const char *config_keys[] = {"Socket", "PerZoneStats", "Zone",
+                                    "IgnoreSelected"};
+static const int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
+static const char *socket_path_default = "/run/knot/knot.sock";
+
+static char *socket_path = NULL;
+static _Bool per_zone_stats = 0;
+static ignorelist_t *ignorelist = NULL;
+
+static int knot_init_ignorelist(void) {
+  if (ignorelist == NULL) {
+    ignorelist = ignorelist_create(/* invert = */ 1);
+    if (ignorelist == NULL) {
+      ERROR("knot: creating ignore list failed");
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static char *knot_normalize_zone_alloc(const char *z) {
+  if (z == NULL) {
+    return NULL;
+  }
+  char *zone = strdup(z);
+  if (zone == NULL) {
+    ERROR("knot: strdup failed to allocate memory");
+    return NULL;
+  }
+  // trim trailing '.' except if it's the root zone
+  size_t len = strlen(zone);
+  if (len > 1 && zone[len - 1] == '.') {
+    zone[len - 1] = '\0';
+  }
+  return zone;
+}
+
+static int knot_config(const char *key, const char *value) {
+  if (knot_init_ignorelist() != 0) {
+    return 1;
+  }
+
+  if (strcasecmp(key, "Socket") == 0) {
+    socket_path = strdup(value);
+    if (socket_path == NULL) {
+      ERROR("knot: strdup failed to allocate memory");
+      return 1;
+    }
+    return 0;
+  } else if (strcasecmp(key, "PerZoneStats") == 0) {
+    per_zone_stats = IS_TRUE(value);
+    return 0;
+  } else if (strcasecmp(key, "Zone") == 0) {
+    char *zone = knot_normalize_zone_alloc(value);
+    if (zone == NULL) {
+      return 1;
+    }
+    ignorelist_add(ignorelist, zone);
+    free(zone);
+    return 0;
+  } else if (strcasecmp(key, "IgnoreSelected") == 0) {
+    ignorelist_set_invert(ignorelist, !IS_TRUE(value));
+    return 0;
+  } else {
+    return -1;
+  }
+}
+
+static int knot_init(void) {
+  if (knot_init_ignorelist() != 0) {
+    return 1;
+  }
+
+  return 0;
+}
+
+static const struct {
+  // matches
+  const char *section;
+  const char *item;
+
+  // results
+  int ds_type;
+  const char *type;
+  const char *type_instance;
+} stats_map[] = {
+    // section,   item,   ds_type,   type,   type_instance
+    {"server", "zone-count", DS_TYPE_GAUGE, "count", "zones"},
+    {"mod-stats", "request-protocol", DS_TYPE_DERIVE, "dns_request", NULL},
+    {"mod-stats", "server-operation", DS_TYPE_DERIVE, "operations", NULL},
+    {"mod-stats", "request-bytes", DS_TYPE_DERIVE, "if_rx_octets", NULL},
+    {"mod-stats", "response-bytes", DS_TYPE_DERIVE, "if_tx_octets", NULL},
+    {"mod-stats", "response-code", DS_TYPE_DERIVE, "dns_rcode", NULL},
+    {"mod-stats", "query-type", DS_TYPE_DERIVE, "dns_qtype", NULL},
+    // TODO: edns-presence flag-presence reply-nodata query-size reply-size?
+};
+static const int stats_map_num = STATIC_ARRAY_SIZE(stats_map);
+
+static int knot_handle_value(const char *section, const char *item,
+                             const char *id, const char *zone,
+                             const char *value) {
+  if (zone != NULL && ignorelist_match(ignorelist, zone) != 0) {
+    return 0;
+  }
+
+  for (int i = 0; i < stats_map_num; i++) {
+    if (strcmp(section, stats_map[i].section) != 0) {
+      continue;
+    } else if (strcmp(item, stats_map[i].item) != 0) {
+      continue;
+    }
+
+    value_t values[1];
+    if (parse_value(value, &values[0], stats_map[i].ds_type) != 0) {
+      return 1;
+    }
+
+    const char *plugin_instance = zone;
+    if (plugin_instance == NULL) {
+      plugin_instance = "";
+    }
+    const char *type_instance = stats_map[i].type_instance;
+    if (type_instance == NULL) {
+      type_instance = id;
+    }
+    if (type_instance == NULL) {
+      type_instance = "";
+    }
+
+    value_list_t vl = VALUE_LIST_INIT;
+    vl.values = values;
+    vl.values_len = 1;
+    sstrncpy(vl.plugin, "knot", sizeof(vl.plugin));
+    sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
+    sstrncpy(vl.type, stats_map[i].type, sizeof(vl.type));
+    sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+
+    plugin_dispatch_values(&vl);
+    break;
+  }
+
+  return 0;
+}
+
+static int knot_send_command(knot_ctl_t *ctl, const char *cmd,
+                             const char *flags) {
+  knot_ctl_data_t data = {[KNOT_CTL_IDX_CMD] = cmd,
+                          [KNOT_CTL_IDX_FLAGS] = flags};
+
+  knot_ctl_send(ctl, KNOT_CTL_TYPE_DATA, &data);
+  knot_ctl_send(ctl, KNOT_CTL_TYPE_BLOCK, NULL);
+
+  return 0;
+}
+
+static int knot_read_stats_result(knot_ctl_t *ctl) {
+  while (true) {
+    knot_ctl_type_t type;
+    knot_ctl_data_t data;
+
+    int ret = knot_ctl_receive(ctl, &type, &data);
+    if (ret != KNOT_EOK) {
+      ERROR("knot: cannot read from control socket: %s", knot_strerror(ret));
+      return 1;
+    }
+
+    const char *error = data[KNOT_CTL_IDX_ERROR];
+    const char *section = data[KNOT_CTL_IDX_SECTION];
+    const char *item = data[KNOT_CTL_IDX_ITEM];
+    const char *id = data[KNOT_CTL_IDX_ID];
+    const char *zone = data[KNOT_CTL_IDX_ZONE];
+    const char *value = data[KNOT_CTL_IDX_DATA];
+
+    if (error != NULL) {
+      ERROR("knot: received error: %s", error);
+      return 1;
+    }
+
+    if (type == KNOT_CTL_TYPE_DATA || type == KNOT_CTL_TYPE_EXTRA) {
+      if (section != NULL && value != NULL) {
+        char *zone_norm = knot_normalize_zone_alloc(zone);
+        knot_handle_value(section, item, id, zone_norm, value);
+        free(zone_norm);
+      }
+    } else if (type == KNOT_CTL_TYPE_BLOCK) {
+      return 0;
+    } else {
+      ERROR("knot: received unexpected message of type %d", type);
+    }
+  }
+}
+
+static int knot_read(void) {
+  int result = 0;
+
+  knot_ctl_t *ctl = knot_ctl_alloc();
+  if (ctl == NULL) {
+    ERROR("knot: cannot allocate control structure");
+    result = 1;
+    goto out;
+  }
+
+  result =
+      knot_ctl_connect(ctl, socket_path ? socket_path : socket_path_default);
+  if (result != KNOT_EOK) {
+    ERROR("knot: cannot connect to control socket: %s", knot_strerror(result));
+    result = 1;
+    goto out_allocated;
+  }
+
+  result = knot_send_command(ctl, "stats", "F");
+  if (result != 0) {
+    goto out_connected;
+  }
+
+  result = knot_read_stats_result(ctl);
+  if (result != 0) {
+    goto out_connected;
+  }
+
+  if (per_zone_stats) {
+    result = knot_send_command(ctl, "zone-stats", "F");
+    if (result != 0) {
+      goto out_connected;
+    }
+
+    result = knot_read_stats_result(ctl);
+    if (result != 0) {
+      goto out_connected;
+    }
+  }
+
+out_connected:
+  knot_ctl_close(ctl);
+out_allocated:
+  knot_ctl_free(ctl);
+out:
+  return result;
+}
+
+static int knot_shutdown(void) {
+  ignorelist_free(ignorelist);
+  free(socket_path);
+  return 0;
+}
+
+void module_register(void) {
+  plugin_register_config("knot", knot_config, config_keys, config_keys_num);
+  plugin_register_init("knot", knot_init);
+  plugin_register_read("knot", knot_read);
+  plugin_register_shutdown("knot", knot_shutdown);
+}


### PR DESCRIPTION
This pull request implementes a new plugin that allows collecting metrics from the [Knot DNS server](https://www.knot-dns.cz/) from its UNIX domain socket using libknot.

It's still work in progress. The logic should be done but the handling of the individual metrics is not fully done. A few values are not handled at all (see TODO comment in the source), some like reply-size also don't really make sense to periodically collect in my opinion, so they probably won't be implemented at all (Knot keeps counters for packet sizes in 256 buckets, I think it makes more sense to just plot the total number as a histogram, but not in a collectd plugin I guess).

The second open question corresponds to types. For most of the metrics, there already exist types in types.db. Unfortunately, the dns_octets type doesn't fit the request-bytes/response-bytes as it has both rx and tx values as there is no direct 1:1 mapping between requests (query, update, other) and and reponses (reply, transfer, other). For now, I've just used some other types which kind of fit, but maybe this justifies adding a new type?