### PR TITLE
LogOnce option for df plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -578,6 +578,7 @@
 #	MountPoint "/home"
 #	FSType "ext3"
 #	IgnoreSelected false
+#	LogOnce false
 #	ReportByDevice false
 #	ReportInodes false
 #	ValuesAbsolute true

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2745,6 +2745,10 @@ match any one of the criteria are collected. By default only selected
 partitions are collected if a selection is made. If no selection is configured
 at all, B<all> partitions are selected.
 
+=item B<LogOnce> B<false>|B<false>
+
+Only log stat() errors once.
+
 =item B<ReportByDevice> B<true>|B<false>
 
 Report using the device name rather than the mountpoint. i.e. with this I<false>,

--- a/src/utils/ignorelist/ignorelist.c
+++ b/src/utils/ignorelist/ignorelist.c
@@ -279,6 +279,37 @@ int ignorelist_add(ignorelist_t *il, const char *entry) {
 } /* int ignorelist_add (ignorelist_t *il, const char *entry) */
 
 /*
+ * remove entry from ignorelist_t
+ * return 0 for success
+ */
+int ignorelist_remove(ignorelist_t *il, const char *entry) {
+  /* if no entries, nothing to remove */
+  if ((il == NULL) || (il->head == NULL))
+    return (1);
+
+  if ((entry == NULL) || (strlen(entry) == 0))
+    return (1);
+
+  /* traverse list and check entries */
+  for (ignorelist_item_t *prev = NULL, *traverse = il->head; traverse != NULL;
+       prev = traverse, traverse = traverse->next) {
+    if (traverse->smatch != NULL && strcmp(traverse->smatch, entry) == 0) {
+      if (prev == NULL) {
+        il->head = traverse->next;
+      } else {
+        prev->next = traverse->next;
+      }
+      sfree(traverse->smatch);
+      traverse->smatch = NULL;
+      sfree(traverse);
+      return (0);
+    }
+  } /* for traverse */
+
+  return (1);
+} /* int ignorelist_remove (ignorelist_t *il, const char *entry) */
+
+/*
  * check list for entry
  * return 1 for ignored entry
  */

--- a/src/utils/ignorelist/ignorelist.h
+++ b/src/utils/ignorelist/ignorelist.h
@@ -61,6 +61,12 @@ void ignorelist_set_invert(ignorelist_t *il, int invert);
 int ignorelist_add(ignorelist_t *il, const char *entry);
 
 /*
+ * remote entry from ignorelist_t
+ * returns zero on success, non-zero upon failure.
+ */
+int ignorelist_remove(ignorelist_t *il, const char *entry);
+
+/*
  * check list for entry
  * return 1 for ignored entry
  */


### PR DESCRIPTION
ChangeLog: plugin df: Add LogOnce option

Enabling LogOnce true option in df plugin reduces syslog spam when stat
constantly fails for any of the mounted partitions.