### PR TITLE
mysql: support for MariaDB multi master replication

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -64,7 +64,7 @@ struct mysql_database_s /* {{{ */
   bool slave_stats;
   bool innodb_stats;
   bool wsrep_stats;
-  boot is_mariadb;
+  bool is_mariadb;
 
   bool slave_notif;
   bool slave_io_running;

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -595,9 +595,9 @@ static int mariadb_read_slave_stats(mysql_database_t *db, MYSQL *con) {
       connection_name = row[CONNECTION_NAME];
 
     if (replication[row_count] == NULL) {
-      INFO("mysql plugin: mariadb replication '%s' found.",
-           connection_name);
-      replication[row_count] = (maria_replication_t *) malloc(sizeof(maria_replication_t));
+      INFO("mysql plugin: mariadb replication '%s' found.", connection_name);
+      replication[row_count] =
+          (maria_replication_t *)malloc(sizeof(maria_replication_t));
       replication[row_count]->connection_name = strdup(connection_name);
       replication[row_count]->slave_io_running = true;
       replication[row_count]->slave_sql_running = true;
@@ -639,7 +639,7 @@ static int mariadb_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     }
 
     if (db->slave_notif) {
-      notification_t n = {0, cdtime(),      "", "",  "mysql",
+      notification_t n = {0,  cdtime(),      "", "",  "mysql",
                           "", "time_offset", "", NULL};
       char *io, *sql;
 
@@ -649,8 +649,7 @@ static int mariadb_read_slave_stats(mysql_database_t *db, MYSQL *con) {
       set_host(db, n.host, sizeof(n.host));
 
       if (strlen(connection_name))
-        sstrncpy(n.type_instance, connection_name,
-                 strlen(connection_name)+1);
+        sstrncpy(n.type_instance, connection_name, strlen(connection_name) + 1);
 
       /* Assured by "mysql_config_database" */
       assert(db->instance != NULL);
@@ -660,14 +659,14 @@ static int mariadb_read_slave_stats(mysql_database_t *db, MYSQL *con) {
           (replication[row_count]->slave_io_running)) {
         n.severity = NOTIF_WARNING;
         snprintf(n.message, sizeof(n.message),
-                  "slave I/O thread not started or not connected to master");
+                 "slave I/O thread not started or not connected to master");
         plugin_dispatch_notification(&n);
         replication[row_count]->slave_io_running = false;
       } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                  (!replication[row_count]->slave_io_running)) {
         n.severity = NOTIF_OKAY;
         snprintf(n.message, sizeof(n.message),
-                  "slave I/O thread started and connected to master");
+                 "slave I/O thread started and connected to master");
         plugin_dispatch_notification(&n);
         replication[row_count]->slave_io_running = true;
       }

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -308,15 +308,12 @@ static MYSQL *getconnection(mysql_database_t *db) {
        mysql_get_host_info(db->con), (cipher != NULL) ? cipher : "<none>",
        mysql_get_server_info(db->con), mysql_get_proto_info(db->con));
 
-<<<<<<< HEAD
   db->is_mariadb = 0;
   if (strstr(mysql_get_server_info(db->con), "MariaDB") != NULL)
     db->is_mariadb = 1;
 
-  db->is_connected = 1;
-=======
   db->is_connected = true;
->>>>>>> c23146326ce4c1099df5bd2e02dc80a641eae258
+
   return db->con;
 } /* static MYSQL *getconnection (mysql_database_t *db) */
 


### PR DESCRIPTION
ChangeLog: Support for MariaDB multi master replication
MariaDB supports multi-master replications (see. https://mariadb.com/kb/en/library/multi-source-replication/). In order to handle several sources, each source is named while created by the database administrator. It induces changes in 'show slave status' command syntax and output.

Mysql plugin detects that it is actually connected to a MariaDB instance and use the corresponding read_slave_stats function. Retrieved values and identifiers leave unchanged except for a named replication. Replication name is injected in type-instance. For example:
```
hostname/mysql-localhost/mysql_log_position-slave-exec
hostname/mysql-localhost/mysql_log_position-slave-exec-replication-name1
hostname/mysql-localhost/mysql_log_position-slave-exec-replication-name2
hostname/mysql-localhost/mysql_log_position-slave-read
hostname/mysql-localhost/mysql_log_position-slave-read-replication-name1
hostname/mysql-localhost/mysql_log_position-slave-read-replication-name2
hostname/mysql-localhost/time_offset
hostname/mysql-localhost/time_offset-replication-name1
hostname/mysql-localhost/time_offset-replication-name2
```

 