### PR TITLE
Added missing include of 'config.h'

### DIFF
--- a/src/libcollectdclient/collectd/network_buffer.h
+++ b/src/libcollectdclient/collectd/network_buffer.h
@@ -27,6 +27,8 @@
 #ifndef LIBCOLLECTDCLIENT_NETWORK_BUFFER_H
 #define LIBCOLLECTDCLIENT_NETWORK_BUFFER_H 1
 
+#include "config.h"
+
 #include "collectd/network.h" /* for lcc_security_level_t */
 #include "collectd/types.h"
 


### PR DESCRIPTION
This adressed to solve compilation issue on Solaris platform:

In file included from src/libcollectdclient/network_parse.c:26:0,
                 from src/libcollectdclient/network_parse_test.c:32:
                 ./src/config.h:1517:0: error: "_FILE_OFFSET_BITS" redefined