### PR TITLE
Add Apache connections stats

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -552,6 +552,14 @@ static int apache_read_host(user_data_t *user_data) /* {{{ */
       else if ((strcmp(fields[0], "IdleServers:") == 0) /* Apache 1.x */
                || (strcmp(fields[0], "IdleWorkers:") == 0) /* Apache 2.x */)
         submit_gauge("apache_idle_workers", NULL, atol(fields[1]), st);
+      else if (strcmp(fields[0], "ConnsTotal:") == 0)
+        submit_gauge("apache_connections", "total", atol(fields[1]), st);
+      else if (strcmp(fields[0], "ConnsAsyncWriting:") == 0)
+        submit_gauge("apache_connections", "writing", atol(fields[1]), st);
+      else if (strcmp(fields[0], "ConnsAsyncKeepAlive:") == 0)
+        submit_gauge("apache_connections", "keep_alive", atol(fields[1]), st);
+      else if (strcmp(fields[0], "ConnsAsyncClosing:") == 0)
+        submit_gauge("apache_connections", "closing", atol(fields[1]), st);
     }
   }
 


### PR DESCRIPTION
This commit adds async connections stats.
It is important metrics because e.g. keep alive connections are not shown in scoreboard.