### PR TITLE
oauth.c: fix compiler warning

### DIFF
--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -280,7 +280,7 @@ static int get_assertion(oauth_t *auth, char *buffer,
   status = snprintf(buffer, buffer_size, "%s.%s.%s", header, claim, signature);
   if (status < 1)
     return -1;
-  else if (status >= buffer_size)
+  else if ((size_t)status >= buffer_size)
     return ENOMEM;
 
   return 0;


### PR DESCRIPTION
make[1]: Entering directory '/home/ruben/src/collectd'
  CC       src/utils/oauth/liboauth_la-oauth.lo
src/utils/oauth/oauth.c: In function ‘get_assertion’:
src/utils/oauth/oauth.c:283:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  283 |   else if (status >= buffer_size)
      |                   ^~