### PR TITLE
contrib/docker/rootfs_prefix: Add MIT license header.

### DIFF
--- a/contrib/docker/rootfs_prefix/rootfs_prefix.c
+++ b/contrib/docker/rootfs_prefix/rootfs_prefix.c
@@ -1,3 +1,33 @@
+/**
+ * collectd - contrib/docker/rootfs_prefix/rootfs_prefix.c
+ * Copyright (C) 2016-2018  Marc Fournier
+ * Copyright (C) 2016-2018  Ruben Kerkhof
+ *
+ * MIT License:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Marc Fournier <marc.fournier at camptocamp.com>
+ *   Ruben Kerkhof <ruben at rubenkerkhof.com>
+ **/
+
 #define _GNU_SOURCE
 
 #include <dirent.h>


### PR DESCRIPTION
On 2018-09-06 Marc Fournier wrote:

> Hello Florian !
> 
> Yes, sure, sorry to have omitted this! I'm fine with MIT. Glad this is
> useful to others :-)
> 
> +1 for adding a default "fallback" licence to COPYING. In case this has
> unexpected implications, let's just add the MIT licence to root_prefix/* so
> Baruch can move forward with his project.
> 
> Cheers,
> Marc