### PR TITLE
write_prometheus plugin: fix compiler warning

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -722,7 +722,7 @@ metric_family_get(data_set_t const *ds, value_list_t const *vl, size_t ds_index,
 
   int status = c_avl_insert(metrics, fam->name, fam);
   if (status != 0) {
-    ERROR("write_prometheus plugin: Adding \"%s\" failed.", name);
+    ERROR("write_prometheus plugin: Adding \"%s\" failed.", fam->name);
     metric_family_destroy(fam);
     return NULL;
   }


### PR DESCRIPTION
make[1]: Entering directory '/home/ruben/src/collectd'
  CC       src/write_prometheus_la-write_prometheus.lo
In file included from src/write_prometheus.c:29:
src/write_prometheus.c: In function ‘metric_family_get’:
./src/daemon/plugin.h:393:20: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  393 | #define ERROR(...) plugin_log(LOG_ERR, __VA_ARGS__)
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/write_prometheus.c:725:5: note: in expansion of macro ‘ERROR’
  725 |     ERROR("write_prometheus plugin: Adding \"%s\" failed.", name);
      |     ^~~~~
src/write_prometheus.c:725:46: note: format string is defined here
  725 |     ERROR("write_prometheus plugin: Adding \"%s\" failed.", name);
      |                                              ^~
  CCLD     write_prometheus.la