### PR TITLE
Fix crashes when some external APIs fail

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -71,7 +71,8 @@ static void sig_usr1_handler(int __attribute__((unused)) signal) {
    * so it should be done asynchronously */
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  pthread_create(&thread, &attr, do_flush, NULL);
+  if (pthread_create(&thread, &attr, do_flush, NULL) != 0)
+    fprintf(stderr, "Can not create thread: %s.\n", strerror(errno));
   pthread_attr_destroy(&attr);
 }
 

--- a/src/python.c
+++ b/src/python.c
@@ -1257,16 +1257,34 @@ static int cpy_init_python(void) {
   Py_Initialize();
   python_sigint_handler = PyOS_setsig(SIGINT, cur_sig);
 
-  PyType_Ready(&ConfigType);
-  PyType_Ready(&PluginDataType);
+  if (PyType_Ready(&ConfigType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
+  if (PyType_Ready(&PluginDataType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
   ValuesType.tp_base = &PluginDataType;
-  PyType_Ready(&ValuesType);
+  if (PyType_Ready(&ValuesType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
   NotificationType.tp_base = &PluginDataType;
-  PyType_Ready(&NotificationType);
+  if (PyType_Ready(&NotificationType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
   SignedType.tp_base = &PyLong_Type;
-  PyType_Ready(&SignedType);
+  if (PyType_Ready(&SignedType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
   UnsignedType.tp_base = &PyLong_Type;
-  PyType_Ready(&UnsignedType);
+  if (PyType_Ready(&UnsignedType) < 0) {
+    cpy_log_exception("python initialization");
+    return 1;
+  }
   errordict = PyDict_New();
   PyDict_SetItemString(
       errordict, "__doc__",


### PR DESCRIPTION
Hi,

I analyzed the collectd source code and found some potential API bugs that may cause crashes. These crashes are mainly caused by insufficient error handling of API functions like PyType_Ready or pthread_create.

I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly (at least printing a message).

Best,
Zhouyang