### PR TITLE
collection3: Improve index.cgi form fieldset border style

### DIFF
--- a/contrib/collection3/share/style.css
+++ b/contrib/collection3/share/style.css
@@ -1,3 +1,12 @@
+form {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+fieldset {
+  margin-left: 0;
+}
+
 div.graph
 {
 }


### PR DESCRIPTION
- Fit to the form contents instead of filling the page width
- Relate better to the table below by aligning left-hand side and
  rounding corners