### PR TITLE
dpdk: fix deprecation warning

### DIFF
--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -420,7 +420,11 @@ static int dpdk_helper_link_status_get(dpdk_helper_ctx_t *phc) {
   dpdk_events_ctx_t *ec = DPDK_EVENTS_CTX_GET(phc);
 
   /* get Link Status values from DPDK */
+#if RTE_VERSION < RTE_VERSION_NUM(18, 05, 0, 0)
   uint8_t nb_ports = rte_eth_dev_count();
+#else
+  uint8_t nb_ports = rte_eth_dev_count_avail();
+#endif
   if (nb_ports == 0) {
     DPDK_CHILD_LOG("dpdkevent-helper: No DPDK ports available. "
                    "Check bound devices to DPDK driver.\n");

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -853,7 +853,11 @@ uint128_t str_to_uint128(const char *str, int len) {
 }
 
 uint8_t dpdk_helper_eth_dev_count() {
+#if RTE_VERSION < RTE_VERSION_NUM(18, 05, 0, 0)
   uint8_t ports = rte_eth_dev_count();
+#else
+  uint8_t ports = rte_eth_dev_count_avail();
+#endif
   if (ports == 0) {
     ERROR(
         "%s:%d: No DPDK ports available. Check bound devices to DPDK driver.\n",


### PR DESCRIPTION
This fixes a warning produced by a change introduced in the latest DPDK
relase caused by a deprecation notice.

Signed-off-by: Kevin Laatz <kevin.laatz@intel.com>