### PR TITLE
write_stackdriver plugin: Fix potential NULL dereference and error reporting.

### DIFF
--- a/src/daemon/utils_cache_mock.c
+++ b/src/daemon/utils_cache_mock.c
@@ -49,9 +49,19 @@ int uc_get_value_by_name(const char *name, value_t **ret_values,
   return ENOTSUP;
 }
 
+int uc_meta_data_get_signed_int(const value_list_t *vl, const char *key,
+                                int64_t *value) {
+  return -ENOENT;
+}
+
 int uc_meta_data_get_unsigned_int(const value_list_t *vl, const char *key,
                                   uint64_t *value) {
   return -ENOENT;
+}
+
+int uc_meta_data_add_signed_int(const value_list_t *vl, const char *key,
+                                int64_t value) {
+  return 0;
 }
 
 int uc_meta_data_add_unsigned_int(const value_list_t *vl, const char *key,

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -225,8 +225,10 @@ static int do_post(wg_callback_t *cb, char const *url, void const *payload,
 
   if (status != CURLE_OK) {
     ERROR("write_stackdriver plugin: POST %s failed: %s", url, cb->curl_errbuf);
-    sfree(ret_content->memory);
-    ret_content->size = 0;
+    if (ret_content != NULL) {
+      sfree(ret_content->memory);
+      ret_content->size = 0;
+    }
     return -1;
   }
 

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -341,11 +341,6 @@ static int wg_flush_nolock(cdtime_t timeout, wg_callback_t *cb) /* {{{ */
 
   char *payload = sd_output_reset(cb->formatter);
   int status = wg_call_timeseries_write(cb, payload);
-  if (status != 0) {
-    ERROR("write_stackdriver plugin: Sending buffer failed with status %d.",
-          status);
-  }
-
   wg_reset_buffer(cb);
   return status;
 } /* }}} wg_flush_nolock */

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -236,10 +236,10 @@ static int do_post(wg_callback_t *cb, char const *url, void const *payload,
   curl_easy_getinfo(cb->curl, CURLINFO_RESPONSE_CODE, &http_code);
 
   if (ret_content != NULL) {
-    if ((status >= 400) && (status < 500)) {
+    if ((http_code >= 400) && (http_code < 500)) {
       ERROR("write_stackdriver plugin: POST %s: %s", url,
             API_ERROR_STRING(parse_api_error(ret_content->memory)));
-    } else if (status >= 500) {
+    } else if (http_code >= 500) {
       WARNING("write_stackdriver plugin: POST %s: %s", url,
               ret_content->memory);
     }


### PR DESCRIPTION
All current uses of `do_post()` did provide a non-NULL pointer, but NULL is explicitly handled elsewhere, so we should cover all cases.

`http_code` vs. `status` was a simple mistake.