### PR TITLE
lua plugin: Make it possible to register more than one reader/writer; bugfixes; cleanup.

### DIFF
--- a/src/collectd-lua.pod
+++ b/src/collectd-lua.pod
@@ -72,8 +72,8 @@ These are used to collect the actual data. It is called once
 per interval (see the B<Interval> configuration option of collectd). Usually
 it will call B<collectd.dispatch_values> to dispatch the values to collectd
 which will pass them on to all registered B<write functions>. If this function
-does not return 0 the plugin will be skipped for an increasing
-amount of time until it returns normally again.
+does not return 0, interval between its calls will grow until function returns
+0 again. See the B<MaxReadInterval> configuration option of collectd.
 
 =item write functions
 
@@ -90,12 +90,14 @@ The following functions are provided to Lua modules:
 
 =item register_read(callback)
 
+Function to register read callbacks.
 The callback will be called without arguments.
 If this callback function does not return 0 the next call will be delayed by
 an increasing interval.
 
-=item register_write
+=item register_write(callback)
 
+Function to register write callbacks.
 The callback function will be called with one argument passed, which will be a
 table of values.
 If this callback function does not return 0 next call will be delayed by
@@ -136,8 +138,8 @@ A very simple write function might look like:
 
 To register those functions with collectd:
 
-  collectd.register_read(read)
-  collectd.register_write(write)
+  collectd.register_read(read)     -- pass function as variable
+  collectd.register_write("write") -- pass by global-scope function name
 
 =back
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -41,7 +41,6 @@
 #include <pthread.h>
 
 typedef struct lua_script_s {
-  char *script_path;
   lua_State *lua_state;
   struct lua_script_s *next;
 } lua_script_t;
@@ -389,7 +388,6 @@ static void lua_script_free(lua_script_t *script) /* {{{ */
     script->lua_state = NULL;
   }
 
-  sfree(script->script_path);
   sfree(script);
 
   lua_script_free(next);
@@ -453,14 +451,7 @@ static int lua_script_load(const char *script_path) /* {{{ */
     return status;
   }
 
-  script->script_path = strdup(script_path);
-  if (script->script_path == NULL) {
-    ERROR("Lua plugin: strdup failed.");
-    lua_script_free(script);
-    return -1;
-  }
-
-  status = luaL_loadfile(script->lua_state, script->script_path);
+  status = luaL_loadfile(script->lua_state, script_path);
   if (status != 0) {
     ERROR("Lua plugin: luaL_loadfile failed: %s",
           lua_tostring(script->lua_state, -1));
@@ -482,7 +473,7 @@ static int lua_script_load(const char *script_path) /* {{{ */
             status);
     else
       ERROR("Lua plugin: Executing script \"%s\" failed:\n%s",
-            script->script_path, errmsg);
+            script_path, errmsg);
 
     lua_script_free(script);
     return -1;

--- a/src/lua.c
+++ b/src/lua.c
@@ -261,6 +261,7 @@ static int lua_cb_dispatch_values(lua_State *L) /* {{{ */
 static void lua_cb_free(void *data) {
   clua_callback_data_t *cb = data;
   free(cb->lua_function_name);
+  pthread_mutex_destroy(&cb->lock);
   free(cb);
 }
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -79,18 +79,14 @@ static int clua_load_callback(lua_State *L, int callback_ref) /* {{{ */
  * garbage collector. */
 static int clua_store_thread(lua_State *L, int idx) /* {{{ */
 {
-  if (idx < 0)
-    idx += lua_gettop(L) + 1;
-
-  /* Copy the thread pointer */
-  lua_pushvalue(L, idx); /* +1 = 3 */
-  if (!lua_isthread(L, -1)) {
-    lua_pop(L, 3); /* -3 = 0 */
+  if (!lua_isthread(L, idx)) {
     return -1;
   }
 
+  /* Copy the thread pointer */
+  lua_pushvalue(L, idx);
+
   luaL_ref(L, LUA_REGISTRYINDEX);
-  lua_pop(L, 1); /* -1 = 0 */
   return 0;
 } /* }}} int clua_store_thread */
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -469,7 +469,7 @@ static int lua_script_load(const char *script_path) /* {{{ */
             "In addition, no error message could be retrieved from the stack.",
             status);
     else
-      ERROR("Lua plugin: Executing script \"%s\" failed:\n%s",
+      ERROR("Lua plugin: Executing script \"%s\" failed: %s",
             script_path, errmsg);
   }
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -471,9 +471,6 @@ static int lua_script_load(const char *script_path) /* {{{ */
     else
       ERROR("Lua plugin: Executing script \"%s\" failed:\n%s",
             script_path, errmsg);
-
-    lua_script_free(script);
-    return -1;
   }
 
   /* Append this script to the global list of scripts. */
@@ -486,6 +483,9 @@ static int lua_script_load(const char *script_path) /* {{{ */
   } else {
     scripts = script;
   }
+
+  if (status != 0)
+    return -1;
 
   return 0;
 } /* }}} int lua_script_load */


### PR DESCRIPTION
Changelog: lua plugin: Make it possible to register more than one reader/writer (bug)
Changelog: lua plugin: Don't destroy interpreter too early (bug)
Changelog: lua plugin: free mutex on callback destroy (issue)
Changelog: lua plugin: Cleanup

Closes: #2379
Closes: #3139