### PR TITLE
Disable new gcc8 warnings

### DIFF
--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -149,6 +149,11 @@ static int parse_int(void *payload, size_t payload_size, uint64_t *out) {
   return 0;
 }
 
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+
 static int parse_string(void *payload, size_t payload_size, char *out,
                         size_t out_size) {
   char *in = payload;
@@ -160,6 +165,8 @@ static int parse_string(void *payload, size_t payload_size, char *out,
   strncpy(out, in, out_size);
   return 0;
 }
+
+#pragma GCC diagnostic pop
 
 static int parse_identifier(uint16_t type, void *payload, size_t payload_size,
                             lcc_value_list_t *state) {

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -570,6 +570,11 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   return ret_str;
 } /* }}} char *sensu_value_to_json */
 
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 /*
  * Uses replace_str2() implementation from
  * http://creativeandcritical.net/str-replace-c/
@@ -631,6 +636,8 @@ static char *replace_str(const char *str, const char *old, /* {{{ */
 
   return ret;
 } /* }}} char *replace_str */
+
+#pragma GCC diagnostic pop
 
 static char *replace_json_reserved(const char *message) /* {{{ */
 {


### PR DESCRIPTION
GCC seems to be not able to detect the checks for size are
already in place

Signed-off-by: Khem Raj <raj.khem@gmail.com>