### PR TITLE
Tree wide: Replace sstrerror() with STRERRNO.

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -358,10 +358,9 @@ static int link_filter_cb(const struct nlmsghdr *nlh,
       continue;
 
     if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*stats.stats64)) < 0) {
-      char errbuf[1024];
       ERROR("netlink plugin: link_filter_cb: IFLA_STATS64 mnl_attr_validate2 "
             "failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return MNL_CB_ERROR;
     }
     stats.stats64 = mnl_attr_get_payload(attr);
@@ -376,10 +375,9 @@ static int link_filter_cb(const struct nlmsghdr *nlh,
       continue;
 
     if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*stats.stats32)) < 0) {
-      char errbuf[1024];
       ERROR("netlink plugin: link_filter_cb: IFLA_STATS mnl_attr_validate2 "
             "failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return MNL_CB_ERROR;
     }
     stats.stats32 = mnl_attr_get_payload(attr);
@@ -404,10 +402,9 @@ static int qos_attr_cb(const struct nlattr *attr, void *data) {
 
   if (mnl_attr_get_type(attr) == TCA_STATS_BASIC) {
     if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*q_stats->bs)) < 0) {
-      char errbuf[1024];
       ERROR("netlink plugin: qos_attr_cb: TCA_STATS_BASIC mnl_attr_validate2 "
             "failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return MNL_CB_ERROR;
     }
     q_stats->bs = mnl_attr_get_payload(attr);
@@ -556,10 +553,9 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       continue;
 
     if (mnl_attr_validate2(attr, MNL_TYPE_UNSPEC, sizeof(*ts)) < 0) {
-      char errbuf[1024];
       ERROR("netlink plugin: qos_filter_cb: TCA_STATS mnl_attr_validate2 "
             "failed: %s",
-            sstrerror(errno, errbuf, sizeof(errbuf)));
+            STRERRNO);
       return MNL_CB_ERROR;
     }
     ts = mnl_attr_get_payload(attr);
@@ -694,9 +690,7 @@ static int ir_read(void) {
     ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
   }
   if (ret < 0) {
-    char errbuf[1024];
-    ERROR("netlink plugin: ir_read: mnl_socket_recvfrom failed: %s",
-          sstrerror(errno, errbuf, sizeof(errbuf)));
+    ERROR("netlink plugin: ir_read: mnl_socket_recvfrom failed: %s", STRERRNO);
     return (-1);
   }
 
@@ -741,9 +735,8 @@ static int ir_read(void) {
         ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
       }
       if (ret < 0) {
-        char errbuf[1024];
         ERROR("netlink plugin: ir_read: mnl_socket_recvfrom failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
         continue;
       }
     } /* for (type_index) */

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -766,9 +766,8 @@ static int prom_open_socket(int addrfamily) {
 
     int tmp = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof(tmp)) != 0) {
-      char errbuf[1024];
       WARNING("write_prometheus: setsockopt(SO_REUSEADDR) failed: %s",
-              sstrerror(errno, errbuf, sizeof(errbuf)));
+              STRERRNO);
       close(fd);
       fd = -1;
       continue;


### PR DESCRIPTION
References: #2519