### PR TITLE
Include kstat.h if available to provide kstat_ctl_t

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -134,6 +134,9 @@ static mach_msg_type_number_t cpu_list_len;
 /* #endif KERNEL_LINUX */
 
 #elif defined(HAVE_LIBKSTAT)
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
 /* colleague tells me that Sun doesn't sell systems with more than 100 or so
  * CPUs.. */
 #define MAX_NUMCPU 256

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -43,6 +43,10 @@
 #include <statgrab.h>
 #endif
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #ifndef COLLECTD_LOCALE
 #define COLLECTD_LOCALE "C"
 #endif
@@ -201,6 +205,7 @@ static int change_basedir(const char *orig_dir, _Bool create) {
 } /* static int change_basedir (char *dir) */
 
 #if HAVE_LIBKSTAT
+extern kstat_ctl_t *kc;
 static void update_kstat(void) {
   if (kc == NULL) {
     if ((kc = kstat_open()) == NULL)

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -60,6 +60,10 @@
 #include <sys/capability.h>
 #endif
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #ifdef HAVE_LIBKSTAT
 extern kstat_ctl_t *kc;
 #endif

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -27,6 +27,10 @@
 #include "common.h"
 #include "testing.h"
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;
 #endif /* HAVE_LIBKSTAT */

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -26,6 +26,10 @@
 
 #include "plugin.h"
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc = NULL;
 #endif /* HAVE_LIBKSTAT */

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -30,6 +30,10 @@
 #include "testing.h"
 #include "utils_subst.h"
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;
 #endif /* HAVE_LIBKSTAT */

--- a/src/daemon/utils_subst_test.c
+++ b/src/daemon/utils_subst_test.c
@@ -24,8 +24,8 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "common.h" /* for STATIC_ARRAY_SIZE */
 #include "collectd.h"
+#include "common.h" /* for STATIC_ARRAY_SIZE */
 
 #include "testing.h"
 #include "utils_subst.h"

--- a/src/disk.c
+++ b/src/disk.c
@@ -120,6 +120,9 @@ static struct gmesh geom_tree;
 /* #endif KERNEL_FREEBSD */
 
 #elif HAVE_LIBKSTAT
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
 #define MAX_NUMDISK 1024
 extern kstat_ctl_t *kc;
 static kstat_t *ksp[MAX_NUMDISK];

--- a/src/interface.c
+++ b/src/interface.c
@@ -91,6 +91,9 @@ static ignorelist_t *ignorelist = NULL;
 static _Bool report_inactive = 1;
 
 #ifdef HAVE_LIBKSTAT
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
 #define MAX_NUMIF 256
 extern kstat_ctl_t *kc;
 static kstat_t *ksp[MAX_NUMIF];

--- a/src/tape.c
+++ b/src/tape.c
@@ -29,6 +29,10 @@
 #error "No applicable input method."
 #endif
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #define MAX_NUMTAPE 256
 extern kstat_ctl_t *kc;
 static kstat_t *ksp[MAX_NUMTAPE];

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -53,6 +53,10 @@
  * Global variables
  */
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 extern kstat_ctl_t *kc;
 #endif /* #endif HAVE_LIBKSTAT */

--- a/src/utils_mount_test.c
+++ b/src/utils_mount_test.c
@@ -30,6 +30,10 @@
 #include "testing.h"
 #include "utils_mount.h"
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;
 #endif /* HAVE_LIBKSTAT */

--- a/src/utils_vl_lookup.c
+++ b/src/utils_vl_lookup.c
@@ -33,6 +33,10 @@
 #include "utils_avltree.h"
 #include "utils_vl_lookup.h"
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #if HAVE_LIBKSTAT
 kstat_ctl_t *kc;
 #endif /* HAVE_LIBKSTAT */

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -99,6 +99,11 @@ static void free_zfs_values(kstat_t *ksp) {
 }
 
 #elif defined(KERNEL_SOLARIS)
+
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 extern kstat_ctl_t *kc;
 
 static long long get_zfs_value(kstat_t *ksp, char *name) {


### PR DESCRIPTION
I just tried rebuilding collectd on Solaris again and noticed a lot of failured because kstat_ctl_t requires the inclusion of kstat.h.