### PR TITLE
write_prometheus plugin: Add support for custom labels

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1679,6 +1679,7 @@
 
 #<Plugin write_prometheus>
 #	Port "9103"
+#	Label "foo" "bar"
 #</Plugin>
 
 #<Plugin write_redis>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9246,6 +9246,10 @@ considered the time of the update. The result is that there appear more
 datapoints in I<Prometheus> than were actually created, but at least the metric
 doesn't disappear periodically.
 
+=item B<Label> I<Key> I<Value>
+
+Add a custom label to all metrics. It can be used multiple times.
+
 =back
 
 =head2 Plugin C<write_http>


### PR DESCRIPTION
Using the "Label" parameter in the write_prometheus configuration will add the specified label to all metrics exposed by the plugin.
This parameter can be used as many times as needed.