### PR TITLE
gps: fix gps_read

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -141,7 +141,11 @@ static void *cgps_thread(void *pData) {
         continue;
       }
 
+#if GPSD_API_MAJOR_VERSION > 6
+      if (gps_read(&gpsd_conn, NULL, 0) == -1) {
+#else
       if (gps_read(&gpsd_conn) == -1) {
+#endif
         WARNING("gps plugin: incorrect data! (err_count: %d)", err_count);
         err_count++;
 


### PR DESCRIPTION
gps_read now takes three arguments since version 3.18 of gpsd: see
http://git.savannah.gnu.org/cgit/gpsd.git/commit/?id=6bba8b329fc7687b15863d30471d5af402467802

Fixes:
 - http://autobuild.buildroot.net/results/63a4f980d7cdb4b0823840f747589803fcd0d69f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>