### PR TITLE
virt: Fix tracking of VM state changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ EXTRA_DIST = \
 	src/types.db \
 	src/types.db.pod \
 	src/valgrind.FreeBSD.suppress \
+	src/valgrind.suppress \
 	testwrapper.sh \
 	version-gen.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1762,14 +1762,15 @@ virt_la_LIBADD = libignorelist.la $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML
 # the libvirt on wheezy is linked in libnl v1, and there is a small leak here,
 # triggered by the library initialization. There are no means to avoid it,
 # and libvirt switched to libnl3 anyway
-#test_plugin_virt_SOURCES = src/virt_test.c
-#test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
-#	$(BUILD_WITH_LIBVIRT_CFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
-#test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS)
-#test_plugin_virt_LDADD = libplugin_mock.la \
-#	$(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
-#check_PROGRAMS += test_plugin_virt
-#TESTS += test_plugin_virt
+test_plugin_virt_SOURCES = src/virt_test.c 
+test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
+	$(BUILD_WITH_LIBVIRT_CPPFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
+test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS) \
+	$(BUILD_WITH_LIBVIRT_LDFLAGS) $(BUILD_WITH_LIBXML2_LDFLAGS)
+test_plugin_virt_LDADD = libplugin_mock.la \
+	$(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
+check_PROGRAMS += test_plugin_virt
+TESTS += test_plugin_virt
 endif
 
 if BUILD_PLUGIN_VMEM

--- a/Makefile.am
+++ b/Makefile.am
@@ -1758,11 +1758,7 @@ virt_la_CFLAGS = $(AM_CFLAGS) \
 virt_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 virt_la_LIBADD = libignorelist.la $(BUILD_WITH_LIBVIRT_LIBS) $(BUILD_WITH_LIBXML2_LIBS)
 
-# TODO: enable once we support only modern libvirts which depends on libnl-3
-# the libvirt on wheezy is linked in libnl v1, and there is a small leak here,
-# triggered by the library initialization. There are no means to avoid it,
-# and libvirt switched to libnl3 anyway
-test_plugin_virt_SOURCES = src/virt_test.c 
+test_plugin_virt_SOURCES = src/virt_test.c
 test_plugin_virt_CPPFLAGS = $(AM_CPPFLAGS) \
 	$(BUILD_WITH_LIBVIRT_CPPFLAGS) $(BUILD_WITH_LIBXML2_CFLAGS)
 test_plugin_virt_LDFLAGS = $(PLUGIN_LDFLAGS) \

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1607,6 +1607,7 @@
 #	PluginInstanceFormat name
 #	Instances 1
 #	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpupin"
+#	PersistentNotification false
 #</Plugin>
 
 #<Plugin vmem>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8918,6 +8918,12 @@ B<Note>: I<perf> metrics can't be collected if I<intel_rdt> plugin is enabled.
 
 =back
 
+=item B<PersistentNotification> B<true>|B<false>
+Override default configuration to only send notifications when there is a change
+in the lifecycle state of a domain. When set to true notifications will be sent
+for every read cycle. Default is false. Does not affect the stats being
+dispatched.
+
 =back
 
 =head2 Plugin C<vmem>

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -71,21 +71,36 @@ int plugin_register_data_set(const data_set_t *ds) { return ENOTSUP; }
 
 int plugin_dispatch_values(value_list_t const *vl) { return ENOTSUP; }
 
-int plugin_dispatch_notification(const notification_t *notif) { return ENOTSUP; }
+int plugin_dispatch_notification(const notification_t *notif) {
+  return ENOTSUP;
+}
 
 int plugin_notification_meta_add_string(notification_t *n, const char *name,
-                                        const char *value) { return ENOTSUP; }
+                                        const char *value) {
+  return ENOTSUP;
+}
 int plugin_notification_meta_add_signed_int(notification_t *n, const char *name,
-                                            int64_t value) { return ENOTSUP; }
+                                            int64_t value) {
+  return ENOTSUP;
+}
 int plugin_notification_meta_add_unsigned_int(notification_t *n,
-                                              const char *name, uint64_t value) { return ENOTSUP; }
+                                              const char *name,
+                                              uint64_t value) {
+  return ENOTSUP;
+}
 int plugin_notification_meta_add_double(notification_t *n, const char *name,
-                                        double value) { return ENOTSUP; }
+                                        double value) {
+  return ENOTSUP;
+}
 int plugin_notification_meta_add_boolean(notification_t *n, const char *name,
-                                         _Bool value) { return ENOTSUP; }
+                                         _Bool value) {
+  return ENOTSUP;
+}
 
 int plugin_notification_meta_copy(notification_t *dst,
-                                  const notification_t *src) { return ENOTSUP; }
+                                  const notification_t *src) {
+  return ENOTSUP;
+}
 
 int plugin_notification_meta_free(notification_meta_t *n) { return ENOTSUP; }
 

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -71,38 +71,64 @@ int plugin_register_data_set(const data_set_t *ds) { return ENOTSUP; }
 
 int plugin_dispatch_values(value_list_t const *vl) { return ENOTSUP; }
 
