### PR TITLE
Fix typo in amqp1 JSON format error message

### DIFF
--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -479,7 +479,7 @@ static int amqp1_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     }
     cdm->mbuf.size = strlen(cdm->mbuf.start);
     if (cdm->mbuf.size >= BUFSIZE) {
-      ERROR("amqp1 plugin: format graphite failed");
+      ERROR("amqp1 plugin: format json failed");
       cd_message_free(cdm);
       return -1;
     }


### PR DESCRIPTION
Fixes a formatting error log message that mistakenly mentions "graphite" when it should say "json" (as it is in the context of trying to output JSON data)