### PR TITLE
collection3: Output graph.cgi debug as UTF-8

### DIFF
--- a/contrib/collection3/bin/graph.cgi
+++ b/contrib/collection3/bin/graph.cgi
@@ -140,10 +140,10 @@ sub main
   if (param ('debug'))
   {
     print <<HTTP;
-Content-Type: text/plain
+Content-Type: text/plain; charset=utf-8
 
 HTTP
-    $ContentType = 'text/plain';
+    $ContentType = 'text/plain; charset=utf-8';
   }
 
   if ($GraphWidth)


### PR DESCRIPTION
collection3: Output graph.cgi debug as UTF-8

Ensure text and symbols e.g. degrees Celsius are shown as intended.