### PR TITLE
ovs_stats plugin: fix compiler warning

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -860,7 +860,7 @@ static int ovs_stats_update_port(const char *uuid, yajl_val port) {
 
     // ifaces_list is [[ "uuid", "<some_uuid>" ], [ "uuid",
     // "<another_uuid>" ], ... ]]
-    for (int i = 0; i < YAJL_GET_ARRAY(ifaces_list)->len; i++) {
+    for (size_t i = 0; i < YAJL_GET_ARRAY(ifaces_list)->len; i++) {
       yajl_val iface_tuple = YAJL_GET_ARRAY(ifaces_list)->values[i];
 
       // iface_tuple is [ "uuid", "<some_uuid>" ]


### PR DESCRIPTION
src/ovs_stats.c:863:23: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    for (int i = 0; i < YAJL_GET_ARRAY(ifaces_list)->len; i++) {
                    ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.