### PR TITLE
src/utils_oauth.c: Renew OAuth tokens 30 seconds before they expire.

### DIFF
--- a/src/utils_oauth.c
+++ b/src/utils_oauth.c
@@ -425,9 +425,10 @@ static int new_token(oauth_t *auth) /* {{{ */
 
 static int renew_token(oauth_t *auth) /* {{{ */
 {
-  /* TODO(octo): Make sure that we get a new token 60 seconds or so before the
-   * old one expires. */
-  if (auth->valid_until > cdtime())
+  /* Renew OAuth token 30 seconds *before* it expires. */
+  cdtime_t const slack = TIME_T_TO_CDTIME_T(30);
+
+  if (auth->valid_until > (cdtime() + slack))
     return 0;
 
   return new_token(auth);


### PR DESCRIPTION
This solves sporious errors like this one:

> write_stackdriver plugin: POST https://monitoring.googleapis.com/v3/projects/{projectId}/timeSeries: API error 401: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.