### PR TITLE
powerdns plugin: no-packet-error should be counter, not gauge

### DIFF
--- a/src/powerdns.c
+++ b/src/powerdns.c
@@ -279,7 +279,7 @@ static statname_lookup_t lookup_table[] = /* {{{ */
         {"ipv6-questions", "dns_question", "incoming-ipv6"},
         {"malloc-bytes", "gauge", "malloc_bytes"},
         {"max-mthread-stack", "gauge", "max_mthread_stack"},
-        {"no-packet-error", "gauge", "no_packet_error"},
+        {"no-packet-error", "errors", "no_packet_error"},
         {"noedns-outqueries", "dns_question", "outgoing-noedns"},
         {"noping-outqueries", "dns_question", "outgoing-noping"},
         {"over-capacity-drops", "dns_question", "incoming-over_capacity"},


### PR DESCRIPTION
It is a counter of erroneous packets, and it always goes up so it should be returned as one (just like other counters returned by PDNS)
![zaznaczenie_2018-08-17_001](https://user-images.githubusercontent.com/147394/44272152-543fb980-a23c-11e8-952e-93d7049adf1a.png)
