### PR TITLE
Remove judgemental "small" from description

### DIFF
--- a/README
+++ b/README
@@ -5,9 +5,8 @@ https://collectd.org/
 About
 -----
 
-  collectd is a small daemon which collects system information periodically
-  and provides mechanisms to store and monitor the values in a variety of
-  ways.
+  collectd is a daemon which collects system information periodically and
+  provides mechanisms to store and monitor the values in a variety of ways.
 
 
 Features


### PR DESCRIPTION
There is probably no agreed definition of "small daemon". From my perspective, it uses 52 MB of memory on my server which makes it the third biggest daemon there.

Removing "small" also makes the description more concise about the things collectd does.