### PR TITLE
ipmi plugin: Add SELSensor and SELIgnoreSelected config options.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -689,6 +689,9 @@
 #		NotifySensorNotPresent false
 #		NotifyIPMIConnectionState false
 #		SELEnabled false
+#		SELSensor "some_sensor"
+#		SELSensor "another_one"
+#		SELIgnoreSelected false
 #		SELClearEvent false
 #	</Instance>
 #	<Instance "remote">
@@ -705,6 +708,9 @@
 #		NotifySensorNotPresent false
 #		NotifyIPMIConnectionState false
 #		SELEnabled false
+#		SELSensor "some_sensor"
+#		SELSensor "another_one"
+#		SELIgnoreSelected false
 #		SELClearEvent false
 #	</Instance>
 #</Plugin>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3453,7 +3453,22 @@ a notification is sent. Defaults to B<false>.
 
 If system event log (SEL) is enabled, plugin will listen for sensor threshold
 and discrete events. When event is received the notification is sent.
+SEL event filtering can be configured using B<SELSensor> and B<SELIgnoreSelected>
+config options.
 Defaults to B<false>.
+
+=item B<SELSensor> I<SELSensor>
+
+Selects sensors to get events from or to ignore, depending on B<SELIgnoreSelected>.
+
+See F</"IGNORELISTS"> for details.
+
+=item B<SELIgnoreSelected> I<true>|I<false>
+
+If no configuration is given, the B<ipmi> plugin will pass events from all
+sensors. This option enables you to do that: By setting B<SELIgnoreSelected>
+to I<true> the effect of B<SELSensor> is inverted: All events from selected
+sensors are ignored and all events from other sensors are passed.
 
 =item B<SELClearEvent> I<true>|I<false>
 


### PR DESCRIPTION
As requested and discussed in #2703 and #2713
New options to allow independent filtering of SEL events.
Functionality is similar to existing options 'Sensor' and 'IgnoreSelected',
which are used now for filtering metrics. 

Change-Id: I0fde54a25577e61a4c90a4ff52f62117540a4343
Signed-off-by: Mariusz Szafranski <mariuszx.szafranski@intel.com>