### PR TITLE
[python-3.7-fix]: Allow compilation with Python 3.7

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -1133,7 +1133,11 @@ static void *cpy_interactive(void *pipefd) {
     cpy_log_exception("interactive session init");
   }
   cur_sig = PyOS_setsig(SIGINT, python_sigint_handler);
+#if PY_VERSION_HEX < 0x03070000
   PyOS_AfterFork();
+#else
+  PyOS_AfterFork_Child();
+#endif
   PyEval_InitThreads();
   close(*(int *)pipefd);
   PyRun_InteractiveLoop(stdin, "<stdin>");


### PR DESCRIPTION
PyOS_AfterFork() is deprecated in favour of the new functions PyOS_BeforeFork(), PyOS_AfterFork_Parent() and PyOS_AfterFork_Child(). (Contributed by Antoine Pitrou in bpo-16500.)

Since the -Werror=deprecated-declarations flag is on, the fact that PyOS_AfterFork is deprecated now results in a warning, and since all warnings being treated as errors, collectd fails to compile.

This commit detects when we have python 3.7 or newer, and uses the new replacement function.

Signed-off-by: Manoj Srivastava <srivasta@golden-gryphon.com>