### PR TITLE
exec plugin: fix potential deadlock after fork()

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -268,6 +268,19 @@ static void set_environment(void) /* {{{ */
 #endif
 } /* }}} void set_environment */
 
+static void unset_environment(void) /* {{{ */
+{
+#ifdef HAVE_SETENV
+  unsetenv("COLLECTD_INTERVAL");
+  unsetenv("COLLECTD_HOSTNAME");
+#else
+  snprintf(env_interval, sizeof(env_interval), "COLLECTD_INTERVAL");
+  putenv(env_interval);
+  snprintf(env_hostname, sizeof(env_hostname), "COLLECTD_HOSTNAME");
+  putenv(env_hostname);
+#endif
+} /* }}} void unset_environment */
+
 __attribute__((noreturn)) static void exec_child(program_list_t *pl, int uid,
                                                  int gid, int egid) /* {{{ */
 {
@@ -435,6 +448,8 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
     }
   } /* if (pl->group == NULL) */
 
+  set_environment();
+
   pid = fork();
   if (pid < 0) {
     ERROR("exec plugin: fork failed: %s", STRERRNO);
@@ -469,14 +484,14 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
       close(fd_pipe_err[1]);
     }
 
-    set_environment();
-
     /* Unblock all signals */
     reset_signal_mask();
 
     exec_child(pl, uid, gid, egid);
     /* does not return */
   }
+
+  unset_environment();
 
   close(fd_pipe_in[0]);
   close(fd_pipe_out[1]);
@@ -500,6 +515,8 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
   return pid;
 
 failed:
+  unset_environment();
+
   close_pipe(fd_pipe_in);
   close_pipe(fd_pipe_out);
   close_pipe(fd_pipe_err);


### PR DESCRIPTION
POSIX forbids calling functions which are not thread-safe like
setenv() after fork() in multi-threaded programs. It happens to
work just fine with some libc implementations, but it causes a
deadlock in the child process with uClibc for example.

The proper way to pass new environment variables to the child
process is to update parent's environment before the fork(), so
that the child inherits the updated environment and then undo the
changes in the parent process again.