### PR TITLE
contrib/docker/: Switch to Debian slim, separate ENTRYPOINT/CMD, install suggestions.

### DIFF
--- a/contrib/docker/50docker-apt-conf
+++ b/contrib/docker/50docker-apt-conf
@@ -1,4 +1,4 @@
 APT::Install-Recommends "1";
-APT::Install-Suggests "0";
+APT::Install-Suggests "1";
 APT::Get::Assume-Yes "1";
 APT::Get::AutomaticRemove "1";

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -21,4 +21,5 @@ COPY collectd.conf.d /etc/collectd/collectd.conf.d
 
 ENV LD_PRELOAD /usr/src/rootfs_prefix/rootfs_prefix.so
 
-CMD [ "/usr/sbin/collectd", "-f"]
+ENTRYPOINT ["/usr/sbin/collectd"]
+CMD ["-f"]

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:stable-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 COPY 50docker-apt-conf /etc/apt/apt.conf.d/


### PR DESCRIPTION
I originally created this change in the context of #2973, which has been fixed in the mean time. I though I'd leave this here in case anyone is interested.

No changelog since it touches contrib/ only.