### PR TITLE
intel_rdt plugin: fix compiler warnings

### DIFF
--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -71,7 +71,7 @@ static void rdt_dump_cgroups(void) {
     core_group_t *cgroup = g_rdt->cores.cgroups + i;
 
     memset(cores, 0, sizeof(cores));
-    for (int j = 0; j < cgroup->num_cores; j++) {
+    for (size_t j = 0; j < cgroup->num_cores; j++) {
       snprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
                cgroup->cores[j]);
     }
@@ -100,8 +100,7 @@ static void rdt_dump_data(void) {
    * MBR - remote memory bandwidth
    */
   DEBUG("  CORE     RMID    LLC[KB]   MBL[MB]    MBR[MB]");
-  for (int i = 0; i < g_rdt->num_groups; i++) {
-
+  for (size_t i = 0; i < g_rdt->num_groups; i++) {
     const struct pqos_event_values *pv = &g_rdt->pgroups[i]->values;
 
     double llc = bytes_to_kb(pv->llc);


### PR DESCRIPTION
make[1]: Entering directory '/home/ruben/src/collectd'
  CC       src/intel_rdt_la-intel_rdt.lo
src/intel_rdt.c: In function ‘rdt_dump_cgroups’:
src/intel_rdt.c:74:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   74 |     for (int j = 0; j < cgroup->num_cores; j++) {
      |                       ^
src/intel_rdt.c: In function ‘rdt_dump_data’:
src/intel_rdt.c:103:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  103 |   for (int i = 0; i < g_rdt->num_groups; i++) {
      |                     ^
  CCLD     intel_rdt.la