### PR TITLE
zfs_arc: Ignore the first two lines of the statistics file on Linux (5.7 cherry-pick)

### DIFF
--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -212,6 +212,21 @@ static int za_read(void) {
     return (-1);
   }
 
+  // Ignore the first two lines because they contain information about
+  // the rest of the file.
+  // See kstat_seq_show_headers module/spl/spl-kstat.c of the spl kernel
+  // module.
+  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
+    ERROR("zfs_arc plugin: \"%s\" does not contain a single line.", ZOL_ARCSTATS_FILE);
+    fclose(fh);
+    return (-1);
+  }
+  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
+    ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.", ZOL_ARCSTATS_FILE);
+    fclose(fh);
+    return (-1);
+  }
+
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
     char *fields[3];
     value_t v;


### PR DESCRIPTION
The first two lines of the statistics file on Linux contain information about
the rest of the file. They do not contain any usable statistics.
See module/spl/spl-kstat.c of the spl module of ZFS on Linux for more
information.

This is a cherry-pick of #2097 into *collectd-5.7*.

Fixes: #2954