### PR TITLE
Build system: enable the "df" plugin when getmntent_r() is available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6308,7 +6308,7 @@ then
 	plugin_df="yes"
 fi
 
-if test "x$c_cv_have_getmntent_r" = "xyes"
+if test "x$have_getmntent_r" = "xyes"
 then
 	plugin_df="yes"
 fi


### PR DESCRIPTION
Looks like the check result used to be stored in a variable of a different name.

I hope that this will fix the Cirrus CI builds.

ChangeLog: Build system: The "df" plugin is now built when `getmntent_r()` is available.