### PR TITLE
Stop poisoning function in debug mode

### DIFF
--- a/src/daemon/collectd.h
+++ b/src/daemon/collectd.h
@@ -240,26 +240,6 @@
 #define __attribute__(x) /**/
 #endif
 
-#if defined(COLLECT_DEBUG) && COLLECT_DEBUG && defined(__GNUC__) && __GNUC__
-#undef strcpy
-#undef strcat
-#undef strtok
-#pragma GCC poison strcpy strcat strtok
-#endif
-
-/*
- * Special hack for the perl plugin: Because the later included perl.h defines
- * a macro which is never used, but contains `sprintf', we cannot poison that
- * identifies just yet. The parl plugin will do that itself once perl.h is
- * included.
- */
-#ifndef DONT_POISON_SPRINTF_YET
-#if defined(COLLECT_DEBUG) && COLLECT_DEBUG && defined(__GNUC__) && __GNUC__
-#undef sprintf
-#pragma GCC poison sprintf
-#endif
-#endif
-
 #ifndef GAUGE_FORMAT
 #define GAUGE_FORMAT "%.15g"
 #endif

--- a/src/lua.c
+++ b/src/lua.c
@@ -28,26 +28,17 @@
  *   Ruben Kerkhof <ruben at rubenkerkhof.com>
  **/
 
-/* <lua5.1/luaconf.h> defines a macro using "sprintf". Although not used here,
- * GCC will complain about the macro definition. */
-#define DONT_POISON_SPRINTF_YET
-
+#include "collectd.h"
 #include "common.h"
 #include "plugin.h"
-#include "collectd.h"
+#include "utils_lua.h"
 
 /* Include the Lua API header files. */
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>
-#include "utils_lua.h"
 
 #include <pthread.h>
-
-#if COLLECT_DEBUG && __GNUC__
-#undef sprintf
-#pragma GCC poison sprintf
-#endif
 
 typedef struct lua_script_s {
   char *script_path;

--- a/src/perl.c
+++ b/src/perl.c
@@ -33,20 +33,10 @@
 /* do not automatically get the thread specific Perl interpreter */
 #define PERL_NO_GET_CONTEXT
 
-#define DONT_POISON_SPRINTF_YET 1
-#include "collectd.h"
-
-#undef DONT_POISON_SPRINTF_YET
-
 #include <stdbool.h>
 
 #include <EXTERN.h>
 #include <perl.h>
-
-#if defined(COLLECT_DEBUG) && COLLECT_DEBUG && defined(__GNUC__) && __GNUC__
-#undef sprintf
-#pragma GCC poison sprintf
-#endif
 
 #include <XSUB.h>
 

--- a/src/utils_lua.c
+++ b/src/utils_lua.c
@@ -24,10 +24,6 @@
  *   Florian Forster <octo at collectd.org>
  **/
 
-/* <lua5.1/luaconf.h> defines a macro using "sprintf". Although not used here,
- * GCC will complain about the macro definition. */
-#define DONT_POISON_SPRINTF_YET
-
 #include "common.h"
 #include "utils_lua.h"
 

--- a/src/utils_lua.h
+++ b/src/utils_lua.h
@@ -27,12 +27,9 @@
 #ifndef UTILS_LUA_H
 #define UTILS_LUA_H 1
 
-#include "plugin.h"
 #include "collectd.h"
+#include "plugin.h"
 
-#ifndef DONT_POISON_SPRINTF_YET
-#error "Files including utils_lua.h need to define DONT_POISON_SPRINTF_YET."
-#endif
 #include <lua.h>
 
 /*


### PR DESCRIPTION
This breaks when external headers use those functions.

Fixes #2769