### PR TITLE
Added missing include of 'kstat.h' and variable declaration

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -43,6 +43,10 @@
 #include <statgrab.h>
 #endif
 
+#if HAVE_KSTAT_H
+#include <kstat.h>
+#endif
+
 #ifndef COLLECTD_LOCALE
 #define COLLECTD_LOCALE "C"
 #endif
@@ -208,6 +212,7 @@ static int change_basedir(const char *orig_dir, _Bool create) {
 } /* static int change_basedir (char *dir) */
 
 #if HAVE_LIBKSTAT
+extern kstat_ctl_t *kc;
 static void update_kstat(void) {
   if (kc == NULL) {
     if ((kc = kstat_open()) == NULL)


### PR DESCRIPTION
This adressed to solve compilation issue on Solaris platform:

src/daemon/collectd.c:212: error: 'kc' undeclared (first use in this function)
src/daemon/collectd.c:213: error: implicit declaration of function 'kstat_open'