### PR TITLE
adding mosquitto_loop after mosquitto_publish, otherwise qos=1 messag…

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -445,9 +445,13 @@ static int publish(mqtt_client_conf_t *conf, char const *topic,
     return -1;
   }
 
-  // -1 means default timeout, 1000ms
-  // second argument is unused, set to 1 for future compatibility
-  status = mosquitto_loop(conf->mosq, -1, 1);
+  #if LIBMOSQUITTO_MAJOR == 0
+    status = mosquitto_loop(conf->mosq, /* timeout = */ 1000 /* ms */);
+  #else
+    status = mosquitto_loop(conf->mosq,
+                            /* timeout[ms] = */ 1000,
+                            /* max_packets = */ 1);
+  #endif
 
   if (status != MOSQ_ERR_SUCCESS) {
     c_complain(LOG_ERR, &conf->complaint_cantpublish,


### PR DESCRIPTION
ChangeLog: collectd-mod-mqtt: hangs after 20 (qos=1) messages are sent

adding mosquitto_loop after mosquitto_publish, otherwise qos=1 messages would not be considered acknowledged by the broker.

A proposed fix for https://github.com/collectd/collectd/issues/2727

I haven't tested yet with messages of QoS=2 but now collectd-mod-mqtt is able to push more than 20 messages (without the mosquitto_loop reading the socket after mosquitto_publish, libmosquitto was unaware that the messages were acknowledged by the broker).