### PR TITLE
Add GNULIB_DIR to LDFLAGS in configure.ac on Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ build_cygwin()
     echo "Installing collectd to ${INSTALL_DIR}."
     TOP_SRCDIR=$(pwd)
     MINGW_ROOT="$(x86_64-w64-mingw32-gcc -print-sysroot)/mingw"
-    GNULIB_DIR="${TOP_SRCDIR}/gnulib/build/gllib"
+    export GNULIB_DIR="${TOP_SRCDIR}/gnulib/build/gllib"
 
     export CC="x86_64-w64-mingw32-gcc"
 

--- a/configure.ac
+++ b/configure.ac
@@ -779,8 +779,12 @@ AC_FUNC_STRERROR_R
 
 SAVE_CFLAGS="$CFLAGS"
 CFLAGS="-Wall -Werror"
-SAVE_LDFAGS="$LDFLAGS"
+SAVE_LDFLAGS="$LDFLAGS"
 LDFLAGS=""
+if test "x$ac_system" = "xWindows"; then
+  # This is exported from build.sh
+  LDFLAGS="$LDFLAGS -L${GNULIB_DIR}"
+fi
 
 AC_CACHE_CHECK([for strtok_r],
   [c_cv_have_strtok_r_default],


### PR DESCRIPTION
When building on Cygwin, the linker needs to be pointed to the directory with libgnu.dll to build properly.