### PR TITLE
Fix parsing option for avoiding making BaseDir

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -295,7 +295,7 @@ static int do_shutdown(void) {
 static void read_cmdline(int argc, char **argv, struct cmdline_config *config) {
   /* read options */
   while (1) {
-    int c = getopt(argc, argv, "htTC:"
+    int c = getopt(argc, argv, "BhtTC:"
 #if COLLECT_DAEMON
                                "fP:"
 #endif


### PR DESCRIPTION
Parsing is broken since:
386ecab4 Reading configuration file is now done outside main().
So after mentioned commit we've got:

collectd: invalid option -- 'B'

This commit fixes this.