### PR TITLE
Add 'quorum' stat to ZooKeeper plugin

### DIFF
--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -176,6 +176,7 @@ static int zookeeper_read(void) {
   char *save_ptr;
   char *line;
   char *fields[2];
+  long followers = -1;
 
   if (zookeeper_query(buf, sizeof(buf)) < 0) {
     return -1;
@@ -218,15 +219,23 @@ static int zookeeper_read(void) {
     } else if (FIELD_CHECK(fields[0], "zk_approximate_data_size")) {
       zookeeper_submit_gauge("bytes", "approximate_data_size", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_followers")) {
-      zookeeper_submit_gauge("count", "followers", atol(fields[1]));
+      followers = atol(fields[1]);
+      zookeeper_submit_gauge("count", "followers", followers);
     } else if (FIELD_CHECK(fields[0], "zk_synced_followers")) {
       zookeeper_submit_gauge("count", "synced_followers", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_pending_syncs")) {
       zookeeper_submit_gauge("count", "pending_syncs", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_server_state")) {
+      if (followers < 0) {
+        followers = 0;
+      }
     } else {
       DEBUG("Uncollected zookeeper MNTR field %s", fields[0]);
     }
   }
+  /* Reports 0 for followers, -1 for no zk_server_state, # when zk_followers present. */
+  /* Intended to be used for quorum detection by taking max for each time period. */
+  zookeeper_submit_gauge("count", "quorum", followers);
 
   return 0;
 } /* zookeeper_read */

--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -233,8 +233,9 @@ static int zookeeper_read(void) {
       DEBUG("Uncollected zookeeper MNTR field %s", fields[0]);
     }
   }
-  /* Reports 0 for followers, -1 for no zk_server_state, # when zk_followers present. */
-  /* Intended to be used for quorum detection by taking max for each time period. */
+  /* Reports 0 for followers, -1 for no zk_server_state, # when zk_followers
+   * present. Intended to be used for quorum detection by taking max for each
+   * time period. */
   zookeeper_submit_gauge("count", "quorum", followers);
 
   return 0;


### PR DESCRIPTION
ChangeLog: plugin ZooKeeper: Add 'quorum' stat

Add 'quorum' stat to ZooKeeper plugin so that alerts are able to tell the difference between data lag and loss of quorum.