### PR TITLE
configure.ac: run dpdk build tests only if pkgconfig fails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2380,13 +2380,30 @@ if test "x$with_libdpdk" != "xno"; then
 fi
 
 if test "x$with_libdpdk" = "xyes"; then
+  SAVE_LIBS="$LIBS"
+  LIBS="$LIBDPDK_LIBS $LIBS"
   SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LIBDPDK_LDFLAGS $LDFLAGS"
-  AC_CHECK_LIB([dpdk], [rte_eal_init],
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$LIBDPDK_CPPFLAGS $CPPFLAGS"
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$LIBDPDK_CFLAGS $CFLAGS"
+  AC_LINK_IFELSE(
+    [
+      AC_LANG_PROGRAM(
+        [[
+          #include <rte_eal.h>
+        ]],
+        [[return rte_eal_init(0, NULL);]]
+      )
+    ],
     [with_libdpdk="yes"],
     [with_libdpdk="no (symbol 'rte_eal_init' not found)"]
   )
+  LIBS="$SAVE_LIBS"
   LDFLAGS="$SAVE_LDFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  CFLAGS="$SAVE_CFLAGS"
 fi
 
 # }}}


### PR DESCRIPTION
The AC_CHECK_LIB test runs unconditionally, and fails with DPDK 18.11
when built with Meson as there is no longer a libdpdk.so linker script,
but only a pkg-config file, so -ldpdk (which is what AC_CHECK_LIB runs)
fails.

Use AC_LINK_IFELSE instead, with compiler and linker flags set
appropriately.

Signed-off-by: Luca Boccassi <bluca@debian.org>

Issue: #3015