### PR TITLE
turbostat plugin: free the right variable

### DIFF
--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -586,7 +586,8 @@ static int submit_counters(struct thread_data *t, struct core_data *c,
   /* If not using logical core numbering, set core id */
   if (!config_lcn) {
     if (topology.num_packages > 1)
-      snprintf(name, sizeof(name), "pkg%02d-core%02d", p->package_id, c->core_id);
+      snprintf(name, sizeof(name), "pkg%02d-core%02d", p->package_id,
+               c->core_id);
     else
       snprintf(name, sizeof(name), "core%02d", c->core_id);
   }
@@ -1287,15 +1288,15 @@ static int allocate_counters(struct thread_data **threads,
   *cores = calloc(total_cores, sizeof(struct core_data));
   if (*cores == NULL) {
     ERROR("turbostat plugin: calloc failed");
-    sfree(threads);
+    sfree(*threads);
     return -1;
   }
 
   *packages = calloc(topology.num_packages, sizeof(struct pkg_data));
   if (*packages == NULL) {
     ERROR("turbostat plugin: calloc failed");
-    sfree(cores);
-    sfree(threads);
+    sfree(*cores);
+    sfree(*threads);
     return -1;
   }
 


### PR DESCRIPTION
scan-build: Using '/usr/bin/clang-6.0' for static analysis
make  all-am
make[1]: Entering directory '/home/ruben/src/collectd'
  CC       src/turbostat.lo
src/turbostat.c:1292:5: warning: Argument to free() is the address of the global variable 'thread_delta', which is not memory allocated by malloc()
    sfree(threads);
    ^~~~~~~~~~~~~~
./src/daemon/common.h:41:5: note: expanded from macro 'sfree'
    free(ptr);                                                                 \
    ^~~~~~~~~
src/turbostat.c:1299:5: warning: Argument to free() is the address of the global variable 'core_delta', which is not memory allocated by malloc()
    sfree(cores);
    ^~~~~~~~~~~~
./src/daemon/common.h:41:5: note: expanded from macro 'sfree'
    free(ptr);                                                                 \
    ^~~~~~~~~
2 warnings generated.
  CCLD     turbostat.la

(cherry picked from commit 74eda959ddf653b7d20779d84f0a140e85376726)