### PR TITLE
lvm plugin: turn deprecation error into a warning

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -26,7 +26,15 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
+#if GNUC > 4
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wcpp"
+#endif
+
 #include <lvm2app.h>
+#if GNUC > 4
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef HAVE_SYS_CAPABILITY_H
 #include <sys/capability.h>


### PR DESCRIPTION
When you include lmv2app.h it warns that this is deprecated and you have
to use D-BUS.

This warning turns into an error since we build with -Werror by default.
We know using the lvm2 lib is deprecated but until someone writes a
replacement using D-BUS it's all we have.

So turn the error into a warning.