### PR TITLE
virt plugin: Do not fail if no connection on init()

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -2258,8 +2258,11 @@ static int lv_read(user_data_t *ud) {
       return -1;
 
   /* Wait until inst#0 establish connection */
-  if (conn == NULL)
+  if (conn == NULL) {
+    DEBUG(PLUGIN_NAME " plugin#%s: Wait until inst#0 establish connection",
+          inst->tag);
     return 0;
+  }
 
   time_t t;
   time(&t);

--- a/src/virt.c
+++ b/src/virt.c
@@ -2386,7 +2386,8 @@ static int lv_init(void) {
     return -1;
 
   if (!persistent_notification)
-    virt_notif_thread_init(&notif_thread);
+    if (virt_notif_thread_init(&notif_thread) != 0)
+      return -1;
 
   lv_connect();
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -2382,10 +2382,10 @@ static int lv_init(void) {
   if (lv_init_ignorelists() != 0)
     return -1;
 
-  lv_connect();
-
   if (!persistent_notification)
     virt_notif_thread_init(&notif_thread);
+
+  lv_connect();
 
   DEBUG(PLUGIN_NAME " plugin: starting %i instances", nr_instances);
 


### PR DESCRIPTION
If Collectd started before libvirtd, that results as no connection and no more retries.
lv_init()/lv_connect() reworked to avoid this.

Reference: b2541eb463165a5973fedb5d51eab8288fcd7ebc
Reference: 5903e6d5414b1a9580a63c29afff1788cec6c91e

This PR is checked on my production systems.

Changelog: virt plugin: Do not fail if no connection on init()