### PR TITLE
nfs: Fix number of fields for NFSv4

### DIFF
--- a/src/nfs.c
+++ b/src/nfs.c
@@ -519,7 +519,8 @@ static int nfs_submit_nfs4_client(const char *instance, char **fields,
 static void nfs_read_linux(FILE *fh, const char *inst) {
   char buffer[1024];
 
-  char *fields[64];
+  // The stats line is prefixed with type and number of fields, thus plus 2
+  char *fields[MAX(NFS4_SERVER_MAX_PROC, NFS4_CLIENT_MAX_PROC) + 2];
   int fields_num = 0;
 
   if (fh == NULL)


### PR DESCRIPTION
The previous buffer of 64 fields was too short for the current number of
72+2 fields in NFS 4.2, causing the message

  nfs plugin: Unexpected number of fields for NFSv4 server statistics: 62.

This change, originally proposed in [1], fixes that issue in a
forward-compatible manner by reusing the already known number of fields
from the static arrays.

[1]: https://github.com/collectd/collectd/issues/2076#issuecomment-350466628

Fixes #1304, #2076, #2317.