### PR TITLE
Fix detection of xmmsctrl.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5524,15 +5524,15 @@ if test "x$with_libxmms" = "xyes"; then
 fi
 
 if test "x$with_libxmms" = "xyes"; then
-  SAVE_CFLAGS="$CFLAGS"
-  CFLAGS="$with_xmms_cflags"
+  SAVE_CPPFLAGS="$CFLAGS"
+  CPPFLAGS="$with_xmms_cflags"
 
   AC_CHECK_HEADER([xmmsctrl.h],
     [with_libxmms="yes"],
     [with_libxmms="no"],
   )
 
-  CFLAGS="$SAVE_CFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
 fi
 
 if test "x$with_libxmms" = "xyes"; then


### PR DESCRIPTION
checking xmmsctrl.h usability... yes
checking xmmsctrl.h presence... no
configure: WARNING: xmmsctrl.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: xmmsctrl.h: proceeding with the compiler's result
checking for xmmsctrl.h... yes
checking for xmms_remote_get_info in -lxmms... yes

AC_CHECK_HEADER uses the preprocessor, which doesn't look at CFLAGS.
Use CPPFLAGS so it uses the right include path to look for xmmsctrl.h