### PR TITLE
dpdk: fix dpdk runtime config file path

### DIFF
--- a/src/utils_dpdk.c
+++ b/src/utils_dpdk.c
@@ -43,7 +43,11 @@
 #include "common.h"
 #include "utils_dpdk.h"
 
+#if RTE_VERSION <= RTE_VERSION_NUM(18, 5, 0, 0)
 #define DPDK_DEFAULT_RTE_CONFIG "/var/run/.rte_config"
+#else
+#define DPDK_DEFAULT_RTE_CONFIG "/var/run/dpdk/rte/config"
+#endif
 #define DPDK_EAL_ARGC 10
 // Complete trace should fit into 1024 chars. Trace contain some headers
 // and text together with traced data from pipe. This is the reason why
@@ -184,8 +188,13 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
 
       status = cf_util_get_string_buffer(child, prefix, sizeof(prefix));
       if (status == 0) {
+#if RTE_VERSION <= RTE_VERSION_NUM(18, 5, 0, 0)
         snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
                  "/var/run/.%s_config", prefix);
+#else
+        snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
+                 "/var/run/dpdk/%s/config", prefix);
+#endif
         DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
       }
     } else if (strcasecmp("LogLevel", child->key) == 0) {


### PR DESCRIPTION
The config path was changed in DPDK by the commit 'adf1d86  eal: move
runtime config file to new location’. As a result, the dpdk plugins won't
be able to link to the DPDK primary application after this change.

This commit adds a compile time check for the DPDK verison being used and
sets the DPDK runtime config file location accordingly.

Suggested-by: Michael Luo <michael.luo@intel.com>
Signed-off-by: Kevin Laatz <kevin.laatz@intel.com>