### PR TITLE
configure.ac: Fix include of "utils/mount/mount.h".

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1583,7 +1583,7 @@ if test "x$have_getmntent" = "xlibc"; then
       AC_COMPILE_IFELSE(
         [
           AC_LANG_PROGRAM(
-            [[#include "$srcdir/src/utils_mount.h"]],
+            [[#include "$srcdir/src/utils/mount/mount.h"]],
             [[
               FILE *fh;
               struct mntent *me;
@@ -1605,7 +1605,7 @@ if test "x$have_getmntent" = "xlibc"; then
       AC_COMPILE_IFELSE(
         [
           AC_LANG_PROGRAM(
-            [[#include "$srcdir/src/utils_mount.h"]],
+            [[#include "$srcdir/src/utils/mount/mount.h"]],
             [[
               FILE *fh;
               struct mnttab mt;

--- a/src/utils/mount/mount.h
+++ b/src/utils/mount/mount.h
@@ -1,5 +1,5 @@
 /**
- * collectd - src/utils_mount.h
+ * collectd - src/utils/mount/mount.h
  * Copyright (C) 2005,2006  Niki W. Waibel
  *
  * This program is free software; you can redistribute it and/


### PR DESCRIPTION
Fixes a regression introduced in 6378ec288f34ff250b2971a1452338a2b34c240a.