### PR TITLE
Remove ProtectSystem from service file

### DIFF
--- a/contrib/systemd.collectd.service
+++ b/contrib/systemd.collectd.service
@@ -8,8 +8,6 @@ Requires=local-fs.target network-online.target
 ExecStart=/usr/sbin/collectd
 EnvironmentFile=-/etc/sysconfig/collectd
 EnvironmentFile=-/etc/default/collectd
-ProtectSystem=full
-ProtectHome=true
 
 # A few plugins won't work without some privileges, which you'll have to
 # specify using the CapabilityBoundingSet directive below.


### PR DESCRIPTION
This prevents showing eg. /etc if that's a separate file system.

Resolves: https://github.com/collectd/collectd/issues/3134