### PR TITLE
text protocol: Add support for meta_data in PUTVAL

### DIFF
--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -49,9 +49,17 @@ static int set_option(value_list_t *vl, const char *key, const char *value) {
 
     if ((errno == 0) && (endptr != NULL) && (endptr != value) && (tmp > 0.0))
       vl->interval = DOUBLE_TO_CDTIME_T(tmp);
-  } else
+  } else if (strncasecmp("meta:", key, 5) == 0) {
+    if (vl->meta == NULL) {
+      vl->meta = meta_data_create();
+      if (vl->meta == NULL) {
+        return 1;
+      }
+    }
+    return meta_data_add_string(vl->meta, key + 5, value);
+  } else {
     return 1;
-
+  }
   return 0;
 } /* int set_option */
 

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -71,7 +71,11 @@ static int set_option(value_list_t *vl, const char *key, const char *value) {
 
     if (is_quoted(value, value_len)) {
       const char *value_str = strndup(value + 1, value_len - 2);
-      return meta_data_add_string(vl->meta, meta_key, value_str);
+      if (value_str == NULL) {
+        return 1;
+      }
+      meta_data_add_string(vl->meta, meta_key, value_str);
+      free((void *)value_str);
     }
     return 1;
   } else {

--- a/src/utils_cmds_test.c
+++ b/src/utils_cmds_test.c
@@ -51,114 +51,213 @@ static struct {
 } parse_data[] = {
     /* Valid FLUSH commands. */
     {
-        "FLUSH", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=myhost/magic/MAGIC", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=magic/MAGIC", &default_host_opts, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH timeout=123 plugin=\"A\"", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH timeout=123 plugin=\"A\"",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     /* Invalid FLUSH commands. */
     {
         /* Missing hostname; no default. */
-        "FLUSH identifier=magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Missing 'identifier' key. */
-        "FLUSH myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid timeout. */
-        "FLUSH timeout=A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH timeout=A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid identifier. */
-        "FLUSH identifier=invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid option. */
-        "FLUSH invalid=option", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH invalid=option",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid GETVAL commands. */
     {
-        "GETVAL myhost/magic/MAGIC", NULL, CMD_OK, CMD_GETVAL,
+        "GETVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_GETVAL,
     },
     {
-        "GETVAL magic/MAGIC", &default_host_opts, CMD_OK, CMD_GETVAL,
+        "GETVAL magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_GETVAL,
     },
 
     /* Invalid GETVAL commands. */
     {
-        "GETVAL magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid LISTVAL commands. */
     {
-        "LISTVAL", NULL, CMD_OK, CMD_LISTVAL,
+        "LISTVAL",
+        NULL,
+        CMD_OK,
+        CMD_LISTVAL,
     },
 
     /* Invalid LISTVAL commands. */
     {
-        "LISTVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "LISTVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", &default_host_opts, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC N:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42", NULL, CMD_OK,
+        "PUTVAL magic/MAGIC N:42",
+        &default_host_opts,
+        CMD_OK,
         CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23", NULL,
-        CMD_OK, CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC N:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC meta:KEY=\"string_value\" 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC meta:KEY='string_value' 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
     },
 
     /* Invalid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL magic/MAGIC N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL invalid N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL invalid N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC A:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC A:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/UNKNOWN 1234:42", NULL, CMD_PARSE_ERROR,
+        "PUTVAL myhost/magic/UNKNOWN 1234:42",
+        NULL,
+        CMD_PARSE_ERROR,
         CMD_UNKNOWN,
     },
     /*
@@ -173,10 +272,16 @@ static struct {
 
     /* Invalid commands. */
     {
-        "INVALID", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
     {
-        "INVALID interval=2", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID interval=2",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
 };
 
@@ -196,9 +301,10 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    snprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
-                                               "%d (type=%d [%s]); want %d "
-                                               "(type=%d [%s])",
+    snprintf(description, sizeof(description),
+             "cmd_parse (\"%s\", opts=%p) = "
+             "%d (type=%d [%s]); want %d "
+             "(type=%d [%s])",
              parse_data[i].input, parse_data[i].opts, status, cmd.type,
              CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
              parse_data[i].expected_type,

--- a/src/utils_cmds_test.c
+++ b/src/utils_cmds_test.c
@@ -51,213 +51,122 @@ static struct {
 } parse_data[] = {
     /* Valid FLUSH commands. */
     {
-        "FLUSH",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH", NULL, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH identifier=myhost/magic/MAGIC",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH identifier=myhost/magic/MAGIC", NULL, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH identifier=magic/MAGIC",
-        &default_host_opts,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH identifier=magic/MAGIC", &default_host_opts, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH timeout=123 plugin=\"A\"",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH timeout=123 plugin=\"A\"", NULL, CMD_OK, CMD_FLUSH,
     },
     /* Invalid FLUSH commands. */
     {
         /* Missing hostname; no default. */
-        "FLUSH identifier=magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH identifier=magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Missing 'identifier' key. */
-        "FLUSH myhost/magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid timeout. */
-        "FLUSH timeout=A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH timeout=A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid identifier. */
-        "FLUSH identifier=invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH identifier=invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid option. */
-        "FLUSH invalid=option",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH invalid=option", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid GETVAL commands. */
     {
-        "GETVAL myhost/magic/MAGIC",
-        NULL,
-        CMD_OK,
-        CMD_GETVAL,
+        "GETVAL myhost/magic/MAGIC", NULL, CMD_OK, CMD_GETVAL,
     },
     {
-        "GETVAL magic/MAGIC",
-        &default_host_opts,
-        CMD_OK,
-        CMD_GETVAL,
+        "GETVAL magic/MAGIC", &default_host_opts, CMD_OK, CMD_GETVAL,
     },
 
     /* Invalid GETVAL commands. */
     {
-        "GETVAL magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "GETVAL",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "GETVAL invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid LISTVAL commands. */
     {
-        "LISTVAL",
-        NULL,
-        CMD_OK,
-        CMD_LISTVAL,
+        "LISTVAL", NULL, CMD_OK, CMD_LISTVAL,
     },
 
     /* Invalid LISTVAL commands. */
     {
-        "LISTVAL invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "LISTVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42",
-        &default_host_opts,
-        CMD_OK,
+        "PUTVAL magic/MAGIC N:42", &default_host_opts, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC N:42", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42", NULL, CMD_OK,
         CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC N:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23", NULL,
+        CMD_OK, CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC meta:KEY=\"string_value\" 1234:42", NULL,
+        CMD_OK, CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC meta:KEY=\"string_value\" 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC meta:KEY='string_value' 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC meta:KEY='string_value' 1234:42", NULL,
+        CMD_OK, CMD_PUTVAL,
     },
 
     /* Invalid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL magic/MAGIC N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL invalid N:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL invalid N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC A:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC A:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL 1234:A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/UNKNOWN 1234:42",
-        NULL,
-        CMD_PARSE_ERROR,
+        "PUTVAL myhost/magic/UNKNOWN 1234:42", NULL, CMD_PARSE_ERROR,
         CMD_UNKNOWN,
     },
     /*
@@ -272,16 +181,10 @@ static struct {
 
     /* Invalid commands. */
     {
-        "INVALID",
-        NULL,
-        CMD_UNKNOWN_COMMAND,
-        CMD_UNKNOWN,
+        "INVALID", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
     },
     {
-        "INVALID interval=2",
-        NULL,
-        CMD_UNKNOWN_COMMAND,
-        CMD_UNKNOWN,
+        "INVALID interval=2", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
     },
 };
 
@@ -301,10 +204,9 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    snprintf(description, sizeof(description),
-             "cmd_parse (\"%s\", opts=%p) = "
-             "%d (type=%d [%s]); want %d "
-             "(type=%d [%s])",
+    snprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
+                                               "%d (type=%d [%s]); want %d "
+                                               "(type=%d [%s])",
              parse_data[i].input, parse_data[i].opts, status, cmd.type,
              CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
              parse_data[i].expected_type,


### PR DESCRIPTION
This adds the support for string meta_data in PUTVAL. This allows users
to send meta_data using either the unixsock plugin or the exec plugin.

The meta_data is specified using options of the form `meta:<KEY>=<VALUE>`.
As an example, meta:foo=bar will add an entry with key "foo" and value
"bar".