### PR TITLE
Disk pending operation data is missing

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -819,7 +819,7 @@ static int disk_read(void) {
       if (read_merged || write_merged)
         ds->has_merged = 1;
 
-      if (in_progress)
+      if (in_progress != NAN)
         ds->has_in_progress = 1;
 
       if (io_time)


### PR DESCRIPTION
Hello,
I noticed that disk `pending_operation` datasource is missing on some of my servers. On these servers `in_progress` value is nearly always 0. I made a quick fix to allow `in_progress` value to be dispatched when equal to zero but I don't know if is it safe to compare with `NAN`..


