### PR TITLE
dpdk: increase buffer size for parsing lcores

### DIFF
--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -831,7 +831,7 @@ uint128_t str_to_uint128(const char *str, int len) {
       return lcore_mask;
   } else {
     char low_str[DATA_MAX_NAME_LEN];
-    char high_str[DATA_MAX_NAME_LEN*2];
+    char high_str[DATA_MAX_NAME_LEN * 2];
 
     memset(high_str, 0, sizeof(high_str));
     memset(low_str, 0, sizeof(low_str));

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -831,7 +831,7 @@ uint128_t str_to_uint128(const char *str, int len) {
       return lcore_mask;
   } else {
     char low_str[DATA_MAX_NAME_LEN];
-    char high_str[DATA_MAX_NAME_LEN];
+    char high_str[DATA_MAX_NAME_LEN*2];
 
     memset(high_str, 0, sizeof(high_str));
     memset(low_str, 0, sizeof(low_str));


### PR DESCRIPTION
This commit increases the size of the "high_str" buffer,
which is later used by the strncpy() function. Static analysis
showed that there was a potential issue in accessing this string
if the buffer is smaller.

Signed-off-by: Harry van Haaren <harry.van.haaren@intel.com>