### PR TITLE
write_prometheus: Added MHD_USE_INTERNAL_POLLING_THREAD flag

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -804,8 +804,13 @@ static struct MHD_Daemon *prom_start_daemon() {
     return NULL;
   }
 
+  unsigned int flags = MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG;
+#if MHD_VERSION >= 0x00095300
+  flags |= MHD_USE_INTERNAL_POLLING_THREAD;
+#endif
+
   struct MHD_Daemon *d = MHD_start_daemon(
-      MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG, httpd_port,
+      flags, httpd_port,
       /* MHD_AcceptPolicyCallback = */ NULL,
       /* MHD_AcceptPolicyCallback arg = */ NULL, http_handler, NULL,
       MHD_OPTION_LISTEN_SOCKET, fd, MHD_OPTION_EXTERNAL_LOGGER, prom_logger,


### PR DESCRIPTION
Since 0.9.53, libmicrohttpd requires explicit setting of this flag.

Closes: #2849