### PR TITLE
Remove empty `cmd_listval_t` data structure and related no-op code.

### DIFF
--- a/src/utils_cmd_listval.c
+++ b/src/utils_cmd_listval.c
@@ -34,8 +34,6 @@
 #include "utils_parse_option.h"
 
 cmd_status_t cmd_parse_listval(size_t argc, char **argv,
-                               cmd_listval_t *ret_listval
-                               __attribute__((unused)),
                                const cmd_options_t *opts
                                __attribute__((unused)),
                                cmd_error_handler_t *err) {
@@ -103,7 +101,3 @@ cmd_status_t cmd_handle_listval(FILE *fh, char *buffer) {
 
   free_everything_and_return(CMD_OK);
 } /* cmd_status_t cmd_handle_listval */
-
-void cmd_destroy_listval(cmd_listval_t *listval __attribute__((unused))) {
-  /* nothing to do */
-} /* void cmd_destroy_listval */

--- a/src/utils_cmd_listval.h
+++ b/src/utils_cmd_listval.h
@@ -32,12 +32,9 @@
 #include "utils_cmds.h"
 
 cmd_status_t cmd_parse_listval(size_t argc, char **argv,
-                               cmd_listval_t *ret_listval,
                                const cmd_options_t *opts,
                                cmd_error_handler_t *err);
 
 cmd_status_t cmd_handle_listval(FILE *fh, char *buffer);
-
-void cmd_destroy_listval(cmd_listval_t *listval);
 
 #endif /* UTILS_CMD_LISTVAL_H */

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -206,8 +206,7 @@ cmd_status_t cmd_parsev(size_t argc, char **argv, cmd_t *ret_cmd,
         cmd_parse_getval(argc - 1, argv + 1, &ret_cmd->cmd.getval, opts, err);
   } else if (strcasecmp("LISTVAL", command) == 0) {
     ret_cmd->type = CMD_LISTVAL;
-    status =
-        cmd_parse_listval(argc - 1, argv + 1, opts, err);
+    status = cmd_parse_listval(argc - 1, argv + 1, opts, err);
   } else if (strcasecmp("PUTVAL", command) == 0) {
     ret_cmd->type = CMD_PUTVAL;
     status =

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -207,7 +207,7 @@ cmd_status_t cmd_parsev(size_t argc, char **argv, cmd_t *ret_cmd,
   } else if (strcasecmp("LISTVAL", command) == 0) {
     ret_cmd->type = CMD_LISTVAL;
     status =
-        cmd_parse_listval(argc - 1, argv + 1, &ret_cmd->cmd.listval, opts, err);
+        cmd_parse_listval(argc - 1, argv + 1, opts, err);
   } else if (strcasecmp("PUTVAL", command) == 0) {
     ret_cmd->type = CMD_PUTVAL;
     status =
@@ -252,7 +252,6 @@ void cmd_destroy(cmd_t *cmd) {
     cmd_destroy_getval(&cmd->cmd.getval);
     break;
   case CMD_LISTVAL:
-    cmd_destroy_listval(&cmd->cmd.listval);
     break;
   case CMD_PUTVAL:
     cmd_destroy_putval(&cmd->cmd.putval);

--- a/src/utils_cmds.h
+++ b/src/utils_cmds.h
@@ -62,9 +62,6 @@ typedef struct {
 } cmd_getval_t;
 
 typedef struct {
-} cmd_listval_t;
-
-typedef struct {
   /* The raw identifier as provided by the user. */
   char *raw_identifier;
 
@@ -86,7 +83,6 @@ typedef struct {
   union {
     cmd_flush_t flush;
     cmd_getval_t getval;
-    cmd_listval_t listval;
     cmd_putval_t putval;
   } cmd;
 } cmd_t;

--- a/src/utils_cmds.h
+++ b/src/utils_cmds.h
@@ -39,13 +39,13 @@ typedef enum {
   CMD_PUTVAL = 4,
 } cmd_type_t;
 #define CMD_TO_STRING(type)                                                    \
-  ((type) == CMD_FLUSH) ? "FLUSH" : ((type) == CMD_GETVAL)                     \
-                                        ? "GETVAL"                             \
-                                        : ((type) == CMD_LISTVAL)              \
-                                              ? "LISTVAL"                      \
-                                              : ((type) == CMD_PUTVAL)         \
-                                                    ? "PUTVAL"                 \
-                                                    : "UNKNOWN"
+  ((type) == CMD_FLUSH)                                                        \
+      ? "FLUSH"                                                                \
+      : ((type) == CMD_GETVAL)                                                 \
+            ? "GETVAL"                                                         \
+            : ((type) == CMD_LISTVAL)                                          \
+                  ? "LISTVAL"                                                  \
+                  : ((type) == CMD_PUTVAL) ? "PUTVAL" : "UNKNOWN"
 
 typedef struct {
   double timeout;


### PR DESCRIPTION
Closes: #2739