### PR TITLE
utils_cache: fix pointer reference and meta_data ingestion

### DIFF
--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -203,6 +203,10 @@ static int uc_insert(const data_set_t *ds, const value_list_t *vl,
   ce->interval = vl->interval;
   ce->state = STATE_OKAY;
 
+  if (vl->meta != NULL) {
+    ce->meta = meta_data_clone(vl->meta);
+  }
+
   if (c_avl_insert(cache_tree, key_copy, ce) != 0) {
     sfree(key_copy);
     ERROR("uc_insert: c_avl_insert failed.");
@@ -891,13 +895,12 @@ int uc_iterator_get_values(uc_iter_t *iter, value_t **ret_values,
   if ((iter == NULL) || (iter->entry == NULL) || (ret_values == NULL) ||
       (ret_num == NULL))
     return -1;
-
   *ret_values =
       calloc(iter->entry->values_num, sizeof(*iter->entry->values_raw));
   if (*ret_values == NULL)
     return -1;
   for (size_t i = 0; i < iter->entry->values_num; ++i)
-    *ret_values[i] = iter->entry->values_raw[i];
+    (*ret_values)[i] = iter->entry->values_raw[i];
 
   *ret_num = iter->entry->values_num;
 


### PR DESCRIPTION
This changes a bad pointer reference in uc_iterator_get_values, which
would cause the grpc plugin to crash.

This also fixes uc_insert by making it properly add the meta_data to
the cache.

Both of these changes should make the grpc QueryValues call work as
expected.