### PR TITLE
Fix routeros unset radio-name showing up as "(null)"

### DIFF
--- a/src/routeros.c
+++ b/src/routeros.c
@@ -142,7 +142,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** RX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
-           r->radio_name);
+           r->radio_name ? r->radio_name : "default");
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -151,7 +151,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** TX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
-           r->radio_name);
+           r->radio_name ? r->radio_name : "default");
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -160,7 +160,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** RX / TX ***/
   snprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface,
-           r->radio_name);
+           r->radio_name ? r->radio_name : "default");
   cr_submit_io(rd, "if_octets", type_instance, (derive_t)r->rx_bytes,
                (derive_t)r->tx_bytes);
   cr_submit_gauge(rd, "snr", type_instance, (gauge_t)r->signal_to_noise);


### PR DESCRIPTION
This happens when the `radio-name` property is unset on a wireless
interface. Why this is done is beyond me, but it does seem to be a thing.