### PR TITLE
strjoin(): Fix behavior if output buffer is NULL.

### DIFF
--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -352,6 +352,9 @@ int strjoin(char *buffer, size_t buffer_size, char **fields, size_t fields_num,
       buffer_req += sep_len;
     buffer_req += field_len;
 
+    if (buffer_size == 0)
+      continue;
+
     if ((i != 0) && (sep_len > 0)) {
       if (sep_len >= avail) {
         /* prevent subsequent iterations from writing to the

--- a/src/daemon/common_test.c
+++ b/src/daemon/common_test.c
@@ -185,10 +185,12 @@ DEF_TEST(strjoin) {
                      cases[i].fields_num, cases[i].separator);
     EXPECT_EQ_INT(cases[i].want_return, status);
     EXPECT_EQ_STR(cases[i].want_buffer, buffer);
-  }
 
-  /* use (NULL, 0) to determine required buffer size. */
-  EXPECT_EQ_INT(3, strjoin(NULL, 0, (char *[]){"a", "b"}, 2, "-"));
+    /* use (NULL, 0) to determine required buffer size. */
+    EXPECT_EQ_INT(cases[i].want_return,
+                  strjoin(NULL, 0, cases[i].fields, cases[i].fields_num,
+                          cases[i].separator));
+  }
 
   return (0);
 }


### PR DESCRIPTION
Additionally, test the (NULL, 0) output buffer for all test cases rather
than an individual, isolated test case.

Fixes: #3062
ChangeLog: collectd: An invalid memory access in the `strjoin()` function has been fixed.