### PR TITLE
virt plugin: Support new metric from libvirt-5.0.0 virDomainMemoryStats()

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -916,10 +916,10 @@ static void memory_submit(virDomainPtr dom, gauge_t value) {
 
 static void memory_stats_submit(gauge_t value, virDomainPtr dom,
                                 int tag_index) {
-  static const char *tags[] = {"swap_in",        "swap_out", "major_fault",
-                               "minor_fault",    "unused",   "available",
-                               "actual_balloon", "rss",      "usable",
-                               "last_update"};
+  static const char *tags[] = {"swap_in",        "swap_out",   "major_fault",
+                               "minor_fault",    "unused",     "available",
+                               "actual_balloon", "rss",        "usable",
+                               "last_update",    "disk_caches"};
 
   if ((tag_index < 0) || (tag_index >= (int)STATIC_ARRAY_SIZE(tags))) {
     ERROR("virt plugin: Array index out of bounds: tag_index = %d", tag_index);


### PR DESCRIPTION
Changelog: virt plugin: Support new metric from libvirt-5.0.0 virDomainMemoryStats()

Closes: #3143