### PR TITLE
write_prometheus: Set SO_REUSEADDR on listening socket

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -764,6 +764,16 @@ static int prom_open_socket(int addrfamily) {
     if (fd == -1)
       continue;
 
+    int tmp = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof(tmp)) != 0) {
+      char errbuf[1024];
+      WARNING("write_prometheus: setsockopt(SO_REUSEADDR) failed: %s",
+              sstrerror(errno, errbuf, sizeof(errbuf)));
+      close(fd);
+      fd = -1;
+      continue;
+    }
+
     if (bind(fd, ai->ai_addr, ai->ai_addrlen) != 0) {
       close(fd);
       fd = -1;


### PR DESCRIPTION
Otherwise Collectd fails to bind the socket after restart.

Thanks to Richard Weinberger and Brandon Hume for reporting. 

Closes: #2570
Closes: #2673
Closes: #2715
(cherry picked from commit 2c78bdf94c0fdd6240d5d202cf5aba12ac8c5a20)