### PR TITLE
Fix most truncation warnings from GCC 8.2 (WIP)

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -198,15 +198,15 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+                "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+                "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
-               AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+                "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
+                AGG_FUNC_PLACEHOLDER);
   }
 
   /* Type */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -217,23 +217,23 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
     if (r.reply.id == AMQP_CONNECTION_CLOSE_METHOD) {
       amqp_connection_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      snprintf(buffer, buffer_size, "Server connection error %d: %s",
-               m->reply_code, tmp);
+      ssnprintf(buffer, buffer_size, "Server connection error %d: %s",
+                m->reply_code, tmp);
       sfree(tmp);
     } else if (r.reply.id == AMQP_CHANNEL_CLOSE_METHOD) {
       amqp_channel_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      snprintf(buffer, buffer_size, "Server channel error %d: %s",
-               m->reply_code, tmp);
+      ssnprintf(buffer, buffer_size, "Server channel error %d: %s",
+                m->reply_code, tmp);
       sfree(tmp);
     } else {
-      snprintf(buffer, buffer_size, "Server error method %#" PRIx32,
-               r.reply.id);
+      ssnprintf(buffer, buffer_size, "Server error method %#" PRIx32,
+                r.reply.id);
     }
     break;
 
   default:
-    snprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
+    ssnprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
   }
 
   return buffer;
@@ -748,9 +748,9 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (conf->routing_key != NULL) {
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
   } else {
-    snprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
-             vl->host, vl->plugin, vl->plugin_instance, vl->type,
-             vl->type_instance);
+    ssnprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
+              vl->host, vl->plugin, vl->plugin_instance, vl->type,
+              vl->type_instance);
 
     /* Switch slashes (the only character forbidden by collectd) and dots
      * (the separation character used by AMQP). */
@@ -970,7 +970,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
 
   if (publish) {
     char cbname[128];
-    snprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
+    ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
     status =
         plugin_register_write(cbname, camqp_write,

--- a/src/apache.c
+++ b/src/apache.c
@@ -214,9 +214,9 @@ static int config_add(oconfig_item_t *ci) {
 
   char callback_name[3 * DATA_MAX_NAME_LEN];
 
-  snprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
-           (st->host != NULL) ? st->host : hostname_g,
-           (st->name != NULL) ? st->name : "default");
+  ssnprintf(callback_name, sizeof(callback_name), "apache/%s/%s",
+            (st->host != NULL) ? st->host : hostname_g,
+            (st->name != NULL) ? st->name : "default");
 
   return plugin_register_complex_read(
       /* group = */ NULL,

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -81,8 +81,8 @@ static void aquaero_submit_array(const char *type,
     if (value_array[i] == AQ5_FLOAT_UNDEF)
       continue;
 
-    snprintf(type_instance, sizeof(type_instance), "%s%d", type_instance_prefix,
-             i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "%s%d", type_instance_prefix,
+              i + 1);
     aquaero_submit(type, type_instance, value_array[i]);
   }
 }
@@ -130,7 +130,7 @@ static int aquaero_read(void) {
         (aq_data.fan_vrm_temp[i] != AQ5_FLOAT_UNDEF))
       continue;
 
-    snprintf(type_instance, sizeof(type_instance), "fan%d", i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "fan%d", i + 1);
 
     aquaero_submit("fanspeed", type_instance, aq_data.fan_rpm[i]);
     aquaero_submit("percent", type_instance, aq_data.fan_duty[i]);
@@ -139,7 +139,7 @@ static int aquaero_read(void) {
 
     /* Report the voltage reglator module (VRM) temperature with a
      * different type instance. */
-    snprintf(type_instance, sizeof(type_instance), "fan%d-vrm", i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "fan%d-vrm", i + 1);
     aquaero_submit("temperature", type_instance, aq_data.fan_vrm_temp[i]);
   }
 

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -499,8 +499,8 @@ static int ascent_init(void) /* {{{ */
     static char credentials[1024];
     int status;
 
-    status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
-                      (pass == NULL) ? "" : pass);
+    status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
+                       (pass == NULL) ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "
             "credentials have been truncated.");

--- a/src/battery.c
+++ b/src/battery.c
@@ -347,7 +347,7 @@ static int sysfs_file_to_buffer(char const *dir, /* {{{ */
   char filename[PATH_MAX];
   int status;
 
-  snprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply, basename);
+  ssnprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply, basename);
 
   status = (int)read_file_contents(filename, buffer, buffer_size - 1);
   if (status < 0)
