### PR TITLE
virt plugin: Updates regarding to 'domain_state' metric

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9466,9 +9466,7 @@ I<0.9.5> or later.
 =item B<disk_err>: report disk errors if any occured. Requires libvirt API version
 I<0.9.10> or later.
 
-=item B<domain_state>: report domain state and reason in human-readable format as
-a notification. If libvirt API version I<0.9.2> or later is available, domain
-reason will be included in notification.
+=item B<domain_state>: report domain state and reason as 'domain_state' metric.
 
 =item B<fs_info>: report file system information as a notification. Requires
 libvirt API version I<1.2.11> or later. Can be collected only if I<Guest Agent>

--- a/src/virt.c
+++ b/src/virt.c
@@ -2297,7 +2297,7 @@ static int lv_read(user_data_t *ud) {
     if (dom->active)
       status = get_domain_metrics(dom);
 #ifdef HAVE_DOM_REASON
-    else
+    else if (extra_stats & ex_stats_domain_state)
       status = submit_domain_state(dom->ptr);
 #endif
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -1668,8 +1668,7 @@ static int get_domain_state_notify(virDomainPtr domain) {
     return status;
   }
 
-  if (persistent_notification)
-    domain_state_submit_notif(domain, domain_state, domain_reason);
+  domain_state_submit_notif(domain, domain_state, domain_reason);
 
   return status;
 }


### PR DESCRIPTION
PR #2701 (which is not released) adds 'domain_state' metric and ExtraStats's option `domain_state`
selector behaviour was changed: now it enables metric, not notification.
Removed inconsistency between documentation and implementation.

Not all `get_domain_state` calls was covered by selector check.
As result, metric was always sent for inactive domains.
That is fixed now.


Changelog: virt plugin: Updates regarding to 'domain_state' metric

ChangelogX: Do not report 'domain_state' metric when not enabled by ExtraStats;; Updated documentation according to changed `domain_state` selector behaviour.

