### PR TITLE
Use CLOCK_REALTIME for collectd-tg times (fixes issue 2219)

### DIFF
--- a/src/collectd-tg.c
+++ b/src/collectd-tg.c
@@ -104,7 +104,7 @@ static double dtime(void) /* {{{ */
 {
   struct timespec ts = {0};
 
-  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+  if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
     perror("clock_gettime");
 
   return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;


### PR DESCRIPTION
collectd-tg currently uses CLOCK_MONOTONIC when calling clock_gettime to acquire a time value for use in its lcc_value_list_t objects.  By definition, CLOCK_MONOTONIC "represents monotonic time since some unspecified starting point."  Apparently this "unspecified starting point" is some time further into the future than the standard Unix epoch (1-1-1970).  As a result, the timestamps that are sent out from collectd-tg are not standard epoch timestamps, and convert into human-readable dates much further into the past than the system's actual time.  Using CLOCK_REALTIME instead fixes this problem.