### PR TITLE
ovs_stats: use correct OpenFlow value

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -968,7 +968,7 @@ static int ovs_stats_plugin_read(__attribute__((unused)) user_data_t *ud) {
           ovs_stats_submit_two(devname, "if_packets", "512_to_1023_packets",
                                port->stats[rx_512_to_1023_packets],
                                port->stats[tx_512_to_1023_packets], meta);
-          ovs_stats_submit_two(devname, "if_packets", "1024_to_1518_packets",
+          ovs_stats_submit_two(devname, "if_packets", "1024_to_1522_packets",
                                port->stats[rx_1024_to_1522_packets],
                                port->stats[tx_1024_to_1522_packets], meta);
           ovs_stats_submit_two(devname, "if_packets", "1523_to_max_packets",


### PR DESCRIPTION
The correct value in the OpenFlow 1.4 statistics is 1024_to_1522_packets,
even if collectd is using 1024_to_1518_packets:

$ ovs-ofctl -O OpenFlow14 dump-ports ovsbr0
OFPST_PORT reply (OF1.4) (xid=0x2): 3 ports
  port  guest2: rx pkts=0, bytes=0, drop=0, errs=0, frame=?, over=?, crc=?
           tx pkts=0, bytes=0, drop=0, errs=?, coll=?
           duration=132.213s
           rx rfc2819 1_to_64_packets=0, 65_to_127_packets=0,
           128_to_255_packets=0, 256_to_511_packets=0,
           512_to_1023_packets=0, 1024_to_1522_packets=0,
           1523_to_max_packets=0,

Correct it to the right value.

Signed-off-by: Matteo Croce <mcroce@redhat.com>