### PR TITLE
Fixes for ipmi plugin

### DIFF
--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -794,11 +794,9 @@ entity_sensor_update_handler(enum ipmi_update_e op,
 
     if (st->sel_enabled) {
       int status = 0;
-      /* register threshold event if threshold sensor support events */
-      if ((ipmi_sensor_get_event_reading_type(sensor) ==
-           IPMI_EVENT_READING_TYPE_THRESHOLD) &&
-          (ipmi_sensor_get_threshold_access(sensor) !=
-           IPMI_THRESHOLD_ACCESS_SUPPORT_NONE))
+      /* register threshold event handler */
+      if (ipmi_sensor_get_event_reading_type(sensor) ==
+          IPMI_EVENT_READING_TYPE_THRESHOLD)
         status = ipmi_sensor_add_threshold_event_handler(
             sensor, sensor_threshold_event_handler, st);
       /* register discrete handler if discrete/specific sensor support events */

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -1210,7 +1210,7 @@ static int c_ipmi_init(void) {
   }
 
   /* Don't send `ADD' notifications during startup (~ 1 minute) */
-  int cycles = 1 + (60 / CDTIME_T_TO_TIME_T(plugin_get_interval()));
+  int cycles = 1 + (int)(TIME_T_TO_CDTIME_T(60) / plugin_get_interval());
 
   st = instances;
   while (NULL != st) {

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -388,8 +388,12 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
         ipmi_sensor_get_event_support(sensor));
 
   /* Both `ignorelist' and `sensor_name_ptr' may be NULL. */
-  if (ignorelist_match(st->ignorelist, sensor_name_ptr) != 0)
-    return 0;
+  if (ignorelist_match(st->ignorelist, sensor_name_ptr) != 0) {
+    INFO("ipmi plugin: sensor_list_add: Ignore sensor `%s` of `%s`, "
+         "because it is on ignore list.",
+         sensor_name_ptr, st->name);
+    return -1;
+  }
 
   /* FIXME: Use rate unit or base unit to scale the value */
 
@@ -778,6 +782,11 @@ entity_sensor_update_handler(enum ipmi_update_e op,
                              ipmi_entity_t __attribute__((unused)) * entity,
                              ipmi_sensor_t *sensor, void *user_data) {
   c_ipmi_instance_t *st = user_data;
+  char sensor_name[DATA_MAX_NAME_LEN] = {0};
+
+  sensor_get_name(sensor, sensor_name, sizeof(sensor_name));
+  if (ignorelist_match(st->ignorelist, sensor_name) != 0)
+    return; /* Ignore - sensor on ignore list */
 
   if ((op == IPMI_ADDED) || (op == IPMI_CHANGED)) {
     /* Will check for duplicate entries.. */
@@ -798,9 +807,8 @@ entity_sensor_update_handler(enum ipmi_update_e op,
             sensor, sensor_discrete_event_handler, st);
 
       if (status) {
-        char buf[DATA_MAX_NAME_LEN] = {0};
-        sensor_get_name(sensor, buf, sizeof(buf));
-        ERROR("Unable to add sensor %s event handler, status: %d", buf, status);
+        ERROR("Unable to add sensor %s event handler, status: %d", sensor_name,
+              status);
       }
     }
   } else if (op == IPMI_DELETED) {


### PR DESCRIPTION
This PR contains three fixes for ipmi plugin:
- Fix crash in ipmi.so while interval set below 0,5
- Fix to ignore events from sensors on ignore list.
- Fix registration for events from specific sensors (e.g. 'System Airflow')