@@ -478,7 +478,7 @@ static int read_acpi_full_capacity(char const *dir, /* {{{ */
 
   FILE *fh;
 
-  snprintf(filename, sizeof(filename), "%s/%s/info", dir, power_supply);
+  ssnprintf(filename, sizeof(filename), "%s/%s/info", dir, power_supply);
   fh = fopen(filename, "r");
   if (fh == NULL)
     return errno;
@@ -531,7 +531,7 @@ static int read_acpi_callback(char const *dir, /* {{{ */
 
   FILE *fh;
 
-  snprintf(filename, sizeof(filename), "%s/%s/state", dir, power_supply);
+  ssnprintf(filename, sizeof(filename), "%s/%s/state", dir, power_supply);
   fh = fopen(filename, "r");
   if (fh == NULL) {
     if ((errno == EAGAIN) || (errno == EINTR) || (errno == ENOENT))
@@ -640,11 +640,11 @@ static int read_pmu(void) /* {{{ */
     gauge_t voltage = NAN;
     gauge_t charge = NAN;
 
-    snprintf(filename, sizeof(filename), PROC_PMU_PATH_FORMAT, i);
+    ssnprintf(filename, sizeof(filename), PROC_PMU_PATH_FORMAT, i);
     if (access(filename, R_OK) != 0)
       break;
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%i", i);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "%i", i);
 
     fh = fopen(filename, "r");
     if (fh == NULL) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -714,8 +714,8 @@ static int bind_xml_stats_handle_zone(int version, xmlDoc *doc, /* {{{ */
                                          nsstats_translation_table_length,
                                          plugin_instance};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s", view->name,
-             zone_name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-zone-%s", view->name,
+              zone_name);
 
     if (version == 3) {
       list_info_ptr_t list_info = {plugin_instance,
@@ -843,7 +843,7 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     list_info_ptr_t list_info = {plugin_instance,
                                  /* type = */ "dns_qtype"};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes", view->name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-qtypes", view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
           /* xpath = */ "counters[@type='resqtype']",
@@ -865,8 +865,8 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
                                          resstats_translation_table_length,
                                          plugin_instance};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-resolver_stats",
-             view->name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-resolver_stats",
+              view->name);
     if (version == 3) {
       bind_parse_generic_name_attr_value_list(
           "counters[@type='resstats']",
@@ -888,8 +888,8 @@ static int bind_xml_stats_handle_view(int version, xmlDoc *doc, /* {{{ */
     list_info_ptr_t list_info = {plugin_instance,
                                  /* type = */ "dns_qtype_cached"};
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "%s-cache_rr_sets",
-             view->name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-cache_rr_sets",
+              view->name);
 
     bind_parse_generic_name_value(/* xpath = */ "cache/rrset",
                                   /* callback = */ bind_xml_list_callback,

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -990,7 +990,7 @@ static int cconn_connect(struct cconn *io) {
     return err;
   }
   address.sun_family = AF_UNIX;
-  snprintf(address.sun_path, sizeof(address.sun_path), "%s", io->d->asok_path);
+  ssnprintf(address.sun_path, sizeof(address.sun_path), "%s", io->d->asok_path);
   RETRY_ON_EINTR(err, connect(fd, (struct sockaddr *)&address,
                               sizeof(struct sockaddr_un)));
   if (err < 0) {
@@ -1153,8 +1153,8 @@ static ssize_t cconn_handle_event(struct cconn *io) {
     return -EDOM;
   case CSTATE_WRITE_REQUEST: {
     char cmd[32];
-    snprintf(cmd, sizeof(cmd), "%s%d%s", "{ \"prefix\": \"", io->request_type,
-             "\" }\n");
+    ssnprintf(cmd, sizeof(cmd), "%s%d%s", "{ \"prefix\": \"", io->request_type,
+              "\" }\n");
     size_t cmd_len = strlen(cmd);
     RETRY_ON_EINTR(
         ret, write(io->asok, ((char *)&cmd) + io->amt, cmd_len - io->amt));

--- a/src/ceph_test.c
+++ b/src/ceph_test.c
@@ -45,7 +45,7 @@ static int test_handler(void *user, char const *val, char const *key) {
   if (strcmp("filestore.example_latency", key) == 0)
     return RETRY_AVGCOUNT;
 
-  snprintf(status, sizeof(status),
+  ssnprintf(status, sizeof(status),
            "unexpected call: test_handler(\"%s\") = \"%s\"", key, val);
   ok = false;
 
@@ -54,14 +54,14 @@ static int test_handler(void *user, char const *val, char const *key) {
       continue;
 
     if (strcmp(val, t->cases[i].value) != 0) {
-      snprintf(status, sizeof(status),
-               "test_handler(\"%s\") = \"%s\", want \"%s\"", key, val,
-               t->cases[i].value);
+      ssnprintf(status, sizeof(status),
+                "test_handler(\"%s\") = \"%s\", want \"%s\"", key, val,
+                t->cases[i].value);
       ok = false;
       break;
     }
 
-    snprintf(status, sizeof(status), "test_handler(\"%s\") = \"%s\"", key, val);
+    ssnprintf(status, sizeof(status), "test_handler(\"%s\") = \"%s\"", key, val);
     ok = true;
     break;
   }

--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -63,7 +63,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   if (ignorelist_match(il_cgroup, cgroup_name))
     return 0;
 
-  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, cgroup_name);
+  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, cgroup_name);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {
@@ -75,8 +75,8 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
   if (!S_ISDIR(statbuf.st_mode))
     return 0;
 
-  snprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
-           cgroup_name);
+  ssnprintf(abs_path, sizeof(abs_path), "%s/%s/cpuacct.stat", dirname,
+            cgroup_name);
   fh = fopen(abs_path, "r");
   if (fh == NULL) {
     ERROR("cgroups plugin: fopen (\"%s\") failed: %s", abs_path, STRERRNO);
@@ -136,7 +136,7 @@ static int read_cpuacct_root(const char *dirname, const char *filename,
   struct stat statbuf;
   int status;
 
-  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
+  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
   status = lstat(abs_path, &statbuf);
   if (status != 0) {

--- a/src/collectd-nagios.c
+++ b/src/collectd-nagios.c
@@ -522,12 +522,11 @@ static int do_check(lcc_connection_t *connection) {
   gauge_t *values;
   char **values_names;
   size_t values_num;
-  char ident_str[1024];
+  char ident_str[1024] = {};
   lcc_identifier_t ident;
   int status;
 
-  snprintf(ident_str, sizeof(ident_str), "%s/%s", hostname_g, value_string_g);
-  ident_str[sizeof(ident_str) - 1] = 0;
+  snprintf(ident_str, sizeof(ident_str) - 1, "%s/%s", hostname_g, value_string_g);
 
   status = lcc_string_to_identifier(connection, &ident, ident_str);
   if (status != 0) {
@@ -571,7 +570,7 @@ static int do_check(lcc_connection_t *connection) {
 } /* int do_check */
 
 int main(int argc, char **argv) {
-  char address[1024];
+  char address[1024] = {};
   lcc_connection_t *connection;
 
   int status;
@@ -651,8 +650,7 @@ int main(int argc, char **argv) {
     usage(argv[0]);
   }
 
-  snprintf(address, sizeof(address), "unix:%s", socket_file_g);
-  address[sizeof(address) - 1] = 0;
+  snprintf(address, sizeof(address) - 1, "unix:%s", socket_file_g);
 
   connection = NULL;
   status = lcc_connect(address, &connection);

--- a/src/collectd-tg.c
+++ b/src/collectd-tg.c
@@ -190,15 +190,15 @@ static lcc_value_list_t *create_value_list(void) /* {{{ */
     vl->values_types[0] = LCC_TYPE_DERIVE;
 
   snprintf(vl->identifier.host, sizeof(vl->identifier.host), "host%04i",
-           host_num);
+            host_num);
   snprintf(vl->identifier.plugin, sizeof(vl->identifier.plugin), "plugin%03i",
-           get_boundet_random(0, conf_num_plugins));
+            get_boundet_random(0, conf_num_plugins));
   strncpy(vl->identifier.type,
-          (vl->values_types[0] == LCC_TYPE_GAUGE) ? "gauge" : "derive",
-          sizeof(vl->identifier.type));
+           (vl->values_types[0] == LCC_TYPE_GAUGE) ? "gauge" : "derive",
+           sizeof(vl->identifier.type));
   vl->identifier.type[sizeof(vl->identifier.type) - 1] = 0;
-  snprintf(vl->identifier.type_instance, sizeof(vl->identifier.type_instance),
-           "ti%li", random());
+  snprintf(vl->identifier.type_instance,
+           sizeof(vl->identifier.type_instance), "ti%li", random());
 
   return vl;
 } /* }}} int create_value_list */

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -333,7 +333,7 @@ static void submit_value(int cpu_num, int cpu_state, const char *type,
            sizeof(vl.type_instance));
 
   if (cpu_num >= 0) {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
   }
   plugin_dispatch_values(&vl);
 }

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -34,10 +34,9 @@ static int cpufreq_init(void) {
   num_cpu = 0;
 
   while (1) {
-    status = snprintf(filename, sizeof(filename),
-                      "/sys/devices/system/cpu/cpu%d/cpufreq/"
-                      "scaling_cur_freq",
-                      num_cpu);
+    status = ssnprintf(filename, sizeof(filename),
+                       "/sys/devices/system/cpu/cpu%d/cpufreq/"
+                       "scaling_cur_freq", num_cpu);
     if ((status < 1) || ((unsigned int)status >= sizeof(filename)))
       break;
 
@@ -62,7 +61,7 @@ static void cpufreq_submit(int cpu_num, value_t value) {
   vl.values_len = 1;
   sstrncpy(vl.plugin, "cpufreq", sizeof(vl.plugin));
   sstrncpy(vl.type, "cpufreq", sizeof(vl.type));
-  snprintf(vl.type_instance, sizeof(vl.type_instance), "%i", cpu_num);
+  ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i", cpu_num);
 
   plugin_dispatch_values(&vl);
 }
@@ -70,8 +69,8 @@ static void cpufreq_submit(int cpu_num, value_t value) {
 static int cpufreq_read(void) {
   for (int i = 0; i < num_cpu; i++) {
     char filename[PATH_MAX];
-    snprintf(filename, sizeof(filename),
-             "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", i);
+    ssnprintf(filename, sizeof(filename),
+              "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", i);
 
     value_t v;
     if (parse_value_file(filename, &v, DS_TYPE_GAUGE) != 0) {

--- a/src/curl.c
+++ b/src/curl.c
@@ -364,8 +364,8 @@ static int cc_page_init_curl(web_page_t *wp) /* {{{ */
       return -1;
     }
 
-    snprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
-             (wp->pass == NULL) ? "" : wp->pass);
+    ssnprintf(wp->credentials, credentials_size, "%s:%s", wp->user,
+              (wp->pass == NULL) ? "" : wp->pass);
     curl_easy_setopt(wp->curl, CURLOPT_USERPWD, wp->credentials);
 #endif
 

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -217,7 +217,7 @@ static void cj_advance_array(cj_t *db) {
   db->state[db->depth].index++;
 
   char name[DATA_MAX_NAME_LEN];
-  snprintf(name, sizeof(name), "%d", db->state[db->depth].index);
+  ssnprintf(name, sizeof(name), "%d", db->state[db->depth].index);
   cj_load_key(db, name);
 }
 
@@ -601,8 +601,8 @@ static int cj_init_curl(cj_t *db) /* {{{ */
       return -1;
     }
 
-    snprintf(db->credentials, credentials_size, "%s:%s", db->user,
-             (db->pass == NULL) ? "" : db->pass);
+    ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
+              (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif
 
@@ -800,8 +800,8 @@ static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value) /* {{{ */
   if (key->instance == NULL) {
     int len = 0;
     for (int i = 0; i < db->depth; i++)
-      len += snprintf(vl.type_instance + len, sizeof(vl.type_instance) - len,
-                      i ? "-%s" : "%s", db->state[i + 1].name);
+      len += ssnprintf(vl.type_instance + len, sizeof(vl.type_instance) - len,
+                       i ? "-%s" : "%s", db->state[i + 1].name);
   } else
     sstrncpy(vl.type_instance, key->instance, sizeof(vl.type_instance));
 

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -395,8 +395,8 @@ static int cx_handle_instance_xpath(xmlXPathContextPtr xpath_ctx, /* {{{ */
       return -1;
 
     if (xpath->instance_prefix != NULL)
-      snprintf(vl->type_instance, sizeof(vl->type_instance), "%s%s",
-               xpath->instance_prefix, node_value);
+      ssnprintf(vl->type_instance, sizeof(vl->type_instance), "%s%s",
+                xpath->instance_prefix, node_value);
     else
       sstrncpy(vl->type_instance, node_value, sizeof(vl->type_instance));
 
@@ -755,8 +755,8 @@ static int cx_init_curl(cx_t *db) /* {{{ */
       return -1;
     }
 
-    snprintf(db->credentials, credentials_size, "%s:%s", db->user,
-             (db->pass == NULL) ? "" : db->pass);
+    ssnprintf(db->credentials, credentials_size, "%s:%s", db->user,
+              (db->pass == NULL) ? "" : db->pass);
     curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
 #endif
 

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -83,11 +83,24 @@ static pthread_mutex_t strerror_r_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 char *sstrncpy(char *dest, const char *src, size_t n) {
-  strncpy(dest, src, n);
+  strncpy(dest, src, n - 1);
   dest[n - 1] = '\0';
 
   return dest;
 } /* char *sstrncpy */
+
+int ssnprintf(char *str, size_t size, const char *format, ...) {
+  int status;
+  va_list ap;
+
+  va_start(ap, format);
+  status = vsnprintf(str, size, format, ap);
+  va_end(ap);
+  if (status >= size)
+    str[size - 1] = '\0';
+
+  return status;
+} /* int ssnprintf */
 
 char *ssnprintf_alloc(char const *format, ...) /* {{{ */
 {
@@ -664,7 +677,7 @@ int get_kstat(kstat_t **ksp_ptr, char *module, int instance, char *name) {
   if (kc == NULL)
     return -1;
 
-  snprintf(ident, sizeof(ident), "%s,%i,%s", module, instance, name);
+  ssnprintf(ident, sizeof(ident), "%s,%i,%s", module, instance, name);
 
   *ksp_ptr = kstat_lookup(kc, module, instance, name);
   if (*ksp_ptr == NULL) {

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -66,6 +66,10 @@ typedef struct value_to_rate_state_s value_to_rate_state_t;
 
 char *sstrncpy(char *dest, const char *src, size_t n);
 
+__attribute__((format(printf, 3, 4))) int ssnprintf(char *str, size_t size,
+                                                    char const *format,
+                                                    ...);
+
 __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
                                                             ...);
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -200,7 +200,7 @@ static int dispatch_global_option(const oconfig_item_t *ci) {
     return global_option_set(ci->key, ci->values[0].value.string, 0);
   else if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
+    ssnprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
     return global_option_set(ci->key, tmp, 0);
   } else if (ci->values[0].type == OCONFIG_TYPE_BOOLEAN) {
     if (ci->values[0].value.boolean)
@@ -664,7 +664,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
     if ((de->d_name[0] == '.') || (de->d_name[0] == 0))
       continue;
 
-    status = snprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
+    status = ssnprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
     if ((status < 0) || ((size_t)status >= sizeof(name))) {
       ERROR("configfile: Not including `%s/%s' because its"
             " name is too long.",
@@ -1075,8 +1075,7 @@ int cf_util_get_string_buffer(const oconfig_item_t *ci, char *buffer, /* {{{ */
     return -1;
   }
 
-  strncpy(buffer, ci->values[0].value.string, buffer_size);
-  buffer[buffer_size - 1] = 0;
+  sstrncpy(buffer, ci->values[0].value.string, buffer_size);
 
   return 0;
 } /* }}} int cf_util_get_string_buffer */
@@ -1233,7 +1232,7 @@ int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
     P_ERROR("cf_util_get_service: Out of memory.");
     return -1;
   }
-  snprintf(service, 6, "%i", port);
+  ssnprintf(service, 6, "%i", port);
 
   sfree(*ret_string);
   *ret_string = service;

--- a/src/daemon/filter_chain.c
+++ b/src/daemon/filter_chain.c
@@ -343,8 +343,8 @@ static int fc_config_add_rule(fc_chain_t *chain, /* {{{ */
 
   if (ci->values_num == 1) {
     sstrncpy(rule->name, ci->values[0].value.string, sizeof(rule->name));
-    snprintf(rule_name, sizeof(rule_name), "Rule \"%s\"",
-             ci->values[0].value.string);
+    ssnprintf(rule_name, sizeof(rule_name), "Rule \"%s\"",
+              ci->values[0].value.string);
   }
 
   for (int i = 0; i < ci->children_num; i++) {

--- a/src/daemon/meta_data.c
+++ b/src/daemon/meta_data.c
@@ -713,15 +713,15 @@ int meta_data_as_string(meta_data_t *md, /* {{{ */
     actual = e->value.mv_string;
     break;
   case MD_TYPE_SIGNED_INT:
-    snprintf(buffer, sizeof(buffer), "%" PRIi64, e->value.mv_signed_int);
+    ssnprintf(buffer, sizeof(buffer), "%" PRIi64, e->value.mv_signed_int);
     actual = buffer;
     break;
   case MD_TYPE_UNSIGNED_INT:
-    snprintf(buffer, sizeof(buffer), "%" PRIu64, e->value.mv_unsigned_int);
+    ssnprintf(buffer, sizeof(buffer), "%" PRIu64, e->value.mv_unsigned_int);
     actual = buffer;
     break;
   case MD_TYPE_DOUBLE:
-    snprintf(buffer, sizeof(buffer), GAUGE_FORMAT, e->value.mv_double);
+    ssnprintf(buffer, sizeof(buffer), GAUGE_FORMAT, e->value.mv_double);
     actual = buffer;
     break;
   case MD_TYPE_BOOLEAN:

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -411,12 +411,12 @@ static int plugin_load_file(char const *file, bool global) {
   if (dlh == NULL) {
     char errbuf[1024] = "";
 
-    snprintf(errbuf, sizeof(errbuf),
-             "dlopen(\"%s\") failed: %s. "
-             "The most common cause for this problem is missing dependencies. "
-             "Use ldd(1) to check the dependencies of the plugin / shared "
-             "object.",
-             file, dlerror());
+    ssnprintf(errbuf, sizeof(errbuf),
+              "dlopen(\"%s\") failed: %s. "
+              "The most common cause for this problem is missing dependencies. "
+              "Use ldd(1) to check the dependencies of the plugin / shared "
+              "object.",
+              file, dlerror());
 
     /* This error is printed to STDERR unconditionally. If list_log is NULL,
      * plugin_log() will also print to STDERR. We avoid duplicate output by
@@ -648,7 +648,7 @@ static void start_read_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    snprintf(name, sizeof(name), "reader#%" PRIu64, (uint64_t)read_threads_num);
+    ssnprintf(name, sizeof(name), "reader#%" PRIu64, (uint64_t)read_threads_num);
     set_thread_name(read_threads[read_threads_num], name);
 
     read_threads_num++;
@@ -837,8 +837,8 @@ static void start_write_threads(size_t num) /* {{{ */
     }
 
     char name[THREAD_NAME_MAX];
-    snprintf(name, sizeof(name), "writer#%" PRIu64,
-             (uint64_t)write_threads_num);
+    ssnprintf(name, sizeof(name), "writer#%" PRIu64,
+              (uint64_t)write_threads_num);
     set_thread_name(write_threads[write_threads_num], name);
 
     write_threads_num++;
@@ -992,7 +992,7 @@ int plugin_load(char const *plugin_name, bool global) {
 
   /* `cpu' should not match `cpufreq'. To solve this we add SHLIB_SUFFIX to the
    * type when matching the filename */
-  status = snprintf(typename, sizeof(typename), "%s" SHLIB_SUFFIX, plugin_name);
+  status = ssnprintf(typename, sizeof(typename), "%s" SHLIB_SUFFIX, plugin_name);
   if ((status < 0) || ((size_t)status >= sizeof(typename))) {
     WARNING("plugin_load: Filename too long: \"%s" SHLIB_SUFFIX "\"",
             plugin_name);
@@ -1008,7 +1008,7 @@ int plugin_load(char const *plugin_name, bool global) {
     if (strcasecmp(de->d_name, typename))
       continue;
 
-    status = snprintf(filename, sizeof(filename), "%s/%s", dir, de->d_name);
+    status = ssnprintf(filename, sizeof(filename), "%s/%s", dir, de->d_name);
     if ((status < 0) || ((size_t)status >= sizeof(filename))) {
       WARNING("plugin_load: Filename too long: \"%s/%s\"", dir, de->d_name);
       continue;
@@ -2221,7 +2221,7 @@ EXPORT void plugin_log(int level, const char *format, ...) {
 #endif
 
   va_start(ap, format);
-  vsnprintf(msg, sizeof(msg), format, ap);
+  vsnprintf(msg, sizeof(msg) - 1, format, ap);
   msg[sizeof(msg) - 1] = '\0';
   va_end(ap);
 
@@ -2256,7 +2256,8 @@ void daemon_log(int level, const char *format, ...) {
 
   va_list ap;
   va_start(ap, format);
-  vsnprintf(msg, sizeof(msg), format, ap);
+  vsnprintf(msg, sizeof(msg) - 1, format, ap);
+  msg[sizeof(msg) - 1] = '\0';
   va_end(ap);
 
   plugin_log(level, "%s plugin: %s", name, msg);

--- a/src/daemon/plugin_mock.c
+++ b/src/daemon/plugin_mock.c
@@ -164,7 +164,8 @@ void plugin_log(int level, char const *format, ...) {
   va_list ap;
 
   va_start(ap, format);
-  vsnprintf(buffer, sizeof(buffer), format, ap);
+  vsnprintf(buffer, sizeof(buffer) - 1, format, ap);
+  buffer[sizeof(buffer) - 1] = '\0';
   va_end(ap);
 
   printf("plugin_log (%i, \"%s\");\n", level, buffer);
@@ -175,7 +176,8 @@ void daemon_log(int level, char const *format, ...) {
   va_list ap;
 
   va_start(ap, format);
-  vsnprintf(buffer, sizeof(buffer), format, ap);
+  vsnprintf(buffer, sizeof(buffer) - 1, format, ap);
+  buffer[sizeof(buffer) - 1] = '\0';
   va_end(ap);
 
   printf("daemon_log (%i, \"%s\");\n", level, buffer);

--- a/src/daemon/utils_complain.c
+++ b/src/daemon/utils_complain.c
@@ -52,7 +52,7 @@ vcomplain(int level, c_complain_t *c, const char *format, va_list ap) {
   if (c->interval > TIME_T_TO_CDTIME_T(86400))
     c->interval = TIME_T_TO_CDTIME_T(86400);
 
-  vsnprintf(message, sizeof(message), format, ap);
+  vsnprintf(message, sizeof(message) - 1, format, ap);
   message[sizeof(message) - 1] = '\0';
 
   plugin_log(level, "%s", message);
@@ -91,7 +91,7 @@ void c_do_release(int level, c_complain_t *c, const char *format, ...) {
   c->complained_once = false;
 
   va_start(ap, format);
-  vsnprintf(message, sizeof(message), format, ap);
+  vsnprintf(message, sizeof(message) - 1, format, ap);
   message[sizeof(message) - 1] = '\0';
   va_end(ap);
 

--- a/src/daemon/utils_subst.c
+++ b/src/daemon/utils_subst.c
@@ -126,7 +126,7 @@ char *subst_string(char *buf, size_t buflen, const char *string,
     }
 
     /* Copy the new string in `temp' to `buf' for the next round. */
-    strncpy(buf, temp, buflen);
+    sstrncpy(buf, temp, buflen);
   }
 
   if (i >= buflen) {

--- a/src/daemon/utils_time.c
+++ b/src/daemon/utils_time.c
@@ -156,7 +156,7 @@ int format_rfc3339(char *buffer, size_t buffer_size, struct tm const *t_tm,
   size_left -= len;
 
   if (print_nano) {
-    if ((len = snprintf(pos, size_left, ".%09ld", nsec)) == 0)
+    if ((len = ssnprintf(pos, size_left, ".%09ld", nsec)) == 0)
       return ENOMEM;
     pos += len;
     size_left -= len;

--- a/src/dbi.c
+++ b/src/dbi.c
@@ -106,10 +106,10 @@ static const char *cdbi_strerror(dbi_conn conn, /* {{{ */
   msg = NULL;
   status = dbi_conn_error(conn, &msg);
   if ((status >= 0) && (msg != NULL))
-    snprintf(buffer, buffer_size, "%s (status %i)", msg, status);
+    ssnprintf(buffer, buffer_size, "%s (status %i)", msg, status);
   else
-    snprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
-             status);
+    ssnprintf(buffer, buffer_size, "dbi_conn_error failed with status %i",
+              status);
 
   return buffer;
 } /* }}} const char *cdbi_conn_error */
@@ -130,12 +130,12 @@ static int cdbi_result_get_field(dbi_result res, /* {{{ */
     long long value;
 
     value = dbi_result_get_longlong_idx(res, index);
-    snprintf(buffer, buffer_size, "%lli", value);
+    ssnprintf(buffer, buffer_size, "%lli", value);
   } else if (src_type == DBI_TYPE_DECIMAL) {
     double value;
 
     value = dbi_result_get_double_idx(res, index);
-    snprintf(buffer, buffer_size, "%63.15g", value);
+    ssnprintf(buffer, buffer_size, "%63.15g", value);
   } else if (src_type == DBI_TYPE_STRING) {
     const char *value;
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -493,10 +493,10 @@ static int disk_read(void) {
         sstrncpy(disk_name, props_disk_name_bsd, sizeof(disk_name));
       else {
         ERROR("disk plugin: can't find bsd disk name.");
-        snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+        ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
       }
     } else
-      snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+      ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
 
     DEBUG("disk plugin: disk_name = \"%s\"", disk_name);
 
@@ -954,9 +954,7 @@ static int disk_read(void) {
     return 0;
 
   for (int counter = 0; counter < disks; counter++) {
-    strncpy(name, ds->disk_name, sizeof(name));
-    name[sizeof(name) - 1] =
-        '\0'; /* strncpy doesn't terminate longer strings */
+    sstrncpy(name, ds->disk_name, sizeof(name));
 
     if (ignorelist_match(ignorelist, name) != 0) {
       ds++;

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -511,17 +511,17 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
 
         char dev_name[DATA_MAX_NAME_LEN];
         if (ec->config.link_status.port_name[i][0] != 0) {
-          snprintf(dev_name, sizeof(dev_name), "%s",
-                   ec->config.link_status.port_name[i]);
+          ssnprintf(dev_name, sizeof(dev_name), "%s",
+                    ec->config.link_status.port_name[i]);
         } else {
-          snprintf(dev_name, sizeof(dev_name), "port.%d", i);
+          ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
         }
 
         if (ec->config.link_status.notify) {
           int sev = ec->link_info[i].link_status ? NOTIF_OKAY : NOTIF_WARNING;
           char msg[DATA_MAX_NAME_LEN];
-          snprintf(msg, sizeof(msg), "Link Status: %s",
-                   ec->link_info[i].link_status ? "UP" : "DOWN");
+          ssnprintf(msg, sizeof(msg), "Link Status: %s",
+                    ec->link_info[i].link_status ? "UP" : "DOWN");
           dpdk_events_notification_dispatch(sev, dev_name,
                                             ec->link_info[i].read_time, msg);
         } else {
@@ -557,7 +557,7 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
     }
 
     char core_name[DATA_MAX_NAME_LEN];
-    snprintf(core_name, sizeof(core_name), "lcore%u", i);
+    ssnprintf(core_name, sizeof(core_name), "lcore%u", i);
 
     if (!ec->config.keep_alive.send_updated ||
         (ec->core_info[i].lcore_state !=
@@ -572,34 +572,34 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
         switch (ec->config.keep_alive.shm->core_state[i]) {
         case RTE_KA_STATE_ALIVE:
           sev = NOTIF_OKAY;
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
           break;
         case RTE_KA_STATE_MISSING:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
           sev = NOTIF_WARNING;
           break;
         case RTE_KA_STATE_DEAD:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_UNUSED:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_GONE:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_DOZING:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_SLEEP:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
           sev = NOTIF_OKAY;
           break;
         default:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
           sev = NOTIF_FAILURE;
         }
 

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -395,9 +395,9 @@ static int dpdk_stats_counters_dispatch(dpdk_helper_ctx_t *phc) {
 
     char dev_name[64];
     if (ctx->config.port_name[i][0] != 0) {
-      snprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
+      ssnprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
     } else {
-      snprintf(dev_name, sizeof(dev_name), "port.%d", i);
+      ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
     }
 
     DEBUG(" === Dispatch stats for port %d (name=%s; stats_count=%d)", i,

--- a/src/drbd.c
+++ b/src/drbd.c
@@ -77,7 +77,7 @@ static int drbd_submit_fields(long int resource, char **fields,
     return EINVAL;
   }
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "r%ld", resource);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "r%ld", resource);
 
   for (size_t i = 0; i < drbd_names_num; i++) {
     char *data;

--- a/src/exec.c
+++ b/src/exec.c
@@ -187,7 +187,7 @@ static int exec_config_exec(oconfig_item_t *ci) /* {{{ */
       pl->argv[i] = strdup(ci->values[i + 1].value.string);
     } else {
       if (ci->values[i + 1].type == OCONFIG_TYPE_NUMBER) {
-        snprintf(buffer, sizeof(buffer), "%lf", ci->values[i + 1].value.number);
+        ssnprintf(buffer, sizeof(buffer), "%lf", ci->values[i + 1].value.number);
       } else {
         if (ci->values[i + 1].value.boolean)
           sstrncpy(buffer, "true", sizeof(buffer));
@@ -245,18 +245,18 @@ static void set_environment(void) /* {{{ */
   char buffer[1024];
 
 #ifdef HAVE_SETENV
-  snprintf(buffer, sizeof(buffer), "%.3f",
-           CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+  ssnprintf(buffer, sizeof(buffer), "%.3f",
+            CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   setenv("COLLECTD_INTERVAL", buffer, /* overwrite = */ 1);
 
   sstrncpy(buffer, hostname_g, sizeof(buffer));
   setenv("COLLECTD_HOSTNAME", buffer, /* overwrite = */ 1);
 #else
-  snprintf(buffer, sizeof(buffer), "COLLECTD_INTERVAL=%.3f",
-           CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+  ssnprintf(buffer, sizeof(buffer), "COLLECTD_INTERVAL=%.3f",
+            CDTIME_T_TO_DOUBLE(plugin_get_interval()));
   putenv(buffer);
 
-  snprintf(buffer, sizeof(buffer), "COLLECTD_HOSTNAME=%s", hostname_g);
+  ssnprintf(buffer, sizeof(buffer), "COLLECTD_HOSTNAME=%s", hostname_g);
   putenv(buffer);
 #endif
 } /* }}} void set_environment */

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -458,7 +458,7 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
   if (dir == NULL)
     return -1;
 
-  snprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
+  ssnprintf(abs_path, sizeof(abs_path), "%s/%s", dirname, filename);
 
   int status = lstat(abs_path, &statbuf);
   if (status != 0) {

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -399,8 +399,8 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   if (staging_tree == NULL)
     return NULL;
 
-  snprintf(key, sizeof(key), "%s/%s/%s", host, type,
-           (type_instance != NULL) ? type_instance : "");
+  ssnprintf(key, sizeof(key), "%s/%s/%s", host, type,
+            (type_instance != NULL) ? type_instance : "");
 
   se = NULL;
   status = c_avl_get(staging_tree, key, (void *)&se);

--- a/src/hddtemp.c
+++ b/src/hddtemp.c
@@ -206,7 +206,7 @@ static int hddtemp_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "Port") == 0) {
     int port = (int)(atof(value));
     if ((port > 0) && (port <= 65535))
-      snprintf(hddtemp_port, sizeof(hddtemp_port), "%i", port);
+      ssnprintf(hddtemp_port, sizeof(hddtemp_port), "%i", port);
     else
       sstrncpy(hddtemp_port, value, sizeof(hddtemp_port));
   } else {

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -87,11 +87,11 @@ static void submit_hp(const struct entry_info *info) {
 
   sstrncpy(vl.plugin, g_plugin_name, sizeof(vl.plugin));
   if (info->node) {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",
-             info->node, info->page_size_kb);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%zuKb",
+              info->node, info->page_size_kb);
   } else {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%zuKb",
-             info->page_size_kb);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%zuKb",
+              info->page_size_kb);
   }
 
   /* ensure all metrics have the same timestamp */
@@ -125,7 +125,7 @@ static int read_hugepage_entry(const char *path, const char *entry,
   struct entry_info *info = e_info;
   double value;
 
-  snprintf(path2, sizeof(path2), "%s/%s", path, entry);
+  ssnprintf(path2, sizeof(path2), "%s/%s", path, entry);
 
   FILE *fh = fopen(path2, "rt");
   if (fh == NULL) {
@@ -191,7 +191,7 @@ static int read_syshugepages(const char *path, const char *node) {
     }
 
     /* /sys/devices/system/node/node?/hugepages/ */
-    snprintf(path2, sizeof(path2), "%s/%s", path, result->d_name);
+    ssnprintf(path2, sizeof(path2), "%s/%s", path, result->d_name);
 
     walk_directory(path2, read_hugepage_entry,
                    &(struct entry_info){
@@ -236,7 +236,7 @@ static int read_nodes(void) {
       continue;
     }
 
-    snprintf(path, sizeof(path), sys_node_hugepages, result->d_name);
+    ssnprintf(path, sizeof(path), sys_node_hugepages, result->d_name);
     read_syshugepages(path, result->d_name);
     errno = 0;
   }

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -72,8 +72,8 @@ static void rdt_dump_cgroups(void) {
 
     memset(cores, 0, sizeof(cores));
     for (int j = 0; j < cgroup->num_cores; j++) {
-      snprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
-               cgroup->cores[j]);
+      ssnprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
+                cgroup->cores[j]);
     }
 
     DEBUG(RDT_PLUGIN ":  group[%zu]:", i);
@@ -146,7 +146,7 @@ static int rdt_default_cgroups(void) {
     cgroup->num_cores = 1;
     cgroup->cores[0] = i;
 
-    snprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
+    ssnprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
     cgroup->desc = strdup(desc);
     if (cgroup->desc == NULL) {
       ERROR(RDT_PLUGIN ": Error allocating core group description");
@@ -344,7 +344,7 @@ static void rdt_submit_derive(const char *cgroup, const char *type,
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, RDT_PLUGIN, sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
   sstrncpy(vl.type, type, sizeof(vl.type));
   if (type_instance)
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
@@ -360,7 +360,7 @@ static void rdt_submit_gauge(const char *cgroup, const char *type,
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, RDT_PLUGIN, sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
   sstrncpy(vl.type, type, sizeof(vl.type));
   if (type_instance)
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));

--- a/src/interface.c
+++ b/src/interface.c
@@ -297,8 +297,8 @@ static int interface_read(void) {
       continue;
 
     if (unique_name)
-      snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
-               ksp[i]->ks_instance, ksp[i]->ks_name);
+      ssnprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
+                ksp[i]->ks_instance, ksp[i]->ks_name);
     else
       sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));
 

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -111,7 +111,7 @@ static void c_ipmi_error(c_ipmi_instance_t *st, const char *func, int status) {
   }
 
   if (errbuf[0] == 0) {
-    snprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
+    ssnprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
   }
   errbuf[sizeof(errbuf) - 1] = 0;
 
@@ -122,7 +122,8 @@ static void c_ipmi_log(os_handler_t *handler, const char *format,
                        enum ipmi_log_type_e log_type, va_list ap) {
   char msg[ERR_BUF_SIZE];
 
-  vsnprintf(msg, sizeof(msg), format, ap);
+  vsnprintf(msg, sizeof(msg) - 1, format, ap);
+  msg[sizeof(msg) - 1] = '\0';
 
   switch (log_type) {
   case IPMI_LOG_INFO:
@@ -201,8 +202,8 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
           sstrncpy(n.type_instance, list_item->type_instance,
                    sizeof(n.type_instance));
           sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-          snprintf(n.message, sizeof(n.message), "sensor %s not present",
-                   list_item->sensor_name);
+          ssnprintf(n.message, sizeof(n.message), "sensor %s not present",
+                    list_item->sensor_name);
 
           plugin_dispatch_notification(&n);
         }
@@ -254,8 +255,8 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
       sstrncpy(n.type_instance, list_item->type_instance,
                sizeof(n.type_instance));
       sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-      snprintf(n.message, sizeof(n.message), "sensor %s present",
-               list_item->sensor_name);
+      ssnprintf(n.message, sizeof(n.message), "sensor %s present",
+                list_item->sensor_name);
 
       plugin_dispatch_notification(&n);
     }
@@ -313,7 +314,7 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
   temp[sizeof(temp) - 1] = 0;
 
   if (entity_id_string != NULL && strlen(temp))
-    snprintf(sensor_name, sizeof(sensor_name), "%s %s", temp, entity_id_string);
+    ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", temp, entity_id_string);
   else if (entity_id_string != NULL)
     sstrncpy(sensor_name, entity_id_string, sizeof(sensor_name));
   else
@@ -338,8 +339,8 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
       sensor_id_ptr = strstr(temp, "(");
       if (sensor_id_ptr != NULL) {
         /* `sensor_id_ptr' now points to "(123)". */
-        snprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
-                 sensor_id_ptr);
+        ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
+                  sensor_id_ptr);
       }
       /* else: don't touch sensor_name. */
     }
@@ -493,8 +494,8 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
   /* if sensor provides the percentage value, use "percent" collectd type
      and add the `percent` to the type instance of the reported value */
   if (ipmi_sensor_get_percentage(sensor)) {
-    snprintf(list_item->type_instance, sizeof(list_item->type_instance),
-             "percent-%s", sensor_name_ptr);
+    ssnprintf(list_item->type_instance, sizeof(list_item->type_instance),
+              "percent-%s", sensor_name_ptr);
     type = "percent";
   } else {
     /* use type instance as a name of the sensor */
@@ -514,8 +515,8 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->type_instance,
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    snprintf(n.message, sizeof(n.message), "sensor %s added",
-             list_item->sensor_name);
+    ssnprintf(n.message, sizeof(n.message), "sensor %s added",
+              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }
@@ -561,8 +562,8 @@ static int sensor_list_remove(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->type_instance,
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    snprintf(n.message, sizeof(n.message), "sensor %s removed",
-             list_item->sensor_name);
+    ssnprintf(n.message, sizeof(n.message), "sensor %s removed",
+              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }
@@ -674,13 +675,13 @@ static int sensor_threshold_event_handler(
       ipmi_get_reading_name(event_type, sensor_type, offset);
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
   if (value_present != IPMI_NO_VALUES_PRESENT)
-    snprintf(n.message, sizeof(n.message),
-             "sensor %s received event: %s, value is %f", n.type_instance,
-             event_state, value);
+    ssnprintf(n.message, sizeof(n.message),
+              "sensor %s received event: %s, value is %f", n.type_instance,
+              event_state, value);
   else
-    snprintf(n.message, sizeof(n.message),
-             "sensor %s received event: %s, value not provided",
-             n.type_instance, event_state);
+    ssnprintf(n.message, sizeof(n.message),
+              "sensor %s received event: %s, value not provided",
+              n.type_instance, event_state);
 
   DEBUG("Threshold event received for sensor %s", n.type_instance);
 
@@ -699,7 +700,7 @@ static int sensor_threshold_event_handler(
   /* both values present, so fall-through to add raw value too */
   case IPMI_RAW_VALUE_PRESENT: {
     char buf[DATA_MAX_NAME_LEN] = {0};
-    snprintf(buf, sizeof(buf), "0x%2.2x", raw_value);
+    ssnprintf(buf, sizeof(buf), "0x%2.2x", raw_value);
     plugin_notification_meta_add_string(&n, "raw", buf);
   } break;
   default:
@@ -741,8 +742,8 @@ static int sensor_discrete_event_handler(ipmi_sensor_t *sensor,
   const char *event_state =
       ipmi_get_reading_name(event_type, sensor_type, offset);
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
-  snprintf(n.message, sizeof(n.message), "sensor %s received event: %s",
-           n.type_instance, event_state);
+  ssnprintf(n.message, sizeof(n.message), "sensor %s received event: %s",
+            n.type_instance, event_state);
 
   DEBUG("Discrete event received for sensor %s", n.type_instance);
 
@@ -1253,7 +1254,7 @@ static int c_ipmi_init(void) {
     /* The `st->name` is used as "domain name" for ipmi_open_domain().
      * That value should be unique, so we do plugin_register_complex_read()
      * at first as it checks the uniqueness. */
-    snprintf(callback_name, sizeof(callback_name), "ipmi/%s", st->name);
+    ssnprintf(callback_name, sizeof(callback_name), "ipmi/%s", st->name);
 
     user_data_t ud = {
         .data = st,

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -221,8 +221,8 @@ static int submit6_match(const struct ip6t_entry_match *match,
 
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
 
-  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                    chain->table, chain->chain);
+  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -230,8 +230,8 @@ static int submit6_match(const struct ip6t_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-               chain->rule.num);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }
@@ -269,8 +269,8 @@ static int submit_match(const struct ipt_entry_match *match,
 
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
 
-  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                    chain->table, chain->chain);
+  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -278,8 +278,8 @@ static int submit_match(const struct ipt_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-               chain->rule.num);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -101,7 +101,9 @@
 
 #define LCC_SET_ERRSTR(c, ...)                                                 \
   do {                                                                         \
-    snprintf((c)->errbuf, sizeof((c)->errbuf), __VA_ARGS__);                   \
+    if (snprintf((c)->errbuf, sizeof((c)->errbuf), __VA_ARGS__) >=             \
+        sizeof((c)->errbuf))                                                   \
+      (c)->errbuf[sizeof((c)->errbuf) - 1] = '\0';                             \
   } while (0)
 
 /*
@@ -146,7 +148,7 @@ static char *sstrerror(int errnum, char *buf, size_t buflen) {
   buf[0] = 0;
 
 #if !HAVE_STRERROR_R
-  snprintf(buf, buflen, "Error #%i; strerror_r is not available.", errnum);
+  ssnprintf(buf, buflen, "Error #%i; strerror_r is not available.", errnum);
 /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
@@ -599,7 +601,7 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
                char ***ret_values_names) {
   char ident_str[6 * LCC_NAME_LEN];
   char ident_esc[12 * LCC_NAME_LEN];
-  char command[14 * LCC_NAME_LEN];
+  char command[14 * LCC_NAME_LEN] = {};
 
   lcc_response_t res;
   size_t values_num;
@@ -622,7 +624,7 @@ int lcc_getval(lcc_connection_t *c, lcc_identifier_t *ident, /* {{{ */
   if (status != 0)
     return status;
 
-  snprintf(command, sizeof(command), "GETVAL %s",
+  snprintf(command, sizeof(command) - 1, "GETVAL %s",
            lcc_strescape(ident_esc, ident_str, sizeof(ident_esc)));
   command[sizeof(command) - 1] = 0;
 

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -158,7 +158,8 @@ static int parse_string(void *payload, size_t payload_size, char *out,
       (payload_size > out_size))
     return EINVAL;
 
-  strncpy(out, in, out_size);
+  strncpy(out, in, out_size - 1);
+  out[out_size - 1] = '\0';
   return 0;
 }
 

--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include "oconfig.h"
+#include "common.h"
 
 extern FILE *yyin;
 extern int yyparse(void);
@@ -49,7 +50,7 @@ static oconfig_item_t *oconfig_parse_fh(FILE *fh) {
   yyset_in(fh);
 
   if (NULL == c_file) {
-    status = snprintf(file, sizeof(file), "<fd#%d>", fileno(fh));
+    status = ssnprintf(file, sizeof(file), "<fd#%d>", fileno(fh));
 
     if ((status < 0) || (((size_t)status) >= sizeof(file))) {
       c_file = "<unknown>";

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -84,19 +84,19 @@ static void logfile_print(const char *msg, int severity,
   if (print_severity) {
     switch (severity) {
     case LOG_ERR:
-      snprintf(level_str, sizeof(level_str), "[error] ");
+      ssnprintf(level_str, sizeof(level_str), "[error] ");
       break;
     case LOG_WARNING:
-      snprintf(level_str, sizeof(level_str), "[warning] ");
+      ssnprintf(level_str, sizeof(level_str), "[warning] ");
       break;
     case LOG_NOTICE:
-      snprintf(level_str, sizeof(level_str), "[notice] ");
+      ssnprintf(level_str, sizeof(level_str), "[notice] ");
       break;
     case LOG_INFO:
-      snprintf(level_str, sizeof(level_str), "[info] ");
+      ssnprintf(level_str, sizeof(level_str), "[info] ");
       break;
     case LOG_DEBUG:
-      snprintf(level_str, sizeof(level_str), "[debug] ");
+      ssnprintf(level_str, sizeof(level_str), "[debug] ");
       break;
     default:
       break;

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -224,10 +224,10 @@ static int lpar_read(void) {
     if (pool_busy_cpus < 0.0)
       pool_busy_cpus = 0.0;
 
-    snprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
+    ssnprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
     lpar_submit(typinst, pool_busy_cpus);
 
-    snprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
+    ssnprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
     lpar_submit(typinst, pool_idle_cpus);
   }
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -273,7 +273,8 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
   luaL_checktype(L, 1, LUA_TFUNCTION);
 
   char function_name[DATA_MAX_NAME_LEN];
-  snprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
+  ssnprintf(function_name, sizeof(function_name), "lua/%s",
+            lua_tostring(L, 1));
 
   int callback_id = clua_store_callback(L, 1);
   if (callback_id < 0)
@@ -317,7 +318,8 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
   luaL_checktype(L, 1, LUA_TFUNCTION);
 
   char function_name[DATA_MAX_NAME_LEN] = "";
-  snprintf(function_name, sizeof(function_name), "lua/%s", lua_tostring(L, 1));
+  ssnprintf(function_name, sizeof(function_name), "lua/%s",
+            lua_tostring(L, 1));
 
   int callback_id = clua_store_callback(L, 1);
   if (callback_id < 0)
@@ -525,7 +527,7 @@ static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
   if (base_path[0] == '\0')
     sstrncpy(abs_path, rel_path, sizeof(abs_path));
   else
-    snprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
+    ssnprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
 
   DEBUG("Lua plugin: abs_path = \"%s\";", abs_path);
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -81,7 +81,8 @@ static void report_lv_utilization(lv_t lv, char const *vg_name,
     return;
   used_bytes = lv_size * (used_percent_unscaled * PERCENT_SCALE_FACTOR);
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name, lv_name);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name,
+            lv_name);
   lvm_submit(plugin_instance, "used", used_bytes);
   lvm_submit(plugin_instance, "free", lv_size - used_bytes);
 }

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -519,7 +519,7 @@ static void submit(const char *dev, const char *type, const char *ti1,
   sstrncpy(vl.type, type, sizeof(vl.type));
 
   if ((ti1 != NULL) && (ti2 != NULL))
-    snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s", ti1, ti2);
+    ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s", ti1, ti2);
   else if ((ti1 != NULL) && (ti2 == NULL))
     sstrncpy(vl.type_instance, ti1, sizeof(vl.type_instance));
 
@@ -553,15 +553,15 @@ static void submit_antx(const char *dev, const char *name, u_int32_t *vals,
     if (vals[i] == 0)
       continue;
 
-    snprintf(ti2, sizeof(ti2), "%i", i);
+    ssnprintf(ti2, sizeof(ti2), "%i", i);
     submit_derive(dev, "ath_stat", name, ti2, (derive_t)vals[i]);
   }
 }
 
 static inline void macaddr_to_str(char *buf, size_t bufsize,
                                   const uint8_t mac[IEEE80211_ADDR_LEN]) {
-  snprintf(buf, bufsize, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
-           mac[2], mac[3], mac[4], mac[5]);
+  ssnprintf(buf, bufsize, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
+            mac[2], mac[3], mac[4], mac[5]);
 }
 
 static void process_stat_struct(int which, const void *ptr, const char *dev,
@@ -753,7 +753,7 @@ static int check_devname(const char *dev) {
   if (dev[0] == '.')
     return 0;
 
-  snprintf(buf, sizeof(buf), "/sys/class/net/%s/device/driver", dev);
+  ssnprintf(buf, sizeof(buf), "/sys/class/net/%s/device/driver", dev);
   buf[sizeof(buf) - 1] = '\0';
 
   i = readlink(buf, buf2, sizeof(buf2) - 1);

--- a/src/match_regex.c
+++ b/src/match_regex.c
@@ -224,7 +224,7 @@ static int mr_config_add_meta_regex(llist_t **meta, /* {{{ */
     llist_append(*meta, entry);
   }
 
-  snprintf(buffer, sizeof(buffer), "%s `%s'", ci->key, meta_key);
+  ssnprintf(buffer, sizeof(buffer), "%s `%s'", ci->key, meta_key);
   /* Can't pass &entry->value into mr_add_regex, so copy in/out. */
   re_head = entry->value;
   status = mr_add_regex(&re_head, ci->values[1].value.string, buffer);

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -124,8 +124,8 @@ static llentry_t *mcelog_dimm(const mcelog_memory_rec_t *rec,
   char dimm_name[DATA_MAX_NAME_LEN];
 
   if (strlen(rec->dimm_name) > 0) {
-    snprintf(dimm_name, sizeof(dimm_name), "%s_%s", rec->location,
-             rec->dimm_name);
+    ssnprintf(dimm_name, sizeof(dimm_name), "%s_%s", rec->location,
+              rec->dimm_name);
   } else
     sstrncpy(dimm_name, rec->location, sizeof(dimm_name));
 
@@ -355,8 +355,8 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
   sstrncpy(n.host, hostname_g, sizeof(n.host));
 
   if (mr->dimm_name[0] != '\0')
-    snprintf(n.plugin_instance, sizeof(n.plugin_instance), "%s_%s",
-             mr->location, mr->dimm_name);
+    ssnprintf(n.plugin_instance, sizeof(n.plugin_instance), "%s_%s",
+              mr->location, mr->dimm_name);
   else
     sstrncpy(n.plugin_instance, mr->location, sizeof(n.plugin_instance));
 
@@ -367,7 +367,7 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
                                             mr->corrected_err_total);
     plugin_notification_meta_add_signed_int(&n, MCELOG_CORRECTED_ERR_TIMED,
                                             mr->corrected_err_timed);
-    snprintf(n.message, sizeof(n.message), MCELOG_CORRECTED_ERR);
+    ssnprintf(n.message, sizeof(n.message), MCELOG_CORRECTED_ERR);
     sstrncpy(n.type_instance, MCELOG_CORRECTED_ERR_TYPE_INS,
              sizeof(n.type_instance));
     plugin_dispatch_notification(&n);
@@ -383,7 +383,7 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
                                             mr->uncorrected_err_total);
     plugin_notification_meta_add_signed_int(&n, MCELOG_UNCORRECTED_ERR_TIMED,
                                             mr->uncorrected_err_timed);
-    snprintf(n.message, sizeof(n.message), MCELOG_UNCORRECTED_ERR);
+    ssnprintf(n.message, sizeof(n.message), MCELOG_UNCORRECTED_ERR);
     sstrncpy(n.type_instance, MCELOG_UNCORRECTED_ERR_TYPE_INS,
              sizeof(n.type_instance));
     n.severity = NOTIF_FAILURE;
@@ -421,15 +421,15 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
   mcelog_update_dimm_stats(dimm, mr);
 
   if (mr->dimm_name[0] != '\0')
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s_%s",
-             mr->location, mr->dimm_name);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s_%s",
+              mr->location, mr->dimm_name);
   else
     sstrncpy(vl.plugin_instance, mr->location, sizeof(vl.plugin_instance));
 
   plugin_dispatch_values(&vl);
 
-  snprintf(vl.type_instance, sizeof(vl.type_instance),
-           "corrected_memory_errors_in_%s", mr->corrected_err_timed_period);
+  ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+            "corrected_memory_errors_in_%s", mr->corrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->corrected_err_timed};
   plugin_dispatch_values(&vl);
 
@@ -438,8 +438,9 @@ static int mcelog_submit(const mcelog_memory_rec_t *mr) {
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_total};
   plugin_dispatch_values(&vl);
 
-  snprintf(vl.type_instance, sizeof(vl.type_instance),
-           "uncorrected_memory_errors_in_%s", mr->uncorrected_err_timed_period);
+  ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+            "uncorrected_memory_errors_in_%s",
+            mr->uncorrected_err_timed_period);
   vl.values = &(value_t){.derive = (derive_t)mr->uncorrected_err_timed};
   plugin_dispatch_values(&vl);
 

--- a/src/md.c
+++ b/src/md.c
@@ -66,7 +66,7 @@ static void md_submit(const int minor, const char *type_instance,
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
   sstrncpy(vl.plugin, "md", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", minor);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", minor);
   sstrncpy(vl.type, "md_disks", sizeof(vl.type));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -175,7 +175,7 @@ static int md_read(void) {
      * major/minor, but that again can be tricky if the filesystem
      * with the device file is mounted using the "nodev" option.
      */
-    snprintf(path, sizeof(path), "%s/%s", DEV_DIR, name);
+    ssnprintf(path, sizeof(path), "%s/%s", DEV_DIR, name);
 
     md_process(minor, path);
   }

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -676,8 +676,8 @@ static int memcached_add_read_callback(memcached_t *st) {
     return -1;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "memcached/%s",
-           (st->name != NULL) ? st->name : "__legacy__");
+  ssnprintf(callback_name, sizeof(callback_name), "memcached/%s",
+            (st->name != NULL) ? st->name : "__legacy__");
 
   return plugin_register_complex_read(
       /* group = */ "memcached",

--- a/src/mic.c
+++ b/src/mic.c
@@ -131,10 +131,10 @@ static void mic_submit_memory_use(int micnumber, const char *type_instance,
   vl.values = &(value_t){.gauge = ((gauge_t)value) * 1024.0};
   vl.values_len = 1;
 
-  strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
-  strncpy(vl.type, "memory", sizeof(vl.type));
-  strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+  sstrncpy(vl.plugin, "mic", sizeof(vl.plugin));
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  sstrncpy(vl.type, "memory", sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
   plugin_dispatch_values(&vl);
 }
@@ -163,10 +163,10 @@ static void mic_submit_temp(int micnumber, const char *type, gauge_t value) {
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
 
-  strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
-  strncpy(vl.type, "temperature", sizeof(vl.type));
-  strncpy(vl.type_instance, type, sizeof(vl.type_instance));
+  sstrncpy(vl.plugin, "mic", sizeof(vl.plugin));
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  sstrncpy(vl.type, "temperature", sizeof(vl.type));
+  sstrncpy(vl.type_instance, type, sizeof(vl.type_instance));
 
   plugin_dispatch_values(&vl);
 }
@@ -204,14 +204,14 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
   vl.values = &(value_t){.derive = value};
   vl.values_len = 1;
 
-  strncpy(vl.plugin, "mic", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, "mic", sizeof(vl.plugin));
   if (core < 0) /* global aggregation */
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   else /* per-core statistics */
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
-             micnumber, core);
-  strncpy(vl.type, "cpu", sizeof(vl.type));
-  strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
+              micnumber, core);
+  sstrncpy(vl.type, "cpu", sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
   plugin_dispatch_values(&vl);
 }
@@ -257,10 +257,10 @@ static void mic_submit_power(int micnumber, const char *type,
   vl.values = &(value_t){.gauge = value};
   vl.values_len = 1;
 
-  strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
-  strncpy(vl.type, type, sizeof(vl.type));
-  strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+  sstrncpy(vl.plugin, "mic", sizeof(vl.plugin));
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  sstrncpy(vl.type, type, sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
   plugin_dispatch_values(&vl);
 }

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -252,7 +252,7 @@ static int mb_submit(mb_host_t *host, mb_slave_t *slave, /* {{{ */
     return EINVAL;
 
   if (slave->instance[0] == 0)
-    snprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
+    ssnprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
 
   vl.values = &value;
   vl.values_len = 1;
@@ -1025,7 +1025,7 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char name[1024];
 
-    snprintf(name, sizeof(name), "modbus-%s", host->host);
+    ssnprintf(name, sizeof(name), "modbus-%s", host->host);
 
     plugin_register_complex_read(/* group = */ NULL, name,
                                  /* callback = */ mb_read,

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -599,7 +599,7 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
       ERROR("mqtt plugin: Unknown config option: %s", child->key);
   }
 
-  snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
+  ssnprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
   plugin_register_write(cb_name, mqtt_write,
                         &(user_data_t){
                             .data = conf,

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -218,7 +218,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
           (db->database != NULL) ? db->database : "<default>");
 
     if (db->instance != NULL)
-      snprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
+      ssnprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
     else
       sstrncpy(cb_name, "mysql", sizeof(cb_name));
 
@@ -500,15 +500,15 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((io == NULL) || (strcasecmp(io, "yes") != 0)) &&
         (db->slave_io_running)) {
       n.severity = NOTIF_WARNING;
-      snprintf(n.message, sizeof(n.message),
-               "slave I/O thread not started or not connected to master");
+      ssnprintf(n.message, sizeof(n.message),
+                "slave I/O thread not started or not connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = false;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                (!db->slave_io_running)) {
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message),
-               "slave I/O thread started and connected to master");
+      ssnprintf(n.message, sizeof(n.message),
+                "slave I/O thread started and connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = true;
     }
@@ -516,13 +516,13 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((sql == NULL) || (strcasecmp(sql, "yes") != 0)) &&
         (db->slave_sql_running)) {
       n.severity = NOTIF_WARNING;
-      snprintf(n.message, sizeof(n.message), "slave SQL thread not started");
+      ssnprintf(n.message, sizeof(n.message), "slave SQL thread not started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = false;
     } else if (((sql != NULL) && (strcasecmp(sql, "yes") == 0)) &&
                (!db->slave_sql_running)) {
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message), "slave SQL thread started");
+      ssnprintf(n.message, sizeof(n.message), "slave SQL thread started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = true;
     }

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -773,8 +773,8 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   if ((hostname == NULL) || (old_data == NULL) || (new_data == NULL))
     return -1;
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
-           old_data->name);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
+            old_data->name);
 
   /* Check for and submit disk-octet values */
   if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_IO) &&
@@ -1404,7 +1404,7 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
     uint64_t snap_reserve_free = v->snap_reserved;
     uint64_t snap_norm_used = v->snap_used;
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
     if (HAS_ALL_FLAGS(v->flags,
                       HAVE_VOLUME_USAGE_SNAP_USED |
@@ -1498,12 +1498,13 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
 
   if ((v->flags & IS_VOLUME_USAGE_OFFLINE) != 0) {
     n.severity = NOTIF_OKAY;
-    snprintf(n.message, sizeof(n.message), "Volume %s is now online.", v->name);
+    ssnprintf(n.message, sizeof(n.message), "Volume %s is now online.",
+              v->name);
     v->flags &= ~IS_VOLUME_USAGE_OFFLINE;
   } else {
     n.severity = NOTIF_WARNING;
-    snprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
-             v->name);
+    ssnprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
+              v->name);
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
 
@@ -1832,8 +1833,8 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
     if (volume_name == NULL)
       continue;
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
-             volume_name, tree_name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
+              volume_name, tree_name);
 
     value = na_child_get_uint64(elem_quota, "disk-used", UINT64_MAX);
     if (value != UINT64_MAX) {
@@ -1945,8 +1946,8 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
       continue;
 
     /* possible TODO: make plugin instance configurable */
-    snprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
-             dest_path);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
+              dest_path);
     submit_double(hostname, plugin_instance, /* type = */ "delay", NULL,
                   (double)value, /* timestamp = */ 0, interval);
 
@@ -2787,10 +2788,10 @@ static int cna_register_host(host_config_t *host) /* {{{ */
   char cb_name[256];
 
   if (host->vfiler)
-    snprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
-             host->vfiler);
+    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
+              host->vfiler);
   else
-    snprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
+    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
 
   plugin_register_complex_read(
       /* group = */ NULL, cb_name,

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -509,8 +509,8 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (strcmp(tc_type, "filter") == 0)
       numberic_id = tm->tcm_parent;
 
-    snprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
-             numberic_id & 0x0000FFFF);
+    ssnprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
+              numberic_id & 0x0000FFFF);
   }
 
   DEBUG("netlink plugin: qos_filter_cb: got %s for %s (%i).", tc_type, dev,

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -382,8 +382,8 @@ static void nfs_submit_fields(int nfs_version, const char *instance,
   char plugin_instance[DATA_MAX_NAME_LEN];
   value_t values[fields_num];
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
-           instance);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
+            instance);
 
   for (size_t i = 0; i < fields_num; i++)
     (void)parse_value(fields[i], &values[i], DS_TYPE_DERIVE);
@@ -559,8 +559,8 @@ static int nfs_read_kstat(kstat_t *ksp, int nfs_version, const char *inst,
   if (ksp == NULL)
     return EINVAL;
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
-           inst);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "v%i%s", nfs_version,
+            inst);
 
   kstat_read(kc, ksp, NULL);
   for (size_t i = 0; i < proc_names_num; i++) {

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -122,8 +122,8 @@ static int init(void) {
     curl_easy_setopt(curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
 #else
     static char credentials[1024];
-    int status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
-                          pass == NULL ? "" : pass);
+    int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
+                           pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");
       return -1;

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -93,12 +93,8 @@ static int c_notify(const notification_t *n,
     timeout = fail_timeout;
   }
 
-  snprintf(summary, sizeof(summary), "collectd %s notification",
-           (NOTIF_FAILURE == n->severity)
-               ? "FAILURE"
-               : (NOTIF_WARNING == n->severity)
-                     ? "WARNING"
-                     : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
+  ssnprintf(summary, sizeof(summary), "collectd %s notification",
+            (NOTIF_FAILURE == n->severity) ? "FAILURE" : (NOTIF_WARNING == n->severity) ? "WARNING" : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
 
   notification = notify_notification_new(summary, n->message, NULL
 #if NOTIFY_CHECK_VERSION(0, 7, 0)

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -104,8 +104,8 @@ static void monitor_cb(const char *buf, int buflen, int writing,
 static int notify_email_init(void) {
   char server[MAXSTRING];
 
-  snprintf(server, sizeof(server), "%s:%i",
-           (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
+  ssnprintf(server, sizeof(server), "%s:%i",
+            (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
 
   pthread_mutex_lock(&session_lock);
 
@@ -214,16 +214,12 @@ static int notify_email_notification(const notification_t *n,
   char *buf_ptr = buf;
   int buf_len = sizeof(buf);
 
-  snprintf(severity, sizeof(severity), "%s",
-           (n->severity == NOTIF_FAILURE)
-               ? "FAILURE"
-               : ((n->severity == NOTIF_WARNING)
-                      ? "WARNING"
-                      : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
+  ssnprintf(severity, sizeof(severity), "%s",
+            (n->severity == NOTIF_FAILURE) ? "FAILURE" : ((n->severity == NOTIF_WARNING) ? "WARNING" : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
 
-  snprintf(subject, sizeof(subject),
-           (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
-           severity, n->host);
+  ssnprintf(subject, sizeof(subject),
+            (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
+            severity, n->host);
 
   localtime_r(&CDTIME_T_TO_TIME_T(n->time), &timestamp_tm);
   strftime(timestamp_str, sizeof(timestamp_str), "%Y-%m-%d %H:%M:%S",
@@ -231,7 +227,7 @@ static int notify_email_notification(const notification_t *n,
   timestamp_str[sizeof(timestamp_str) - 1] = '\0';
 
   /* Let's make RFC822 message text with \r\n EOLs */
-  int status = snprintf(buf, buf_len,
+  int status = ssnprintf(buf, buf_len,
                         "MIME-Version: 1.0\r\n"
                         "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
                         "Content-Transfer-Encoding: 8bit\r\n"
@@ -248,7 +244,7 @@ static int notify_email_notification(const notification_t *n,
 
 #define APPEND(format, value)                                                  \
   if ((buf_len > 0) && (strlen(value) > 0)) {                                  \
-    status = snprintf(buf_ptr, buf_len, format "\r\n", value);                 \
+    status = ssnprintf(buf_ptr, buf_len, format "\r\n", value);                \
     if (status > 0) {                                                          \
       buf_ptr += status;                                                       \
       buf_len -= status;                                                       \

--- a/src/notify_nagios.c
+++ b/src/notify_nagios.c
@@ -135,10 +135,10 @@ static int nagios_notify(const notification_t *n, /* {{{ */
     break;
   }
 
-  snprintf(buffer, sizeof(buffer),
-           "[%.0f] PROCESS_SERVICE_CHECK_RESULT;%s;%s;%d;%s\n",
-           CDTIME_T_TO_DOUBLE(n->time), n->host, &svc_description[1], code,
-           n->message);
+  ssnprintf(buffer, sizeof(buffer),
+            "[%.0f] PROCESS_SERVICE_CHECK_RESULT;%s;%s;%d;%s\n",
+            CDTIME_T_TO_DOUBLE(n->time), n->host, &svc_description[1], code,
+            n->message);
 
   return nagios_print(buffer);
 } /* }}} int nagios_notify */

--- a/src/ntpd.c
+++ b/src/ntpd.c
@@ -267,7 +267,7 @@ static int ntpd_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "Port") == 0) {
     int port = (int)(atof(value));
     if ((port > 0) && (port <= 65535))
-      snprintf(ntpd_port, sizeof(ntpd_port), "%i", port);
+      ssnprintf(ntpd_port, sizeof(ntpd_port), "%i", port);
     else
       sstrncpy(ntpd_port, value, sizeof(ntpd_port));
   } else if (strcasecmp(key, "ReverseLookups") == 0) {
@@ -771,8 +771,8 @@ static int ntpd_get_name_refclock(char *buffer, size_t buffer_size,
     return ntpd_get_name_from_address(buffer, buffer_size, peer_info, 0);
 
   if (include_unit_id)
-    snprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
-             unit_id);
+    ssnprintf(buffer, buffer_size, "%s-%" PRIu32, refclock_names[refclock_id],
+              unit_id);
   else
     sstrncpy(buffer, refclock_names[refclock_id], buffer_size);
 

--- a/src/numa.c
+++ b/src/numa.c
@@ -47,7 +47,7 @@ static void numa_dispatch_value(int node, /* {{{ */
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, "numa", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "node%i", node);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "node%i", node);
   sstrncpy(vl.type, "vmpage_action", sizeof(vl.type));
   sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -62,7 +62,7 @@ static int numa_read_node(int node) /* {{{ */
   int status;
   int success;
 
-  snprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i/numastat", node);
+  ssnprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i/numastat", node);
 
   fh = fopen(path, "r");
   if (fh == NULL) {
@@ -126,7 +126,7 @@ static int numa_init(void) /* {{{ */
     struct stat statbuf = {0};
     int status;
 
-    snprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i", max_node + 1);
+    ssnprintf(path, sizeof(path), NUMA_ROOT_DIR "/node%i", max_node + 1);
 
     status = stat(path, &statbuf);
     if (status == 0) {

--- a/src/olsrd.c
+++ b/src/olsrd.c
@@ -291,8 +291,8 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     if (config_want_links == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
-               fields[1]);
+      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
+                fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s;  lq = %g;", type_instance,
             lq);
@@ -315,8 +315,8 @@ static int olsrd_cb_links(int lineno, /* {{{ */
     if (config_want_links == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", fields[0],
-               fields[1]);
+      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", fields[0],
+                fields[1]);
 
       DEBUG("olsrd plugin: links: type_instance = %s; nlq = %g;", type_instance,
             lq);
@@ -493,8 +493,8 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     if (config_want_topology == OLSRD_WANT_DETAIL) {
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
-               fields[1]);
+      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-lq", fields[0],
+                fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; lq = %g;", type_instance, lq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
                    type_instance, lq);
@@ -512,8 +512,8 @@ static int olsrd_cb_topology(int lineno, /* {{{ */
     } else {
       char type_instance[DATA_MAX_NAME_LEN] = {0};
 
-      snprintf(type_instance, sizeof(type_instance), "%s-%s-nlq", fields[0],
-               fields[1]);
+      ssnprintf(type_instance, sizeof(type_instance), "%s-%s-nlq", fields[0],
+                fields[1]);
       DEBUG("olsrd plugin: type_instance = %s; nlq = %g;", type_instance, nlq);
       olsrd_submit(/* p.-inst = */ "topology", /* type = */ "signal_quality",
                    type_instance, nlq);

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -297,8 +297,8 @@ static int cow_read_values(const char *path, const char *name,
     char file[4096];
     char *endptr;
 
-    snprintf(file, sizeof(file), "%s/%s", path,
-             family_info->features[i].filename);
+    ssnprintf(file, sizeof(file), "%s/%s", path,
+              family_info->features[i].filename);
     file[sizeof(file) - 1] = 0;
 
     buffer = NULL;
@@ -348,11 +348,11 @@ static int cow_read_ds2409(const char *path) {
   char subpath[4096];
   int status;
 
-  status = snprintf(subpath, sizeof(subpath), "%s/main", path);
+  status = ssnprintf(subpath, sizeof(subpath), "%s/main", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
-  status = snprintf(subpath, sizeof(subpath), "%s/aux", path);
+  status = ssnprintf(subpath, sizeof(subpath), "%s/aux", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
@@ -384,9 +384,9 @@ static int cow_read_bus(const char *path) {
     dummy = NULL;
 
     if (strcmp("/", path) == 0)
-      status = snprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
+      status = ssnprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
     else
-      status = snprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
+      status = ssnprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
     if ((status <= 0) || (status >= (int)sizeof(subpath)))
       continue;
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -306,8 +306,8 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list =
                  ldap_get_values_len(st->ld, e, "olmBDBEntryCache")) != NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
-                   nc_data.bv_val);
+          ssnprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -316,7 +316,8 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBDNCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbdncache-%s", nc_data.bv_val);
+          ssnprintf(typeinst, sizeof(typeinst), "bdbdncache-%s",
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -325,8 +326,8 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBIDLCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
-                   nc_data.bv_val);
+          ssnprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -462,9 +463,9 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
 
   char callback_name[3 * DATA_MAX_NAME_LEN] = {0};
 
-  snprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
-           (st->host != NULL) ? st->host : hostname_g,
-           (st->name != NULL) ? st->name : "default");
+  ssnprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
+            (st->host != NULL) ? st->host : hostname_g,
+            (st->name != NULL) ? st->name : "default");
 
   return plugin_register_complex_read(/* group = */ NULL,
                                       /* name      = */ callback_name,

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -494,7 +494,7 @@ static int openvpn_config(const char *key, const char *value) {
     instance->file = status_file;
     instance->name = status_name;
 
-    snprintf(callback_name, sizeof(callback_name), "openvpn/%s", status_name);
+    ssnprintf(callback_name, sizeof(callback_name), "openvpn/%s", status_name);
 
     int status = plugin_register_complex_read(
         /* group = */ "openvpn",

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -642,7 +642,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
     if ((status != OCI_SUCCESS) && (status != OCI_SUCCESS_WITH_INFO)) {
       char errfunc[256];
 
-      snprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
+      ssnprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
 
       o_report_error("o_read_database", db->name, NULL, errfunc, oci_error);
       DEBUG("oracle plugin: OCILogon (%s): db->oci_service_context = %p;",

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -158,8 +158,8 @@ static char *ovs_events_get_select_params() {
       return NULL;
     }
     opt_buff = new_buff;
-    int ret = snprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
-                       iface->name);
+    int ret = ssnprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
+                        iface->name);
     if (ret < 0) {
       sfree(opt_buff);
       return NULL;
@@ -180,7 +180,7 @@ static char *ovs_events_get_select_params() {
   }
 
   /* create OVS DB select params */
-  if (snprintf(params_buff, params_size, params_fmt, opt_buff) < 0)
+  if (ssnprintf(params_buff, params_size, params_fmt, opt_buff) < 0)
     sfree(params_buff);
 
   sfree(opt_buff);
@@ -339,9 +339,9 @@ ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifinfo) {
   }
 
   /* fill the notification data */
-  snprintf(n.message, sizeof(n.message),
-           "link state of \"%s\" interface has been changed to \"%s\"",
-           ifinfo->name, msg_link_status);
+  ssnprintf(n.message, sizeof(n.message),
+            "link state of \"%s\" interface has been changed to \"%s\"",
+            ifinfo->name, msg_link_status);
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ifinfo->name, sizeof(n.plugin_instance));
   sstrncpy(n.type, "gauge", sizeof(n.type));

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -927,7 +927,8 @@ static int ovs_stats_plugin_read(__attribute__((unused)) user_data_t *ud) {
             if (strlen(port->ex_iface_id))
               meta_data_add_string(meta, "iface-id", port->ex_iface_id);
           }
-          snprintf(devname, sizeof(devname), "%s.%s", bridge->name, port->name);
+          ssnprintf(devname, sizeof(devname), "%s.%s", bridge->name,
+                    port->name);
           ovs_stats_submit_one(devname, "if_collisions", NULL,
                                port->stats[collisions], meta);
           ovs_stats_submit_two(devname, "if_dropped", NULL,

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -403,8 +403,8 @@ static void pcie_dispatch_notification(pcie_device_t *dev, notification_t *n,
                                        const char *type,
                                        const char *type_instance) {
   sstrncpy(n->host, hostname_g, sizeof(n->host));
-  snprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
-           dev->domain, dev->bus, dev->device, dev->function);
+  ssnprintf(n->plugin_instance, sizeof(n->plugin_instance), "%04x:%02x:%02x.%d",
+            dev->domain, dev->bus, dev->device, dev->function);
   sstrncpy(n->type, type, sizeof(n->type));
   sstrncpy(n->type_instance, type_instance, sizeof(n->type_instance));
 
@@ -432,8 +432,8 @@ static void pcie_dispatch_correctable_errors(pcie_device_t *dev,
 
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
-      snprintf(n.message, sizeof(n.message), "Correctable Error set: %s",
-               err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Correctable Error set: %s",
+                err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
 
     } else if (err->mask & dev->correctable_errors) {
@@ -441,8 +441,8 @@ static void pcie_dispatch_correctable_errors(pcie_device_t *dev,
             dev->bus, dev->device, dev->function, err->desc);
 
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message), "Correctable Error cleared: %s",
-               err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Correctable Error cleared: %s",
+                err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, PCIE_SEV_CE);
     }
   }
@@ -472,8 +472,8 @@ static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
             dev->bus, dev->device, dev->function, err->desc, type_instance);
 
       n.severity = (severity & err->mask) ? NOTIF_FAILURE : NOTIF_WARNING;
-      snprintf(n.message, sizeof(n.message), "Uncorrectable(%s) Error set: %s",
-               type_instance, err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Uncorrectable(%s) Error set: %s",
+                type_instance, err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
 
     } else if (err->mask & dev->uncorrectable_errors) {
@@ -482,8 +482,8 @@ static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
             type_instance);
 
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message),
-               "Uncorrectable(%s) Error cleared: %s", type_instance, err->desc);
+      ssnprintf(n.message, sizeof(n.message),
+                "Uncorrectable(%s) Error cleared: %s", type_instance, err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
     }
   }
@@ -575,16 +575,16 @@ static void pcie_check_dev_status(pcie_device_t *dev, int pos) {
 
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s set", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
-      snprintf(n.message, sizeof(n.message), "Device Status Error set: %s",
-               err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Device Status Error set: %s",
+                err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
 
     } else if (err->mask & dev->device_status) {
       DEBUG(PCIE_ERRORS_PLUGIN ": %04x:%02x:%02x.%d: %s cleared", dev->domain,
             dev->bus, dev->device, dev->function, err->desc);
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message), "Device Status Error cleared: %s",
-               err->desc);
+      ssnprintf(n.message, sizeof(n.message), "Device Status Error cleared: %s",
+                err->desc);
       pcie_dispatch_notification(dev, &n, PCIE_ERROR, type_instance);
     }
   }

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
+    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -323,7 +323,7 @@ static int c_psql_connect(c_psql_database_t *db) {
   if ((!db) || (!db->database))
     return -1;
 
-  status = snprintf(buf, buf_len, "dbname = '%s'", db->database);
+  status = ssnprintf(buf, buf_len, "dbname = '%s'", db->database);
   if (0 < status) {
     buf += status;
     buf_len -= status;
@@ -426,8 +426,8 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
       params[i] = db->user;
       break;
     case C_PSQL_PARAM_INTERVAL:
-      snprintf(interval, sizeof(interval), "%.3f",
-               CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+      ssnprintf(interval, sizeof(interval), "%.3f",
+                CDTIME_T_TO_DOUBLE(plugin_get_interval()));
       params[i] = interval;
       break;
     case C_PSQL_PARAM_INSTANCE:
@@ -940,7 +940,7 @@ static int c_psql_shutdown(void) {
 
     if (db->writers_num > 0) {
       char cb_name[DATA_MAX_NAME_LEN];
-      snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
+      ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
 
       if (!had_flush) {
         plugin_unregister_flush("postgresql");
@@ -1201,7 +1201,7 @@ static int c_psql_config_database(oconfig_item_t *ci) {
     }
   }
 
-  snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
+  ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
 
   user_data_t ud = {.data = db, .free_func = c_psql_database_delete};
 

--- a/src/processes.c
+++ b/src/processes.c
@@ -980,7 +980,7 @@ static int ps_read_tasks_status(process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  snprintf(dirname, sizeof(dirname), "/proc/%li/task", ps->id);
+  ssnprintf(dirname, sizeof(dirname), "/proc/%li/task", ps->id);
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
@@ -1056,7 +1056,7 @@ static int ps_read_status(long pid, process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  snprintf(filename, sizeof(filename), "/proc/%li/status", pid);
+  ssnprintf(filename, sizeof(filename), "/proc/%li/status", pid);
   if ((fh = fopen(filename, "r")) == NULL)
     return -1;
 
@@ -1108,7 +1108,7 @@ static int ps_read_io(process_entry_t *ps) {
   char *fields[8];
   int numfields;
 
-  snprintf(filename, sizeof(filename), "/proc/%li/io", ps->id);
+  ssnprintf(filename, sizeof(filename), "/proc/%li/io", ps->id);
   if ((fh = fopen(filename, "r")) == NULL) {
     DEBUG("ps_read_io: Failed to open file `%s'", filename);
     return -1;
@@ -1160,7 +1160,7 @@ static int ps_count_maps(pid_t pid) {
   char filename[64];
   int count = 0;
 
-  snprintf(filename, sizeof(filename), "/proc/%d/maps", pid);
+  ssnprintf(filename, sizeof(filename), "/proc/%d/maps", pid);
   if ((fh = fopen(filename, "r")) == NULL) {
     DEBUG("ps_count_maps: Failed to open file `%s'", filename);
     return -1;
@@ -1184,7 +1184,7 @@ static int ps_count_fd(int pid) {
   struct dirent *ent;
   int count = 0;
 
-  snprintf(dirname, sizeof(dirname), "/proc/%i/fd", pid);
+  ssnprintf(dirname, sizeof(dirname), "/proc/%i/fd", pid);
 
   if ((dh = opendir(dirname)) == NULL) {
     DEBUG("Failed to open directory `%s'", dirname);
@@ -1313,7 +1313,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   ssize_t status;
 
-  snprintf(filename, sizeof(filename), "/proc/%li/stat", pid);
+  ssnprintf(filename, sizeof(filename), "/proc/%li/stat", pid);
 
   status = read_file_contents(filename, buffer, sizeof(buffer) - 1);
   if (status <= 0)
@@ -1440,7 +1440,7 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
   if ((pid < 1) || (NULL == buf) || (buf_len < 2))
     return NULL;
 
-  snprintf(file, sizeof(file), "/proc/%li/cmdline", pid);
+  ssnprintf(file, sizeof(file), "/proc/%li/cmdline", pid);
 
   errno = 0;
   fd = open(file, O_RDONLY);
@@ -1492,7 +1492,7 @@ static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {
     if (NULL == name)
       return NULL;
 
-    snprintf(buf, buf_len, "[%s]", name);
+    ssnprintf(buf, buf_len, "[%s]", name);
     return buf;
   }
 
@@ -1566,7 +1566,7 @@ static char *ps_get_cmdline(long pid,
   psinfo_t info;
   ssize_t status;
 
-  snprintf(path, sizeof(path), "/proc/%li/psinfo", pid);
+  ssnprintf(path, sizeof(path), "/proc/%li/psinfo", pid);
 
   status = read_file_contents(path, (void *)&info, sizeof(info));
   if ((status < 0) || (((size_t)status) != sizeof(info))) {
@@ -1599,9 +1599,9 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   psinfo_t *myInfo;
   prusage_t *myUsage;
 
-  snprintf(filename, sizeof(filename), "/proc/%li/status", pid);
-  snprintf(f_psinfo, sizeof(f_psinfo), "/proc/%li/psinfo", pid);
-  snprintf(f_usage, sizeof(f_usage), "/proc/%li/usage", pid);
+  ssnprintf(filename, sizeof(filename), "/proc/%li/status", pid);
+  ssnprintf(f_psinfo, sizeof(f_psinfo), "/proc/%li/psinfo", pid);
+  ssnprintf(f_usage, sizeof(f_usage), "/proc/%li/usage", pid);
 
   buffer = calloc(1, sizeof(pstatus_t));
   read_file_contents(filename, buffer, sizeof(pstatus_t));
@@ -1765,7 +1765,7 @@ static int mach_get_task_name(task_t t, int *pid, char *name,
   if (name_max_len > (MAXCOMLEN + 1))
     name_max_len = MAXCOMLEN + 1;
 
-  strncpy(name, kp.kp_proc.p_comm, name_max_len - 1);
+  sstrncpy(name, kp.kp_proc.p_comm, name_max_len - 1);
   name[name_max_len - 1] = '\0';
 
   DEBUG("pid = %i; name = %s;", *pid, name);

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -154,8 +154,8 @@ static int read_file(const char *path) {
       if (values_list != NULL) {
         char match_name[2 * DATA_MAX_NAME_LEN];
 
-        snprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
-                 key_fields[i]);
+        ssnprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
+                  key_fields[i]);
 
         if (ignorelist_match(values_list, match_name))
           continue;

--- a/src/redis.c
+++ b/src/redis.c
@@ -112,7 +112,7 @@ static int redis_node_add(redis_node_t *rn) /* {{{ */
   redis_have_instances = true;
 
   char cb_name[sizeof("redis/") + DATA_MAX_NAME_LEN];
-  snprintf(cb_name, sizeof(cb_name), "redis/%s", rn->name);
+  ssnprintf(cb_name, sizeof(cb_name), "redis/%s", rn->name);
 
   return plugin_register_complex_read(
       /* group = */ "redis",
@@ -141,7 +141,7 @@ static redis_query_t *redis_config_query(oconfig_item_t *ci) /* {{{ */
   /*
    * Default to a gauge type.
    */
-  (void)strncpy(rq->type, "gauge", sizeof(rq->type));
+  (void)sstrncpy(rq->type, "gauge", sizeof(rq->type));
   (void)sstrncpy(rq->instance, rq->query, sizeof(rq->instance));
   replace_special(rq->instance, sizeof(rq->instance));
 
@@ -481,7 +481,7 @@ static int redis_db_stats(const char *node, char const *info_line) /* {{{ */
     char *str;
     int i;
 
-    snprintf(field_name, sizeof(field_name), "db%d:keys=", db);
+    ssnprintf(field_name, sizeof(field_name), "db%d:keys=", db);
 
     str = strstr(info_line, field_name);
     if (!str)
@@ -497,7 +497,7 @@ static int redis_db_stats(const char *node, char const *info_line) /* {{{ */
       return -1;
     }
 
-    snprintf(db_id, sizeof(db_id), "%d", db);
+    ssnprintf(db_id, sizeof(db_id), "%d", db);
     redis_submit(node, "records", db_id, val);
   }
   return 0;

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -150,7 +150,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
     name = "default";
 
   /*** RX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
@@ -159,7 +159,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->rx_ccq);
 
   /*** TX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
@@ -168,7 +168,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->tx_ccq);
 
   /*** RX / TX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface, name);
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface, name);
   cr_submit_io(rd, "if_octets", type_instance, (derive_t)r->rx_bytes,
                (derive_t)r->tx_bytes);
   cr_submit_gauge(rd, "snr", type_instance, (gauge_t)r->signal_to_noise);
@@ -438,7 +438,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
     return status;
   }
 
-  snprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
+  ssnprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
   return plugin_register_complex_read(
       /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
       &(user_data_t){

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -480,9 +480,9 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
     return EINVAL;
 
   if (datadir != NULL)
-    snprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
+    ssnprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
   else
-    snprintf(filename, sizeof(filename), "%s.rrd", identifier);
+    ssnprintf(filename, sizeof(filename), "%s.rrd", identifier);
 
   rrd_clear_error();
   status = rrdc_connect(daemon_address);

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -566,9 +566,9 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
   now = cdtime();
 
   if (datadir == NULL)
-    snprintf(key, sizeof(key), "%s.rrd", identifier);
+    ssnprintf(key, sizeof(key), "%s.rrd", identifier);
   else
-    snprintf(key, sizeof(key), "%s/%s.rrd", datadir, identifier);
+    ssnprintf(key, sizeof(key), "%s/%s.rrd", datadir, identifier);
   key[sizeof(key) - 1] = 0;
 
   status = c_avl_get(cache, key, (void *)&rc);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -176,13 +176,13 @@ static int sensors_snprintf_chip_name(char *buf, size_t buf_size,
   int status = -1;
 
   if (chip->bus == SENSORS_CHIP_NAME_BUS_ISA) {
-    status = snprintf(buf, buf_size, "%s-isa-%04x", chip->prefix, chip->addr);
+    status = ssnprintf(buf, buf_size, "%s-isa-%04x", chip->prefix, chip->addr);
   } else if (chip->bus == SENSORS_CHIP_NAME_BUS_DUMMY) {
-    status = snprintf(buf, buf_size, "%s-%s-%04x", chip->prefix, chip->busname,
-                      chip->addr);
+    status = ssnprintf(buf, buf_size, "%s-%s-%04x", chip->prefix, chip->busname,
+                       chip->addr);
   } else {
-    status = snprintf(buf, buf_size, "%s-i2c-%d-%02x", chip->prefix, chip->bus,
-                      chip->addr);
+    status = ssnprintf(buf, buf_size, "%s-i2c-%d-%02x", chip->prefix, chip->bus,
+                       chip->addr);
   }
 
   return status;
@@ -434,8 +434,8 @@ static void sensors_submit(const char *plugin_instance, const char *type,
 
   value_list_t vl = VALUE_LIST_INIT;
 
-  status = snprintf(match_key, sizeof(match_key), "%s/%s-%s", plugin_instance,
-                    type, type_instance);
+  status = ssnprintf(match_key, sizeof(match_key), "%s/%s-%s",
+                     plugin_instance, type, type_instance);
   if (status < 1)
     return;
 

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -59,7 +59,8 @@ static int sigrok_log_callback(void *cb_data __attribute__((unused)),
   char s[512];
 
   if (msg_loglevel <= loglevel) {
-    vsnprintf(s, 512, format, args);
+    if (vsnprintf(s, 512, format, args) >= 512)
+      s[511] = '\0';
     plugin_log(LOG_INFO, "sigrok plugin: %s", s);
   }
 
@@ -247,10 +248,10 @@ static int sigrok_init_driver(struct config_device *cfdev,
   }
   cfdev->sdi = devlist->data;
   g_slist_free(devlist);
-  snprintf(hwident, sizeof(hwident), "%s %s %s",
-           cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
-           cfdev->sdi->model ? cfdev->sdi->model : "",
-           cfdev->sdi->version ? cfdev->sdi->version : "");
+  ssnprintf(hwident, sizeof(hwident), "%s %s %s",
+            cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
+            cfdev->sdi->model ? cfdev->sdi->model : "",
+            cfdev->sdi->version ? cfdev->sdi->version : "");
   INFO("sigrok plugin: Device \"%s\" is a %s", cfdev->name, hwident);
 
   if (sr_dev_open(cfdev->sdi) != SR_OK)

--- a/src/smart.c
+++ b/src/smart.c
@@ -116,9 +116,9 @@ static void handle_attribute(SkDisk *d, const SkSmartAttributeParsedData *a,
     sstrncpy(notif.host, hostname_g, sizeof(notif.host));
     sstrncpy(notif.plugin_instance, name, sizeof(notif.plugin_instance));
     sstrncpy(notif.type_instance, a->name, sizeof(notif.type_instance));
-    snprintf(notif.message, sizeof(notif.message),
-             "attribute %s is below allowed threshold (%d < %d)", a->name,
-             a->current_value, a->threshold);
+    ssnprintf(notif.message, sizeof(notif.message),
+              "attribute %s is below allowed threshold (%d < %d)", a->name,
+              a->current_value, a->threshold);
     plugin_dispatch_notification(&notif);
   }
 }

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -171,7 +171,7 @@ static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -871,7 +871,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
         "= %i }",
         hd->name, hd->address, hd->community, hd->version);
 
-  snprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
+  ssnprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
 
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, interval,
@@ -1140,8 +1140,8 @@ static int csnmp_strvbcopy_hexstring(char *dst, /* {{{ */
   for (size_t i = 0; i < vb->val_len; i++) {
     int status;
 
-    status = snprintf(buffer_ptr, buffer_free, (i == 0) ? "%02x" : ":%02x",
-                      (unsigned int)vb->val.bitstring[i]);
+    status = ssnprintf(buffer_ptr, buffer_free, (i == 0) ? "%02x" : ":%02x",
+                       (unsigned int)vb->val.bitstring[i]);
     assert(status >= 0);
 
     if (((size_t)status) >= buffer_free) /* truncated */
@@ -1173,10 +1173,10 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
   else if (vb->type == ASN_BIT_STR)
     src = (char *)vb->val.bitstring;
   else if (vb->type == ASN_IPADDRESS) {
-    return snprintf(dst, dst_size,
-                    "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
-                    (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
-                    (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
+    return ssnprintf(dst, dst_size,
+                     "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
+                     (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
+                     (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
   } else {
     dst[0] = 0;
     return EINVAL;
@@ -1234,7 +1234,7 @@ static csnmp_cell_char_t *csnmp_get_char_cell(const struct variable_list *vb,
     value_t val = csnmp_value_list_to_value(
         vb, DS_TYPE_COUNTER,
         /* scale = */ 1.0, /* shift = */ 0.0, hd->name, dd->name);
-    snprintf(il->value, sizeof(il->value), "%" PRIu64, (uint64_t)val.counter);
+    ssnprintf(il->value, sizeof(il->value), "%" PRIu64, (uint64_t)val.counter);
   }
 
   return il;
@@ -1479,7 +1479,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->host.prefix == NULL)
         sstrncpy(vl.host, temp, sizeof(vl.host));
       else
-        snprintf(vl.host, sizeof(vl.host), "%s%s", data->host.prefix, temp);
+        ssnprintf(vl.host, sizeof(vl.host), "%s%s", data->host.prefix, temp);
     } else {
       sstrncpy(vl.host, host->name, sizeof(vl.host));
     }
@@ -1495,8 +1495,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->type_instance.prefix == NULL)
         sstrncpy(vl.type_instance, temp, sizeof(vl.type_instance));
       else
-        snprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
-                 data->type_instance.prefix, temp);
+        ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
+                  data->type_instance.prefix, temp);
     } else if (data->type_instance.value) {
       sstrncpy(vl.type_instance, data->type_instance.value,
                sizeof(vl.type_instance));
@@ -1513,8 +1513,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->plugin_instance.prefix == NULL)
         sstrncpy(vl.plugin_instance, temp, sizeof(vl.plugin_instance));
       else
-        snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s%s",
-                 data->plugin_instance.prefix, temp);
+        ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s%s",
+                  data->plugin_instance.prefix, temp);
     } else if (data->plugin_instance.value) {
       sstrncpy(vl.plugin_instance, data->plugin_instance.value,
                sizeof(vl.plugin_instance));

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -172,7 +172,7 @@ static int snmp_agent_oid_to_string(char *buf, size_t buf_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -736,13 +736,13 @@ static void snmp_agent_table_data_remove(data_definition_t *dd,
   if (index == NULL)
     snmp_agent_oid_to_string(index_str, sizeof(index_str), index_oid);
   else
-    snprintf(index_str, sizeof(index_str), "%d", *index);
+    ssnprintf(index_str, sizeof(index_str), "%d", *index);
 
   notification_t n = {
       .severity = NOTIF_WARNING, .time = cdtime(), .plugin = PLUGIN_NAME};
   sstrncpy(n.host, hostname_g, sizeof(n.host));
-  snprintf(n.message, sizeof(n.message),
-           "Removed data row from table %s with index %s", td->name, index_str);
+  ssnprintf(n.message, sizeof(n.message),
+            "Removed data row from table %s with index %s", td->name, index_str);
   DEBUG(PLUGIN_NAME ": %s", n.message);
   plugin_dispatch_notification(&n);
 
@@ -960,8 +960,8 @@ static int snmp_agent_build_name(char **name, c_avl_tree_t *tokens) {
     strncat(out, tok->str, DATA_MAX_NAME_LEN - strlen(out) - 1);
     if (tok->key != NULL) {
       if (tok->key->type == ASN_INTEGER) {
-        snprintf(str, sizeof(str), "%ld", *tok->key->val.integer);
-        strncat(out, str, DATA_MAX_NAME_LEN - strlen(out) - 1);
+        ssnprintf(str, sizeof(str), "%ld", *tok->key->val.integer);
+        ssnprintf(out + strlen(out), DATA_MAX_NAME_LEN - strlen(out), "%s", str);
       } else /* OCTET_STR */
         strncat(out, (char *)tok->key->val.string,
                 DATA_MAX_NAME_LEN - strlen(out) - 1);
@@ -1013,7 +1013,7 @@ static int snmp_agent_format_name(char *name, int name_len,
         }
 
         if (td->index_keys[i].type == ASN_INTEGER) {
-          snprintf(str, sizeof(str), "%ld", *key->val.integer);
+          ssnprintf(str, sizeof(str), "%ld", *key->val.integer);
           fields[source] = str;
         } else /* OCTET_STR */
           fields[source] = (char *)key->val.string;
@@ -1836,7 +1836,7 @@ static int snmp_agent_set_vardata(void *data, size_t *data_len, u_char asn_type,
   case ASN_OCTET_STR:
     if (type == DS_TYPE_GAUGE) {
       char buf[DATA_MAX_NAME_LEN];
-      snprintf(buf, sizeof(buf), "%.2f", val->gauge);
+      ssnprintf(buf, sizeof(buf), "%.2f", val->gauge);
       if (*data_len < strlen(buf))
         return -EINVAL;
       *data_len = strlen(buf);
@@ -1995,13 +1995,13 @@ static int snmp_agent_update_index(data_definition_t *dd,
     if (index == NULL)
       snmp_agent_oid_to_string(index_str, sizeof(index_str), index_oid);
     else
-      snprintf(index_str, sizeof(index_str), "%d", *index);
+      ssnprintf(index_str, sizeof(index_str), "%d", *index);
 
     notification_t n = {
         .severity = NOTIF_OKAY, .time = cdtime(), .plugin = PLUGIN_NAME};
     sstrncpy(n.host, hostname_g, sizeof(n.host));
-    snprintf(n.message, sizeof(n.message),
-             "Data added to table %s with index %s", td->name, index_str);
+    ssnprintf(n.message, sizeof(n.message),
+              "Data added to table %s with index %s", td->name, index_str);
     DEBUG(PLUGIN_NAME ": %s", n.message);
 
     plugin_dispatch_notification(&n);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -722,7 +722,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     /* Make sure all timer metrics share the *same* timestamp. */
     vl.time = cdtime();
 
-    snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-average", name);
+    ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-average", name);
     vl.values[0].gauge =
         have_events
             ? CDTIME_T_TO_DOUBLE(latency_counter_get_average(metric->latency))
@@ -730,7 +730,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     plugin_dispatch_values(&vl);
 
     if (conf_timer_lower) {
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-lower", name);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-lower", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_min(metric->latency))
@@ -739,7 +739,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     if (conf_timer_upper) {
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-upper", name);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-upper", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_max(metric->latency))
@@ -748,7 +748,7 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     if (conf_timer_sum) {
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-sum", name);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-sum", name);
       vl.values[0].gauge =
           have_events
               ? CDTIME_T_TO_DOUBLE(latency_counter_get_sum(metric->latency))
@@ -757,8 +757,8 @@ static int statsd_metric_submit_unsafe(char const *name,
     }
 
     for (size_t i = 0; i < conf_timer_percentile_num; i++) {
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-percentile-%.0f",
-               name, conf_timer_percentile[i]);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+                "%s-percentile-%.0f", name, conf_timer_percentile[i]);
       vl.values[0].gauge =
           have_events ? CDTIME_T_TO_DOUBLE(latency_counter_get_percentile(
                             metric->latency, conf_timer_percentile[i]))
@@ -770,7 +770,7 @@ static int statsd_metric_submit_unsafe(char const *name,
      * vl.type's above are implicitly set to "latency". */
     if (conf_timer_count) {
       sstrncpy(vl.type, "gauge", sizeof(vl.type));
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-count", name);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-count", name);
       vl.values[0].gauge = latency_counter_get_num(metric->latency);
       plugin_dispatch_values(&vl);
     }

--- a/src/tail.c
+++ b/src/tail.c
@@ -266,7 +266,7 @@ static int ctail_config_add_file(oconfig_item_t *ci) {
   }
 
   char str[255];
-  snprintf(str, sizeof(str), "tail-%zu", tail_file_num++);
+  ssnprintf(str, sizeof(str), "tail-%zu", tail_file_num++);
 
   plugin_register_complex_read(
       NULL, str, ctail_read, interval,

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -477,7 +477,7 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
     return -1;
   }
 
-  snprintf(cb_name, sizeof(cb_name), "tail_csv/%s", id->path);
+  ssnprintf(cb_name, sizeof(cb_name), "tail_csv/%s", id->path);
 
   status = plugin_register_complex_read(
       NULL, cb_name, tcsv_read, interval,

--- a/src/target_notification.c
+++ b/src/target_notification.c
@@ -222,8 +222,8 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
     char value_str[DATA_MAX_NAME_LEN];
 
     const char *format = "%%{ds:%.*s}";
-    snprintf(template, sizeof(template), format,
-             DATA_MAX_NAME_LEN - strlen(format), ds->ds[i].name);
+    ssnprintf(template, sizeof(template), format,
+              DATA_MAX_NAME_LEN - strlen(format), ds->ds[i].name);
 
     if (ds->ds[i].type != DS_TYPE_GAUGE) {
       if ((rates == NULL) && (rates_failed == 0)) {
@@ -235,12 +235,12 @@ static int tn_invoke(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
     /* If this is a gauge value, use the current value. */
     if (ds->ds[i].type == DS_TYPE_GAUGE)
-      snprintf(value_str, sizeof(value_str), GAUGE_FORMAT,
-               (double)vl->values[i].gauge);
+      ssnprintf(value_str, sizeof(value_str), GAUGE_FORMAT,
+                (double)vl->values[i].gauge);
     /* If it's a counter, try to use the current rate. This may fail, if the
      * value has been renamed. */
     else if (rates != NULL)
-      snprintf(value_str, sizeof(value_str), GAUGE_FORMAT, (double)rates[i]);
+      ssnprintf(value_str, sizeof(value_str), GAUGE_FORMAT, (double)rates[i]);
     /* Since we don't know any better, use the string `unknown'. */
     else
       sstrncpy(value_str, "unknown", sizeof(value_str));

--- a/src/target_scale.c
+++ b/src/target_scale.c
@@ -56,12 +56,12 @@ static int ts_invoke_counter(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_counter = (uint64_t)vl->values[dsrc_index].counter;
 
-  snprintf(key_prev_counter, sizeof(key_prev_counter),
-           "target_scale[%p,%i]:prev_counter", (void *)data, dsrc_index);
-  snprintf(key_int_counter, sizeof(key_int_counter),
-           "target_scale[%p,%i]:int_counter", (void *)data, dsrc_index);
-  snprintf(key_int_fraction, sizeof(key_int_fraction),
-           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+  ssnprintf(key_prev_counter, sizeof(key_prev_counter),
+            "target_scale[%p,%i]:prev_counter", (void *)data, dsrc_index);
+  ssnprintf(key_int_counter, sizeof(key_int_counter),
+            "target_scale[%p,%i]:int_counter", (void *)data, dsrc_index);
+  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_counter = curr_counter;
   int_counter = 0;
@@ -149,12 +149,12 @@ static int ts_invoke_derive(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_derive = (int64_t)vl->values[dsrc_index].derive;
 
-  snprintf(key_prev_derive, sizeof(key_prev_derive),
-           "target_scale[%p,%i]:prev_derive", (void *)data, dsrc_index);
-  snprintf(key_int_derive, sizeof(key_int_derive),
-           "target_scale[%p,%i]:int_derive", (void *)data, dsrc_index);
-  snprintf(key_int_fraction, sizeof(key_int_fraction),
-           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+  ssnprintf(key_prev_derive, sizeof(key_prev_derive),
+            "target_scale[%p,%i]:prev_derive", (void *)data, dsrc_index);
+  ssnprintf(key_int_derive, sizeof(key_int_derive),
+            "target_scale[%p,%i]:int_derive", (void *)data, dsrc_index);
+  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   prev_derive = curr_derive;
   int_derive = 0;
@@ -232,8 +232,8 @@ static int ts_invoke_absolute(const data_set_t *ds, value_list_t *vl, /* {{{ */
 
   curr_absolute = (uint64_t)vl->values[dsrc_index].absolute;
 
-  snprintf(key_int_fraction, sizeof(key_int_fraction),
-           "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
+  ssnprintf(key_int_fraction, sizeof(key_int_fraction),
+            "target_scale[%p,%i]:int_fraction", (void *)data, dsrc_index);
 
   int_fraction = 0.0;
 

--- a/src/target_set.c
+++ b/src/target_set.c
@@ -194,7 +194,7 @@ static void ts_subst(char *dest, size_t size, const char *string, /* {{{ */
       char *value_str;
       const char *key = meta_toc[i];
 
-      snprintf(meta_name, sizeof(meta_name), "%%{meta:%s}", key);
+      ssnprintf(meta_name, sizeof(meta_name), "%%{meta:%s}", key);
       if (meta_data_as_string(vl->meta, key, &value_str) != 0)
         continue;
 

--- a/src/target_v5upgrade.c
+++ b/src/target_v5upgrade.c
@@ -238,23 +238,23 @@ static int v5_zfs_arc_counts(const data_set_t *ds, value_list_t *vl) /* {{{ */
 
   /* Dispatch new value lists instead of this one */
   new_vl.values[0].derive = (derive_t)vl->values[0].counter;
-  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance), "demand_data-%s",
-           is_hits ? "hit" : "miss");
+  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+            "demand_data-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[1].counter;
-  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-           "demand_metadata-%s", is_hits ? "hit" : "miss");
+  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+            "demand_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[2].counter;
-  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-           "prefetch_data-%s", is_hits ? "hit" : "miss");
+  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+            "prefetch_data-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   new_vl.values[0].derive = (derive_t)vl->values[3].counter;
-  snprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
-           "prefetch_metadata-%s", is_hits ? "hit" : "miss");
+  ssnprintf(new_vl.type_instance, sizeof(new_vl.type_instance),
+            "prefetch_metadata-%s", is_hits ? "hit" : "miss");
   plugin_dispatch_values(&new_vl);
 
   /* Abort processing */

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -292,8 +292,8 @@ static void conn_submit_port_entry(port_entry_t *pe) {
 
   if (((port_collect_listening != 0) && (pe->flags & PORT_IS_LISTENING)) ||
       (pe->flags & PORT_COLLECT_LOCAL)) {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
-             "%" PRIu16 "-local", pe->port);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
+              "%" PRIu16 "-local", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {
       vl.values[0].gauge = pe->count_local[i];
@@ -305,8 +305,8 @@ static void conn_submit_port_entry(port_entry_t *pe) {
   }
 
   if (pe->flags & PORT_COLLECT_REMOTE) {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
-             "%" PRIu16 "-remote", pe->port);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance),
+              "%" PRIu16 "-remote", pe->port);
 
     for (int i = 1; i <= TCP_STATE_MAX; i++) {
       vl.values[0].gauge = pe->count_remote[i];

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -323,7 +323,7 @@ static int tss2_select_vserver(FILE *read_fh, FILE *write_fh,
   int status;
 
   /* Send request */
-  snprintf(command, sizeof(command), "sel %i\r\n", vserver->port);
+  ssnprintf(command, sizeof(command), "sel %i\r\n", vserver->port);
 
   status = tss2_send_request(write_fh, command);
   if (status != 0) {
@@ -453,8 +453,8 @@ static int tss2_read_vserver(vserver_list_t *vserver) {
     status = tss2_send_request(write_fh, "gi\r\n");
   } else {
     /* Request server information */
-    snprintf(plugin_instance, sizeof(plugin_instance), "vserver%i",
-             vserver->port);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "vserver%i",
+              vserver->port);
 
     /* Select the server */
     status = tss2_select_vserver(read_fh, write_fh, vserver);

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -65,14 +65,15 @@ static int thermal_sysfs_device_read(const char __attribute__((unused)) * dir,
   if (device_list && ignorelist_match(device_list, name))
     return -1;
 
-  snprintf(filename, sizeof(filename), "%s/%s/temp", dirname_sysfs, name);
+  ssnprintf(filename, sizeof(filename), "%s/%s/temp", dirname_sysfs, name);
   if (parse_value_file(filename, &value, DS_TYPE_GAUGE) == 0) {
     value.gauge /= 1000.0;
     thermal_submit(name, TEMP, value);
     success = true;
   }
 
-  snprintf(filename, sizeof(filename), "%s/%s/cur_state", dirname_sysfs, name);
+  ssnprintf(filename, sizeof(filename), "%s/%s/cur_state", dirname_sysfs,
+            name);
   if (parse_value_file(filename, &value, DS_TYPE_GAUGE) == 0) {
     thermal_submit(name, COOLING_DEV, value);
     success = true;
@@ -98,8 +99,8 @@ static int thermal_procfs_device_read(const char __attribute__((unused)) * dir,
    * temperature:             55 C
    */
 
-  len = snprintf(filename, sizeof(filename), "%s/%s/temperature",
-                 dirname_procfs, name);
+  len = ssnprintf(filename, sizeof(filename), "%s/%s/temperature",
+                  dirname_procfs, name);
   if ((len < 0) || ((size_t)len >= sizeof(filename)))
     return -1;
 

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -332,22 +332,22 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
   n.time = vl->time;
 
-  status = snprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
+  status = ssnprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
   buf += status;
   bufsize -= status;
 
   if (vl->plugin_instance[0] != '\0') {
-    status = snprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
+    status = ssnprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
     buf += status;
     bufsize -= status;
   }
 
-  status = snprintf(buf, bufsize, " type %s", vl->type);
+  status = ssnprintf(buf, bufsize, " type %s", vl->type);
   buf += status;
   bufsize -= status;
 
   if (vl->type_instance[0] != '\0') {
-    status = snprintf(buf, bufsize, " (instance %s)", vl->type_instance);
+    status = ssnprintf(buf, bufsize, " (instance %s)", vl->type_instance);
     buf += status;
     bufsize -= status;
   }
@@ -362,9 +362,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
   /* Send an okay notification */
   if (state == STATE_OKAY) {
     if (state_old == STATE_MISSING)
-      snprintf(buf, bufsize, ": Value is no longer missing.");
+      ssnprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      snprintf(buf, bufsize, ": All data sources are within range again. "
+      ssnprintf(buf, bufsize, ": All data sources are within range again. "
                              "Current value of \"%s\" is %f.",
                ds->ds[ds_index].name, values[ds_index]);
   } else {
@@ -376,21 +376,21 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
     if (th->flags & UT_FLAG_INVERT) {
       if (!isnan(min) && !isnan(max)) {
-        snprintf(buf, bufsize,
-                 ": Data source \"%s\" is currently "
-                 "%f. That is within the %s region of %f%s and %f%s.",
-                 ds->ds[ds_index].name, values[ds_index],
-                 (state == STATE_ERROR) ? "failure" : "warning", min,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+        ssnprintf(buf, bufsize,
+                  ": Data source \"%s\" is currently "
+                  "%f. That is within the %s region of %f%s and %f%s.",
+                  ds->ds[ds_index].name, values[ds_index],
+                  (state == STATE_ERROR) ? "failure" : "warning", min,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        snprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                               "%f. That is %s the %s threshold of %f%s.",
-                 ds->ds[ds_index].name, values[ds_index],
-                 isnan(min) ? "below" : "above",
-                 (state == STATE_ERROR) ? "failure" : "warning",
-                 isnan(min) ? max : min,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+                                "%f. That is %s the %s threshold of %f%s.",
+                  ds->ds[ds_index].name, values[ds_index],
+                  isnan(min) ? "below" : "above",
+                  (state == STATE_ERROR) ? "failure" : "warning",
+                  isnan(min) ? max : min,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       }
     } else if (th->flags & UT_FLAG_PERCENTAGE) {
       gauge_t value;
@@ -409,21 +409,21 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
       else
         value = 100.0 * values[ds_index] / sum;
 
-      snprintf(buf, bufsize,
-               ": Data source \"%s\" is currently "
-               "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
-               ds->ds[ds_index].name, values[ds_index], value,
-               (value < min) ? "below" : "above",
-               (state == STATE_ERROR) ? "failure" : "warning",
-               (value < min) ? min : max);
+      ssnprintf(buf, bufsize,
+                ": Data source \"%s\" is currently "
+                "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
+                ds->ds[ds_index].name, values[ds_index], value,
+                (value < min) ? "below" : "above",
+                (state == STATE_ERROR) ? "failure" : "warning",
+                (value < min) ? min : max);
     } else /* is not inverted */
     {
-      snprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                             "%f. That is %s the %s threshold of %f.",
-               ds->ds[ds_index].name, values[ds_index],
-               (values[ds_index] < min) ? "below" : "above",
-               (state == STATE_ERROR) ? "failure" : "warning",
-               (values[ds_index] < min) ? min : max);
+      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+                              "%f. That is %s the %s threshold of %f.",
+                ds->ds[ds_index].name, values[ds_index],
+                (values[ds_index] < min) ? "below" : "above",
+                (state == STATE_ERROR) ? "failure" : "warning",
+                (values[ds_index] < min) ? min : max);
     }
   }
 
@@ -680,9 +680,9 @@ static int ut_missing(const value_list_t *vl,
   FORMAT_VL(identifier, sizeof(identifier), vl);
 
   NOTIFICATION_INIT_VL(&n, vl);
-  snprintf(n.message, sizeof(n.message),
-           "%s has not been updated for %.3f seconds.", identifier,
-           CDTIME_T_TO_DOUBLE(missing_time));
+  ssnprintf(n.message, sizeof(n.message),
+            "%s has not been updated for %.3f seconds.", identifier,
+            CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;
 
   plugin_dispatch_notification(&n);

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -266,7 +266,7 @@ open_msr(unsigned int cpu, bool multiple_read) {
     }
   }
 
-  snprintf(pathname, sizeof(pathname), "/dev/cpu/%d/msr", cpu);
+  ssnprintf(pathname, sizeof(pathname), "/dev/cpu/%d/msr", cpu);
   fd = open(pathname, O_RDONLY);
   if (fd < 0) {
     ERROR("turbostat plugin: failed to open %s", pathname);
@@ -556,7 +556,7 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   DEBUG("turbostat plugin: submit stats for cpu: %d, core: %d, pkg: %d",
         t->cpu_id, c->core_id, p->package_id);
 
-  snprintf(name, sizeof(name), "cpu%02d", t->cpu_id);
+  ssnprintf(name, sizeof(name), "cpu%02d", t->cpu_id);
 
   if (!aperf_mperf_unstable)
     turbostat_submit(name, "percent", "c0", 100.0 * t->mperf / t->tsc);
@@ -586,10 +586,10 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   /* If not using logical core numbering, set core id */
   if (!config_lcn) {
     if (topology.num_packages > 1)
-      snprintf(name, sizeof(name), "pkg%02d-core%02d", p->package_id,
-               c->core_id);
+      ssnprintf(name, sizeof(name), "pkg%02d-core%02d", p->package_id,
+                c->core_id);
     else
-      snprintf(name, sizeof(name), "core%02d", c->core_id);
+      ssnprintf(name, sizeof(name), "core%02d", c->core_id);
   }
 
   if (do_core_cstate & (1 << 3))
@@ -606,7 +606,7 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   if (!(t->flags & CPU_IS_FIRST_CORE_IN_PACKAGE))
     goto done;
 
-  snprintf(name, sizeof(name), "pkg%02d", p->package_id);
+  ssnprintf(name, sizeof(name), "pkg%02d", p->package_id);
 
   if (do_ptm)
     turbostat_submit(name, "temperature", NULL, p->pkg_temp_c);
@@ -1069,8 +1069,9 @@ static int get_threads_on_core(unsigned int cpu) {
   int matches;
   char character;
 
-  snprintf(path, sizeof(path),
-           "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
+  ssnprintf(path, sizeof(path),
+            "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list",
+            cpu);
   filep = fopen(path, "r");
   if (!filep) {
     ERROR("turbostat plugin: Failed to open '%s'", path);

--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -276,10 +276,10 @@ int cmd_create_putval(char *ret, size_t ret_len, /* {{{ */
     return status;
   escape_string(buffer_values, sizeof(buffer_values));
 
-  snprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
-           (vl->interval > 0) ? CDTIME_T_TO_DOUBLE(vl->interval)
-                              : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
-           buffer_values);
+  ssnprintf(ret, ret_len, "PUTVAL %s interval=%.3f %s", buffer_ident,
+            (vl->interval > 0) ? CDTIME_T_TO_DOUBLE(vl->interval)
+                               : CDTIME_T_TO_DOUBLE(plugin_get_interval()),
+            buffer_values);
 
   return 0;
 } /* }}} int cmd_create_putval */

--- a/src/utils_cmds.c
+++ b/src/utils_cmds.c
@@ -296,7 +296,7 @@ void cmd_error_fh(void *ud, cmd_status_t status, const char *format,
   if (status == CMD_OK)
     code = 0;
 
-  vsnprintf(buf, sizeof(buf), format, ap);
+  vsnprintf(buf, sizeof(buf) - 1, format, ap);
   buf[sizeof(buf) - 1] = '\0';
   if (fprintf(fh, "%i %s\n", code, buf) < 0) {
     WARNING("utils_cmds: failed to write to file-handle #%i: %s", fileno(fh),

--- a/src/utils_cmds_test.c
+++ b/src/utils_cmds_test.c
@@ -196,13 +196,12 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    snprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
-                                               "%d (type=%d [%s]); want %d "
-                                               "(type=%d [%s])",
-             parse_data[i].input, parse_data[i].opts, status, cmd.type,
-             CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
-             parse_data[i].expected_type,
-             CMD_TO_STRING(parse_data[i].expected_type));
+    ssnprintf(description, sizeof(description),
+              "cmd_parse (\"%s\", opts=%p) = " "%d (type=%d [%s]); want %d "
+              "(type=%d [%s])", parse_data[i].input, parse_data[i].opts,
+              status, cmd.type, CMD_TO_STRING(cmd.type),
+              parse_data[i].expected_status, parse_data[i].expected_type,
+              CMD_TO_STRING(parse_data[i].expected_type));
     result = (status == parse_data[i].expected_status) &&
              (cmd.type == parse_data[i].expected_type);
     LOG(result, description);

--- a/src/utils_config_cores.c
+++ b/src/utils_config_cores.c
@@ -254,7 +254,7 @@ int config_cores_parse(const oconfig_item_t *ci, core_groups_list_t *cgl) {
     } else {
       for (size_t j = 0; j < n && cg_idx < STATIC_ARRAY_SIZE(cgroups); j++) {
         char desc[DATA_MAX_NAME_LEN];
-        snprintf(desc, sizeof(desc), "%u", cores[j]);
+        ssnprintf(desc, sizeof(desc), "%u", cores[j]);
 
         cgroups[cg_idx].desc = strdup(desc);
         if (cgroups[cg_idx].desc == NULL) {
@@ -313,7 +313,7 @@ int config_cores_default(int num_cores, core_groups_list_t *cgl) {
 
   for (int i = 0; i < num_cores; i++) {
     char desc[DATA_MAX_NAME_LEN];
-    snprintf(desc, sizeof(desc), "%d", i);
+    ssnprintf(desc, sizeof(desc), "%d", i);
 
     cgl->cgroups[i].cores = calloc(1, sizeof(*(cgl->cgroups[i].cores)));
     if (cgl->cgroups[i].cores == NULL) {

--- a/src/utils_db_query.c
+++ b/src/utils_db_query.c
@@ -228,8 +228,8 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
       }
       tmp[sizeof(tmp) - 1] = 0;
 
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s",
-               r->instance_prefix, tmp);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s",
+                r->instance_prefix, tmp);
     }
   }
   vl.type_instance[sizeof(vl.type_instance) - 1] = 0;

--- a/src/utils_dns.c
+++ b/src/utils_dns.c
@@ -912,7 +912,7 @@ const char *qtype_str(int t) {
     return "ANY"; /* ... 255 */
 #endif /* __BIND >= 19950621 */
   default:
-    snprintf(buf, sizeof(buf), "#%i", t);
+    ssnprintf(buf, sizeof(buf), "#%i", t);
     return buf;
   } /* switch (t) */
 }
@@ -931,7 +931,7 @@ const char *opcode_str(int o) {
   case 5:
     return "Update";
   default:
-    snprintf(buf, sizeof(buf), "Opcode%d", o);
+    ssnprintf(buf, sizeof(buf), "Opcode%d", o);
     return buf;
   }
 }
@@ -998,7 +998,7 @@ const char *rcode_str(int rcode) {
 #endif /* RFC2136 rcodes */
 #endif /* __BIND >= 19950621 */
   default:
-    snprintf(buf, sizeof(buf), "RCode%i", rcode);
+    ssnprintf(buf, sizeof(buf), "RCode%i", rcode);
     return buf;
   }
 } /* const char *rcode_str (int rcode) */

--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -106,10 +106,10 @@ static void dpdk_helper_config_default(dpdk_helper_ctx_t *phc) {
 
   DPDK_HELPER_TRACE(phc->shm_name);
 
-  snprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
-  snprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
-  snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
-           DPDK_DEFAULT_RTE_CONFIG);
+  ssnprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
+  ssnprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
+  ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
+            DPDK_DEFAULT_RTE_CONFIG);
 }
 
 int dpdk_helper_eal_config_set(dpdk_helper_ctx_t *phc, dpdk_eal_config_t *ec) {
@@ -184,8 +184,8 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
 
       status = cf_util_get_string_buffer(child, prefix, sizeof(prefix));
       if (status == 0) {
-        snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
-                 "/var/run/.%s_config", prefix);
+        ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
+                  "/var/run/.%s_config", prefix);
         DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
       }
     } else if (strcasecmp("LogLevel", child->key) == 0) {
@@ -836,8 +836,8 @@ uint128_t str_to_uint128(const char *str, int len) {
     memset(high_str, 0, sizeof(high_str));
     memset(low_str, 0, sizeof(low_str));
 
-    strncpy(high_str, str, len - 16);
-    strncpy(low_str, str + len - 16, 16);
+    sstrncpy(high_str, str, len - 16);
+    sstrncpy(low_str, str + len - 16, 16);
 
     lcore_mask.low = strtoull_safe(low_str, &err);
     if (err)

--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -128,24 +128,24 @@ static int gr_format_name_tagged(char *ret, int ret_len, value_list_t const *vl,
   gr_copy_escape_part(n_type_instance, vl->type_instance,
                       sizeof(n_type_instance), escape_char, 1);
 
-  snprintf(tmp_plugin, sizeof(tmp_plugin), ";plugin=%s", n_plugin);
+  ssnprintf(tmp_plugin, sizeof(tmp_plugin), ";plugin=%s", n_plugin);
 
   if (n_plugin_instance[0] != '\0')
-    snprintf(tmp_plugin_instance, sizeof(tmp_plugin_instance),
-             ";plugin_instance=%s", n_plugin_instance);
+    ssnprintf(tmp_plugin_instance, sizeof(tmp_plugin_instance),
+              ";plugin_instance=%s", n_plugin_instance);
   else
     tmp_plugin_instance[0] = '\0';
 
   if (!(flags & GRAPHITE_DROP_DUPE_FIELDS) || strcmp(n_plugin, n_type) != 0)
-    snprintf(tmp_type, sizeof(tmp_type), ";type=%s", n_type);
+    ssnprintf(tmp_type, sizeof(tmp_type), ";type=%s", n_type);
   else
     tmp_type[0] = '\0';
 
   if (n_type_instance[0] != '\0') {
     if (!(flags & GRAPHITE_DROP_DUPE_FIELDS) ||
         strcmp(n_plugin_instance, n_type_instance) != 0)
-      snprintf(tmp_type_instance, sizeof(tmp_type_instance),
-               ";type_instance=%s", n_type_instance);
+      ssnprintf(tmp_type_instance, sizeof(tmp_type_instance),
+                ";type_instance=%s", n_type_instance);
     else
       tmp_type_instance[0] = '\0';
   } else
@@ -154,25 +154,25 @@ static int gr_format_name_tagged(char *ret, int ret_len, value_list_t const *vl,
   /* Assert always_append_ds -> ds_name */
   assert(!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
   if (ds_name != NULL) {
-    snprintf(tmp_ds_name, sizeof(tmp_ds_name), ";ds_name=%s", ds_name);
+    ssnprintf(tmp_ds_name, sizeof(tmp_ds_name), ";ds_name=%s", ds_name);
 
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
-      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, ds_name);
+      ssnprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, ds_name);
     else
-      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s.%s", n_plugin, n_type,
-               ds_name);
+      ssnprintf(tmp_metric, sizeof(tmp_metric), "%s.%s.%s", n_plugin, n_type,
+                ds_name);
   } else {
     tmp_ds_name[0] = '\0';
 
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
-      snprintf(tmp_metric, sizeof(tmp_metric), "%s", n_plugin);
+      ssnprintf(tmp_metric, sizeof(tmp_metric), "%s", n_plugin);
     else
-      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, n_type);
+      ssnprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, n_type);
   }
 
-  snprintf(ret, ret_len, "%s%s%s;host=%s%s%s%s%s%s", prefix, tmp_metric,
-           postfix, n_host, tmp_plugin, tmp_plugin_instance, tmp_type,
-           tmp_type_instance, tmp_ds_name);
+  ssnprintf(ret, ret_len, "%s%s%s;host=%s%s%s%s%s%s", prefix, tmp_metric,
+            postfix, n_host, tmp_plugin, tmp_plugin_instance, tmp_type,
+            tmp_type_instance, tmp_ds_name);
 
   return 0;
 }
@@ -211,9 +211,9 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
                       sizeof(n_type_instance), escape_char, preserve_separator);
 
   if (n_plugin_instance[0] != '\0')
-    snprintf(tmp_plugin, sizeof(tmp_plugin), "%s%c%s", n_plugin,
-             (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
-             n_plugin_instance);
+    ssnprintf(tmp_plugin, sizeof(tmp_plugin), "%s%c%s", n_plugin,
+              (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
+              n_plugin_instance);
   else
     sstrncpy(tmp_plugin, n_plugin, sizeof(tmp_plugin));
 
@@ -221,9 +221,9 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
       sstrncpy(tmp_type, n_type_instance, sizeof(tmp_type));
     else
-      snprintf(tmp_type, sizeof(tmp_type), "%s%c%s", n_type,
-               (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
-               n_type_instance);
+      ssnprintf(tmp_type, sizeof(tmp_type), "%s%c%s", n_type,
+                (flags & GRAPHITE_SEPARATE_INSTANCES) ? '.' : '-',
+                n_type_instance);
   } else
     sstrncpy(tmp_type, n_type, sizeof(tmp_type));
 
@@ -232,14 +232,14 @@ static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
   if (ds_name != NULL) {
     if ((flags & GRAPHITE_DROP_DUPE_FIELDS) &&
         strcmp(tmp_plugin, tmp_type) == 0)
-      snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix,
-               tmp_plugin, ds_name);
+      ssnprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix,
+                tmp_plugin, ds_name);
     else
-      snprintf(ret, ret_len, "%s%s%s.%s.%s.%s", prefix, n_host, postfix,
-               tmp_plugin, tmp_type, ds_name);
+      ssnprintf(ret, ret_len, "%s%s%s.%s.%s.%s", prefix, n_host, postfix,
+                tmp_plugin, tmp_type, ds_name);
   } else
-    snprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
-             tmp_type);
+    ssnprintf(ret, ret_len, "%s%s%s.%s.%s", prefix, n_host, postfix, tmp_plugin,
+              tmp_type);
 
   return 0;
 }
@@ -310,8 +310,8 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
 
     /* Compute the graphite command */
     message_len =
-        (size_t)snprintf(message, sizeof(message), "%s %s %u\r\n", key, values,
-                         (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
+        (size_t) ssnprintf(message, sizeof(message), "%s %s %u\r\n", key,
+                           values, (unsigned int)CDTIME_T_TO_TIME_T(vl->time));
     if (message_len >= sizeof(message)) {
       P_ERROR("format_graphite: message buffer too small: "
               "Need %" PRIsz " bytes.",

--- a/src/utils_format_graphite_test.c
+++ b/src/utils_format_graphite_test.c
@@ -154,7 +154,7 @@ DEF_TEST(metric_name) {
     };
 
     char want[1024];
-    snprintf(want, sizeof(want), "%s 42 1480063672\r\n", cases[i].want_name);
+    ssnprintf(want, sizeof(want), "%s 42 1480063672\r\n", cases[i].want_name);
 
     if (cases[i].plugin_instance != NULL)
       sstrncpy(vl.plugin_instance, cases[i].plugin_instance,

--- a/src/utils_format_json_test.c
+++ b/src/utils_format_json_test.c
@@ -91,10 +91,10 @@ static int expect_label(char const *name, char const *got, char const *want) {
   char msg[1024];
 
   if (ok)
-    snprintf(msg, sizeof(msg), "label[\"%s\"] = \"%s\"", name, got);
+    ssnprintf(msg, sizeof(msg), "label[\"%s\"] = \"%s\"", name, got);
   else
-    snprintf(msg, sizeof(msg), "label[\"%s\"] = \"%s\", want \"%s\"", name, got,
-             want);
+    ssnprintf(msg, sizeof(msg), "label[\"%s\"] = \"%s\", want \"%s\"", name,
+              got, want);
 
   OK1(ok, msg);
   return 0;

--- a/src/utils_mount.c
+++ b/src/utils_mount.c
@@ -258,7 +258,7 @@ static void uuidcache_init(void) {
         * (This is useful, if the cdrom on /dev/hdc must not
         * be accessed.)
         */
-        snprintf(device, sizeof(device), "%s/%s", DEVLABELDIR, ptname);
+        ssnprintf(device, sizeof(device), "%s/%s", DEVLABELDIR, ptname);
         if (!get_label_uuid(device, &label, uuid)) {
           uuidcache_addentry(sstrdup(device), label, uuid);
         }

--- a/src/utils_ovs.c
+++ b/src/utils_ovs.c
@@ -1114,7 +1114,7 @@ int ovs_db_send_request(ovs_db_t *pdb, const char *method, const char *params,
   /* generate id field */
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, "id");
   uid = ovs_uid_generate();
-  snprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
+  ssnprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_buff);
 
   OVS_YAJL_CALL(yajl_gen_map_close, jgen);
@@ -1200,7 +1200,7 @@ int ovs_db_table_cb_register(ovs_db_t *pdb, const char *tb_name,
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, OVS_DB_DEFAULT_DB_NAME);
 
     /* uid string <json-value> */
-    snprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
+    ssnprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_str);
 
     /* <monitor-requests> */

--- a/src/utils_rrdcreate.c
+++ b/src/utils_rrdcreate.c
@@ -208,8 +208,8 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
       if (rra_num >= rra_max)
         break;
 
-      status = snprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
-                        rra_types[j], cfg->xff, cdp_len, cdp_num);
+      status = ssnprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
+                         rra_types[j], cfg->xff, cdp_len, cdp_num);
 
       if ((status < 0) || ((size_t)status >= sizeof(buffer))) {
         P_ERROR("rra_get: Buffer would have been truncated.");
@@ -278,18 +278,17 @@ static int ds_get(char ***ret, /* {{{ */
     if (isnan(d->min)) {
       sstrncpy(min, "U", sizeof(min));
     } else
-      snprintf(min, sizeof(min), "%f", d->min);
+      ssnprintf(min, sizeof(min), "%f", d->min);
 
     if (isnan(d->max)) {
       sstrncpy(max, "U", sizeof(max));
     } else
-      snprintf(max, sizeof(max), "%f", d->max);
+      ssnprintf(max, sizeof(max), "%f", d->max);
 
-    status = snprintf(
-        buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name, type,
-        (cfg->heartbeat > 0) ? cfg->heartbeat
-                             : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
-        min, max);
+    status = ssnprintf(buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name,
+                       type,
+                       (cfg->heartbeat > 0) ? cfg->heartbeat : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
+                       min, max);
     if ((status < 1) || ((size_t)status >= sizeof(buffer)))
       break;
 
@@ -367,8 +366,8 @@ static int srrd_create(const char *filename, /* {{{ */
   if (last_up == 0)
     last_up = time(NULL) - 10;
 
-  snprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
-  snprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
+  ssnprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
+  ssnprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
 
   new_argv[0] = "create";
   new_argv[1] = (void *)filename;
@@ -496,7 +495,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     return 0;
   }
 
-  snprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
+  ssnprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
 
   status = srrd_create(tmpfile, args->pdp_step, args->last_up, args->argc,
                        (void *)args->argv);

--- a/src/utils_tail_match.c
+++ b/src/utils_tail_match.c
@@ -112,11 +112,11 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
   sstrncpy(vl.type, data->type, sizeof(vl.type));
   for (size_t i = 0; i < data->latency_config.percentile_num; i++) {
     if (strlen(data->type_instance) != 0)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%.5g",
-               data->type_instance, data->latency_config.percentile[i]);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%.5g",
+                data->type_instance, data->latency_config.percentile[i]);
     else
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.5g",
-               data->latency_config.percentile[i]);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%.5g",
+                data->latency_config.percentile[i]);
 
     vl.values = &(value_t){
         .gauge =
@@ -144,11 +144,12 @@ static int latency_submit_match(cu_match_t *match, void *user_data) {
         bucket.upper_bound ? CDTIME_T_TO_DOUBLE(bucket.upper_bound) : INFINITY;
 
     if (strlen(data->type_instance) != 0)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%.50s-%g_%g",
-               data->type, data->type_instance, lower_bound, upper_bound);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance),
+                "%.50s-%.50s-%g_%g", data->type, data->type_instance,
+                lower_bound, upper_bound);
     else
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%g_%g",
-               data->type, lower_bound, upper_bound);
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%.50s-%g_%g",
+                data->type, lower_bound, upper_bound);
 
     vl.values = &(value_t){
         .gauge =

--- a/src/utils_vl_lookup_test.c
+++ b/src/utils_vl_lookup_test.c
@@ -28,6 +28,7 @@
 
 #include "testing.h"
 #include "utils_vl_lookup.h"
+#include "common.h"
 
 static bool expect_new_obj;
 static bool have_new_obj;
@@ -68,12 +69,12 @@ static void *lookup_class_callback(data_set_t const *ds, value_list_t const *vl,
   memcpy(&last_class_ident, class, sizeof(last_class_ident));
 
   obj = malloc(sizeof(*obj));
-  strncpy(obj->host, vl->host, sizeof(obj->host));
-  strncpy(obj->plugin, vl->plugin, sizeof(obj->plugin));
-  strncpy(obj->plugin_instance, vl->plugin_instance,
-          sizeof(obj->plugin_instance));
-  strncpy(obj->type, vl->type, sizeof(obj->type));
-  strncpy(obj->type_instance, vl->type_instance, sizeof(obj->type_instance));
+  sstrncpy(obj->host, vl->host, sizeof(obj->host));
+  sstrncpy(obj->plugin, vl->plugin, sizeof(obj->plugin));
+  sstrncpy(obj->plugin_instance, vl->plugin_instance,
+           sizeof(obj->plugin_instance));
+  sstrncpy(obj->type, vl->type, sizeof(obj->type));
+  sstrncpy(obj->type_instance, vl->type_instance, sizeof(obj->type_instance));
 
   have_new_obj = true;
 
@@ -88,12 +89,12 @@ static int checked_lookup_add(lookup_t *obj, /* {{{ */
   lookup_identifier_t ident;
   void *user_class;
 
-  strncpy(ident.host, host, sizeof(ident.host));
-  strncpy(ident.plugin, plugin, sizeof(ident.plugin));
-  strncpy(ident.plugin_instance, plugin_instance,
-          sizeof(ident.plugin_instance));
-  strncpy(ident.type, type, sizeof(ident.type));
-  strncpy(ident.type_instance, type_instance, sizeof(ident.type_instance));
+  sstrncpy(ident.host, host, sizeof(ident.host));
+  sstrncpy(ident.plugin, plugin, sizeof(ident.plugin));
+  sstrncpy(ident.plugin_instance, plugin_instance,
+           sizeof(ident.plugin_instance));
+  sstrncpy(ident.type, type, sizeof(ident.type));
+  sstrncpy(ident.type_instance, type_instance, sizeof(ident.type_instance));
 
   user_class = malloc(sizeof(ident));
   memmove(user_class, &ident, sizeof(ident));
@@ -110,11 +111,11 @@ static int checked_lookup_search(lookup_t *obj, char const *host,
   value_list_t vl = VALUE_LIST_INIT;
   data_set_t const *ds = &ds_unknown;
 
-  strncpy(vl.host, host, sizeof(vl.host));
-  strncpy(vl.plugin, plugin, sizeof(vl.plugin));
-  strncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
-  strncpy(vl.type, type, sizeof(vl.type));
-  strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+  sstrncpy(vl.host, host, sizeof(vl.host));
+  sstrncpy(vl.plugin, plugin, sizeof(vl.plugin));
+  sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
+  sstrncpy(vl.type, type, sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
   if (strcmp(vl.type, "test") == 0)
     ds = &ds_test;

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -107,8 +107,8 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
 
   if (plugin_instance == NULL)
     plugin_instance = "default";
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-           plugin_instance, category);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+            plugin_instance, category);
 
   sstrncpy(vl.type, type, sizeof(vl.type));
 
@@ -1759,8 +1759,8 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     return EINVAL;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "varnish/%s",
-           (conf->instance == NULL) ? "localhost" : conf->instance);
+  ssnprintf(callback_name, sizeof(callback_name), "varnish/%s",
+            (conf->instance == NULL) ? "localhost" : conf->instance);
 
   plugin_register_complex_read(
       /* group = */ "varnish",

--- a/src/virt.c
+++ b/src/virt.c
@@ -946,7 +946,7 @@ static void vcpu_submit(derive_t value, virDomainPtr dom, int vcpu_nr,
                         const char *type) {
   char type_instance[DATA_MAX_NAME_LEN];
 
-  snprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
+  ssnprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
   submit(dom, type, type_instance, &(value_t){.derive = value}, 1);
 }
 
@@ -967,8 +967,8 @@ static void disk_submit(struct lv_block_info *binfo, virDomainPtr dom,
   }
 
   char flush_type_instance[DATA_MAX_NAME_LEN];
-  snprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
-           type_instance);
+  ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
+            type_instance);
 
   if ((binfo->bi.rd_req != -1) && (binfo->bi.wr_req != -1))
     submit_derive2("disk_ops", (derive_t)binfo->bi.rd_req,
@@ -1043,8 +1043,8 @@ static void domain_state_submit_notif(virDomainPtr dom, int state, int reason) {
   const char *reason_str = "N/A";
 #endif
 
-  snprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
-           reason_str);
+  ssnprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
+            reason_str);
 
   int severity;
   switch (state) {
@@ -1400,7 +1400,8 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
     char type_instance[DATA_MAX_NAME_LEN];
     bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu);
 
-    snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
+    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
+              cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
   }
 }
@@ -2123,7 +2124,7 @@ static int lv_init_instance(size_t i, plugin_read_cb callback) {
 
   memset(lv_ud, 0, sizeof(*lv_ud));
 
-  snprintf(inst->tag, sizeof(inst->tag), "%s-%" PRIsz, PLUGIN_NAME, i);
+  ssnprintf(inst->tag, sizeof(inst->tag), "%s-%" PRIsz, PLUGIN_NAME, i);
   inst->id = i;
 
   user_data_t *ud = &(lv_ud->ud);
@@ -2199,8 +2200,8 @@ static int lv_domain_get_tag(xmlXPathContextPtr xpath_ctx, const char *dom_name,
     goto done;
   }
 
-  snprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
-           METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
+  ssnprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
+            METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
   xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
   if (xpath_obj == NULL) {
     ERROR(PLUGIN_NAME " plugin: xmlXPathEval(%s) failed on domain %s",
@@ -2625,7 +2626,7 @@ static int add_interface_device(struct lv_read_state *state, virDomainPtr dom,
     return -1;
   }
 
-  snprintf(number_string, sizeof(number_string), "interface-%u", number);
+  ssnprintf(number_string, sizeof(number_string), "interface-%u", number);
 
   if (state->interface_devices)
     new_ptr = realloc(state->interface_devices, new_size);
@@ -2660,7 +2661,7 @@ static int ignore_device_match(ignorelist_t *il, const char *domname,
     ERROR(PLUGIN_NAME " plugin: malloc failed.");
     return 0;
   }
-  snprintf(name, n, "%s:%s", domname, devpath);
+  ssnprintf(name, n, "%s:%s", domname, devpath);
   r = ignorelist_match(il, name);
   sfree(name);
   return r;

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -156,7 +156,7 @@ static int vserver_read(void) {
     if (dent->d_name[0] == '.')
       continue;
 
-    len = snprintf(file, sizeof(file), PROCDIR "/%s", dent->d_name);
+    len = ssnprintf(file, sizeof(file), PROCDIR "/%s", dent->d_name);
     if ((len < 0) || (len >= BUFSIZE))
       continue;
 
@@ -170,7 +170,7 @@ static int vserver_read(void) {
       continue;
 
     /* socket message accounting */
-    len = snprintf(file, sizeof(file), PROCDIR "/%s/cacct", dent->d_name);
+    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/cacct", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 
@@ -212,7 +212,7 @@ static int vserver_read(void) {
     }
 
     /* thread information and load */
-    len = snprintf(file, sizeof(file), PROCDIR "/%s/cvirt", dent->d_name);
+    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/cvirt", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 
@@ -256,7 +256,7 @@ static int vserver_read(void) {
     }
 
     /* processes and memory usage */
-    len = snprintf(file, sizeof(file), PROCDIR "/%s/limit", dent->d_name);
+    len = ssnprintf(file, sizeof(file), PROCDIR "/%s/limit", dent->d_name);
     if ((len < 0) || ((size_t)len >= sizeof(file)))
       continue;
 

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -237,7 +237,8 @@ static int wg_callback_init(struct wg_callback *cb) {
     cb->sock_fd =
         socket(ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
     if (cb->sock_fd < 0) {
-      snprintf(connerr, sizeof(connerr), "failed to open socket: %s", STRERRNO);
+      ssnprintf(connerr, sizeof(connerr), "failed to open socket: %s",
+                STRERRNO);
       continue;
     }
 
@@ -245,8 +246,8 @@ static int wg_callback_init(struct wg_callback *cb) {
 
     status = connect(cb->sock_fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
     if (status != 0) {
-      snprintf(connerr, sizeof(connerr), "failed to connect to remote host: %s",
-               STRERRNO);
+      ssnprintf(connerr, sizeof(connerr),
+                "failed to connect to remote host: %s", STRERRNO);
       close(cb->sock_fd);
       cb->sock_fd = -1;
       continue;
@@ -541,11 +542,11 @@ static int wg_config_node(oconfig_item_t *ci) {
 
   /* FIXME: Legacy configuration syntax. */
   if (cb->name == NULL)
-    snprintf(callback_name, sizeof(callback_name), "write_graphite/%s/%s/%s",
-             cb->node, cb->service, cb->protocol);
+    ssnprintf(callback_name, sizeof(callback_name), "write_graphite/%s/%s/%s",
+              cb->node, cb->service, cb->protocol);
   else
-    snprintf(callback_name, sizeof(callback_name), "write_graphite/%s",
-             cb->name);
+    ssnprintf(callback_name, sizeof(callback_name), "write_graphite/%s",
+              cb->name);
 
   plugin_register_write(callback_name, wg_write,
                         &(user_data_t){

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -195,8 +195,8 @@ static int wh_callback_init(wh_callback_t *cb) /* {{{ */
       return -1;
     }
 
-    snprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
-             (cb->pass == NULL) ? "" : cb->pass);
+    ssnprintf(cb->credentials, credentials_size, "%s:%s", cb->user,
+              (cb->pass == NULL) ? "" : cb->pass);
     curl_easy_setopt(cb->curl, CURLOPT_USERPWD, cb->credentials);
 #endif
     curl_easy_setopt(cb->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
@@ -375,9 +375,9 @@ static int wh_write_command(const data_set_t *ds,
     return status;
   }
 
-  command_len = (size_t)snprintf(command, sizeof(command),
-                                 "PUTVAL %s interval=%.3f %s\r\n", key,
-                                 CDTIME_T_TO_DOUBLE(vl->interval), values);
+  command_len = (size_t) ssnprintf(command, sizeof(command),
+                                   "PUTVAL %s interval=%.3f %s\r\n", key,
+                                   CDTIME_T_TO_DOUBLE(vl->interval), values);
   if (command_len >= sizeof(command)) {
     ERROR("write_http plugin: Command buffer too small: "
           "Need %" PRIsz " bytes.",
@@ -810,7 +810,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   /* Nulls the buffer and sets ..._free and ..._fill. */
   wh_reset_buffer(cb);
 
-  snprintf(callback_name, sizeof(callback_name), "write_http/%s", cb->name);
+  ssnprintf(callback_name, sizeof(callback_name), "write_http/%s", cb->name);
   DEBUG("write_http: Registering write callback '%s' with URL '%s'",
         callback_name, cb->location);
 

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -97,7 +97,7 @@ static uint32_t kafka_hash(const char *keydata, size_t keylen) {
 #define KAFKA_RANDOM_KEY_BUFFER                                                \
   (char[KAFKA_RANDOM_KEY_SIZE]) { "" }
 static char *kafka_random_key(char buffer[static KAFKA_RANDOM_KEY_SIZE]) {
-  snprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
+  ssnprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
   return buffer;
 }
 
@@ -410,8 +410,8 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   rd_kafka_topic_conf_set_partitioner_cb(tctx->conf, kafka_partition);
   rd_kafka_topic_conf_set_opaque(tctx->conf, tctx);
 
-  snprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
-           tctx->topic_name);
+  ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
+            tctx->topic_name);
 
   status = plugin_register_write(
       callback_name, kafka_write,

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -96,7 +96,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       BSON_APPEND_DOUBLE(&subarray, key, vl->values[i].gauge);
@@ -121,7 +121,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (store_rates)
       BSON_APPEND_UTF8(&subarray, key, "gauge");
@@ -134,7 +134,7 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
     char key[16];
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
     BSON_APPEND_UTF8(&subarray, key, ds->ds[i].name);
   }
   bson_append_array_end(ret, &subarray); /* }}} dsnames */
@@ -368,7 +368,7 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char cb_name[sizeof("write_mongodb/") + DATA_MAX_NAME_LEN];
 
-    snprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
+    ssnprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
 
     status =
         plugin_register_write(cb_name, wm_write,

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -163,8 +163,8 @@ static char *format_labels(char *buffer, size_t buffer_size,
    * know that they are sane. */
   for (size_t i = 0; i < m->n_label; i++) {
     char value[LABEL_VALUE_SIZE];
-    snprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
-             escape_label_value(value, sizeof(value), m->label[i]->value));
+    ssnprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
+              escape_label_value(value, sizeof(value), m->label[i]->value));
   }
 
   strjoin(buffer, buffer_size, labels, m->n_label, ",");
@@ -182,13 +182,11 @@ static void format_text(ProtobufCBuffer *buffer) {
   while (c_avl_iterator_next(iter, (void *)&unused_name, (void *)&fam) == 0) {
     char line[1024]; /* 4x DATA_MAX_NAME_LEN? */
 
-    snprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
+    ssnprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
-    snprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
-             (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-                 ? "gauge"
-                 : "counter");
+    ssnprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
+              (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE) ? "gauge" : "counter");
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
     for (size_t i = 0; i < fam->n_metric; i++) {
@@ -198,17 +196,17 @@ static void format_text(ProtobufCBuffer *buffer) {
 
       char timestamp_ms[24] = "";
       if (m->has_timestamp_ms)
-        snprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
-                 m->timestamp_ms);
+        ssnprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
+                  m->timestamp_ms);
 
       if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-        snprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
-                 format_labels(labels, sizeof(labels), m), m->gauge->value,
-                 timestamp_ms);
+        ssnprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n",
+                  fam->name, format_labels(labels, sizeof(labels), m),
+                  m->gauge->value, timestamp_ms);
       else /* if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__COUNTER) */
-        snprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
-                 format_labels(labels, sizeof(labels), m), m->counter->value,
-                 timestamp_ms);
+        ssnprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
+                  format_labels(labels, sizeof(labels), m), m->counter->value,
+                  timestamp_ms);
 
       buffer->append(buffer, strlen(line), (uint8_t *)line);
     }
@@ -216,8 +214,9 @@ static void format_text(ProtobufCBuffer *buffer) {
   c_avl_iterator_destroy(iter);
 
   char server[1024];
-  snprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
-           PACKAGE_VERSION, hostname_g);
+  ssnprintf(server, sizeof(server),
+            "\n# collectd/write_prometheus %s at %s\n", PACKAGE_VERSION,
+            hostname_g);
   buffer->append(buffer, strlen(server), (uint8_t *)server);
 
   pthread_mutex_unlock(&metrics_lock);
@@ -634,11 +633,10 @@ metric_family_create(char *name, data_set_t const *ds, value_list_t const *vl,
   msg->name = name;
 
   char help[1024];
-  snprintf(
-      help, sizeof(help),
-      "write_prometheus plugin: '%s' Type: '%s', Dstype: '%s', Dsname: '%s'",
-      vl->plugin, vl->type, DS_TYPE_TO_STRING(ds->ds[ds_index].type),
-      ds->ds[ds_index].name);
+  ssnprintf(help, sizeof(help),
+            "write_prometheus plugin: '%s' Type: '%s', Dstype: '%s', Dsname: '%s'",
+            vl->plugin, vl->type, DS_TYPE_TO_STRING(ds->ds[ds_index].type),
+            ds->ds[ds_index].name);
   msg->help = strdup(help);
 
   msg->type = (ds->ds[ds_index].type == DS_TYPE_GAUGE)
@@ -734,7 +732,8 @@ static void prom_logger(__attribute__((unused)) void *arg, char const *fmt,
                         va_list ap) {
   /* {{{ */
   char errbuf[1024];
-  vsnprintf(errbuf, sizeof(errbuf), fmt, ap);
+  vsnprintf(errbuf, sizeof(errbuf) - 1, fmt, ap);
+  errbuf[sizeof(errbuf) - 1] = '\0';
 
   ERROR("write_prometheus plugin: %s", errbuf);
 } /* }}} prom_logger */
@@ -743,7 +742,7 @@ static void prom_logger(__attribute__((unused)) void *arg, char const *fmt,
 static int prom_open_socket(int addrfamily) {
   /* {{{ */
   char service[NI_MAXSERV];
-  snprintf(service, sizeof(service), "%hu", httpd_port);
+  ssnprintf(service, sizeof(service), "%hu", httpd_port);
 
   struct addrinfo *res;
   int status = getaddrinfo(NULL, service,

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -71,9 +71,10 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   status = FORMAT_VL(ident, sizeof(ident), vl);
   if (status != 0)
     return status;
-  snprintf(key, sizeof(key), "%s%s",
-           (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX, ident);
-  snprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
+  ssnprintf(key, sizeof(key), "%s%s",
+            (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX,
+            ident);
+  ssnprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   value_size = sizeof(value);
   value_ptr = &value[0];
@@ -239,7 +240,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char cb_name[sizeof("write_redis/") + DATA_MAX_NAME_LEN];
 
-    snprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
+    ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
     status =
         plugin_register_write(cb_name, wr_write,

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -291,17 +291,18 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
               vl->type_instance);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      snprintf(service_buffer, sizeof(service_buffer), "%s/%s", &name_buffer[1],
-               ds->ds[index].name);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s/%s",
+                &name_buffer[1], ds->ds[index].name);
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
-               host->event_service_prefix, &name_buffer[1], ds->ds[index].name);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
+                host->event_service_prefix, &name_buffer[1],
+                ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, &name_buffer[1], sizeof(service_buffer));
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s",
-               host->event_service_prefix, &name_buffer[1]);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
+                host->event_service_prefix, &name_buffer[1]);
   }
 
   riemann_event_set(
@@ -349,8 +350,8 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
 
-    snprintf(ds_type, sizeof(ds_type), "%s:rate",
-             DS_TYPE_TO_STRING(ds->ds[index].type));
+    ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
+              DS_TYPE_TO_STRING(ds->ds[index].type));
     riemann_event_string_attribute_add(event, "ds_type", ds_type);
   } else {
     riemann_event_string_attribute_add(event, "ds_type",
@@ -360,7 +361,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   {
     char ds_index[DATA_MAX_NAME_LEN];
 
-    snprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
+    ssnprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
     riemann_event_string_attribute_add(event, "ds_index", ds_index);
   }
 
@@ -777,8 +778,8 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
     return status;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
-           host->name);
+  ssnprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
+            host->name);
 
   user_data_t ud = {.data = host, .free_func = wrr_free};
 

--- a/src/write_sensu.c
+++ b/src/write_sensu.c
@@ -419,8 +419,8 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   // incorporate the data source type
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
-    snprintf(ds_type, sizeof(ds_type), "%s:rate",
-             DS_TYPE_TO_STRING(ds->ds[index].type));
+    ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
+              DS_TYPE_TO_STRING(ds->ds[index].type));
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_type\": \"%s\"",
                       ret_str, ds_type);
     free(ret_str);
@@ -453,7 +453,7 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
   // incorporate the data source index
   {
     char ds_index[DATA_MAX_NAME_LEN];
-    snprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
+    ssnprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
     res = my_asprintf(&temp_str, "%s, \"collectd_data_source_index\": %s",
                       ret_str, ds_index);
     free(ret_str);
@@ -534,17 +534,17 @@ static char *sensu_value_to_json(struct sensu_host const *host, /* {{{ */
                      host->separator);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      snprintf(service_buffer, sizeof(service_buffer), "%s.%s", name_buffer,
-               ds->ds[index].name);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s.%s", name_buffer,
+                ds->ds[index].name);
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s.%s",
-               host->event_service_prefix, name_buffer, ds->ds[index].name);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s.%s",
+                host->event_service_prefix, name_buffer, ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, name_buffer, sizeof(service_buffer));
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s",
-               host->event_service_prefix, name_buffer);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
+                host->event_service_prefix, name_buffer);
   }
 
   // Replace collectd sensor name reserved characters so that time series DB is
@@ -1139,7 +1139,8 @@ static int sensu_config_node(oconfig_item_t *ci) /* {{{ */
     return -1;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "write_sensu/%s", host->name);
+  ssnprintf(callback_name, sizeof(callback_name), "write_sensu/%s",
+            host->name);
 
   user_data_t ud = {.data = host, .free_func = sensu_free};
 

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -455,8 +455,8 @@ static int wt_send_message(const char *key, const char *value, cdtime_t time,
   }
 
   status =
-      snprintf(message, sizeof(message), "put %s %.0f %s fqdn=%s %s %s\r\n",
-               key, CDTIME_T_TO_DOUBLE(time), value, host, tags, host_tags);
+      ssnprintf(message, sizeof(message), "put %s %.0f %s fqdn=%s %s %s\r\n",
+                key, CDTIME_T_TO_DOUBLE(time), value, host, tags, host_tags);
   sfree(temp);
   if (status < 0)
     return -1;
@@ -606,9 +606,9 @@ static int wt_config_tsd(oconfig_item_t *ci) {
     }
   }
 
-  snprintf(callback_name, sizeof(callback_name), "write_tsdb/%s/%s",
-           cb->node != NULL ? cb->node : WT_DEFAULT_NODE,
-           cb->service != NULL ? cb->service : WT_DEFAULT_SERVICE);
+  ssnprintf(callback_name, sizeof(callback_name), "write_tsdb/%s/%s",
+            cb->node != NULL ? cb->node : WT_DEFAULT_NODE,
+            cb->service != NULL ? cb->service : WT_DEFAULT_SERVICE);
 
   user_data_t user_data = {.data = cb, .free_func = wt_callback_free};
 

--- a/src/xencpu.c
+++ b/src/xencpu.c
@@ -112,7 +112,7 @@ static void submit_value(int cpu_num, gauge_t value) {
   sstrncpy(vl.type_instance, "load", sizeof(vl.type_instance));
 
   if (cpu_num >= 0) {
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", cpu_num);
   }
   plugin_dispatch_values(&vl);
 } /* static void submit_value */

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -127,7 +127,7 @@ static long long get_zfs_value(kstat_t *dummy __attribute__((unused)),
   size_t valuelen = sizeof(value);
   int rv;
 
-  snprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
+  ssnprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
   rv = sysctlbyname(buffer, (void *)&value, &valuelen,
                     /* new value = */ NULL, /* new length = */ (size_t)0);
   if (rv == 0)

--- a/src/zone.c
+++ b/src/zone.c
@@ -62,7 +62,7 @@ static int zone_read_procfile(char const *pidstr, char const *name, void *buf,
   int fd;
 
   char procfile[MAX_PROCFS_PATH];
-  (void)snprintf(procfile, sizeof(procfile), "/proc/%s/%s", pidstr, name);
+  (void) ssnprintf(procfile, sizeof(procfile), "/proc/%s/%s", pidstr, name);
   if ((fd = open(procfile, O_RDONLY)) == -1) {
     return 1;
   }


### PR DESCRIPTION
GCC 8.2 now warns about possible truncation in snprintf() and
strncat(). As for snprintf(), we introduce an helper ssnprintf() to
handle this correctly. It silently adds the missing '\0' at the end.
The change is mostly mechanical (some help from Coccinelle) and may be
a bit overzealous as in some case, it may be unneeded (GCC doesn't
detect all cases either).

vsnprintf() is also handled by putting the terminal null character in
case of overflow.

As for strncat(), the situation is far more grim. GCC seems to not
understand what this function is about. The canonical use of such a
function is `strncat(out, src, sizeof(out) - strlen(out) - 1)`. But
GCC won't accept that.

This PR is a WIP. Would such changes be acceptable? Moreover, I have
no clue on how to deal with the perfectly `strncat()` in
`snmp_agent.c`:

```
  CC       src/snmp_agent_la-snmp_agent.lo
In function ‘snmp_agent_build_name’,
    inlined from ‘snmp_agent_format_name.constprop’ at ../src/snmp_agent.c:1029:13,
    inlined from ‘snmp_agent_form_reply.isra.22’ at ../src/snmp_agent.c:1091:9:
../src/snmp_agent.c:964:9: error: ‘strncat’ output may be truncated copying between 0 and 127 bytes from a string of length 127 [-Werror=stringop-truncation]
         strncat(out, str, sizeof(out) - strlen(out) - 1);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:6920: src/snmp_agent_la-snmp_agent.lo] Error 1
```

Apart from that, the result compiles without warnings and tests are
successful. It would need a second pass, but I've skipped that until I
get an informal ack on the change.