### PR TITLE
virt: Add block info statistics for disk devices

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1677,7 +1677,7 @@
 #	InterfaceFormat name
 #	PluginInstanceFormat name
 #	Instances 1
-#	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpupin"
+#	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpupin disk_physical disk_allocation disk_capacity"
 #	PersistentNotification false
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9414,6 +9414,18 @@ B<Note>: I<perf> metrics can't be collected if I<intel_rdt> plugin is enabled.
 
 =item B<vcpupin>: report pinning of domain VCPUs to host physical CPUs.
 
+=item B<disk_physical>: report 'disk_physical' statistic for disk device.
+B<Note>: This statistic is only reported for disk devices with 'source'
+property available.
+
+=item B<disk_allocation>: report 'disk_allocation' statistic for disk device.
+B<Note>: This statistic is only reported for disk devices with 'source'
+property available.
+
+=item B<disk_capacity>: report 'disk_capacity' statistic for disk device.
+B<Note>: This statistic is only reported for disk devices with 'source'
+property available.
+
 =back
 
 =item B<PersistentNotification> B<true>|B<false>

--- a/src/types.db
+++ b/src/types.db
@@ -51,6 +51,8 @@ df                      used:GAUGE:0:1125899906842623, free:GAUGE:0:112589990684
 df_complex              value:GAUGE:0:U
 df_inodes               value:GAUGE:0:U
 dilution_of_precision   value:GAUGE:0:U
+disk_allocation         value:GAUGE:0:U
+disk_capacity           value:GAUGE:0:U
 disk_error              value:GAUGE:0:U
 disk_io_time            io_time:DERIVE:0:U, weighted_io_time:DERIVE:0:U
 disk_latency            read:GAUGE:0:U, write:GAUGE:0:U
@@ -58,6 +60,7 @@ disk_merged             read:DERIVE:0:U, write:DERIVE:0:U
 disk_octets             read:DERIVE:0:U, write:DERIVE:0:U
 disk_ops                read:DERIVE:0:U, write:DERIVE:0:U
 disk_ops_complex        value:DERIVE:0:U
+disk_physical           value:GAUGE:0:U
 disk_time               read:DERIVE:0:U, write:DERIVE:0:U
 dns_answer              value:DERIVE:0:U
 dns_notify              value:DERIVE:0:U

--- a/src/virt.c
+++ b/src/virt.c
@@ -1718,21 +1718,26 @@ static int get_disk_err(virDomainPtr domain) {
 #endif /* HAVE_DISK_ERR */
 
 static int get_block_device_stats(struct block_device *block_dev) {
-  virDomainBlockInfo binfo;
-  init_block_info(&binfo);
-
   if (!block_dev) {
     ERROR(PLUGIN_NAME " plugin: get_block_stats NULL pointer");
     return -1;
   }
 
-  /* Block info statistics can be only fetched from devices with 'source'
-   * defined */
-  if (block_dev->has_source) {
-    if (virDomainGetBlockInfo(block_dev->dom, block_dev->path, &binfo, 0) < 0) {
-      ERROR(PLUGIN_NAME " plugin: virDomainGetBlockInfo failed for path: %s",
-            block_dev->path);
-      return -1;
+  virDomainBlockInfo binfo;
+  init_block_info(&binfo);
+
+  /* Fetching block info stats only if needed*/
+  if (extra_stats & (ex_stats_disk_allocation | ex_stats_disk_capacity |
+                     ex_stats_disk_physical)) {
+    /* Block info statistics can be only fetched from devices with 'source'
+     * defined */
+    if (block_dev->has_source) {
+      if (virDomainGetBlockInfo(block_dev->dom, block_dev->path, &binfo, 0) <
+          0) {
+        ERROR(PLUGIN_NAME " plugin: virDomainGetBlockInfo failed for path: %s",
+              block_dev->path);
+        return -1;
+      }
     }
   }
 


### PR DESCRIPTION
ChangeLog: virt: Add block info statistics for disk devices

Previously block info statistics(allocation, capacity, physical) were available through libvirt api but were missing in data from collectd-virt plugin.
virDomainBlockInfo statistics are now exposed through virt plugin as:
    -disk_allocation
    -disk_capacity
    -disk_physical

NOTE: newly added block info statistics can be fetched from libvirt only for devices with available 'source' property - because of this scenario additional logic for checking if source is available has been added to virt plugin
NOTE2: previously 'block stats' statistics were stored and described in source code as 'block info' - this pull request contains refactoring that renames 'block_info_*' family of functions to 'block_stats_*' as it should be named from beginning. Without that it would be confusing to have functions with 'block_info' names used for fetching completely different properties from libvirt