### PR TITLE
Backport: ceph plugin: fix scan-build warnings

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -281,7 +281,9 @@ static int ceph_cb_number(void *ctx, const char *number_val,
    * "rate", use the "sum" in the pair and assign that to the derive
    * value. */
   if (convert_special_metrics && (state->depth > 2) &&
+      state->stack[state->depth - 2] &&
       (strcmp("filestore", state->stack[state->depth - 2]) == 0) &&
+      state->stack[state->depth - 1] &&
       (strcmp("journal_wr_bytes", state->stack[state->depth - 1]) == 0) &&
       (strcmp("avgcount", state->key) == 0)) {
     DEBUG("ceph plugin: Skipping avgcount for filestore.JournalWrBytes");


### PR DESCRIPTION
src/ceph.c:284:8: warning: Null pointer argument in call to string comparison function
  (strcmp("filestore", state->stack[state->depth - 2]) == 0) &&
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/x86_64-linux-gnu/bits/string2.h:817:8: note: expanded from macro 'strcmp'
	: __builtin_strcmp (s1, s2)))); })
	  ^~~~~~~~~~~~~~~~~~~~~~~~~
src/ceph.c:285:8: warning: Null pointer argument in call to string comparison function
  (strcmp("journal_wr_bytes", state->stack[state->depth - 1]) == 0) &&
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/x86_64-linux-gnu/bits/string2.h:817:8: note: expanded from macro 'strcmp'
	: __builtin_strcmp (s1, s2)))); })
	  ^~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.

Cherry-pick for collectd-5.8.