### PR TITLE
Fix collecdmon not start collectd

### DIFF
--- a/src/collectdmon.c
+++ b/src/collectdmon.c
@@ -135,7 +135,7 @@ static int daemonize(void) {
   }
 
   pid_t pid = fork();
-  if (pid  < 0) {
+  if (pid < 0) {
     fprintf(stderr, "Error: fork() failed: %s\n", strerror(errno));
     return -1;
   } else if (pid != 0) {
@@ -323,8 +323,7 @@ int main(int argc, char **argv) {
   }
 
   struct sigaction sa = {
-    .sa_handler = sig_int_term_handler,
-    .sa_flags = 0,
+      .sa_handler = sig_int_term_handler, .sa_flags = 0,
   };
   sigemptyset(&sa.sa_mask);
 


### PR DESCRIPTION
Because collectdmon cannot exit parse command line options loop,
it cannot execute collectd start processing.