### PR TITLE
iptables chain name pattern matching feature.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -960,7 +960,8 @@ pkglib_LTLIBRARIES += iptables.la
 iptables_la_SOURCES = src/iptables.c
 iptables_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBIPTC_CPPFLAGS)
 iptables_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-iptables_la_LIBADD = $(BUILD_WITH_LIBIPTC_LDFLAGS)
+iptables_la_LIBADD = libignorelist.la
+iptables_la_LIBADD += $(BUILD_WITH_LIBIPTC_LDFLAGS)
 endif
 
 if BUILD_PLUGIN_IPMI

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -712,6 +712,7 @@
 #<Plugin iptables>
 #	Chain table chain
 #	Chain6 table chain
+#	IgnoreSelected false
 #</Plugin>
 
 #<Plugin irq>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3476,7 +3476,7 @@ Select the iptables/ip6tables filter rules to count packets and bytes from.
 
 If only I<Table> and I<Chain> are given, this plugin will collect the counters
 of all rules which have a comment-match. The comment is then used as
-type-instance.
+type-instance.You can provide pattern in chain name.
 
 If I<Comment> or I<Number> is given, only the rule with the matching comment or
 the I<n>th rule will be collected. Again, the comment (or the number) will be
@@ -3484,6 +3484,21 @@ used as the type-instance.
 
 If I<Name> is supplied, it will be used as the type-instance instead of the
 comment or the number.
+
+  <Plugin iptables>
+    Chain "mangle" "/^custom_chain/"
+    Chain6 "magle" "custom_chain" "comment_name"
+  </Plugin>
+
+See F</"IGNORELISTS"> for details.
+
+=item B<IgnoreSelected>
+
+The behavior is the same as with all other similar plugins: If nothing is
+selected at all, everything is collected. If some things are selected using the
+options described above, only these statistics are collected. If you set
+B<IgnoreSelected> to B<true>, this behavior is inverted, i.E<nbsp>e. the
+specified statistics will not be collected.
 
 =back
 

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -31,6 +31,7 @@
 
 #include <libiptc/libip6tc.h>
 #include <libiptc/libiptc.h>
+#include "utils_ignorelist.h"
 
 #ifdef HAVE_SYS_CAPABILITY_H
 #include <sys/capability.h>
@@ -63,7 +64,7 @@ typedef struct ip6tc_handle ip6tc_handle_t;
  * Config format should be `Chain table chainname',
  * e. g. `Chain mangle incoming'
  */
-static const char *config_keys[] = {"Chain", "Chain6"};
+static const char *config_keys[] = {"Chain", "Chain6", "IgnoreSelected"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 enum protocol_version_e { IPV4, IPV6 };
 typedef enum protocol_version_e protocol_version_t;
@@ -88,17 +89,27 @@ typedef struct {
 
 static ip_chain_t **chain_list = NULL;
 static int chain_num = 0;
+static ignorelist_t *ignorelist = NULL;
 
 static int iptables_config(const char *key, const char *value) {
+  if (ignorelist == NULL)
+    ignorelist = ignorelist_create(/* invert = */ 1);
   /* int ip_value; */
   protocol_version_t ip_version = 0;
-
-  if (strcasecmp(key, "Chain") == 0)
+  if (strcasecmp(key, "Chain") == 0) {
     ip_version = IPV4;
-  else if (strcasecmp(key, "Chain6") == 0)
+  }
+  else if (strcasecmp(key, "Chain6") == 0) {
     ip_version = IPV6;
-  else
+  }
+  else if (strcasecmp(key, "IgnoreSelected") == 0) {
+    int invert = 1;
+    if (IS_TRUE(value))
+      invert = 0;
+    ignorelist_set_invert(ignorelist, invert);
+  } else {
     return 1;
+  }
 
   ip_chain_t temp = {0};
   ip_chain_t *final, **list;
@@ -151,7 +162,7 @@ static int iptables_config(const char *key, const char *value) {
     return 1;
   }
   sstrncpy(temp.chain, chain, chain_len);
-
+  ignorelist_add(ignorelist, chain);
   if (fields_num >= 3) {
     char *comment = fields[2];
     int rule = atoi(comment);
@@ -351,15 +362,16 @@ static void submit_chain(iptc_handle_t *handle, ip_chain_t *chain) {
 static int iptables_read(void) {
   int num_failures = 0;
   ip_chain_t *chain;
-
+  ip_chain_t temp_chain = {0};
+  const char *chain_name = NULL;
   /* Init the iptc handle structure and query the correct table */
   for (int i = 0; i < chain_num; i++) {
     chain = chain_list[i];
-
     if (!chain) {
       DEBUG("iptables plugin: chain == NULL");
       continue;
     }
+    memcpy(&temp_chain, chain, sizeof(*chain));
 
     if (chain->ip_version == IPV4) {
 #ifdef HAVE_IPTC_HANDLE_T
@@ -378,8 +390,12 @@ static int iptables_read(void) {
         num_failures++;
         continue;
       }
-
-      submit_chain(handle, chain);
+	for (chain_name = iptc_first_chain(handle); chain_name; chain_name = iptc_next_chain(handle)) {
+	  if (ignorelist_match(ignorelist, chain_name) == 0) {
+	    sstrncpy(temp_chain.chain, chain_name, sizeof(temp_chain.chain));
+	    submit_chain(handle, &temp_chain);
+	  }
+	}
       iptc_free(handle);
     } else if (chain->ip_version == IPV6) {
 #ifdef HAVE_IP6TC_HANDLE_T
@@ -397,8 +413,12 @@ static int iptables_read(void) {
         num_failures++;
         continue;
       }
-
-      submit6_chain(handle, chain);
+      for (chain_name = ip6tc_first_chain(handle); chain_name; chain_name = ip6tc_next_chain(handle)) {
+        if (ignorelist_match(ignorelist, chain_name) == 0) {
+	  sstrncpy(temp_chain.chain, chain_name, sizeof(temp_chain.chain));
+	  submit6_chain(handle, &temp_chain);
+	}
+      }
       ip6tc_free(handle);
     } else
       num_failures++;


### PR DESCRIPTION
in some organisation security team creates their own custom chains and jump to those chains from basic chains. currently iptables dont support chain pattern matching feature. Adding the same. 