-int plugin_dispatch_notification(const notification_t *notif) {
+int plugin_dispatch_notification(__attribute__((unused))
+                                 const notification_t *notif) {
   return ENOTSUP;
 }
 
-int plugin_notification_meta_add_string(notification_t *n, const char *name,
+int plugin_notification_meta_add_string(__attribute__((unused))
+                                        notification_t *n,
+                                        __attribute__((unused))
+                                        const char *name,
+                                        __attribute__((unused))
                                         const char *value) {
   return ENOTSUP;
 }
-int plugin_notification_meta_add_signed_int(notification_t *n, const char *name,
+
+int plugin_notification_meta_add_signed_int(__attribute__((unused))
+                                            notification_t *n,
+                                            __attribute__((unused))
+                                            const char *name,
+                                            __attribute__((unused))
                                             int64_t value) {
   return ENOTSUP;
 }
-int plugin_notification_meta_add_unsigned_int(notification_t *n,
+
+int plugin_notification_meta_add_unsigned_int(__attribute__((unused))
+                                              notification_t *n,
+                                              __attribute__((unused))
                                               const char *name,
+                                              __attribute__((unused))
                                               uint64_t value) {
   return ENOTSUP;
 }
-int plugin_notification_meta_add_double(notification_t *n, const char *name,
-                                        double value) {
-  return ENOTSUP;
-}
-int plugin_notification_meta_add_boolean(notification_t *n, const char *name,
-                                         _Bool value) {
+
+int plugin_notification_meta_add_double(__attribute__((unused))
+                                        notification_t *n,
+                                        __attribute__((unused))
+                                        const char *name,
+                                        __attribute__((unused)) double value) {
   return ENOTSUP;
 }
 
-int plugin_notification_meta_copy(notification_t *dst,
+int plugin_notification_meta_add_boolean(__attribute__((unused))
+                                         notification_t *n,
+                                         __attribute__((unused))
+                                         const char *name,
+                                         __attribute__((unused)) _Bool value) {
+  return ENOTSUP;
+}
+
+int plugin_notification_meta_copy(__attribute__((unused)) notification_t *dst,
+                                  __attribute__((unused))
                                   const notification_t *src) {
   return ENOTSUP;
 }
 
-int plugin_notification_meta_free(notification_meta_t *n) { return ENOTSUP; }
+int plugin_notification_meta_free(__attribute__((unused))
+                                  notification_meta_t *n) {
+  return ENOTSUP;
+}
 
 int plugin_flush(const char *plugin, cdtime_t timeout, const char *identifier) {
   return ENOTSUP;

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -71,6 +71,24 @@ int plugin_register_data_set(const data_set_t *ds) { return ENOTSUP; }
 
 int plugin_dispatch_values(value_list_t const *vl) { return ENOTSUP; }
 
+int plugin_dispatch_notification(const notification_t *notif) { return ENOTSUP; }
+
+int plugin_notification_meta_add_string(notification_t *n, const char *name,
+                                        const char *value) { return ENOTSUP; }
+int plugin_notification_meta_add_signed_int(notification_t *n, const char *name,
+                                            int64_t value) { return ENOTSUP; }
+int plugin_notification_meta_add_unsigned_int(notification_t *n,
+                                              const char *name, uint64_t value) { return ENOTSUP; }
+int plugin_notification_meta_add_double(notification_t *n, const char *name,
+                                        double value) { return ENOTSUP; }
+int plugin_notification_meta_add_boolean(notification_t *n, const char *name,
+                                         _Bool value) { return ENOTSUP; }
+
+int plugin_notification_meta_copy(notification_t *dst,
+                                  const notification_t *src) { return ENOTSUP; }
+
+int plugin_notification_meta_free(notification_meta_t *n) { return ENOTSUP; }
+
 int plugin_flush(const char *plugin, cdtime_t timeout, const char *identifier) {
   return ENOTSUP;
 }

--- a/src/valgrind.suppress
+++ b/src/valgrind.suppress
@@ -1,0 +1,7 @@
+{
+   libnl1_virt_initialization_unpreventable_leak
+   Memcheck:Leak
+   ...
+   obj:*libnl.so.1.*
+   ...
+}

--- a/src/virt.c
+++ b/src/virt.c
@@ -1929,7 +1929,7 @@ static int persistent_domains_state_notification(void) {
       }
       /* virDomainGetState is not available. Submit 0, which corresponds to
        * unknown reason. */
-      domain_state_submit_notif(domain->ptr, info.di.state, 0);
+      domain_state_submit_notif(dom, info.state, 0);
     }
     sfree(domids);
   }

--- a/src/virt.c
+++ b/src/virt.c
@@ -1941,14 +1941,15 @@ static int persistent_domains_state_notification(void) {
         continue;
       }
       status = virDomainGetInfo(dom, &info);
-      if (status != 0) {
+      if (status == 0)
+        /* virDomainGetState is not available. Submit 0, which corresponds to
+         * unknown reason. */
+        domain_state_submit_notif(dom, info.state, 0);
+      else
         ERROR(PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
               status);
-        continue;
-      }
-      /* virDomainGetState is not available. Submit 0, which corresponds to
-       * unknown reason. */
-      domain_state_submit_notif(dom, info.state, 0);
+
+      virDomainFree(dom);
     }
     sfree(domids);
   }

--- a/src/virt.c
+++ b/src/virt.c
@@ -1890,7 +1890,7 @@ static int persistent_domains_state_notification(void) {
   int status = 0;
   int n;
 #ifdef HAVE_LIST_ALL_DOMAINS
-  virDomainPtr *domains;
+  virDomainPtr *domains = NULL;
   n = virConnectListAllDomains(conn, &domains,
                                VIR_CONNECT_LIST_DOMAINS_PERSISTENT);
   if (n < 0) {
@@ -1907,6 +1907,7 @@ static int persistent_domains_state_notification(void) {
         ERROR(PLUGIN_NAME " plugin: could not notify state of domain %s",
               virDomainGetName(domains[i]));
       }
+      virDomainFree(domains[i]);
     }
 
     sfree(domains);
@@ -2256,6 +2257,8 @@ static int refresh_lists(struct lv_read_instance *inst) {
 #ifndef HAVE_LIST_ALL_DOMAINS
     sfree(domids);
 #else
+    for (int i = 0; i < m; ++i)
+      virDomainFree(domains_inactive[i]);
     sfree(domains_inactive);
 #endif
     return -1;
@@ -2432,7 +2435,11 @@ static int refresh_lists(struct lv_read_instance *inst) {
   }
 
 #ifdef HAVE_LIST_ALL_DOMAINS
+  for (int i = 0; i < n; ++i)
+    virDomainFree(domains[i]);
   sfree(domains);
+  for (int i = 0; i < m; ++i)
+    virDomainFree(domains_inactive[i]);
   sfree(domains_inactive);
 #else
   sfree(domids);

--- a/src/virt.c
+++ b/src/virt.c
@@ -1892,7 +1892,7 @@ static int persistent_domains_state_notification(void) {
 #ifdef HAVE_LIST_ALL_DOMAINS
   virDomainPtr *domains;
   n = virConnectListAllDomains(conn, &domains,
-                               VIR_CONNECT_GET_ALL_DOMAINS_STATS_PERSISTENT);
+                               VIR_CONNECT_LIST_DOMAINS_PERSISTENT);
   if (n < 0) {
     VIRT_ERROR(conn, "reading list of persistent domains");
     status = -1;

--- a/src/virt.c
+++ b/src/virt.c
@@ -1990,13 +1990,6 @@ static int lv_read(user_data_t *ud) {
   /* Need to refresh domain or device lists? */
   if ((last_refresh == (time_t)0) ||
       ((interval > 0) && ((last_refresh + interval) <= t))) {
-    if (inst->id == 0 && persistent_notification) {
-      int status = persistent_domains_state_notification();
-      if (status != 0)
-        DEBUG(PLUGIN_NAME " plugin: persistent_domains_state_notifications "
-                          "returned with status %i",
-              status);
-    }
     if (refresh_lists(inst) != 0) {
       if (inst->id == 0) {
         if (!persistent_notification)
@@ -2006,6 +1999,15 @@ static int lv_read(user_data_t *ud) {
       return -1;
     }
     last_refresh = t;
+  }
+
+  /* persistent domains state notifications are handled by instance 0 */
+  if (inst->id == 0 && persistent_notification) {
+    int status = persistent_domains_state_notification();
+    if (status != 0)
+      DEBUG(PLUGIN_NAME " plugin: persistent_domains_state_notifications "
+                        "returned with status %i",
+            status);
   }
 
 #if COLLECT_DEBUG

--- a/src/virt.c
+++ b/src/virt.c
@@ -1919,9 +1919,9 @@ static int persistent_domains_state_notification(void) {
   if (n > 0) {
     int *domids;
     /* Get list of domains. */
-    domids = malloc(sizeof(*domids) * n);
+    domids = calloc(n, sizeof(*domids));
     if (domids == NULL) {
-      ERROR(PLUGIN_NAME " plugin: malloc failed.");
+      ERROR(PLUGIN_NAME " plugin: calloc failed.");
       return -1;
     }
     n = virConnectListDomains(conn, domids, n);
@@ -2245,9 +2245,9 @@ static int refresh_lists(struct lv_read_instance *inst) {
   int *domids;
 
   /* Get list of domains. */
-  domids = malloc(sizeof(*domids) * n);
+  domids = calloc(n, sizeof(*domids));
   if (domids == NULL) {
-    ERROR(PLUGIN_NAME " plugin: malloc failed.");
+    ERROR(PLUGIN_NAME " plugin: calloc failed.");
     return -1;
   }
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -183,7 +183,8 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
     case VIR_DOMAIN_EVENT_STARTED_BOOTED: /* Normal startup from boot */
       ret = VIR_DOMAIN_RUNNING_BOOTED;
       break;
-    case VIR_DOMAIN_EVENT_STARTED_MIGRATED: /* Incoming migration from another host */
+    case VIR_DOMAIN_EVENT_STARTED_MIGRATED: /* Incoming migration from another
+                                               host */
       ret = VIR_DOMAIN_RUNNING_MIGRATED;
       break;
     case VIR_DOMAIN_EVENT_STARTED_RESTORED: /* Restored from a state file */
@@ -201,31 +202,40 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
     break;
   case VIR_DOMAIN_EVENT_SUSPENDED:
     switch (detail) {
-    case VIR_DOMAIN_EVENT_SUSPENDED_PAUSED: /* Normal suspend due to admin pause */
+    case VIR_DOMAIN_EVENT_SUSPENDED_PAUSED: /* Normal suspend due to admin
+                                               pause */
       ret = VIR_DOMAIN_PAUSED_USER;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_MIGRATED: /* Suspended for offline migration */
+    case VIR_DOMAIN_EVENT_SUSPENDED_MIGRATED: /* Suspended for offline
+                                                 migration */
       ret = VIR_DOMAIN_PAUSED_MIGRATION;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_IOERROR: /* Suspended due to a disk I/O error */
+    case VIR_DOMAIN_EVENT_SUSPENDED_IOERROR: /* Suspended due to a disk I/O
+                                                error */
       ret = VIR_DOMAIN_PAUSED_IOERROR;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_WATCHDOG: /* Suspended due to a watchdog firing */
+    case VIR_DOMAIN_EVENT_SUSPENDED_WATCHDOG: /* Suspended due to a watchdog
+                                                 firing */
       ret = VIR_DOMAIN_PAUSED_WATCHDOG;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_RESTORED: /* Restored from paused state file */
+    case VIR_DOMAIN_EVENT_SUSPENDED_RESTORED: /* Restored from paused state
+                                                 file */
       ret = VIR_DOMAIN_PAUSED_UNKNOWN;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_FROM_SNAPSHOT: /* Restored from paused snapshot */
+    case VIR_DOMAIN_EVENT_SUSPENDED_FROM_SNAPSHOT: /* Restored from paused
+                                                      snapshot */
       ret = VIR_DOMAIN_PAUSED_FROM_SNAPSHOT;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_API_ERROR: /* Suspended after failure during libvirt API call */
+    case VIR_DOMAIN_EVENT_SUSPENDED_API_ERROR: /* Suspended after failure during
+                                                  libvirt API call */
       ret = VIR_DOMAIN_PAUSED_UNKNOWN;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_POSTCOPY: /* Suspended for post-copy migration */
+    case VIR_DOMAIN_EVENT_SUSPENDED_POSTCOPY: /* Suspended for post-copy
+                                                 migration */
       ret = VIR_DOMAIN_PAUSED_POSTCOPY;
       break;
-    case VIR_DOMAIN_EVENT_SUSPENDED_POSTCOPY_FAILED: /* Suspended after failed post-copy */
+    case VIR_DOMAIN_EVENT_SUSPENDED_POSTCOPY_FAILED: /* Suspended after failed
+                                                        post-copy */
       ret = VIR_DOMAIN_PAUSED_POSTCOPY_FAILED;
       break;
     default:
@@ -234,16 +244,19 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
     break;
   case VIR_DOMAIN_EVENT_RESUMED:
     switch (detail) {
-    case VIR_DOMAIN_EVENT_RESUMED_UNPAUSED: /* Normal resume due to admin unpause */
+    case VIR_DOMAIN_EVENT_RESUMED_UNPAUSED: /* Normal resume due to admin
+                                               unpause */
       ret = VIR_DOMAIN_RUNNING_UNPAUSED;
       break;
-    case VIR_DOMAIN_EVENT_RESUMED_MIGRATED: /* Resumed for completion of migration */
+    case VIR_DOMAIN_EVENT_RESUMED_MIGRATED: /* Resumed for completion of
+                                               migration */
       ret = VIR_DOMAIN_RUNNING_MIGRATED;
       break;
     case VIR_DOMAIN_EVENT_RESUMED_FROM_SNAPSHOT: /* Resumed from snapshot */
       ret = VIR_DOMAIN_RUNNING_FROM_SNAPSHOT;
       break;
-    case VIR_DOMAIN_EVENT_RESUMED_POSTCOPY: /* Resumed, but migration is still running in post-copy mode */
+    case VIR_DOMAIN_EVENT_RESUMED_POSTCOPY: /* Resumed, but migration is still
+                                               running in post-copy mode */
       ret = VIR_DOMAIN_RUNNING_POSTCOPY;
       break;
     default:
@@ -279,7 +292,8 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
     break;
   case VIR_DOMAIN_EVENT_SHUTDOWN:
     switch (detail) {
-    case VIR_DOMAIN_EVENT_SHUTDOWN_FINISHED: /* Guest finished shutdown sequence */
+    case VIR_DOMAIN_EVENT_SHUTDOWN_FINISHED: /* Guest finished shutdown
+                                                sequence */
       ret = VIR_DOMAIN_SHUTDOWN_USER;
       break;
     default:
@@ -288,7 +302,8 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
     break;
   case VIR_DOMAIN_EVENT_PMSUSPENDED:
     switch (detail) {
-    case VIR_DOMAIN_EVENT_PMSUSPENDED_MEMORY: /* Guest was PM suspended to memory */
+    case VIR_DOMAIN_EVENT_PMSUSPENDED_MEMORY: /* Guest was PM suspended to
+                                                 memory */
       ret = VIR_DOMAIN_PMSUSPENDED_UNKNOWN;
       break;
     case VIR_DOMAIN_EVENT_PMSUSPENDED_DISK: /* Guest was PM suspended to disk */
@@ -1856,12 +1871,10 @@ static int start_event_loop(void) {
 /* stop event loop thread and deregister callback */
 static void stop_event_loop(void) {
   if (pthread_cancel(event_loop_tid) != 0)
-    ERROR(PLUGIN_NAME " plugin: cancelling thread %lu failed",
-          event_loop_tid);
+    ERROR(PLUGIN_NAME " plugin: cancelling thread %lu failed", event_loop_tid);
 
   if (pthread_join(event_loop_tid, NULL) != 0)
-    ERROR(PLUGIN_NAME " plugin: stopping thread %lu failed",
-          event_loop_tid);
+    ERROR(PLUGIN_NAME " plugin: stopping thread %lu failed", event_loop_tid);
 
   if (conn != NULL && domain_event_cb_id != -1)
     virConnectDomainEventDeregisterAny(conn, domain_event_cb_id);
@@ -1877,8 +1890,7 @@ static int persistent_domains_state_notification(void) {
   if (n < 0) {
     VIRT_ERROR(conn, "reading list of persistent domains");
     status = -1;
-  }
-  else {
+  } else {
     DEBUG(PLUGIN_NAME " plugin: getting state of %i persistent domains", n);
     /* Fetch each persistent domain's state and notify it */
     int n_notified = n;
@@ -1974,8 +1986,9 @@ static int lv_read(user_data_t *ud) {
     if (inst->id == 0 && persistent_notification) {
       int status = persistent_domains_state_notification();
       if (status != 0)
-        DEBUG(PLUGIN_NAME " plugin: persistent_domains_state_notifications " \
-              "returned with status %i", status);
+        DEBUG(PLUGIN_NAME " plugin: persistent_domains_state_notifications "
+                          "returned with status %i",
+              status);
     }
     if (refresh_lists(inst) != 0) {
       if (inst->id == 0) {
@@ -1988,19 +2001,19 @@ static int lv_read(user_data_t *ud) {
     last_refresh = t;
   }
 
-  #if COLLECT_DEBUG
-    for (int i = 0; i < state->nr_domains; ++i)
-        DEBUG(PLUGIN_NAME " plugin: domain %s",
-              virDomainGetName(state->domains[i].ptr));
-    for (int i = 0; i < state->nr_block_devices; ++i)
-        DEBUG(PLUGIN_NAME " plugin: block device %d %s:%s",
-              i, virDomainGetName(state->block_devices[i].dom),
-              state->block_devices[i].path);
-    for (int i = 0; i < state->nr_interface_devices; ++i)
-        DEBUG(PLUGIN_NAME " plugin: interface device %d %s:%s",
-              i, virDomainGetName(state->interface_devices[i].dom),
-              state->interface_devices[i].path);
-  #endif
+#if COLLECT_DEBUG
+  for (int i = 0; i < state->nr_domains; ++i)
+    DEBUG(PLUGIN_NAME " plugin: domain %s",
+          virDomainGetName(state->domains[i].ptr));
+  for (int i = 0; i < state->nr_block_devices; ++i)
+    DEBUG(PLUGIN_NAME " plugin: block device %d %s:%s", i,
+          virDomainGetName(state->block_devices[i].dom),
+          state->block_devices[i].path);
+  for (int i = 0; i < state->nr_interface_devices; ++i)
+    DEBUG(PLUGIN_NAME " plugin: interface device %d %s:%s", i,
+          virDomainGetName(state->interface_devices[i].dom),
+          state->interface_devices[i].path);
+#endif
 
   /* Get domains' metrics */
   for (int i = 0; i < state->nr_domains; ++i) {
@@ -2216,8 +2229,7 @@ static int refresh_lists(struct lv_read_instance *inst) {
   virDomainPtr *domains, *domains_inactive;
   int m = virConnectListAllDomains(conn, &domains_inactive,
                                    VIR_CONNECT_LIST_DOMAINS_INACTIVE);
-  n = virConnectListAllDomains(conn, &domains,
-                               VIR_CONNECT_LIST_DOMAINS_ACTIVE);
+  n = virConnectListAllDomains(conn, &domains, VIR_CONNECT_LIST_DOMAINS_ACTIVE);
 #else
   int *domids;
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -630,7 +630,7 @@ static const struct ex_stats_item ex_stats_table[] = {
 };
 
 /* BlockDeviceFormatBasename */
-static bool blockdevice_format_basename = false;
+static bool blockdevice_format_basename;
 static enum bd_field blockdevice_format = target;
 static enum if_field interface_format = if_name;
 
@@ -1397,8 +1397,7 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
                             unsigned char *cpu_maps, int cpu_map_len) {
   for (int cpu = 0; cpu < max_cpus; ++cpu) {
     char type_instance[DATA_MAX_NAME_LEN];
-    bool is_set =
-        VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? true : false;
+    bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu);
 
     snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);

--- a/src/virt.c
+++ b/src/virt.c
@@ -1932,8 +1932,7 @@ static void stop_event_loop(virt_notif_thread_t *thread_data) {
     virConnectDomainEventDeregisterAny(conn, thread_data->domain_event_cb_id);
 
   if (pthread_join(notif_thread.event_loop_tid, NULL) != 0)
-    ERROR(PLUGIN_NAME " plugin: stopping thread %lu failed",
-          notif_thread.event_loop_tid);
+    ERROR(PLUGIN_NAME " plugin: stopping notification thread failed");
 }
 
 static int persistent_domains_state_notification(void) {

--- a/src/virt.c
+++ b/src/virt.c
@@ -34,6 +34,7 @@
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
+#include <stdbool.h>
 
 /* Plugin name */
 #define PLUGIN_NAME "virt"
@@ -113,7 +114,7 @@ typedef struct virt_notif_thread_s {
   pthread_t event_loop_tid;
   int domain_event_cb_id;
   pthread_mutex_t active_mutex; /* protects 'is_active' member access*/
-  _Bool is_active;
+  bool is_active;
 } virt_notif_thread_t;
 
 static const char *config_keys[] = {"Connection",
@@ -138,7 +139,7 @@ static const char *config_keys[] = {"Connection",
                                     NULL};
 
 /* PersistentNotification is false by default */
-static _Bool persistent_notification = 0;
+static bool persistent_notification = false;
 
 /* Thread used for handling libvirt notifications events */
 static virt_notif_thread_t notif_thread;
@@ -504,7 +505,7 @@ struct interface_device {
 typedef struct domain_s {
   virDomainPtr ptr;
   virDomainInfo info;
-  _Bool active;
+  bool active;
 } domain_t;
 
 struct lv_read_state {
@@ -521,7 +522,7 @@ struct lv_read_state {
 
 static void free_domains(struct lv_read_state *state);
 static int add_domain(struct lv_read_state *state, virDomainPtr dom,
-                      _Bool active);
+                      bool active);
 
 static void free_block_devices(struct lv_read_state *state);
 static int add_block_device(struct lv_read_state *state, virDomainPtr dom,
@@ -629,7 +630,7 @@ static const struct ex_stats_item ex_stats_table[] = {
 };
 
 /* BlockDeviceFormatBasename */
-_Bool blockdevice_format_basename = 0;
+static bool blockdevice_format_basename = false;
 static enum bd_field blockdevice_format = target;
 static enum if_field interface_format = if_name;
 
@@ -1122,7 +1123,7 @@ static int lv_config(const char *key, const char *value) {
     return 0;
   }
   if (strcasecmp(key, "BlockDeviceFormatBasename") == 0) {
-    blockdevice_format_basename = IS_TRUE(value);
+    blockdevice_format_basename = IS_TRUE(value) ? true : false;
     return 0;
   }
   if (strcasecmp(key, "InterfaceDevice") == 0) {
@@ -1396,7 +1397,8 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
                             unsigned char *cpu_maps, int cpu_map_len) {
   for (int cpu = 0; cpu < max_cpus; ++cpu) {
     char type_instance[DATA_MAX_NAME_LEN];
-    _Bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? 1 : 0;
+    bool is_set =
+        VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu) ? true : false;
 
     snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
@@ -1849,22 +1851,22 @@ static int register_event_impl(void) {
 }
 
 static void virt_notif_thread_set_active(virt_notif_thread_t *thread_data,
-                                         const _Bool active) {
+                                         const bool active) {
   assert(thread_data != NULL);
   pthread_mutex_lock(&thread_data->active_mutex);
   thread_data->is_active = active;
   pthread_mutex_unlock(&thread_data->active_mutex);
 }
 
-static _Bool virt_notif_thread_is_active(virt_notif_thread_t *thread_data) {
-  _Bool state = 0;
+static bool virt_notif_thread_is_active(virt_notif_thread_t *thread_data) {
+  bool active = false;
 
   assert(thread_data != NULL);
   pthread_mutex_lock(&thread_data->active_mutex);
-  state = thread_data->is_active;
+  active = thread_data->is_active;
   pthread_mutex_unlock(&thread_data->active_mutex);
 
-  return state;
+  return active;
 }
 
 /* worker function running default event implementation */
@@ -2020,7 +2022,7 @@ static int lv_read(user_data_t *ud) {
   inst = ud->data;
   state = &inst->read_state;
 
-  _Bool reconnect = conn == NULL ? 1 : 0;
+  bool reconnect = conn == NULL ? true : false;
   /* event implementation must be registered before connection is opened */
   if (inst->id == 0) {
     if (!persistent_notification && reconnect)
@@ -2530,7 +2532,7 @@ static void free_domains(struct lv_read_state *state) {
 }
 
 static int add_domain(struct lv_read_state *state, virDomainPtr dom,
-                      _Bool active) {
+                      bool active) {
   domain_t *new_ptr;
   int new_size = sizeof(state->domains[0]) * (state->nr_domains + 1);
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -467,6 +467,7 @@ struct interface_device {
 typedef struct domain_s {
   virDomainPtr ptr;
   virDomainInfo info;
+  _Bool active;
 } domain_t;
 
 struct lv_read_state {
@@ -482,7 +483,8 @@ struct lv_read_state {
 };
 
 static void free_domains(struct lv_read_state *state);
-static int add_domain(struct lv_read_state *state, virDomainPtr dom);
+static int add_domain(struct lv_read_state *state, virDomainPtr dom,
+                      _Bool active);
 
 static void free_block_devices(struct lv_read_state *state);
 static int add_block_device(struct lv_read_state *state, virDomainPtr dom,
@@ -1416,6 +1418,15 @@ static int get_vcpu_stats(virDomainPtr domain, unsigned short nr_virt_cpu) {
 }
 
 #ifdef HAVE_DOM_REASON
+
+static void domain_state_submit(virDomainPtr dom, int state, int reason) {
+  value_t values[] = {
+      {.gauge = (gauge_t)state}, {.gauge = (gauge_t)reason},
+  };
+
+  submit(dom, "domain_state", NULL, values, STATIC_ARRAY_SIZE(values));
+}
+
 static int get_domain_state(virDomainPtr domain) {
   int domain_state = 0;
   int domain_reason = 0;
@@ -1426,6 +1437,8 @@ static int get_domain_state(virDomainPtr domain) {
           status);
     return status;
   }
+
+  domain_state_submit(domain, domain_state, domain_reason);
 
   return status;
 }
@@ -1991,10 +2004,16 @@ static int lv_read(user_data_t *ud) {
 
   /* Get domains' metrics */
   for (int i = 0; i < state->nr_domains; ++i) {
-    int status = get_domain_metrics(&state->domains[i]);
+    domain_t *dom = &state->domains[i];
+    int status;
+    if (dom->active)
+      status = get_domain_metrics(dom);
+    else
+      status = get_domain_state(dom->ptr);
+
     if (status != 0)
       ERROR(PLUGIN_NAME " failed to get metrics for domain=%s",
-            virDomainGetName(state->domains[i].ptr));
+            virDomainGetName(dom->ptr));
   }
 
   /* Get block device stats for each domain. */
@@ -2178,208 +2197,228 @@ static int refresh_lists(struct lv_read_instance *inst) {
   struct lv_read_state *state = &inst->read_state;
   int n;
 
+#ifndef HAVE_LIST_ALL_DOMAINS
   n = virConnectNumOfDomains(conn);
   if (n < 0) {
     VIRT_ERROR(conn, "reading number of domains");
     return -1;
   }
+#endif
 
   lv_clean_read_state(state);
 
-  if (n > 0) {
-#ifdef HAVE_LIST_ALL_DOMAINS
-    virDomainPtr *domains;
-    n = virConnectListAllDomains(conn, &domains,
-                                 VIR_CONNECT_LIST_DOMAINS_ACTIVE);
-#else
-    int *domids;
-
-    /* Get list of domains. */
-    domids = malloc(sizeof(*domids) * n);
-    if (domids == NULL) {
-      ERROR(PLUGIN_NAME " plugin: malloc failed.");
-      return -1;
-    }
-
-    n = virConnectListDomains(conn, domids, n);
-#endif
-
-    if (n < 0) {
-      VIRT_ERROR(conn, "reading list of domains");
 #ifndef HAVE_LIST_ALL_DOMAINS
-      sfree(domids);
+  if (n == 0)
+    goto end;
 #endif
-      return -1;
-    }
-
-    /* Fetch each domain and add it to the list, unless ignore. */
-    for (int i = 0; i < n; ++i) {
-      const char *name;
-      char *xml = NULL;
-      xmlDocPtr xml_doc = NULL;
-      xmlXPathContextPtr xpath_ctx = NULL;
-      xmlXPathObjectPtr xpath_obj = NULL;
-      char tag[PARTITION_TAG_MAX_LEN] = {'\0'};
-      virDomainInfo info;
-      int status;
 
 #ifdef HAVE_LIST_ALL_DOMAINS
-      virDomainPtr dom = domains[i];
+  virDomainPtr *domains, *domains_inactive;
+  int m = virConnectListAllDomains(conn, &domains_inactive,
+                                   VIR_CONNECT_LIST_DOMAINS_INACTIVE);
+  n = virConnectListAllDomains(conn, &domains,
+                               VIR_CONNECT_LIST_DOMAINS_ACTIVE);
 #else
-      virDomainPtr dom = NULL;
-      dom = virDomainLookupByID(conn, domids[i]);
-      if (dom == NULL) {
-        VIRT_ERROR(conn, "virDomainLookupByID");
-        /* Could be that the domain went away -- ignore it anyway. */
-        continue;
-      }
-#endif
+  int *domids;
 
-      name = virDomainGetName(dom);
-      if (name == NULL) {
-        VIRT_ERROR(conn, "virDomainGetName");
-        goto cont;
-      }
-
-      status = virDomainGetInfo(dom, &info);
-      if (status != 0) {
-        ERROR(PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
-              status);
-        continue;
-      }
-
-      if (info.state != VIR_DOMAIN_RUNNING) {
-        DEBUG(PLUGIN_NAME " plugin: skipping inactive domain %s", name);
-        continue;
-      }
-
-      if (il_domains && ignorelist_match(il_domains, name) != 0)
-        goto cont;
-
-      /* Get a list of devices for this domain. */
-      xml = virDomainGetXMLDesc(dom, 0);
-      if (!xml) {
-        VIRT_ERROR(conn, "virDomainGetXMLDesc");
-        goto cont;
-      }
-
-      /* Yuck, XML.  Parse out the devices. */
-      xml_doc = xmlReadDoc((xmlChar *)xml, NULL, NULL, XML_PARSE_NONET);
-      if (xml_doc == NULL) {
-        VIRT_ERROR(conn, "xmlReadDoc");
-        goto cont;
-      }
-
-      xpath_ctx = xmlXPathNewContext(xml_doc);
-
-      if (lv_domain_get_tag(xpath_ctx, name, tag) < 0) {
-        ERROR(PLUGIN_NAME " plugin: lv_domain_get_tag failed.");
-        goto cont;
-      }
-
-      if (!lv_instance_include_domain(inst, name, tag))
-        goto cont;
-
-      if (add_domain(state, dom) < 0) {
-        ERROR(PLUGIN_NAME " plugin: malloc failed.");
-        goto cont;
-      }
-
-      /* Block devices. */
-      const char *bd_xmlpath = "/domain/devices/disk/target[@dev]";
-      if (blockdevice_format == source)
-        bd_xmlpath = "/domain/devices/disk/source[@dev]";
-      xpath_obj = xmlXPathEval((const xmlChar *)bd_xmlpath, xpath_ctx);
-
-      if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
-          xpath_obj->nodesetval == NULL)
-        goto cont;
-
-      for (int j = 0; j < xpath_obj->nodesetval->nodeNr; ++j) {
-        xmlNodePtr node;
-        char *path = NULL;
-
-        node = xpath_obj->nodesetval->nodeTab[j];
-        if (!node)
-          continue;
-        path = (char *)xmlGetProp(node, (xmlChar *)"dev");
-        if (!path)
-          continue;
-
-        if (il_block_devices &&
-            ignore_device_match(il_block_devices, name, path) != 0)
-          goto cont2;
-
-        add_block_device(state, dom, path);
-      cont2:
-        if (path)
-          xmlFree(path);
-      }
-      xmlXPathFreeObject(xpath_obj);
-
-      /* Network interfaces. */
-      xpath_obj = xmlXPathEval(
-          (xmlChar *)"/domain/devices/interface[target[@dev]]", xpath_ctx);
-      if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
-          xpath_obj->nodesetval == NULL)
-        goto cont;
-
-      xmlNodeSetPtr xml_interfaces = xpath_obj->nodesetval;
-
-      for (int j = 0; j < xml_interfaces->nodeNr; ++j) {
-        char *path = NULL;
-        char *address = NULL;
-        xmlNodePtr xml_interface;
-
-        xml_interface = xml_interfaces->nodeTab[j];
-        if (!xml_interface)
-          continue;
-
-        for (xmlNodePtr child = xml_interface->children; child;
-             child = child->next) {
-          if (child->type != XML_ELEMENT_NODE)
-            continue;
-
-          if (xmlStrEqual(child->name, (const xmlChar *)"target")) {
-            path = (char *)xmlGetProp(child, (const xmlChar *)"dev");
-            if (!path)
-              continue;
-          } else if (xmlStrEqual(child->name, (const xmlChar *)"mac")) {
-            address = (char *)xmlGetProp(child, (const xmlChar *)"address");
-            if (!address)
-              continue;
-          }
-        }
-
-        if (il_interface_devices &&
-            (ignore_device_match(il_interface_devices, name, path) != 0 ||
-             ignore_device_match(il_interface_devices, name, address) != 0))
-          goto cont3;
-
-        add_interface_device(state, dom, path, address, j + 1);
-      cont3:
-        if (path)
-          xmlFree(path);
-        if (address)
-          xmlFree(address);
-      }
-
-    cont:
-      if (xpath_obj)
-        xmlXPathFreeObject(xpath_obj);
-      if (xpath_ctx)
-        xmlXPathFreeContext(xpath_ctx);
-      if (xml_doc)
-        xmlFreeDoc(xml_doc);
-      sfree(xml);
-    }
-
-#ifdef HAVE_LIST_ALL_DOMAINS
-    sfree(domains);
-#else
-    sfree(domids);
-#endif
+  /* Get list of domains. */
+  domids = malloc(sizeof(*domids) * n);
+  if (domids == NULL) {
+    ERROR(PLUGIN_NAME " plugin: malloc failed.");
+    return -1;
   }
+
+  n = virConnectListDomains(conn, domids, n);
+#endif
+
+  if (n < 0) {
+    VIRT_ERROR(conn, "reading list of domains");
+#ifndef HAVE_LIST_ALL_DOMAINS
+    sfree(domids);
+#else
+    sfree(domains_inactive);
+#endif
+    return -1;
+  }
+
+#ifdef HAVE_LIST_ALL_DOMAINS
+  for (int i = 0; i < m; ++i)
+    if (add_domain(state, domains_inactive[i], 0) < 0) {
+      ERROR(PLUGIN_NAME " plugin: malloc failed.");
+      continue;
+    }
+#endif
+
+  /* Fetch each domain and add it to the list, unless ignore. */
+  for (int i = 0; i < n; ++i) {
+    const char *name;
+    char *xml = NULL;
+    xmlDocPtr xml_doc = NULL;
+    xmlXPathContextPtr xpath_ctx = NULL;
+    xmlXPathObjectPtr xpath_obj = NULL;
+    char tag[PARTITION_TAG_MAX_LEN] = {'\0'};
+    virDomainInfo info;
+    int status;
+
+#ifdef HAVE_LIST_ALL_DOMAINS
+    virDomainPtr dom = domains[i];
+#else
+    virDomainPtr dom = NULL;
+    dom = virDomainLookupByID(conn, domids[i]);
+    if (dom == NULL) {
+      VIRT_ERROR(conn, "virDomainLookupByID");
+      /* Could be that the domain went away -- ignore it anyway. */
+      continue;
+    }
+#endif
+
+    name = virDomainGetName(dom);
+    if (name == NULL) {
+      VIRT_ERROR(conn, "virDomainGetName");
+      goto cont;
+    }
+
+    status = virDomainGetInfo(dom, &info);
+    if (status != 0) {
+      ERROR(PLUGIN_NAME " plugin: virDomainGetInfo failed with status %i.",
+            status);
+      continue;
+    }
+
+    if (info.state != VIR_DOMAIN_RUNNING) {
+      DEBUG(PLUGIN_NAME " plugin: skipping inactive domain %s", name);
+      continue;
+    }
+
+    if (il_domains && ignorelist_match(il_domains, name) != 0)
+      goto cont;
+
+    /* Get a list of devices for this domain. */
+    xml = virDomainGetXMLDesc(dom, 0);
+    if (!xml) {
+      VIRT_ERROR(conn, "virDomainGetXMLDesc");
+      goto cont;
+    }
+
+    /* Yuck, XML.  Parse out the devices. */
+    xml_doc = xmlReadDoc((xmlChar *)xml, NULL, NULL, XML_PARSE_NONET);
+    if (xml_doc == NULL) {
+      VIRT_ERROR(conn, "xmlReadDoc");
+      goto cont;
+    }
+
+    xpath_ctx = xmlXPathNewContext(xml_doc);
+
+    if (lv_domain_get_tag(xpath_ctx, name, tag) < 0) {
+      ERROR(PLUGIN_NAME " plugin: lv_domain_get_tag failed.");
+      goto cont;
+    }
+
+    if (!lv_instance_include_domain(inst, name, tag))
+      goto cont;
+
+    if (add_domain(state, dom, 1) < 0) {
+      ERROR(PLUGIN_NAME " plugin: malloc failed.");
+      goto cont;
+    }
+
+    /* Block devices. */
+    const char *bd_xmlpath = "/domain/devices/disk/target[@dev]";
+    if (blockdevice_format == source)
+      bd_xmlpath = "/domain/devices/disk/source[@dev]";
+    xpath_obj = xmlXPathEval((const xmlChar *)bd_xmlpath, xpath_ctx);
+
+    if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
+        xpath_obj->nodesetval == NULL)
+      goto cont;
+
+    for (int j = 0; j < xpath_obj->nodesetval->nodeNr; ++j) {
+      xmlNodePtr node;
+      char *path = NULL;
+
+      node = xpath_obj->nodesetval->nodeTab[j];
+      if (!node)
+        continue;
+      path = (char *)xmlGetProp(node, (xmlChar *)"dev");
+      if (!path)
+        continue;
+
+      if (il_block_devices &&
+          ignore_device_match(il_block_devices, name, path) != 0)
+        goto cont2;
+
+      add_block_device(state, dom, path);
+    cont2:
+      if (path)
+        xmlFree(path);
+    }
+    xmlXPathFreeObject(xpath_obj);
+
+    /* Network interfaces. */
+    xpath_obj = xmlXPathEval(
+        (xmlChar *)"/domain/devices/interface[target[@dev]]", xpath_ctx);
+    if (xpath_obj == NULL || xpath_obj->type != XPATH_NODESET ||
+        xpath_obj->nodesetval == NULL)
+      goto cont;
+
+    xmlNodeSetPtr xml_interfaces = xpath_obj->nodesetval;
+
+    for (int j = 0; j < xml_interfaces->nodeNr; ++j) {
+      char *path = NULL;
+      char *address = NULL;
+      xmlNodePtr xml_interface;
+
+      xml_interface = xml_interfaces->nodeTab[j];
+      if (!xml_interface)
+        continue;
+
+      for (xmlNodePtr child = xml_interface->children; child;
+           child = child->next) {
+        if (child->type != XML_ELEMENT_NODE)
+          continue;
+
+        if (xmlStrEqual(child->name, (const xmlChar *)"target")) {
+          path = (char *)xmlGetProp(child, (const xmlChar *)"dev");
+          if (!path)
+            continue;
+        } else if (xmlStrEqual(child->name, (const xmlChar *)"mac")) {
+          address = (char *)xmlGetProp(child, (const xmlChar *)"address");
+          if (!address)
+            continue;
+        }
+      }
+
+      if (il_interface_devices &&
+          (ignore_device_match(il_interface_devices, name, path) != 0 ||
+           ignore_device_match(il_interface_devices, name, address) != 0))
+        goto cont3;
+
+      add_interface_device(state, dom, path, address, j + 1);
+    cont3:
+      if (path)
+        xmlFree(path);
+      if (address)
+        xmlFree(address);
+    }
+
+  cont:
+    if (xpath_obj)
+      xmlXPathFreeObject(xpath_obj);
+    if (xpath_ctx)
+      xmlXPathFreeContext(xpath_ctx);
+    if (xml_doc)
+      xmlFreeDoc(xml_doc);
+    sfree(xml);
+  }
+
+#ifdef HAVE_LIST_ALL_DOMAINS
+  sfree(domains);
+  sfree(domains_inactive);
+#else
+  sfree(domids);
+
+end:
+#endif
 
   DEBUG(PLUGIN_NAME " plugin#%s: refreshing"
                     " domains=%i block_devices=%i iface_devices=%i",
@@ -2399,7 +2438,8 @@ static void free_domains(struct lv_read_state *state) {
   state->nr_domains = 0;
 }
 
-static int add_domain(struct lv_read_state *state, virDomainPtr dom) {
+static int add_domain(struct lv_read_state *state, virDomainPtr dom,
+                      _Bool active) {
   domain_t *new_ptr;
   int new_size = sizeof(state->domains[0]) * (state->nr_domains + 1);
 
@@ -2413,6 +2453,7 @@ static int add_domain(struct lv_read_state *state, virDomainPtr dom) {
 
   state->domains = new_ptr;
   state->domains[state->nr_domains].ptr = dom;
+  state->domains[state->nr_domains].active = active;
   memset(&state->domains[state->nr_domains].info, 0,
          sizeof(state->domains[state->nr_domains].info));
 

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -25,8 +25,8 @@
 #include "testing.h"
 #include "virt.c" /* sic */
 
-static virDomainPtr *domains = NULL;
-static int nr_domains = 0;
+static virDomainPtr *domains;
+static int nr_domains;
 
 static int setup(void) {
   if (virInitialize() != 0) {

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -60,7 +60,7 @@ static int teardown(void) {
 DEF_TEST(get_domain_state_notify) {
   if (setup() == 0) {
     nr_domains = virConnectListAllDomains(
-        conn, &domains, VIR_CONNECT_GET_ALL_DOMAINS_STATS_PERSISTENT);
+        conn, &domains, VIR_CONNECT_LIST_DOMAINS_PERSISTENT);
     if (nr_domains <= 0) {
       printf("ERROR: virConnectListAllDomains: nr_domains <= 0\n");
       return -1;

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -29,8 +29,7 @@
 
 virDomainPtr *domains;
 
-static int setup(void)
-{
+static int setup(void) {
   if (virInitialize() != 0) {
     printf("ERROR: virInitialize() != 0\n");
     return -1;
@@ -45,8 +44,7 @@ static int setup(void)
   return 0;
 }
 
-static int teardown(void)
-{
+static int teardown(void) {
   sfree(domains);
   if (conn != NULL)
     virConnectClose(conn);
@@ -56,7 +54,8 @@ static int teardown(void)
 
 DEF_TEST(get_domain_state_notify) {
   if (setup() == 0) {
-    int n_domains = virConnectListAllDomains(conn, &domains, VIR_CONNECT_GET_ALL_DOMAINS_STATS_PERSISTENT);
+    int n_domains = virConnectListAllDomains(
+        conn, &domains, VIR_CONNECT_GET_ALL_DOMAINS_STATS_PERSISTENT);
     if (n_domains <= 0) {
       printf("ERROR: virConnectListAllDomains: n_domains <= 0\n");
       return -1;
@@ -66,7 +65,7 @@ DEF_TEST(get_domain_state_notify) {
     EXPECT_EQ_INT(0, ret);
   }
   teardown();
-  
+
   return 0;
 }
 
@@ -76,7 +75,7 @@ DEF_TEST(persistent_domains_state_notification) {
     EXPECT_EQ_INT(0, ret);
   }
   teardown();
-  
+
   return 0;
 }
 #endif

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -25,8 +25,6 @@
 #include "testing.h"
 #include "virt.c" /* sic */
 
-#ifdef HAVE_LIST_ALL_DOMAINS
-
 virDomainPtr *domains;
 
 static int setup(void) {
@@ -52,6 +50,7 @@ static int teardown(void) {
   return 0;
 }
 
+#ifdef HAVE_LIST_ALL_DOMAINS
 DEF_TEST(get_domain_state_notify) {
   if (setup() == 0) {
     int n_domains = virConnectListAllDomains(
@@ -68,6 +67,7 @@ DEF_TEST(get_domain_state_notify) {
 
   return 0;
 }
+#endif
 
 DEF_TEST(persistent_domains_state_notification) {
   if (setup() == 0) {
@@ -78,13 +78,12 @@ DEF_TEST(persistent_domains_state_notification) {
 
   return 0;
 }
-#endif
 
 int main(void) {
 #ifdef HAVE_LIST_ALL_DOMAINS
   RUN_TEST(get_domain_state_notify);
-  RUN_TEST(persistent_domains_state_notification);
 #endif
+  RUN_TEST(persistent_domains_state_notification);
 
   END_TEST;
 }

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -25,183 +25,67 @@
 #include "testing.h"
 #include "virt.c" /* sic */
 
-#include <unistd.h>
+#ifdef HAVE_LIST_ALL_DOMAINS
 
-static const char minimal_xml[] =
-    ""
-    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
-    "  <metadata/>"
-    "</domain>";
+virDomainPtr *domains;
 
-static const char minimal_metadata_xml[] =
-    ""
-    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-    "<domain type=\"kvm\" xmlns:ovirt=\"http://ovirt.org/vm/tune/1.0\">"
-    "  <metadata>"
-    "    <ovirtmap:tag "
-    "xmlns:ovirtmap=\"http://ovirt.org/ovirtmap/tag/1.0\">virt-0</ovirtmap:tag>"
-    "  </metadata>"
-    "</domain>";
-
-struct xml_state {
-  xmlDocPtr xml_doc;
-  xmlXPathContextPtr xpath_ctx;
-  xmlXPathObjectPtr xpath_obj;
-  char tag[PARTITION_TAG_MAX_LEN];
-};
-
-static int init_state(struct xml_state *st, const char *xml) {
-  memset(st, 0, sizeof(*st));
-
-  st->xml_doc = xmlReadDoc((const xmlChar *)xml, NULL, NULL, XML_PARSE_NONET);
-  if (st->xml_doc == NULL) {
+static int setup(void)
+{
+  if (virInitialize() != 0) {
+    printf("ERROR: virInitialize() != 0\n");
     return -1;
   }
-  st->xpath_ctx = xmlXPathNewContext(st->xml_doc);
-  if (st->xpath_ctx == NULL) {
+
+  conn = virConnectOpen("test:///default");
+  if (conn == NULL) {
+    printf("ERROR: virConnectOpen == NULL\n");
     return -1;
   }
+
   return 0;
 }
 
-static void fini_state(struct xml_state *st) {
-  if (st->xpath_ctx) {
-    xmlXPathFreeContext(st->xpath_ctx);
-    st->xpath_ctx = NULL;
+static int teardown(void)
+{
+  sfree(domains);
+  if (conn != NULL)
+    virConnectClose(conn);
+
+  return 0;
+}
+
+DEF_TEST(get_domain_state_notify) {
+  if (setup() == 0) {
+    int n_domains = virConnectListAllDomains(conn, &domains, VIR_CONNECT_GET_ALL_DOMAINS_STATS_PERSISTENT);
+    if (n_domains <= 0) {
+      printf("ERROR: virConnectListAllDomains: n_domains <= 0\n");
+      return -1;
+    }
+
+    int ret = get_domain_state_notify(domains[0]);
+    EXPECT_EQ_INT(0, ret);
   }
-  if (st->xml_doc) {
-    xmlFreeDoc(st->xml_doc);
-    st->xml_doc = NULL;
+  teardown();
+  
+  return 0;
+}
+
+DEF_TEST(persistent_domains_state_notification) {
+  if (setup() == 0) {
+    int ret = persistent_domains_state_notification();
+    EXPECT_EQ_INT(0, ret);
   }
-}
-
-#define TAG "virt-0"
-
-DEF_TEST(lv_domain_get_tag_no_metadata_xml) {
-  int err;
-  struct xml_state st;
-  err = init_state(&st, minimal_xml);
-  EXPECT_EQ_INT(0, err);
-
-  err = lv_domain_get_tag(st.xpath_ctx, "test", st.tag);
-
-  EXPECT_EQ_INT(0, err);
-  EXPECT_EQ_STR("", st.tag);
-
-  fini_state(&st);
+  teardown();
+  
   return 0;
 }
-
-DEF_TEST(lv_domain_get_tag_valid_xml) {
-  int err;
-  struct xml_state st;
-  err = init_state(&st, minimal_metadata_xml);
-  EXPECT_EQ_INT(0, err);
-
-  err = lv_domain_get_tag(st.xpath_ctx, "test", st.tag);
-
-  EXPECT_EQ_INT(0, err);
-  EXPECT_EQ_STR(TAG, st.tag);
-
-  return 0;
-}
-
-DEF_TEST(lv_default_instance_include_domain_without_tag) {
-  struct lv_read_instance *inst = NULL;
-  int ret;
-
-  ret = lv_init_instance(0, lv_read);
-  inst = &(lv_read_user_data[0].inst);
-  EXPECT_EQ_STR("virt-0", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "");
-  EXPECT_EQ_INT(1, ret);
-
-  lv_fini_instance(0);
-  return 0;
-}
-
-DEF_TEST(lv_regular_instance_skip_domain_without_tag) {
-  struct lv_read_instance *inst = NULL;
-  int ret;
-
-  ret = lv_init_instance(1, lv_read);
-  inst = &(lv_read_user_data[1].inst);
-  EXPECT_EQ_STR("virt-1", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "");
-  EXPECT_EQ_INT(0, ret);
-
-  lv_fini_instance(0);
-  return 0;
-}
-
-DEF_TEST(lv_include_domain_matching_tags) {
-  struct lv_read_instance *inst = NULL;
-  int ret;
-
-  ret = lv_init_instance(0, lv_read);
-  inst = &(lv_read_user_data[0].inst);
-  EXPECT_EQ_STR("virt-0", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "virt-0");
-  EXPECT_EQ_INT(1, ret);
-
-  ret = lv_init_instance(1, lv_read);
-  inst = &(lv_read_user_data[1].inst);
-  EXPECT_EQ_STR("virt-1", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "virt-1");
-  EXPECT_EQ_INT(1, ret);
-
-  lv_fini_instance(0);
-  lv_fini_instance(1);
-  return 0;
-}
-
-DEF_TEST(lv_default_instance_include_domain_with_unknown_tag) {
-  struct lv_read_instance *inst = NULL;
-  int ret;
-
-  ret = lv_init_instance(0, lv_read);
-  inst = &(lv_read_user_data[0].inst);
-  EXPECT_EQ_STR("virt-0", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "unknownFormat-tag");
-  EXPECT_EQ_INT(1, ret);
-
-  lv_fini_instance(0);
-  return 0;
-}
-
-DEF_TEST(lv_regular_instance_skip_domain_with_unknown_tag) {
-  struct lv_read_instance *inst = NULL;
-  int ret;
-
-  ret = lv_init_instance(1, lv_read);
-  inst = &(lv_read_user_data[1].inst);
-  EXPECT_EQ_STR("virt-1", inst->tag);
-
-  ret = lv_instance_include_domain(inst, "testing", "unknownFormat-tag");
-  EXPECT_EQ_INT(0, ret);
-
-  lv_fini_instance(0);
-  return 0;
-}
-#undef TAG
+#endif
 
 int main(void) {
-  RUN_TEST(lv_domain_get_tag_no_metadata_xml);
-  RUN_TEST(lv_domain_get_tag_valid_xml);
-
-  RUN_TEST(lv_default_instance_include_domain_without_tag);
-  RUN_TEST(lv_regular_instance_skip_domain_without_tag);
-  RUN_TEST(lv_include_domain_matching_tags);
-  RUN_TEST(lv_default_instance_include_domain_with_unknown_tag);
-  RUN_TEST(lv_regular_instance_skip_domain_with_unknown_tag);
+#ifdef HAVE_LIST_ALL_DOMAINS
+  RUN_TEST(get_domain_state_notify);
+  RUN_TEST(persistent_domains_state_notification);
+#endif
 
   END_TEST;
 }
-
-/* vim: set sw=2 sts=2 et : */

--- a/src/virt_test.c
+++ b/src/virt_test.c
@@ -59,8 +59,8 @@ static int teardown(void) {
 #ifdef HAVE_LIST_ALL_DOMAINS
 DEF_TEST(get_domain_state_notify) {
   if (setup() == 0) {
-    nr_domains = virConnectListAllDomains(
-        conn, &domains, VIR_CONNECT_LIST_DOMAINS_PERSISTENT);
+    nr_domains = virConnectListAllDomains(conn, &domains,
+                                          VIR_CONNECT_LIST_DOMAINS_PERSISTENT);
     if (nr_domains <= 0) {
       printf("ERROR: virConnectListAllDomains: nr_domains <= 0\n");
       return -1;


### PR DESCRIPTION
Introduced support for events that are sent directly from libvirt – it can be enabled when “PersistentNotification” parameter is set to “false”. This change is needed to handle properly all notifications for VMs state changes. In that mode collectd sends notification as soon as possible, right after it is received from libvirt (previously some state changes notifications could be not sent by collectd because of issues with caching domains data).
When “PersistentNotification“ parameter is set to “true”, then old implementation will be used – it handles state changes notification on its own in plugin code by caching VM states and comparing state changes but there are some known limitations (e.g there are problems with notifications for domains that were removed from cache before notification could be send).

Also introduced support for dispatching domain state information – previously information about current VM state could only be received using notification and it was not stored in CSV files. Now information about state with corresponding state reason is dispatched as ‘domain_state’,
