### PR TITLE
Set the thread name before detaching the thread

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -683,8 +683,8 @@ static int camqp_subscribe_init(camqp_config_t *conf) /* {{{ */
   tmp = subscriber_threads + subscriber_threads_num;
   memset(tmp, 0, sizeof(*tmp));
 
-  status = plugin_thread_create(tmp, /* attr = */ NULL, camqp_subscribe_thread,
-                                conf, "amqp subscribe");
+  status =
+      plugin_thread_create(tmp, camqp_subscribe_thread, conf, "amqp subscribe");
   if (status != 0) {
     ERROR("amqp plugin: pthread_create failed: %s", STRERROR(status));
     return status;

--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -735,9 +735,8 @@ static int amqp1_init(void) /* {{{ */
   if (proactor == NULL) {
     pthread_mutex_init(&send_lock, /* attr = */ NULL);
     /* start_thread */
-    int status =
-        plugin_thread_create(&event_thread_id, NULL /* no attributes */,
-                             event_thread, NULL /* no argument */, "handle");
+    int status = plugin_thread_create(&event_thread_id, event_thread,
+                                      NULL /* no argument */, "handle");
     if (status != 0) {
       ERROR("amqp1 plugin: pthread_create failed: %s", STRERRNO);
     } else {

--- a/src/connectivity.c
+++ b/src/connectivity.c
@@ -743,7 +743,7 @@ static int start_netlink_thread(void) /* {{{ */
   }
 
   status = plugin_thread_create(&connectivity_netlink_thread_id,
-                                /* attr = */ NULL, connectivity_netlink_thread,
+                                connectivity_netlink_thread,
                                 /* arg = */ (void *)0, "connectivity");
   if (status != 0) {
     connectivity_netlink_thread_loop = 0;
@@ -778,10 +778,9 @@ static int start_dequeue_thread(void) /* {{{ */
 
   connectivity_dequeue_thread_loop = 1;
 
-  int status =
-      plugin_thread_create(&connectivity_dequeue_thread_id,
-                           /* attr = */ NULL, connectivity_dequeue_thread,
-                           /* arg = */ (void *)0, "connectivity");
+  int status = plugin_thread_create(&connectivity_dequeue_thread_id,
+                                    connectivity_dequeue_thread,
+                                    /* arg = */ (void *)0, "connectivity");
   if (status != 0) {
     connectivity_dequeue_thread_loop = 0;
     ERROR("connectivity plugin: Starting dequeue thread failed.");

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1357,7 +1357,8 @@ EXPORT int plugin_register_cache_event(const char *name,
   user_data_t user_data;
   if (ud == NULL) {
     user_data = (user_data_t){
-        .data = NULL, .free_func = NULL,
+        .data = NULL,
+        .free_func = NULL,
     };
   } else {
     user_data = *ud;
@@ -2728,9 +2729,8 @@ static void *plugin_thread_start(void *arg) {
   return start_routine(plugin_arg);
 } /* void *plugin_thread_start */
 
-int plugin_thread_create(pthread_t *thread, const pthread_attr_t *attr,
-                         void *(*start_routine)(void *), void *arg,
-                         char const *name) {
+int plugin_thread_create(pthread_t *thread, void *(*start_routine)(void *),
+                         void *arg, char const *name) {
   plugin_thread_t *plugin_thread;
 
   plugin_thread = malloc(sizeof(*plugin_thread));
@@ -2741,7 +2741,7 @@ int plugin_thread_create(pthread_t *thread, const pthread_attr_t *attr,
   plugin_thread->start_routine = start_routine;
   plugin_thread->arg = arg;
 
-  int ret = pthread_create(thread, attr, plugin_thread_start, plugin_thread);
+  int ret = pthread_create(thread, NULL, plugin_thread_start, plugin_thread);
   if (ret != 0) {
     sfree(plugin_thread);
     return ret;

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -473,9 +473,8 @@ cdtime_t plugin_get_interval(void);
  * Context-aware thread management.
  */
 
-int plugin_thread_create(pthread_t *thread, const pthread_attr_t *attr,
-                         void *(*start_routine)(void *), void *arg,
-                         char const *name);
+int plugin_thread_create(pthread_t *thread, void *(*start_routine)(void *),
+                         void *arg, char const *name);
 
 /*
  * Plugins need to implement this

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -233,7 +233,6 @@ plugin_ctx_t plugin_set_ctx(plugin_ctx_t ctx) {
 cdtime_t plugin_get_interval(void) { return mock_context.interval; }
 
 int plugin_thread_create(__attribute__((unused)) pthread_t *thread,
-                         __attribute__((unused)) const pthread_attr_t *attr,
                          __attribute__((unused)) void *(*start_routine)(void *),
                          __attribute__((unused)) void *arg,
                          __attribute__((unused)) char const *name) {

--- a/src/dns.c
+++ b/src/dns.c
@@ -284,7 +284,7 @@ static int dns_init(void) {
   if (listen_thread_init != 0)
     return -1;
 
-  status = plugin_thread_create(&listen_thread, NULL, dns_child_loop, (void *)0,
+  status = plugin_thread_create(&listen_thread, dns_child_loop, (void *)0,
                                 "dns listen");
   if (status != 0) {
     ERROR("dns plugin: pthread_create failed: %s", STRERRNO);

--- a/src/exec.c
+++ b/src/exec.c
@@ -834,7 +834,6 @@ static int exec_read(void) /* {{{ */
 {
   for (program_list_t *pl = pl_head; pl != NULL; pl = pl->next) {
     pthread_t t;
-    pthread_attr_t attr;
 
     /* Only execute `normal' style executables here. */
     if ((pl->flags & PL_NORMAL) == 0)
@@ -849,14 +848,13 @@ static int exec_read(void) /* {{{ */
     pl->flags |= PL_RUNNING;
     pthread_mutex_unlock(&pl_lock);
 
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     int status =
-        plugin_thread_create(&t, &attr, exec_read_one, (void *)pl, "exec read");
-    if (status != 0) {
+        plugin_thread_create(&t, exec_read_one, (void *)pl, "exec read");
+    if (status == 0) {
+      pthread_detach(t);
+    } else {
       ERROR("exec plugin: plugin_thread_create failed.");
     }
-    pthread_attr_destroy(&attr);
   } /* for (pl) */
 
   return 0;
@@ -868,7 +866,6 @@ static int exec_notification(const notification_t *n, /* {{{ */
 
   for (program_list_t *pl = pl_head; pl != NULL; pl = pl->next) {
     pthread_t t;
-    pthread_attr_t attr;
 
     /* Only execute `notification' style executables here. */
     if ((pl->flags & PL_NOTIF_ACTION) == 0)
@@ -892,14 +889,13 @@ static int exec_notification(const notification_t *n, /* {{{ */
     pln->n.meta = NULL;
     plugin_notification_meta_copy(&pln->n, n);
 
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-    int status = plugin_thread_create(&t, &attr, exec_notification_one,
-                                      (void *)pln, "exec notify");
-    if (status != 0) {
+    int status = plugin_thread_create(&t, exec_notification_one, (void *)pln,
+                                      "exec notify");
+    if (status == 0) {
+      pthread_detach(t);
+    } else {
       ERROR("exec plugin: plugin_thread_create failed.");
     }
-    pthread_attr_destroy(&attr);
   } /* for (pl) */
 
   return 0;

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -789,9 +789,8 @@ static int mc_receive_thread_start(void) /* {{{ */
 
   mc_receive_thread_loop = 1;
 
-  status =
-      plugin_thread_create(&mc_receive_thread_id, /* attr = */ NULL,
-                           mc_receive_thread, /* args = */ NULL, "gmond recv");
+  status = plugin_thread_create(&mc_receive_thread_id, mc_receive_thread,
+                                /* args = */ NULL, "gmond recv");
   if (status != 0) {
     ERROR("gmond plugin: Starting receive thread failed.");
     mc_receive_thread_loop = 0;

--- a/src/gps.c
+++ b/src/gps.c
@@ -287,8 +287,7 @@ static int cgps_init(void) {
         CDTIME_T_TO_DOUBLE(cgps_config_data.timeout),
         CDTIME_T_TO_DOUBLE(cgps_config_data.pause_connect));
 
-  status =
-      plugin_thread_create(&cgps_thread_id, NULL, cgps_thread, NULL, "gps");
+  status = plugin_thread_create(&cgps_thread_id, cgps_thread, NULL, "gps");
   if (status != 0) {
     ERROR("gps plugin: pthread_create() failed.");
     return -1;

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -1275,8 +1275,7 @@ static int c_ipmi_init(void) {
     st->init_in_progress = cycles;
     st->active = true;
 
-    status = plugin_thread_create(&st->thread_id, /* attr = */ NULL,
-                                  c_ipmi_thread_main,
+    status = plugin_thread_create(&st->thread_id, c_ipmi_thread_main,
                                   /* user data = */ (void *)st, "ipmi");
 
     if (status != 0) {

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -636,8 +636,8 @@ static int mcelog_init(void) {
   }
 
   if (strlen(socket_adapter.unix_sock.sun_path)) {
-    if (plugin_thread_create(&g_mcelog_config.tid, NULL, poll_worker, NULL,
-                             NULL) != 0) {
+    if (plugin_thread_create(&g_mcelog_config.tid, poll_worker, NULL, NULL) !=
+        0) {
       ERROR(MCELOG_PLUGIN ": Error creating poll thread.");
       return -1;
     }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -744,7 +744,6 @@ static int mqtt_init(void) {
       continue;
 
     status = plugin_thread_create(&subscribers[i]->thread,
-                                  /* attrs = */ NULL,
                                   /* func  = */ subscribers_thread,
                                   /* args  = */ subscribers[i],
                                   /* name  = */ "mqtt");

--- a/src/network.c
+++ b/src/network.c
@@ -3223,9 +3223,8 @@ static int network_init(void) {
 
   if (dispatch_thread_running == 0) {
     int status;
-    status = plugin_thread_create(&dispatch_thread_id, NULL /* no attributes */,
-                                  dispatch_thread, NULL /* no argument */,
-                                  "network disp");
+    status = plugin_thread_create(&dispatch_thread_id, dispatch_thread,
+                                  NULL /* no argument */, "network disp");
     if (status != 0) {
       ERROR("network: pthread_create failed: %s", STRERRNO);
     } else {
@@ -3235,9 +3234,8 @@ static int network_init(void) {
 
   if (receive_thread_running == 0) {
     int status;
-    status = plugin_thread_create(&receive_thread_id, NULL /* no attributes */,
-                                  receive_thread, NULL /* no argument */,
-                                  "network recv");
+    status = plugin_thread_create(&receive_thread_id, receive_thread,
+                                  NULL /* no argument */, "network recv");
     if (status != 0) {
       ERROR("network: pthread_create failed: %s", STRERRNO);
     } else {

--- a/src/pinba.c
+++ b/src/pinba.c
@@ -574,8 +574,7 @@ static int plugin_init(void) /* {{{ */
   if (collector_thread_running)
     return 0;
 
-  status = plugin_thread_create(&collector_thread_id,
-                                /* attrs = */ NULL, collector_thread,
+  status = plugin_thread_create(&collector_thread_id, collector_thread,
                                 /* args = */ NULL, "pinba collector");
   if (status != 0) {
     ERROR("pinba plugin: pthread_create(3) failed: %s", STRERRNO);

--- a/src/ping.c
+++ b/src/ping.c
@@ -359,7 +359,7 @@ static int start_thread(void) /* {{{ */
 
   ping_thread_loop = 1;
   ping_thread_error = 0;
-  status = plugin_thread_create(&ping_thread_id, /* attr = */ NULL, ping_thread,
+  status = plugin_thread_create(&ping_thread_id, ping_thread,
                                 /* arg = */ (void *)0, "ping");
   if (status != 0) {
     ping_thread_loop = 0;

--- a/src/procevent.c
+++ b/src/procevent.c
@@ -1006,7 +1006,7 @@ static int start_netlink_thread(void) /* {{{ */
   procevent_netlink_thread_loop = 1;
   procevent_netlink_thread_error = 0;
 
-  status = plugin_thread_create(&procevent_netlink_thread_id, /* attr = */ NULL,
+  status = plugin_thread_create(&procevent_netlink_thread_id,
                                 procevent_netlink_thread,
                                 /* arg = */ (void *)0, "procevent");
   if (status != 0) {
@@ -1043,7 +1043,7 @@ static int start_dequeue_thread(void) /* {{{ */
   procevent_dequeue_thread_loop = 1;
 
   int status = plugin_thread_create(&procevent_dequeue_thread_id,
-                                    /* attr = */ NULL, procevent_dequeue_thread,
+                                    procevent_dequeue_thread,
                                     /* arg = */ (void *)0, "procevent");
   if (status != 0) {
     procevent_dequeue_thread_loop = 0;

--- a/src/python.c
+++ b/src/python.c
@@ -1170,7 +1170,7 @@ static int cpy_init(void) {
       ERROR("python: Unable to create pipe.");
       return 1;
     }
-    if (plugin_thread_create(&thread, NULL, cpy_interactive, pipefd + 1,
+    if (plugin_thread_create(&thread, cpy_interactive, pipefd + 1,
                              "python interpreter")) {
       ERROR("python: Error creating thread for interactive interpreter.");
     }

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -1057,9 +1057,8 @@ static int rrd_init(void) {
 
   pthread_mutex_unlock(&cache_lock);
 
-  int status =
-      plugin_thread_create(&queue_thread, /* attr = */ NULL, rrd_queue_thread,
-                           /* args = */ NULL, "rrdtool queue");
+  int status = plugin_thread_create(&queue_thread, rrd_queue_thread,
+                                    /* args = */ NULL, "rrdtool queue");
   if (status != 0) {
     ERROR("rrdtool plugin: Cannot create queue-thread.");
     return -1;

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -337,8 +337,8 @@ static int sigrok_init(void) {
     return -1;
   }
 
-  status = plugin_thread_create(&sr_thread, NULL, sigrok_read_thread, NULL,
-                                "sigrok read");
+  status =
+      plugin_thread_create(&sr_thread, sigrok_read_thread, NULL, "sigrok read");
   if (status != 0) {
     ERROR("sigrok plugin: Failed to create thread: %s.", STRERRNO);
     return -1;

--- a/src/sysevent.c
+++ b/src/sysevent.c
@@ -754,9 +754,9 @@ static int start_socket_thread(void) /* {{{ */
 
   DEBUG("sysevent plugin: starting socket thread");
 
-  int status = plugin_thread_create(&sysevent_socket_thread_id,
-                                    /* attr = */ NULL, sysevent_socket_thread,
-                                    /* arg = */ (void *)0, "sysevent");
+  int status =
+      plugin_thread_create(&sysevent_socket_thread_id, sysevent_socket_thread,
+                           /* arg = */ (void *)0, "sysevent");
   if (status != 0) {
     sysevent_socket_thread_loop = 0;
     ERROR("sysevent plugin: starting socket thread failed.");
@@ -780,9 +780,9 @@ static int start_dequeue_thread(void) /* {{{ */
 
   sysevent_dequeue_thread_loop = 1;
 
-  int status = plugin_thread_create(&sysevent_dequeue_thread_id,
-                                    /* attr = */ NULL, sysevent_dequeue_thread,
-                                    /* arg = */ (void *)0, "ssyevent");
+  int status =
+      plugin_thread_create(&sysevent_dequeue_thread_id, sysevent_dequeue_thread,
+                           /* arg = */ (void *)0, "ssyevent");
   if (status != 0) {
     sysevent_dequeue_thread_loop = 0;
     ERROR("sysevent plugin: Starting dequeue thread failed.");

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -926,8 +926,8 @@ static int ovs_db_event_thread_init(ovs_db_t *pdb) {
   }
   /* start event thread */
   pthread_t tid;
-  if (plugin_thread_create(&tid, NULL, ovs_event_worker, pdb,
-                           "utils_ovs:event") != 0) {
+  if (plugin_thread_create(&tid, ovs_event_worker, pdb, "utils_ovs:event") !=
+      0) {
     pthread_mutex_unlock(&pdb->event_thread.mutex);
     pthread_mutex_destroy(&pdb->event_thread.mutex);
     pthread_cond_destroy(&pdb->event_thread.cond);
@@ -972,8 +972,7 @@ static int ovs_db_poll_thread_init(ovs_db_t *pdb) {
   /* start poll thread */
   pthread_t tid;
   pdb->poll_thread.state = OVS_DB_POLL_STATE_RUNNING;
-  if (plugin_thread_create(&tid, NULL, ovs_poll_worker, pdb,
-                           "utils_ovs:poll") != 0) {
+  if (plugin_thread_create(&tid, ovs_poll_worker, pdb, "utils_ovs:poll") != 0) {
     pthread_mutex_destroy(&pdb->poll_thread.mutex);
     return -1;
   }


### PR DESCRIPTION
``pthread_setname_np()`` does not work reliably when a thread has been created in a detached state. Set the thread name first, and then call ``pthread_detach()`` afterwards (if necessary).

This prevents error messages like this one:
```
set_thread_name("unixsock conn"): No such process
```

ChangeLog: Fix a race condition when setting thread names