### PR TITLE
Fix #2973 Added a shared library "libcurl-gnutls.so"

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -7,9 +7,10 @@ COPY rootfs_prefix/ /usr/src/rootfs_prefix/
 
 RUN apt-get update \
  && apt-get upgrade \
- && apt-get install \
+ && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     collectd-core \
     collectd-utils \
+    libcurl3-gnutls \
     build-essential \
  && make -C /usr/src/rootfs_prefix/ \
  && apt-get --purge remove build-essential \


### PR DESCRIPTION
> libcurl-gnutls.so.4 => not found

Fix Issues #2973.
Added a shared library "libcurl-gnutls.so".
