### PR TITLE
gps plugin: fix build with newer gpsd

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -141,7 +141,12 @@ static void *cgps_thread(void *pData) {
         continue;
       }
 
-      if (gps_read(&gpsd_conn) == -1) {
+#if GPSD_API_MAJOR_VERSION > 6
+      if (gps_read(&gpsd_conn, NULL, 0) == -1)
+#else
+      if (gps_read(&gpsd_conn) == -1)
+#endif
+      {
         WARNING("gps plugin: incorrect data! (err_count: %d)", err_count);
         err_count++;
 


### PR DESCRIPTION
gpsd version 3.18 changed the prototype of gps_read(). Make the
gps_read() call depend on GPSD_API_MAJOR_VERSION to fix that.

This fixes build failures like:

gps.c: In function 'cgps_thread':
gps.c:144:11: error: too few arguments to function 'gps_read'
       if (gps_read(&gpsd_conn) == -1) {
		   ^~~~~~~~