### PR TITLE
Libvirt plugin: split memory report into dedicated types

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -926,6 +926,10 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
     return;
   }
 
+  /* Skip 'last_update' reporting as that is not memory but timestamp */
+  if (tag_index == 9)
+    return;
+
   submit(dom, "memory", tags[tag_index], &(value_t){.gauge = value}, 1);
 }
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -926,10 +926,6 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
     return;
   }
 
-  /* Skip 'last_update' reporting as that is not memory but timestamp */
-  if (tag_index == 9)
-    return;
-
   submit(dom, "memory", tags[tag_index], &(value_t){.gauge = value}, 1);
 }
 
@@ -1697,8 +1693,42 @@ static int get_memory_stats(virDomainPtr domain) {
     return mem_stats;
   }
 
-  for (int i = 0; i < mem_stats; i++)
-    memory_stats_submit((gauge_t)minfo[i].val * 1024, domain, minfo[i].tag);
+  derive_t swap_in = -1;
+  derive_t swap_out = -1;
+  derive_t min_flt = -1;
+  derive_t maj_flt = -1;
+
+  for (int i = 0; i < mem_stats; i++) {
+    if (minfo[i].tag == VIR_DOMAIN_MEMORY_STAT_SWAP_IN)
+      swap_in = minfo[i].val;
+    else if (minfo[i].tag == VIR_DOMAIN_MEMORY_STAT_SWAP_OUT)
+      swap_out = minfo[i].val;
+    else if (minfo[i].tag == VIR_DOMAIN_MEMORY_STAT_MAJOR_FAULT)
+      min_flt = minfo[i].val;
+    else if (minfo[i].tag == VIR_DOMAIN_MEMORY_STAT_MINOR_FAULT)
+      maj_flt = minfo[i].val;
+#ifdef LIBVIR_CHECK_VERSION
+#if LIBVIR_CHECK_VERSION(2, 1, 0)
+    else if (minfo[i].tag == VIR_DOMAIN_MEMORY_STAT_LAST_UPDATE)
+      /* Skip 'last_update' reporting as that is not memory but timestamp */
+      continue;
+#endif
+#endif
+    else
+      memory_stats_submit((gauge_t)minfo[i].val * 1024, domain, minfo[i].tag);
+  }
+
+  if (swap_in > 0 || swap_out > 0) {
+    submit(domain, "swap_io", "in", &(value_t){.gauge = swap_in}, 1);
+    submit(domain, "swap_io", "out", &(value_t){.gauge = swap_out}, 1);
+  }
+
+  if (min_flt > -1 || maj_flt > -1) {
+    value_t values[] = {
+        {.gauge = (gauge_t)min_flt}, {.gauge = (gauge_t)maj_flt},
+    };
+    submit(domain, "ps_pagefaults", NULL, values, STATIC_ARRAY_SIZE(values));
+  }
 
   sfree(minfo);
   return 0;

--- a/src/virt.c
+++ b/src/virt.c
@@ -70,7 +70,8 @@
 
 /*
   virConnectListAllDomains() appeared in 0.10.2 (Sep 2012)
-  Note that LIBVIR_CHECK_VERSION appeared a year later (Dec 2013, libvirt-1.2.0),
+  Note that LIBVIR_CHECK_VERSION appeared a year later (Dec 2013,
+  libvirt-1.2.0),
   so in some systems which actually have virConnectListAllDomains()
   we can't detect this.
  */

--- a/src/virt.c
+++ b/src/virt.c
@@ -69,9 +69,9 @@
 #endif
 
 /*
-  virConnectListAllDomains() appeared in 0.10.2
-  Note that LIBVIR_CHECK_VERSION appeared a year later, so
-  in some systems which actually have virConnectListAllDomains()
+  virConnectListAllDomains() appeared in 0.10.2 (Sep 2012)
+  Note that LIBVIR_CHECK_VERSION appeared a year later (Dec 2013, libvirt-1.2.0),
+  so in some systems which actually have virConnectListAllDomains()
   we can't detect this.
  */
 #if LIBVIR_CHECK_VERSION(0, 10, 2)
@@ -1723,7 +1723,7 @@ static int get_memory_stats(virDomainPtr domain) {
     submit(domain, "swap_io", "out", &(value_t){.gauge = swap_out}, 1);
   }
 
-  if (min_flt > -1 || maj_flt > -1) {
+  if (min_flt > 0 || maj_flt > 0) {
     value_t values[] = {
         {.gauge = (gauge_t)min_flt}, {.gauge = (gauge_t)maj_flt},
     };


### PR DESCRIPTION
Changelog: libvirt plugin: split memory report into dedicated types

As documented (https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainMemoryStats),
statistics elements represents following:

1)
```
VIR_DOMAIN_MEMORY_STAT_SWAP_IN: The total amount of data read from swap space (in kb). 
VIR_DOMAIN_MEMORY_STAT_SWAP_OUT: The total amount of memory written out to swap space (in kb). 
```

These elements are about swap usage, not used amount, and should not be submitted as GAUGE type (which `memory` type is).

So, move these elements values to `swap_io` type which is DERIVE.

2) 
```
VIR_DOMAIN_MEMORY_STAT_MAJOR_FAULT: The number of page faults that required disk IO to service. 
VIR_DOMAIN_MEMORY_STAT_MINOR_FAULT: The number of page faults serviced without disk IO.
```

These elements are `number of page faults`, not bytes. They also should be submitted as DERIVE type `ps_pagefaults`.

3)
``` 
VIR_DOMAIN_MEMORY_STAT_LAST_UPDATE: Timestamp of the last statistic
```

That is timestamp and I see no reasons to report it as `memory` type.
Maybe it should be reported as some type, or used somehow else,  but in this PR its data simply rejected.
