### PR TITLE
Handle failure of simple config callbacks

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -357,8 +357,7 @@ static int configure_collectd(struct cmdline_config *config) {
    * Also, this will automatically load modules.
    */
   if (cf_read(config->configfile)) {
-    fprintf(stderr, "Error: Reading the config file failed!\n"
-                    "Read the logs for details.\n");
+    fprintf(stderr, "Error: Reading the config file failed!\n");
     return 1;
   }
 

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -357,7 +357,7 @@ static int configure_collectd(struct cmdline_config *config) {
    * Also, this will automatically load modules.
    */
   if (cf_read(config->configfile)) {
-    fprintf(stderr, "Error: Reading the config file failed!\n");
+    fprintf(stderr, "Error: Parsing the config file failed!\n");
     return 1;
   }
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -411,10 +411,12 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
   }
 
   /* Hm, no complex plugin found. Dispatch the values one by one */
-  for (int i = 0; i < ci->children_num; i++) {
-    if (ci->children[i].children == NULL)
-      dispatch_value_plugin(name, ci->children + i);
-    else {
+  for (int i = 0, ret = 0; i < ci->children_num; i++) {
+    if (ci->children[i].children == NULL) {
+      ret = dispatch_value_plugin(name, ci->children + i);
+      if (ret != 0)
+        return ret;
+    } else {
       WARNING("There is a `%s' block within the "
               "configuration for the %s plugin. "
               "The plugin either only expects "


### PR DESCRIPTION
When they return an error, collectd should not ignore this.
Fixes #3076 

Changelog: Handle failure of simple config callbacks