### PR TITLE
parser.y: fix deprecation warning

### DIFF
--- a/src/liboconfig/parser.y
+++ b/src/liboconfig/parser.y
@@ -75,7 +75,7 @@ extern char           *c_file;
 %type <ci> entire_file
 
 /* pass an verbose, specific error message to yyerror() */
-%error-verbose
+%define parse.error verbose
 
 %%
 string:


### PR DESCRIPTION
make -sk
  YACC     src/liboconfig/parser.c
/tmp/cirrus-ci-build/src/liboconfig/parser.y:78.1-14: warning: POSIX Yacc does not support %error-verbose [-Wyacc]
 %error-verbose
 ^~~~~~~~~~~~~~
/tmp/cirrus-ci-build/src/liboconfig/parser.y:78.1-14: warning: deprecated directive, use '%define parse.error verbose' [-Wdeprecated]
 %error-verbose
 ^~~~~~~~~~~~~~