### PR TITLE
changed time format to no longer lose microseconds

### DIFF
--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -66,8 +66,8 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
   memset(buffer, '\0', buffer_len);
 
-  time_t t = CDTIME_T_TO_TIME_T(vl->time);
-  int status = snprintf(buffer, buffer_len, "%lu", (unsigned long)t);
+  double t = CDTIME_T_TO_DOUBLE(vl->time);
+  int status = snprintf(buffer, buffer_len, "%f", t);
   if ((status < 1) || (status >= buffer_len))
     return -1;
   int offset = status;

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -66,8 +66,8 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
   memset(buffer, '\0', buffer_len);
 
-  double t = CDTIME_T_TO_DOUBLE(vl->time);
-  int status = snprintf(buffer, buffer_len, "%.6f", t);
+  int status =
+      snprintf(buffer, buffer_len, "%.6f", CDTIME_T_TO_DOUBLE(vl->time));
   if ((status < 1) || (status >= buffer_len))
     return -1;
   int offset = status;

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -67,7 +67,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
   memset(buffer, '\0', buffer_len);
 
   double t = CDTIME_T_TO_DOUBLE(vl->time);
-  int status = snprintf(buffer, buffer_len, "%f", t);
+  int status = snprintf(buffer, buffer_len, "%.6f", t);
   if ((status < 1) || (status >= buffer_len))
     return -1;
   int offset = status;


### PR DESCRIPTION
ChangeLog: rrdcached plugin: Time resolution has been improved to microseconds.

Have been sending an int to rrdcached for the epoch value, it supports microseconds. You want to use microseconds. 

See https://lists.oetiker.ch/pipermail/rrd-developers/2003-March/001007.html for we want this