### PR TITLE
Don't hide errors when creating manpage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2109,20 +2109,10 @@ am__v_POD2MAN_C_0 = @echo "  POD2MAN " $@;
 am__v_POD2MAN_C_1 =
 
 .pod.1:
-	$(AM_V_POD2MAN_C)pod2man --release=$(VERSION) --center=$(PACKAGE) $< \
-		>.pod2man.tmp.$$$$ 2>/dev/null && mv -f .pod2man.tmp.$$$$ $@ || true
-	@if grep '\<POD ERRORS\>' $@ >/dev/null 2>&1; \
-	then \
-		echo "$@ has some POD errors!"; false; \
-	fi
+	$(AM_V_POD2MAN_C)pod2man --errors=die --release=$(VERSION) --center=$(PACKAGE) $< $@
 
 .pod.5:
-	$(AM_V_POD2MAN_C)pod2man --section=5 --release=$(VERSION) --center=$(PACKAGE) $< \
-		>.pod2man.tmp.$$$$ 2>/dev/null && mv -f .pod2man.tmp.$$$$ $@ || true
-	@if grep '\<POD ERRORS\>' $@ >/dev/null 2>&1; \
-	then \
-		echo "$@ has some POD errors!"; false; \
-	fi
+	$(AM_V_POD2MAN_C)pod2man --errors=die --section=5 --release=$(VERSION) --center=$(PACKAGE) $< $@
 
 V_PROTOC = $(v_protoc_@AM_V@)
 v_protoc_ = $(v_protoc_@AM_DEFAULT_V@)


### PR DESCRIPTION
Apparently the default behaviour for pod2man changed at some point and
now it exits with a syntax error instead of exiting successfully with a
<POD ERRORS> section.

Now we do display the syntax issue:
[ruben@localhost collectd]$ make -j
  POD2MAN  src/collectd.conf.5
src/collectd.conf.pod around line 10361: You forgot a '=back' before '=head2'
POD document had syntax errors at /usr/bin/pod2man line 69.
make: *** [Makefile:9641: src/collectd.conf.5] Error 255