### PR TITLE
redis plugin: Remove `operations_per_second` metric.

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -654,8 +654,6 @@ static void redis_read_server_info(redis_node_t *rn) {
                     "total_connections_received", DS_TYPE_DERIVE);
   redis_handle_info(rn->name, rr->str, "total_operations", NULL,
                     "total_commands_processed", DS_TYPE_DERIVE);
-  redis_handle_info(rn->name, rr->str, "operations_per_second", NULL,
-                    "instantaneous_ops_per_sec", DS_TYPE_GAUGE);
   redis_handle_info(rn->name, rr->str, "expired_keys", NULL, "expired_keys",
                     DS_TYPE_DERIVE);
   redis_handle_info(rn->name, rr->str, "evicted_keys", NULL, "evicted_keys",


### PR DESCRIPTION
The `operations_per_second` metric removed as duplicate of other metric and as
it has wrong value also. Collectd should not report wrong values.

Metric `operations_per_second` is based on `instantaneous_ops_per_sec` field
from Redis `INFO` output. That field is calculated based on buffer of 16 values,
updated from `stat_numcommands` once per 100ms.
So, `instantaneous_ops_per_sec` value has average only for last 1.6 seconds.
While Collectd poll period is 10 seconds, statistics for 8.4 seconds is lost.

Herewith, Collectd already has correct metric `total_operations`, based on
`total_commands_processed` field taken from same `stat_numcommands` internally
in Redis. Value of this metric should be used instead of removed metric.