### PR TITLE
Fix segfault in libvirt plugin

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -1636,7 +1636,7 @@ static int lv_read(user_data_t *ud) {
       ERROR(PLUGIN_NAME
             " failed to get stats for block device (%s) in domain %s",
             state->block_devices[i].path,
-            virDomainGetName(state->domains[i].ptr));
+            virDomainGetName(state->block_devices[i].dom));
   }
 
   /* Get interface stats for each domain. */


### PR DESCRIPTION
The libvirt plugin refreshes its list of domains every RefreshInterval
seconds. If a domain crashes after getting the list, getting the stats
for its block devices returns an error. We then try to call
virDomainGetName on an invalid pointer. Fix this.