### PR TITLE
Added missing include of 'kstat.h'

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -60,6 +60,10 @@
 #include <sys/capability.h>
 #endif
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #ifdef HAVE_LIBKSTAT
 extern kstat_ctl_t *kc;
 #endif


### PR DESCRIPTION
This adressed to solve compilation issue on Solaris platform:

src/daemon/common.c:64:8: error: unknown type name 'kstat_ctl_t'
  extern kstat_ctl_t *kc;