### PR TITLE
lua plugin: cleanup properly when shutting down

### DIFF
--- a/src/lua.c
+++ b/src/lua.c
@@ -263,8 +263,7 @@ static int lua_cb_dispatch_values(lua_State *L) /* {{{ */
   return 0;
 } /* }}} lua_cb_dispatch_values */
 
-static void lua_cb_free(void *data)
-{
+static void lua_cb_free(void *data) {
   clua_callback_data_t *cb = data;
   free(cb->lua_function_name);
   free(cb);
@@ -301,14 +300,14 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
   cb->lua_function_name = strdup(function_name);
   pthread_mutex_init(&cb->lock, NULL);
 
-  int status = plugin_register_complex_read(/* group = */ "lua",
-                                            /* name      = */ function_name,
-                                            /* callback  = */ clua_read,
-                                            /* interval  = */ 0,
-                                            &(user_data_t){
-                                                .data = cb,
-                                                .free_func = lua_cb_free,
-                                            });
+  int status =
+      plugin_register_complex_read(/* group = */ "lua",
+                                   /* name      = */ function_name,
+                                   /* callback  = */ clua_read,
+                                   /* interval  = */ 0,
+                                   &(user_data_t){
+                                       .data = cb, .free_func = lua_cb_free,
+                                   });
 
   if (status != 0)
     return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -349,8 +348,7 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
   int status = plugin_register_write(/* name = */ function_name,
                                      /* callback  = */ clua_write,
                                      &(user_data_t){
-                                         .data = cb,
-                                         .free_func = lua_cb_free,
+                                         .data = cb, .free_func = lua_cb_free,
                                      });
 
   if (status != 0)

--- a/src/lua.c
+++ b/src/lua.c
@@ -48,7 +48,7 @@ typedef struct lua_script_s {
 
 typedef struct {
   lua_State *lua_state;
-  const char *lua_function_name;
+  char *lua_function_name;
   pthread_mutex_t lock;
   int callback_id;
 } clua_callback_data_t;
@@ -263,6 +263,13 @@ static int lua_cb_dispatch_values(lua_State *L) /* {{{ */
   return 0;
 } /* }}} lua_cb_dispatch_values */
 
+static void lua_cb_free(void *data)
+{
+  clua_callback_data_t *cb = data;
+  free(cb->lua_function_name);
+  free(cb);
+}
+
 static int lua_cb_register_read(lua_State *L) /* {{{ */
 {
   int nargs = lua_gettop(L);
@@ -300,6 +307,7 @@ static int lua_cb_register_read(lua_State *L) /* {{{ */
                                             /* interval  = */ 0,
                                             &(user_data_t){
                                                 .data = cb,
+                                                .free_func = lua_cb_free,
                                             });
 
   if (status != 0)
@@ -342,6 +350,7 @@ static int lua_cb_register_write(lua_State *L) /* {{{ */
                                      /* callback  = */ clua_write,
                                      &(user_data_t){
                                          .data = cb,
+                                         .free_func = lua_cb_free,
                                      });
 
   if (status != 0)


### PR DESCRIPTION
Found while running collectd -T under valgrind:

==25971== 75 (64 direct, 11 indirect) bytes in 1 blocks are definitely lost in loss record 154 of 274
==25971==    at 0x483AB1A: calloc (vg_replace_malloc.c:762)
==25971==    by 0x4854009: lua_cb_register_read (lua.c:288)
==25971==    by 0x4FBE886: ???
==25971==    by 0x4FD4900: ???
==25971==    by 0x4FBEAD7: ???
==25971==    by 0x4FBEB04: ???
==25971==    by 0x4FBDF16: ???
==25971==    by 0x4FBEE5E: ???
==25971==    by 0x4FB53ED: ???
==25971==    by 0x48536E7: lua_script_load (lua.c:465)
==25971==    by 0x485387E: lua_config_script (lua.c:532)
==25971==    by 0x485395E: lua_config (lua.c:557)

Changelog: Lua plugin: A memory leak has been fixed.