### PR TITLE
Add snprintf wrapper to avoid "Truncation Warnings" with GCC 8.2/3 compiler 

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -398,10 +398,9 @@ static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
     READ_FUNC(average, (inst->sum / ((gauge_t)inst->num)));
     READ_FUNC(min, inst->min);
     READ_FUNC(max, inst->max);
-    READ_FUNC(stddev,
-              sqrt((((gauge_t)inst->num) * inst->squares_sum) -
-                   (inst->sum * inst->sum)) /
-                  ((gauge_t)inst->num));
+    READ_FUNC(stddev, sqrt((((gauge_t)inst->num) * inst->squares_sum) -
+                           (inst->sum * inst->sum)) /
+                          ((gauge_t)inst->num));
   }
 
   /* Reset internal state. */

--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -398,9 +398,10 @@ static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
     READ_FUNC(average, (inst->sum / ((gauge_t)inst->num)));
     READ_FUNC(min, inst->min);
     READ_FUNC(max, inst->max);
-    READ_FUNC(stddev, sqrt((((gauge_t)inst->num) * inst->squares_sum) -
-                           (inst->sum * inst->sum)) /
-                          ((gauge_t)inst->num));
+    READ_FUNC(stddev,
+              sqrt((((gauge_t)inst->num) * inst->squares_sum) -
+                   (inst->sum * inst->sum)) /
+                  ((gauge_t)inst->num));
   }
 
   /* Reset internal state. */

--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -198,13 +198,13 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
                "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
                "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
                "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
                AGG_FUNC_PLACEHOLDER);
   }

--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -198,15 +198,17 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance,
+                sizeof(inst->ident.plugin_instance), "%s-%s", tmp_plugin,
+                AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance,
+                sizeof(inst->ident.plugin_instance), "%s-%s",
+                tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
-      ssnprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
-               AGG_FUNC_PLACEHOLDER);
+      ssnprintf(inst->ident.plugin_instance,
+                sizeof(inst->ident.plugin_instance), "%s-%s-%s", tmp_plugin,
+                tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
   }
 
   /* Type */
@@ -396,10 +398,9 @@ static int agg_instance_read(agg_instance_t *inst, cdtime_t t) /* {{{ */
     READ_FUNC(average, (inst->sum / ((gauge_t)inst->num)));
     READ_FUNC(min, inst->min);
     READ_FUNC(max, inst->max);
-    READ_FUNC(stddev,
-              sqrt((((gauge_t)inst->num) * inst->squares_sum) -
-                   (inst->sum * inst->sum)) /
-                  ((gauge_t)inst->num));
+    READ_FUNC(stddev, sqrt((((gauge_t)inst->num) * inst->squares_sum) -
+                           (inst->sum * inst->sum)) /
+                          ((gauge_t)inst->num));
   }
 
   /* Reset internal state. */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -973,11 +973,11 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
     char cbname[128];
     ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
-    status = plugin_register_write(cbname, camqp_write,
-                                   &(user_data_t){
-                                       .data = conf,
-                                       .free_func = camqp_config_free,
-                                   });
+    status =
+        plugin_register_write(cbname, camqp_write,
+                              &(user_data_t){
+                                  .data = conf, .free_func = camqp_config_free,
+                              });
     if (status != 0) {
       camqp_config_free(conf);
       return status;

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -218,17 +218,17 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
       amqp_connection_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
       ssnprintf(buffer, buffer_size, "Server connection error %d: %s",
-               m->reply_code, tmp);
+                m->reply_code, tmp);
       sfree(tmp);
     } else if (r.reply.id == AMQP_CHANNEL_CLOSE_METHOD) {
       amqp_channel_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
       ssnprintf(buffer, buffer_size, "Server channel error %d: %s",
-               m->reply_code, tmp);
+                m->reply_code, tmp);
       sfree(tmp);
     } else {
       ssnprintf(buffer, buffer_size, "Server error method %#" PRIx32,
-               r.reply.id);
+                r.reply.id);
     }
     break;
 
@@ -322,7 +322,8 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
 
   qd_ret = amqp_queue_declare(conf->connection,
                               /* channel     = */ CAMQP_CHANNEL,
-                              /* queue       = */ (conf->queue != NULL)
+                              /* queue       = */
+                                  (conf->queue != NULL)
                                   ? amqp_cstring_bytes(conf->queue)
                                   : AMQP_EMPTY_BYTES,
                               /* passive     = */ 0,
@@ -353,15 +354,15 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
     amqp_queue_bind_ok_t *qb_ret;
 
     assert(conf->queue != NULL);
-    qb_ret =
-        amqp_queue_bind(conf->connection,
-                        /* channel     = */ CAMQP_CHANNEL,
-                        /* queue       = */ amqp_cstring_bytes(conf->queue),
-                        /* exchange    = */ amqp_cstring_bytes(conf->exchange),
-                        /* routing_key = */ (conf->routing_key != NULL)
-                            ? amqp_cstring_bytes(conf->routing_key)
-                            : AMQP_EMPTY_BYTES,
-                        /* arguments   = */ AMQP_EMPTY_TABLE);
+    qb_ret = amqp_queue_bind(
+        conf->connection,
+        /* channel     = */ CAMQP_CHANNEL,
+        /* queue       = */ amqp_cstring_bytes(conf->queue),
+        /* exchange    = */ amqp_cstring_bytes(conf->exchange),
+        /* routing_key = */
+            (conf->routing_key != NULL) ? amqp_cstring_bytes(conf->routing_key)
+                                        : AMQP_EMPTY_BYTES,
+        /* arguments   = */ AMQP_EMPTY_TABLE);
     if ((qb_ret == NULL) && camqp_is_error(conf)) {
       char errbuf[1024];
       ERROR("amqp plugin: amqp_queue_bind failed: %s",
@@ -428,7 +429,7 @@ static int camqp_connect(camqp_config_t *conf) /* {{{ */
 
 #ifdef HAVE_AMQP_TCP_SOCKET
 #define CLOSE_SOCKET() /* amqp_destroy_connection() closes the socket for us   \
-                          */
+                        */
   /* TODO: add support for SSL using amqp_ssl_socket_new
    *       and related functions */
   socket = amqp_tcp_socket_new(conf->connection);
@@ -749,8 +750,8 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
   } else {
     ssnprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
-             vl->host, vl->plugin, vl->plugin_instance, vl->type,
-             vl->type_instance);
+              vl->host, vl->plugin, vl->plugin_instance, vl->type,
+              vl->type_instance);
 
     /* Switch slashes (the only character forbidden by collectd) and dots
      * (the separation character used by AMQP). */
@@ -972,11 +973,11 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
     char cbname[128];
     ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
-    status =
-        plugin_register_write(cbname, camqp_write,
-                              &(user_data_t){
-                                  .data = conf, .free_func = camqp_config_free,
-                              });
+    status = plugin_register_write(cbname, camqp_write,
+                                   &(user_data_t){
+                                       .data = conf,
+                                       .free_func = camqp_config_free,
+                                   });
     if (status != 0) {
       camqp_config_free(conf);
       return status;

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -217,23 +217,23 @@ static char *camqp_strerror(camqp_config_t *conf, /* {{{ */
     if (r.reply.id == AMQP_CONNECTION_CLOSE_METHOD) {
       amqp_connection_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      snprintf(buffer, buffer_size, "Server connection error %d: %s",
+      ssnprintf(buffer, buffer_size, "Server connection error %d: %s",
                m->reply_code, tmp);
       sfree(tmp);
     } else if (r.reply.id == AMQP_CHANNEL_CLOSE_METHOD) {
       amqp_channel_close_t *m = r.reply.decoded;
       char *tmp = camqp_bytes_cstring(&m->reply_text);
-      snprintf(buffer, buffer_size, "Server channel error %d: %s",
+      ssnprintf(buffer, buffer_size, "Server channel error %d: %s",
                m->reply_code, tmp);
       sfree(tmp);
     } else {
-      snprintf(buffer, buffer_size, "Server error method %#" PRIx32,
+      ssnprintf(buffer, buffer_size, "Server error method %#" PRIx32,
                r.reply.id);
     }
     break;
 
   default:
-    snprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
+    ssnprintf(buffer, buffer_size, "Unknown reply type %i", (int)r.reply_type);
   }
 
   return buffer;
@@ -748,7 +748,7 @@ static int camqp_write(const data_set_t *ds, const value_list_t *vl, /* {{{ */
   if (conf->routing_key != NULL) {
     sstrncpy(routing_key, conf->routing_key, sizeof(routing_key));
   } else {
-    snprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
+    ssnprintf(routing_key, sizeof(routing_key), "collectd/%s/%s/%s/%s/%s",
              vl->host, vl->plugin, vl->plugin_instance, vl->type,
              vl->type_instance);
 
@@ -970,7 +970,7 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
 
   if (publish) {
     char cbname[128];
-    snprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
+    ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
     status =
         plugin_register_write(cbname, camqp_write,

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -973,11 +973,11 @@ static int camqp_config_connection(oconfig_item_t *ci, /* {{{ */
     char cbname[128];
     ssnprintf(cbname, sizeof(cbname), "amqp/%s", conf->name);
 
-    status =
-        plugin_register_write(cbname, camqp_write,
-                              &(user_data_t){
-                                  .data = conf, .free_func = camqp_config_free,
-                              });
+    status = plugin_register_write(cbname, camqp_write,
+                                   &(user_data_t){
+                                       .data = conf,
+                                       .free_func = camqp_config_free,
+                                   });
     if (status != 0) {
       camqp_config_free(conf);
       return status;

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -320,17 +320,17 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
   amqp_queue_declare_ok_t *qd_ret;
   amqp_basic_consume_ok_t *cm_ret;
 
-  qd_ret = amqp_queue_declare(conf->connection,
-                              /* channel     = */ CAMQP_CHANNEL,
-                              /* queue       = */
-                                  (conf->queue != NULL)
-                                  ? amqp_cstring_bytes(conf->queue)
-                                  : AMQP_EMPTY_BYTES,
-                              /* passive     = */ 0,
-                              /* durable     = */ conf->queue_durable,
-                              /* exclusive   = */ 0,
-                              /* auto_delete = */ conf->queue_auto_delete,
-                              /* arguments   = */ AMQP_EMPTY_TABLE);
+  qd_ret =
+      amqp_queue_declare(conf->connection,
+                         /* channel     = */ CAMQP_CHANNEL,
+                         /* queue       = */
+                         (conf->queue != NULL) ? amqp_cstring_bytes(conf->queue)
+                                               : AMQP_EMPTY_BYTES,
+                         /* passive     = */ 0,
+                         /* durable     = */ conf->queue_durable,
+                         /* exclusive   = */ 0,
+                         /* auto_delete = */ conf->queue_auto_delete,
+                         /* arguments   = */ AMQP_EMPTY_TABLE);
   if (qd_ret == NULL) {
     ERROR("amqp plugin: amqp_queue_declare failed.");
     camqp_close_connection(conf);
@@ -360,8 +360,8 @@ static int camqp_setup_queue(camqp_config_t *conf) /* {{{ */
         /* queue       = */ amqp_cstring_bytes(conf->queue),
         /* exchange    = */ amqp_cstring_bytes(conf->exchange),
         /* routing_key = */
-            (conf->routing_key != NULL) ? amqp_cstring_bytes(conf->routing_key)
-                                        : AMQP_EMPTY_BYTES,
+        (conf->routing_key != NULL) ? amqp_cstring_bytes(conf->routing_key)
+                                    : AMQP_EMPTY_BYTES,
         /* arguments   = */ AMQP_EMPTY_TABLE);
     if ((qb_ret == NULL) && camqp_is_error(conf)) {
       char errbuf[1024];

--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -630,7 +630,7 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
       return -1;
     }
     status = ssnprintf(instance->send_to, sizeof(instance->send_to), "/%s/%s",
-                      transport->address, instance->name);
+                       transport->address, instance->name);
     if ((status < 0) || (size_t)status >= sizeof(instance->send_to)) {
       ERROR("amqp1 plugin: send_to address would have been truncated.");
       return -1;
@@ -639,14 +639,16 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
       status = plugin_register_notification(
           tpname, amqp1_notify,
           &(user_data_t){
-              .data = instance, .free_func = amqp1_config_instance_free,
+              .data = instance,
+              .free_func = amqp1_config_instance_free,
           });
     } else {
-      status = plugin_register_write(
-          tpname, amqp1_write,
-          &(user_data_t){
-              .data = instance, .free_func = amqp1_config_instance_free,
-          });
+      status =
+          plugin_register_write(tpname, amqp1_write,
+                                &(user_data_t){
+                                    .data = instance,
+                                    .free_func = amqp1_config_instance_free,
+                                });
     }
 
     if (status != 0) {

--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -639,14 +639,16 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
       status = plugin_register_notification(
           tpname, amqp1_notify,
           &(user_data_t){
-              .data = instance, .free_func = amqp1_config_instance_free,
+              .data = instance,
+              .free_func = amqp1_config_instance_free,
           });
     } else {
-      status = plugin_register_write(
-          tpname, amqp1_write,
-          &(user_data_t){
-              .data = instance, .free_func = amqp1_config_instance_free,
-          });
+      status =
+          plugin_register_write(tpname, amqp1_write,
+                                &(user_data_t){
+                                    .data = instance,
+                                    .free_func = amqp1_config_instance_free,
+                                });
     }
 
     if (status != 0) {

--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -639,16 +639,14 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
       status = plugin_register_notification(
           tpname, amqp1_notify,
           &(user_data_t){
-              .data = instance,
-              .free_func = amqp1_config_instance_free,
+              .data = instance, .free_func = amqp1_config_instance_free,
           });
     } else {
-      status =
-          plugin_register_write(tpname, amqp1_write,
-                                &(user_data_t){
-                                    .data = instance,
-                                    .free_func = amqp1_config_instance_free,
-                                });
+      status = plugin_register_write(
+          tpname, amqp1_write,
+          &(user_data_t){
+              .data = instance, .free_func = amqp1_config_instance_free,
+          });
     }
 
     if (status != 0) {

--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -624,12 +624,12 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
     return status;
   } else {
     char tpname[DATA_MAX_NAME_LEN];
-    status = snprintf(tpname, sizeof(tpname), "amqp1/%s", instance->name);
+    status = ssnprintf(tpname, sizeof(tpname), "amqp1/%s", instance->name);
     if ((status < 0) || (size_t)status >= sizeof(tpname)) {
       ERROR("amqp1 plugin: Instance name would have been truncated.");
       return -1;
     }
-    status = snprintf(instance->send_to, sizeof(instance->send_to), "/%s/%s",
+    status = ssnprintf(instance->send_to, sizeof(instance->send_to), "/%s/%s",
                       transport->address, instance->name);
     if ((status < 0) || (size_t)status >= sizeof(instance->send_to)) {
       ERROR("amqp1 plugin: send_to address would have been truncated.");

--- a/src/apache.c
+++ b/src/apache.c
@@ -224,7 +224,8 @@ static int config_add(oconfig_item_t *ci) {
       /* callback  = */ apache_read_host,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = st, .free_func = apache_free,
+          .data = st,
+          .free_func = apache_free,
       });
 } /* int config_add */
 

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -81,8 +81,8 @@ static void aquaero_submit_array(const char *type,
     if (value_array[i] == AQ5_FLOAT_UNDEF)
       continue;
 
-    ssnprintf(type_instance, sizeof(type_instance), "%s%d", type_instance_prefix,
-             i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "%s%d",
+              type_instance_prefix, i + 1);
     aquaero_submit(type, type_instance, value_array[i]);
   }
 }

--- a/src/aquaero.c
+++ b/src/aquaero.c
@@ -81,7 +81,7 @@ static void aquaero_submit_array(const char *type,
     if (value_array[i] == AQ5_FLOAT_UNDEF)
       continue;
 
-    snprintf(type_instance, sizeof(type_instance), "%s%d", type_instance_prefix,
+    ssnprintf(type_instance, sizeof(type_instance), "%s%d", type_instance_prefix,
              i + 1);
     aquaero_submit(type, type_instance, value_array[i]);
   }
@@ -130,7 +130,7 @@ static int aquaero_read(void) {
         (aq_data.fan_vrm_temp[i] != AQ5_FLOAT_UNDEF))
       continue;
 
-    snprintf(type_instance, sizeof(type_instance), "fan%d", i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "fan%d", i + 1);
 
     aquaero_submit("fanspeed", type_instance, aq_data.fan_rpm[i]);
     aquaero_submit("percent", type_instance, aq_data.fan_duty[i]);
@@ -139,7 +139,7 @@ static int aquaero_read(void) {
 
     /* Report the voltage reglator module (VRM) temperature with a
      * different type instance. */
-    snprintf(type_instance, sizeof(type_instance), "fan%d-vrm", i + 1);
+    ssnprintf(type_instance, sizeof(type_instance), "fan%d-vrm", i + 1);
     aquaero_submit("temperature", type_instance, aq_data.fan_vrm_temp[i]);
   }
 

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -499,7 +499,7 @@ static int ascent_init(void) /* {{{ */
     static char credentials[1024];
     int status;
 
-    status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
+    status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
                       (pass == NULL) ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "

--- a/src/ascent.c
+++ b/src/ascent.c
@@ -500,7 +500,7 @@ static int ascent_init(void) /* {{{ */
     int status;
 
     status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
-                      (pass == NULL) ? "" : pass);
+                       (pass == NULL) ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("ascent plugin: ascent_init: Returning an error because the "
             "credentials have been truncated.");

--- a/src/battery.c
+++ b/src/battery.c
@@ -336,7 +336,7 @@ static int battery_read(void) /* {{{ */
 
   return 0;
 } /* }}} int battery_read */
-/* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
+  /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
 #elif KERNEL_LINUX
 /* Reads a file which contains only a number (and optionally a trailing

--- a/src/bind.c
+++ b/src/bind.c
@@ -1538,8 +1538,9 @@ static int bind_init(void) /* {{{ */
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
 #ifdef HAVE_CURLOPT_TIMEOUT_MS
   curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS,
-                   (timeout >= 0) ? (long)timeout : (long)CDTIME_T_TO_MS(
-                                                        plugin_get_interval()));
+                   (timeout >= 0)
+                       ? (long)timeout
+                       : (long)CDTIME_T_TO_MS(plugin_get_interval()));
 #endif
 
   return 0;

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -990,7 +990,7 @@ static int cconn_connect(struct cconn *io) {
     return err;
   }
   address.sun_family = AF_UNIX;
-  snprintf(address.sun_path, sizeof(address.sun_path), "%s", io->d->asok_path);
+  ssnprintf(address.sun_path, sizeof(address.sun_path), "%s", io->d->asok_path);
   RETRY_ON_EINTR(err, connect(fd, (struct sockaddr *)&address,
                               sizeof(struct sockaddr_un)));
   if (err < 0) {
@@ -1153,7 +1153,7 @@ static ssize_t cconn_handle_event(struct cconn *io) {
     return -EDOM;
   case CSTATE_WRITE_REQUEST: {
     char cmd[32];
-    snprintf(cmd, sizeof(cmd), "%s%d%s", "{ \"prefix\": \"", io->request_type,
+    ssnprintf(cmd, sizeof(cmd), "%s%d%s", "{ \"prefix\": \"", io->request_type,
              "\" }\n");
     size_t cmd_len = strlen(cmd);
     RETRY_ON_EINTR(

--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1154,7 +1154,7 @@ static ssize_t cconn_handle_event(struct cconn *io) {
   case CSTATE_WRITE_REQUEST: {
     char cmd[32];
     ssnprintf(cmd, sizeof(cmd), "%s%d%s", "{ \"prefix\": \"", io->request_type,
-             "\" }\n");
+              "\" }\n");
     size_t cmd_len = strlen(cmd);
     RETRY_ON_EINTR(
         ret, write(io->asok, ((char *)&cmd) + io->amt, cmd_len - io->amt));

--- a/src/chrony.c
+++ b/src/chrony.c
@@ -111,7 +111,9 @@ typedef enum {
 #define ATTRIB_PACKED
 #endif
 
-typedef struct ATTRIB_PACKED { int32_t value; } tFloat;
+typedef struct ATTRIB_PACKED {
+  int32_t value;
+} tFloat;
 
 typedef struct ATTRIB_PACKED {
   uint32_t tv_sec_high;
@@ -148,7 +150,9 @@ typedef struct ATTRIB_PACKED {
                            Amplification) */
 } tChrony_Req_Tracking;
 
-typedef struct ATTRIB_PACKED { uint32_t f_n_sources; } tChrony_Req_N_Sources;
+typedef struct ATTRIB_PACKED {
+  uint32_t f_n_sources;
+} tChrony_Req_N_Sources;
 
 typedef struct ATTRIB_PACKED {
   int32_t f_index;
@@ -183,7 +187,9 @@ typedef struct ATTRIB_PACKED {
 } tChrony_Request;
 
 /* Chrony daemon response packets */
-typedef struct ATTRIB_PACKED { uint32_t f_n_sources; } tChrony_Resp_N_Sources;
+typedef struct ATTRIB_PACKED {
+  uint32_t f_n_sources;
+} tChrony_Resp_N_Sources;
 
 typedef struct ATTRIB_PACKED {
   union {

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -25,9 +25,9 @@
 #include "config.h"
 #endif
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
@@ -293,8 +293,9 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
                 value);
         BAIL_OUT(-1);
       } else if ((endptr != NULL) && (*endptr != '\0')) {
-        fprintf(stderr, "WARNING: Ignoring trailing garbage after timeout: "
-                        "%s.\n",
+        fprintf(stderr,
+                "WARNING: Ignoring trailing garbage after timeout: "
+                "%s.\n",
                 endptr);
       }
     } else if (strcasecmp(key, "plugin") == 0) {
@@ -341,8 +342,9 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
           char id[1024];
 
           lcc_identifier_to_string(c, id, sizeof(id), identifiers + j);
-          fprintf(stderr, "ERROR: Failed to flush plugin `%s', "
-                          "identifier `%s': %s.\n",
+          fprintf(stderr,
+                  "ERROR: Failed to flush plugin `%s', "
+                  "identifier `%s': %s.\n",
                   (plugins[i] == NULL) ? "(all)" : plugins[i], id,
                   lcc_strerror(c));
         }
@@ -386,8 +388,9 @@ static int listval(lcc_connection_t *c, int argc, char **argv) {
 
     status = lcc_identifier_to_string(c, id, sizeof(id), ret_ident + i);
     if (status != 0) {
-      fprintf(stderr, "ERROR: listval: Failed to convert returned "
-                      "identifier to a string: %s\n",
+      fprintf(stderr,
+              "ERROR: listval: Failed to convert returned "
+              "identifier to a string: %s\n",
               lcc_strerror(c));
       continue;
     }
@@ -445,8 +448,9 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
                   value);
           return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
-          fprintf(stderr, "WARNING: Ignoring trailing garbage after "
-                          "interval: %s.\n",
+          fprintf(stderr,
+                  "WARNING: Ignoring trailing garbage after "
+                  "interval: %s.\n",
                   endptr);
         }
       } else {

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -293,9 +293,8 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
                 value);
         BAIL_OUT(-1);
       } else if ((endptr != NULL) && (*endptr != '\0')) {
-        fprintf(stderr,
-                "WARNING: Ignoring trailing garbage after timeout: "
-                "%s.\n",
+        fprintf(stderr, "WARNING: Ignoring trailing garbage after timeout: "
+                        "%s.\n",
                 endptr);
       }
     } else if (strcasecmp(key, "plugin") == 0) {
@@ -342,9 +341,8 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
           char id[1024];
 
           lcc_identifier_to_string(c, id, sizeof(id), identifiers + j);
-          fprintf(stderr,
-                  "ERROR: Failed to flush plugin `%s', "
-                  "identifier `%s': %s.\n",
+          fprintf(stderr, "ERROR: Failed to flush plugin `%s', "
+                          "identifier `%s': %s.\n",
                   (plugins[i] == NULL) ? "(all)" : plugins[i], id,
                   lcc_strerror(c));
         }
@@ -388,9 +386,8 @@ static int listval(lcc_connection_t *c, int argc, char **argv) {
 
     status = lcc_identifier_to_string(c, id, sizeof(id), ret_ident + i);
     if (status != 0) {
-      fprintf(stderr,
-              "ERROR: listval: Failed to convert returned "
-              "identifier to a string: %s\n",
+      fprintf(stderr, "ERROR: listval: Failed to convert returned "
+                      "identifier to a string: %s\n",
               lcc_strerror(c));
       continue;
     }
@@ -448,9 +445,8 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
                   value);
           return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
-          fprintf(stderr,
-                  "WARNING: Ignoring trailing garbage after "
-                  "interval: %s.\n",
+          fprintf(stderr, "WARNING: Ignoring trailing garbage after "
+                          "interval: %s.\n",
                   endptr);
         }
       } else {

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -293,8 +293,9 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
                 value);
         BAIL_OUT(-1);
       } else if ((endptr != NULL) && (*endptr != '\0')) {
-        fprintf(stderr, "WARNING: Ignoring trailing garbage after timeout: "
-                        "%s.\n",
+        fprintf(stderr,
+                "WARNING: Ignoring trailing garbage after timeout: "
+                "%s.\n",
                 endptr);
       }
     } else if (strcasecmp(key, "plugin") == 0) {
@@ -341,8 +342,9 @@ static int flush(lcc_connection_t *c, int argc, char **argv) {
           char id[1024];
 
           lcc_identifier_to_string(c, id, sizeof(id), identifiers + j);
-          fprintf(stderr, "ERROR: Failed to flush plugin `%s', "
-                          "identifier `%s': %s.\n",
+          fprintf(stderr,
+                  "ERROR: Failed to flush plugin `%s', "
+                  "identifier `%s': %s.\n",
                   (plugins[i] == NULL) ? "(all)" : plugins[i], id,
                   lcc_strerror(c));
         }
@@ -386,8 +388,9 @@ static int listval(lcc_connection_t *c, int argc, char **argv) {
 
     status = lcc_identifier_to_string(c, id, sizeof(id), ret_ident + i);
     if (status != 0) {
-      fprintf(stderr, "ERROR: listval: Failed to convert returned "
-                      "identifier to a string: %s\n",
+      fprintf(stderr,
+              "ERROR: listval: Failed to convert returned "
+              "identifier to a string: %s\n",
               lcc_strerror(c));
       continue;
     }
@@ -445,8 +448,9 @@ static int putval(lcc_connection_t *c, int argc, char **argv) {
                   value);
           return -1;
         } else if ((endptr != NULL) && (*endptr != '\0')) {
-          fprintf(stderr, "WARNING: Ignoring trailing garbage after "
-                          "interval: %s.\n",
+          fprintf(stderr,
+                  "WARNING: Ignoring trailing garbage after "
+                  "interval: %s.\n",
                   endptr);
         }
       } else {

--- a/src/collectdmon.c
+++ b/src/collectdmon.c
@@ -255,8 +255,9 @@ static void check_respawn(void) {
   if (counter >= 10) {
     unsigned int time_left = 300;
 
-    syslog(LOG_ERR, "Error: collectd is respawning too fast - "
-                    "disabled for %i seconds",
+    syslog(LOG_ERR,
+           "Error: collectd is respawning too fast - "
+           "disabled for %i seconds",
            time_left);
 
     while (((time_left = sleep(time_left)) > 0) && loop == 0)
@@ -323,7 +324,8 @@ int main(int argc, char **argv) {
   }
 
   struct sigaction sa = {
-      .sa_handler = sig_int_term_handler, .sa_flags = 0,
+      .sa_handler = sig_int_term_handler,
+      .sa_flags = 0,
   };
   sigemptyset(&sa.sa_mask);
 

--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -73,7 +73,7 @@ static int cs_read(void) {
   }
 
   cs_submit(value);
-/* #endif HAVE_SYSCTLBYNAME */
+  /* #endif HAVE_SYSCTLBYNAME */
 
 #elif KERNEL_LINUX
   FILE *fh;
@@ -116,7 +116,7 @@ static int cs_read(void) {
 
   if (status == -2)
     ERROR("contextswitch plugin: Unable to find context switch value.");
-/* #endif  KERNEL_LINUX */
+    /* #endif  KERNEL_LINUX */
 
 #elif HAVE_PERFSTAT
   int status = 0;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -251,7 +251,7 @@ static int init(void) {
 
   INFO("cpu plugin: Found %i processor%s.", (int)cpu_list_len,
        cpu_list_len == 1 ? "" : "s");
-/* #endif PROCESSOR_CPU_LOAD_INFO */
+  /* #endif PROCESSOR_CPU_LOAD_INFO */
 
 #elif defined(HAVE_LIBKSTAT)
   kstat_t *ksp_chain;
@@ -267,7 +267,7 @@ static int init(void) {
        ksp_chain = ksp_chain->ks_next)
     if (strncmp(ksp_chain->ks_module, "cpu_stat", 8) == 0)
       ksp[numcpu++] = ksp_chain;
-/* #endif HAVE_LIBKSTAT */
+      /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
   size_t numcpu_size;
@@ -282,7 +282,7 @@ static int init(void) {
     WARNING("cpu plugin: sysctl: %s", STRERRNO);
     return -1;
   }
-/* #endif CAN_USE_SYSCTL */
+    /* #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME)
   size_t numcpu_size;
@@ -307,7 +307,7 @@ static int init(void) {
            "%i)",
            numcpu);
 #endif
-/* #endif HAVE_SYSCTLBYNAME */
+    /* #endif HAVE_SYSCTLBYNAME */
 
 #elif defined(HAVE_LIBSTATGRAB)
 /* nothing to initialize */
@@ -630,7 +630,7 @@ static int cpu_read(void) {
     cpu_stage(cpu, COLLECTD_CPU_STATE_IDLE,
               (derive_t)cpu_info.cpu_ticks[CPU_STATE_IDLE], now);
   }
-/* }}} #endif PROCESSOR_CPU_LOAD_INFO */
+    /* }}} #endif PROCESSOR_CPU_LOAD_INFO */
 
 #elif defined(KERNEL_LINUX) /* {{{ */
   int cpu;
@@ -708,7 +708,7 @@ static int cpu_read(void) {
     cpu_stage(cpu, COLLECTD_CPU_STATE_NICE, (derive_t)nice_value, now);
   }
   fclose(fh);
-/* }}} #endif defined(KERNEL_LINUX) */
+  /* }}} #endif defined(KERNEL_LINUX) */
 
 #elif defined(HAVE_LIBKSTAT) /* {{{ */
   static cpu_stat_t cs;
@@ -729,7 +729,7 @@ static int cpu_read(void) {
     cpu_stage(ksp[cpu]->ks_instance, COLLECTD_CPU_STATE_WAIT,
               (derive_t)cs.cpu_sysinfo.cpu[CPU_WAIT], now);
   }
-/* }}} #endif defined(HAVE_LIBKSTAT) */
+    /* }}} #endif defined(HAVE_LIBKSTAT) */
 
 #elif CAN_USE_SYSCTL /* {{{ */
   uint64_t cpuinfo[numcpu][CPUSTATES];
@@ -786,10 +786,10 @@ static int cpu_read(void) {
     cpu_stage(i, COLLECTD_CPU_STATE_INTERRUPT, (derive_t)cpuinfo[i][CP_INTR],
               now);
   }
-/* }}} #endif CAN_USE_SYSCTL */
+    /* }}} #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME) && defined(HAVE_SYSCTL_KERN_CP_TIMES) /* {{{  \
-                                                                          */
+                                                                        */
   long cpuinfo[maxcpu][CPUSTATES];
   size_t cpuinfo_size;
 
@@ -809,7 +809,7 @@ static int cpu_read(void) {
     cpu_stage(i, COLLECTD_CPU_STATE_INTERRUPT, (derive_t)cpuinfo[i][CP_INTR],
               now);
   }
-/* }}} #endif HAVE_SYSCTL_KERN_CP_TIMES */
+    /* }}} #endif HAVE_SYSCTL_KERN_CP_TIMES */
 
 #elif defined(HAVE_SYSCTLBYNAME) /* {{{ */
   long cpuinfo[CPUSTATES];
@@ -827,7 +827,7 @@ static int cpu_read(void) {
   cpu_stage(0, COLLECTD_CPU_STATE_SYSTEM, (derive_t)cpuinfo[CP_SYS], now);
   cpu_stage(0, COLLECTD_CPU_STATE_IDLE, (derive_t)cpuinfo[CP_IDLE], now);
   cpu_stage(0, COLLECTD_CPU_STATE_INTERRUPT, (derive_t)cpuinfo[CP_INTR], now);
-/* }}} #endif HAVE_SYSCTLBYNAME */
+  /* }}} #endif HAVE_SYSCTLBYNAME */
 
 #elif defined(HAVE_LIBSTATGRAB) /* {{{ */
   sg_cpu_stats *cs;
@@ -844,7 +844,7 @@ static int cpu_read(void) {
   cpu_state(0, COLLECTD_CPU_STATE_SYSTEM, (derive_t)cs->kernel);
   cpu_state(0, COLLECTD_CPU_STATE_USER, (derive_t)cs->user);
   cpu_state(0, COLLECTD_CPU_STATE_WAIT, (derive_t)cs->iowait);
-/* }}} #endif HAVE_LIBSTATGRAB */
+  /* }}} #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT) /* {{{ */
   perfstat_id_t id;

--- a/src/cpusleep.c
+++ b/src/cpusleep.c
@@ -28,7 +28,7 @@
  * CPU sleep is reported in milliseconds of sleep per second of wall
  * time. For that, the time difference between BOOT and MONOTONIC clocks
  * is reported using derive type.
-**/
+ **/
 
 #include "collectd.h"
 

--- a/src/cpython.h
+++ b/src/cpython.h
@@ -181,7 +181,7 @@ extern PyTypeObject ValuesType;
 
 typedef struct {
   PluginData data;
-  PyObject *meta;   /* dict */
+  PyObject *meta; /* dict */
   int severity;
   char message[NOTIF_MAX_MSG_LEN];
 } Notification;

--- a/src/curl.c
+++ b/src/curl.c
@@ -541,7 +541,8 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
   plugin_register_complex_read(/* group = */ NULL, cb_name, cc_read_page,
                                interval,
                                &(user_data_t){
-                                   .data = page, .free_func = cc_web_page_free,
+                                   .data = page,
+                                   .free_func = cc_web_page_free,
                                });
   sfree(cb_name);
 

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -763,7 +763,8 @@ static int cj_config_add_url(oconfig_item_t *ci) /* {{{ */
 
     plugin_register_complex_read(/* group = */ NULL, cb_name, cj_read, interval,
                                  &(user_data_t){
-                                     .data = db, .free_func = cj_free,
+                                     .data = db,
+                                     .free_func = cj_free,
                                  });
     sfree(cb_name);
   } else {

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -697,8 +697,8 @@ static int cx_config_add_namespace(cx_t *db, /* {{{ */
     return EINVAL;
   }
 
-  cx_namespace_t *ns = realloc(
-      db->namespaces, sizeof(*db->namespaces) * (db->namespaces_num + 1));
+  cx_namespace_t *ns = realloc(db->namespaces, sizeof(*db->namespaces) *
+                                                   (db->namespaces_num + 1));
   if (ns == NULL) {
     ERROR("curl_xml plugin: realloc failed.");
     return ENOMEM;
@@ -925,7 +925,8 @@ static int cx_config_add_url(oconfig_item_t *ci) /* {{{ */
   plugin_register_complex_read(/* group = */ "curl_xml", cb_name, cx_read,
                                /* interval = */ interval,
                                &(user_data_t){
-                                   .data = db, .free_func = cx_free,
+                                   .data = db,
+                                   .free_func = cx_free,
                                });
   sfree(cb_name);
   return 0;

--- a/src/daemon/cmd.c
+++ b/src/daemon/cmd.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 #ifdef KERNEL_LINUX
       && notify_upstart() == 0 && notify_systemd() == 0
 #endif
-      ) {
+  ) {
     pid_t pid;
     if ((pid = fork()) == -1) {
       /* error */

--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -307,11 +307,12 @@ static int do_shutdown(void) {
 static void read_cmdline(int argc, char **argv, struct cmdline_config *config) {
   /* read options */
   while (1) {
-    int c = getopt(argc, argv, "BhtTC:"
+    int c = getopt(argc, argv,
+                   "BhtTC:"
 #if COLLECT_DAEMON
-                               "fP:"
+                   "fP:"
 #endif
-                   );
+    );
 
     if (c == -1)
       break;
@@ -391,7 +392,9 @@ void stop_collectd(void) { loop++; }
 
 struct cmdline_config init_config(int argc, char **argv) {
   struct cmdline_config config = {
-      .daemonize = true, .create_basedir = true, .configfile = CONFIGFILE,
+      .daemonize = true,
+      .create_basedir = true,
+      .configfile = CONFIGFILE,
   };
 
   read_cmdline(argc, argv, &config);

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -267,8 +267,7 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
   /* default to the global interval set before loading this plugin */
   plugin_ctx_t ctx = {
-      .interval = cf_get_default_interval(),
-      .name = strdup(name),
+      .interval = cf_get_default_interval(), .name = strdup(name),
   };
   if (ctx.name == NULL)
     return ENOMEM;
@@ -476,9 +475,9 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
     return 0;
   }
 
-  temp =
-      realloc(dst->children, sizeof(oconfig_item_t) *
-                                 (dst->children_num + src->children_num - 1));
+  temp = realloc(dst->children,
+                 sizeof(oconfig_item_t) *
+                     (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -517,8 +516,9 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   if ((src == NULL) || (src->children_num == 0))
     return 0;
 
-  temp = realloc(dst->children, sizeof(oconfig_item_t) *
-                                    (dst->children_num + src->children_num));
+  temp =
+      realloc(dst->children,
+              sizeof(oconfig_item_t) * (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -267,7 +267,8 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
   /* default to the global interval set before loading this plugin */
   plugin_ctx_t ctx = {
-      .interval = cf_get_default_interval(), .name = strdup(name),
+      .interval = cf_get_default_interval(),
+      .name = strdup(name),
   };
   if (ctx.name == NULL)
     return ENOMEM;
@@ -313,11 +314,11 @@ static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
       status =
           ssnprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
     else if (ci->values[i].type == OCONFIG_TYPE_NUMBER)
-      status =
-          ssnprintf(buffer_ptr, buffer_free, " %lf", ci->values[i].value.number);
+      status = ssnprintf(buffer_ptr, buffer_free, " %lf",
+                         ci->values[i].value.number);
     else if (ci->values[i].type == OCONFIG_TYPE_BOOLEAN)
       status = ssnprintf(buffer_ptr, buffer_free, " %s",
-                        ci->values[i].value.boolean ? "true" : "false");
+                         ci->values[i].value.boolean ? "true" : "false");
 
     if ((status < 0) || (status >= buffer_free))
       return -1;
@@ -475,9 +476,9 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
     return 0;
   }
 
-  temp = realloc(dst->children,
-                 sizeof(oconfig_item_t) *
-                     (dst->children_num + src->children_num - 1));
+  temp =
+      realloc(dst->children, sizeof(oconfig_item_t) *
+                                 (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -516,9 +517,8 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   if ((src == NULL) || (src->children_num == 0))
     return 0;
 
-  temp =
-      realloc(dst->children,
-              sizeof(oconfig_item_t) * (dst->children_num + src->children_num));
+  temp = realloc(dst->children, sizeof(oconfig_item_t) *
+                                    (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -200,7 +200,7 @@ static int dispatch_global_option(const oconfig_item_t *ci) {
     return global_option_set(ci->key, ci->values[0].value.string, 0);
   else if (ci->values[0].type == OCONFIG_TYPE_NUMBER) {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
+    ssnprintf(tmp, sizeof(tmp), "%lf", ci->values[0].value.number);
     return global_option_set(ci->key, tmp, 0);
   } else if (ci->values[0].type == OCONFIG_TYPE_BOOLEAN) {
     if (ci->values[0].value.boolean)
@@ -311,12 +311,12 @@ static int dispatch_value_plugin(const char *plugin, oconfig_item_t *ci) {
 
     if (ci->values[i].type == OCONFIG_TYPE_STRING)
       status =
-          snprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
+          ssnprintf(buffer_ptr, buffer_free, " %s", ci->values[i].value.string);
     else if (ci->values[i].type == OCONFIG_TYPE_NUMBER)
       status =
-          snprintf(buffer_ptr, buffer_free, " %lf", ci->values[i].value.number);
+          ssnprintf(buffer_ptr, buffer_free, " %lf", ci->values[i].value.number);
     else if (ci->values[i].type == OCONFIG_TYPE_BOOLEAN)
-      status = snprintf(buffer_ptr, buffer_free, " %s",
+      status = ssnprintf(buffer_ptr, buffer_free, " %s",
                         ci->values[i].value.boolean ? "true" : "false");
 
     if ((status < 0) || (status >= buffer_free))
@@ -666,7 +666,7 @@ static oconfig_item_t *cf_read_dir(const char *dir, const char *pattern,
     if ((de->d_name[0] == '.') || (de->d_name[0] == 0))
       continue;
 
-    status = snprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
+    status = ssnprintf(name, sizeof(name), "%s/%s", dir, de->d_name);
     if ((status < 0) || ((size_t)status >= sizeof(name))) {
       ERROR("configfile: Not including `%s/%s' because its"
             " name is too long.",
@@ -1235,7 +1235,7 @@ int cf_util_get_service(const oconfig_item_t *ci, char **ret_string) /* {{{ */
     P_ERROR("cf_util_get_service: Out of memory.");
     return -1;
   }
-  snprintf(service, 6, "%i", port);
+  ssnprintf(service, 6, "%i", port);
 
   sfree(*ret_string);
   *ret_string = service;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -366,7 +366,8 @@ static int create_register_callback(llist_t **list, /* {{{ */
   cf->cf_callback = callback;
   if (ud == NULL) {
     cf->cf_udata = (user_data_t){
-        .data = NULL, .free_func = NULL,
+        .data = NULL,
+        .free_func = NULL,
     };
   } else {
     cf->cf_udata = *ud;
@@ -1294,8 +1295,10 @@ EXPORT int plugin_register_flush(const char *name, plugin_flush_cb callback,
         /* name      = */ flush_name,
         /* callback  = */ plugin_flush_timeout_callback,
         /* interval  = */ ctx.flush_interval,
-        /* user data = */ &(user_data_t){
-            .data = cb, .free_func = plugin_flush_timeout_callback_free,
+        /* user data = */
+        &(user_data_t){
+            .data = cb,
+            .free_func = plugin_flush_timeout_callback_free,
         });
 
     sfree(flush_name);

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -279,7 +279,8 @@ int uc_check_timeout(void) {
    * plugin calls the cache interface. */
   for (size_t i = 0; i < expired_num; i++) {
     value_list_t vl = {
-        .time = expired[i].time, .interval = expired[i].interval,
+        .time = expired[i].time,
+        .interval = expired[i].interval,
     };
 
     if (parse_identifier_vl(expired[i].key, &vl) != 0) {

--- a/src/disk.c
+++ b/src/disk.c
@@ -209,7 +209,7 @@ static int disk_init(void) {
     io_master_port = MACH_PORT_NULL;
     return -1;
   }
-  /* #endif HAVE_IOKIT_IOKITLIB_H */
+/* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_LINUX
 #if HAVE_LIBUDEV_H
@@ -221,7 +221,7 @@ static int disk_init(void) {
     }
   }
 #endif /* HAVE_LIBUDEV_H */
-  /* #endif KERNEL_LINUX */
+/* #endif KERNEL_LINUX */
 
 #elif KERNEL_FREEBSD
   int rv;
@@ -236,7 +236,7 @@ static int disk_init(void) {
     ERROR("geom_stats_open() failed, returned %d", rv);
     return -1;
   }
-  /* #endif KERNEL_FREEBSD */
+/* #endif KERNEL_FREEBSD */
 
 #elif HAVE_LIBKSTAT
   kstat_t *ksp_chain;
@@ -275,8 +275,7 @@ static void disk_submit(const char *plugin_instance, const char *type,
                         derive_t read, derive_t write) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = read},
-      {.derive = write},
+      {.derive = read}, {.derive = write},
   };
 
   vl.values = values;
@@ -293,8 +292,7 @@ static void submit_io_time(char const *plugin_instance, derive_t io_time,
                            derive_t weighted_time) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = io_time},
-      {.derive = weighted_time},
+      {.derive = io_time}, {.derive = weighted_time},
   };
 
   vl.values = values;
@@ -535,7 +533,7 @@ static int disk_read(void) {
       disk_submit(disk_name, "disk_time", read_tme / 1000, write_tme / 1000);
   }
   IOObjectRelease(disk_list);
-  /* #endif HAVE_IOKIT_IOKITLIB_H */
+/* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_FREEBSD
   int retry, dirty;
@@ -899,7 +897,7 @@ static int disk_read(void) {
     free(missing_ds);
   }
   fclose(fh);
-  /* #endif defined(KERNEL_LINUX) */
+/* #endif defined(KERNEL_LINUX) */
 
 #elif HAVE_LIBKSTAT
 #if HAVE_KSTAT_IO_T_WRITES && HAVE_KSTAT_IO_T_NWRITES && HAVE_KSTAT_IO_T_WTIME
@@ -947,7 +945,7 @@ static int disk_read(void) {
       disk_submit(ksp[i]->ks_name, "disk_ops", kio.KIO_ROPS, kio.KIO_WOPS);
     }
   }
-  /* #endif defined(HAVE_LIBKSTAT) */
+/* #endif defined(HAVE_LIBKSTAT) */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_disk_io_stats *ds;
@@ -974,7 +972,7 @@ static int disk_read(void) {
     disk_submit(name, "disk_octets", ds->read_bytes, ds->write_bytes);
     ds++;
   }
-  /* #endif defined(HAVE_LIBSTATGRAB) */
+/* #endif defined(HAVE_LIBSTATGRAB) */
 
 #elif defined(HAVE_PERFSTAT)
   derive_t read_sectors;

--- a/src/disk.c
+++ b/src/disk.c
@@ -209,7 +209,7 @@ static int disk_init(void) {
     io_master_port = MACH_PORT_NULL;
     return -1;
   }
-/* #endif HAVE_IOKIT_IOKITLIB_H */
+    /* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_LINUX
 #if HAVE_LIBUDEV_H
@@ -221,7 +221,7 @@ static int disk_init(void) {
     }
   }
 #endif /* HAVE_LIBUDEV_H */
-/* #endif KERNEL_LINUX */
+    /* #endif KERNEL_LINUX */
 
 #elif KERNEL_FREEBSD
   int rv;
@@ -236,7 +236,7 @@ static int disk_init(void) {
     ERROR("geom_stats_open() failed, returned %d", rv);
     return -1;
   }
-/* #endif KERNEL_FREEBSD */
+    /* #endif KERNEL_FREEBSD */
 
 #elif HAVE_LIBKSTAT
   kstat_t *ksp_chain;
@@ -275,7 +275,8 @@ static void disk_submit(const char *plugin_instance, const char *type,
                         derive_t read, derive_t write) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = read}, {.derive = write},
+      {.derive = read},
+      {.derive = write},
   };
 
   vl.values = values;
@@ -292,7 +293,8 @@ static void submit_io_time(char const *plugin_instance, derive_t io_time,
                            derive_t weighted_time) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = io_time}, {.derive = weighted_time},
+      {.derive = io_time},
+      {.derive = weighted_time},
   };
 
   vl.values = values;
@@ -533,7 +535,7 @@ static int disk_read(void) {
       disk_submit(disk_name, "disk_time", read_tme / 1000, write_tme / 1000);
   }
   IOObjectRelease(disk_list);
-/* #endif HAVE_IOKIT_IOKITLIB_H */
+  /* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_FREEBSD
   int retry, dirty;
@@ -897,7 +899,7 @@ static int disk_read(void) {
     free(missing_ds);
   }
   fclose(fh);
-/* #endif defined(KERNEL_LINUX) */
+  /* #endif defined(KERNEL_LINUX) */
 
 #elif HAVE_LIBKSTAT
 #if HAVE_KSTAT_IO_T_WRITES && HAVE_KSTAT_IO_T_NWRITES && HAVE_KSTAT_IO_T_WTIME
@@ -945,7 +947,7 @@ static int disk_read(void) {
       disk_submit(ksp[i]->ks_name, "disk_ops", kio.KIO_ROPS, kio.KIO_WOPS);
     }
   }
-/* #endif defined(HAVE_LIBKSTAT) */
+    /* #endif defined(HAVE_LIBKSTAT) */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_disk_io_stats *ds;
@@ -972,7 +974,7 @@ static int disk_read(void) {
     disk_submit(name, "disk_octets", ds->read_bytes, ds->write_bytes);
     ds++;
   }
-/* #endif defined(HAVE_LIBSTATGRAB) */
+    /* #endif defined(HAVE_LIBSTATGRAB) */
 
 #elif defined(HAVE_PERFSTAT)
   derive_t read_sectors;

--- a/src/disk.c
+++ b/src/disk.c
@@ -209,7 +209,7 @@ static int disk_init(void) {
     io_master_port = MACH_PORT_NULL;
     return -1;
   }
-/* #endif HAVE_IOKIT_IOKITLIB_H */
+  /* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_LINUX
 #if HAVE_LIBUDEV_H
@@ -221,7 +221,7 @@ static int disk_init(void) {
     }
   }
 #endif /* HAVE_LIBUDEV_H */
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif KERNEL_FREEBSD
   int rv;
@@ -236,7 +236,7 @@ static int disk_init(void) {
     ERROR("geom_stats_open() failed, returned %d", rv);
     return -1;
   }
-/* #endif KERNEL_FREEBSD */
+  /* #endif KERNEL_FREEBSD */
 
 #elif HAVE_LIBKSTAT
   kstat_t *ksp_chain;
@@ -275,7 +275,8 @@ static void disk_submit(const char *plugin_instance, const char *type,
                         derive_t read, derive_t write) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = read}, {.derive = write},
+      {.derive = read},
+      {.derive = write},
   };
 
   vl.values = values;
@@ -292,7 +293,8 @@ static void submit_io_time(char const *plugin_instance, derive_t io_time,
                            derive_t weighted_time) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = io_time}, {.derive = weighted_time},
+      {.derive = io_time},
+      {.derive = weighted_time},
   };
 
   vl.values = values;
@@ -493,7 +495,8 @@ static int disk_read(void) {
         sstrncpy(disk_name, props_disk_name_bsd, sizeof(disk_name));
       else {
         ERROR("disk plugin: can't find bsd disk name.");
-        ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+        ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major,
+                  disk_minor);
       }
     } else
       ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
@@ -532,7 +535,7 @@ static int disk_read(void) {
       disk_submit(disk_name, "disk_time", read_tme / 1000, write_tme / 1000);
   }
   IOObjectRelease(disk_list);
-/* #endif HAVE_IOKIT_IOKITLIB_H */
+  /* #endif HAVE_IOKIT_IOKITLIB_H */
 
 #elif KERNEL_FREEBSD
   int retry, dirty;
@@ -896,7 +899,7 @@ static int disk_read(void) {
     free(missing_ds);
   }
   fclose(fh);
-/* #endif defined(KERNEL_LINUX) */
+  /* #endif defined(KERNEL_LINUX) */
 
 #elif HAVE_LIBKSTAT
 #if HAVE_KSTAT_IO_T_WRITES && HAVE_KSTAT_IO_T_NWRITES && HAVE_KSTAT_IO_T_WTIME
@@ -944,7 +947,7 @@ static int disk_read(void) {
       disk_submit(ksp[i]->ks_name, "disk_ops", kio.KIO_ROPS, kio.KIO_WOPS);
     }
   }
-/* #endif defined(HAVE_LIBKSTAT) */
+  /* #endif defined(HAVE_LIBKSTAT) */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_disk_io_stats *ds;
@@ -971,7 +974,7 @@ static int disk_read(void) {
     disk_submit(name, "disk_octets", ds->read_bytes, ds->write_bytes);
     ds++;
   }
-/* #endif defined(HAVE_LIBSTATGRAB) */
+  /* #endif defined(HAVE_LIBSTATGRAB) */
 
 #elif defined(HAVE_PERFSTAT)
   derive_t read_sectors;

--- a/src/disk.c
+++ b/src/disk.c
@@ -493,10 +493,10 @@ static int disk_read(void) {
         sstrncpy(disk_name, props_disk_name_bsd, sizeof(disk_name));
       else {
         ERROR("disk plugin: can't find bsd disk name.");
-        snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+        ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
       }
     } else
-      snprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
+      ssnprintf(disk_name, sizeof(disk_name), "%i-%i", disk_major, disk_minor);
 
     DEBUG("disk plugin: disk_name = \"%s\"", disk_name);
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -324,7 +324,8 @@ static void submit_derive(const char *type, const char *type_instance,
 
 static void submit_octets(derive_t queries, derive_t responses) {
   value_t values[] = {
-      {.derive = queries}, {.derive = responses},
+      {.derive = queries},
+      {.derive = responses},
   };
   value_list_t vl = VALUE_LIST_INIT;
 

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -512,7 +512,7 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
         char dev_name[DATA_MAX_NAME_LEN];
         if (ec->config.link_status.port_name[i][0] != 0) {
           ssnprintf(dev_name, sizeof(dev_name), "%s",
-                   ec->config.link_status.port_name[i]);
+                    ec->config.link_status.port_name[i]);
         } else {
           ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
         }
@@ -521,7 +521,7 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
           int sev = ec->link_info[i].link_status ? NOTIF_OKAY : NOTIF_WARNING;
           char msg[DATA_MAX_NAME_LEN];
           ssnprintf(msg, sizeof(msg), "Link Status: %s",
-                   ec->link_info[i].link_status ? "UP" : "DOWN");
+                    ec->link_info[i].link_status ? "UP" : "DOWN");
           dpdk_events_notification_dispatch(sev, dev_name,
                                             ec->link_info[i].read_time, msg);
         } else {

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -511,16 +511,16 @@ static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
 
         char dev_name[DATA_MAX_NAME_LEN];
         if (ec->config.link_status.port_name[i][0] != 0) {
-          snprintf(dev_name, sizeof(dev_name), "%s",
+          ssnprintf(dev_name, sizeof(dev_name), "%s",
                    ec->config.link_status.port_name[i]);
         } else {
-          snprintf(dev_name, sizeof(dev_name), "port.%d", i);
+          ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
         }
 
         if (ec->config.link_status.notify) {
           int sev = ec->link_info[i].link_status ? NOTIF_OKAY : NOTIF_WARNING;
           char msg[DATA_MAX_NAME_LEN];
-          snprintf(msg, sizeof(msg), "Link Status: %s",
+          ssnprintf(msg, sizeof(msg), "Link Status: %s",
                    ec->link_info[i].link_status ? "UP" : "DOWN");
           dpdk_events_notification_dispatch(sev, dev_name,
                                             ec->link_info[i].read_time, msg);
@@ -557,7 +557,7 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
     }
 
     char core_name[DATA_MAX_NAME_LEN];
-    snprintf(core_name, sizeof(core_name), "lcore%u", i);
+    ssnprintf(core_name, sizeof(core_name), "lcore%u", i);
 
     if (!ec->config.keep_alive.send_updated ||
         (ec->core_info[i].lcore_state !=
@@ -572,34 +572,34 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
         switch (ec->config.keep_alive.shm->core_state[i]) {
         case RTE_KA_STATE_ALIVE:
           sev = NOTIF_OKAY;
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: ALIVE", i);
           break;
         case RTE_KA_STATE_MISSING:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: MISSING", i);
           sev = NOTIF_WARNING;
           break;
         case RTE_KA_STATE_DEAD:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DEAD", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_UNUSED:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNUSED", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_GONE:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: GONE", i);
           sev = NOTIF_FAILURE;
           break;
         case RTE_KA_STATE_DOZING:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: DOZING", i);
           sev = NOTIF_OKAY;
           break;
         case RTE_KA_STATE_SLEEP:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: SLEEP", i);
           sev = NOTIF_OKAY;
           break;
         default:
-          snprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
+          ssnprintf(msg, sizeof(msg), "lcore %u Keep Alive Status: UNKNOWN", i);
           sev = NOTIF_FAILURE;
         }
 

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -395,9 +395,9 @@ static int dpdk_stats_counters_dispatch(dpdk_helper_ctx_t *phc) {
 
     char dev_name[64];
     if (ctx->config.port_name[i][0] != 0) {
-      snprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
+      ssnprintf(dev_name, sizeof(dev_name), "%s", ctx->config.port_name[i]);
     } else {
-      snprintf(dev_name, sizeof(dev_name), "port.%d", i);
+      ssnprintf(dev_name, sizeof(dev_name), "port.%d", i);
     }
 
     DEBUG(" === Dispatch stats for port %d (name=%s; stats_count=%d)", i,

--- a/src/email.c
+++ b/src/email.c
@@ -174,16 +174,18 @@ static int email_config(const char *key, const char *value) {
     long int tmp = strtol(value, NULL, 0);
 
     if (tmp < 1) {
-      fprintf(stderr, "email plugin: `MaxConns' was set to invalid "
-                      "value %li, will use default %i.\n",
+      fprintf(stderr,
+              "email plugin: `MaxConns' was set to invalid "
+              "value %li, will use default %i.\n",
               tmp, MAX_CONNS);
       ERROR("email plugin: `MaxConns' was set to invalid "
             "value %li, will use default %i.\n",
             tmp, MAX_CONNS);
       max_conns = MAX_CONNS;
     } else if (tmp > MAX_CONNS_LIMIT) {
-      fprintf(stderr, "email plugin: `MaxConns' was set to invalid "
-                      "value %li, will use hardcoded limit %i.\n",
+      fprintf(stderr,
+              "email plugin: `MaxConns' was set to invalid "
+              "value %li, will use hardcoded limit %i.\n",
               tmp, MAX_CONNS_LIMIT);
       ERROR("email plugin: `MaxConns' was set to invalid "
             "value %li, will use hardcoded limit %i.\n",

--- a/src/exec.c
+++ b/src/exec.c
@@ -754,8 +754,9 @@ static void *exec_notification_one(void *arg) /* {{{ */
   else if (n->severity == NOTIF_OKAY)
     severity = "OKAY";
 
-  fprintf(fh, "Severity: %s\n"
-              "Time: %.3f\n",
+  fprintf(fh,
+          "Severity: %s\n"
+          "Time: %.3f\n",
           severity, CDTIME_T_TO_DOUBLE(n->time));
 
   /* Print the optional fields */

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -659,9 +659,7 @@ static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
     break;
   }
 
-  default: {
-    return -1;
-  }
+  default: { return -1; }
   }
 
   return 0;

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -397,7 +397,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
   if (staging_tree == NULL)
     return NULL;
 
-  snprintf(key, sizeof(key), "%s/%s/%s", host, type,
+  ssnprintf(key, sizeof(key), "%s/%s/%s", host, type,
            (type_instance != NULL) ? type_instance : "");
 
   se = NULL;

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -398,7 +398,7 @@ static staging_entry_t *staging_entry_get(const char *host, /* {{{ */
     return NULL;
 
   ssnprintf(key, sizeof(key), "%s/%s/%s", host, type,
-           (type_instance != NULL) ? type_instance : "");
+            (type_instance != NULL) ? type_instance : "");
 
   se = NULL;
   status = c_avl_get(staging_tree, key, (void *)&se);
@@ -659,7 +659,9 @@ static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
     break;
   }
 
-  default: { return -1; }
+  default: {
+    return -1;
+  }
   }
 
   return 0;

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -54,7 +54,8 @@ static char *nv_errline = "";
 #define KEY_IGNORESELECTED "IgnoreSelected"
 
 static const char *config_keys[] = {
-    KEY_GPUINDEX, KEY_IGNORESELECTED,
+    KEY_GPUINDEX,
+    KEY_IGNORESELECTED,
 };
 static const unsigned int n_config_keys = STATIC_ARRAY_SIZE(config_keys);
 

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -26,8 +26,8 @@
  *   Kamil Wiatrowski <kamilx.wiatrowski@intel.com>
  **/
 
-#include "collectd.h"
 #include "utils/common/common.h"
+#include "collectd.h"
 
 #include "utils/config_cores/config_cores.h"
 

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -26,8 +26,8 @@
  *   Kamil Wiatrowski <kamilx.wiatrowski@intel.com>
  **/
 
-#include "utils/common/common.h"
 #include "collectd.h"
+#include "utils/common/common.h"
 
 #include "utils/config_cores/config_cores.h"
 

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -28,11 +28,11 @@
  *   Michał Aleksiński <michalx.aleksinski@intel.com>
  **/
 
-#include "collectd.h"
+#include <pqos.h>
 #include "utils/common/common.h"
 #include "utils/config_cores/config_cores.h"
 #include "utils/proc_pids/proc_pids.h"
-#include <pqos.h>
+#include "collectd.h"
 
 #define RDT_PLUGIN "intel_rdt"
 

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -28,11 +28,11 @@
  *   Michał Aleksiński <michalx.aleksinski@intel.com>
  **/
 
-#include <pqos.h>
+#include "collectd.h"
 #include "utils/common/common.h"
 #include "utils/config_cores/config_cores.h"
 #include "utils/proc_pids/proc_pids.h"
-#include "collectd.h"
+#include <pqos.h>
 
 #define RDT_PLUGIN "intel_rdt"
 
@@ -851,9 +851,9 @@ static void rdt_init_pids_monitoring() {
     }
 
     /* update global proc_pids table */
-    proc_pids_t **proc_pids =
-        realloc(g_rdt->proc_pids, (g_rdt->num_proc_pids + ng->num_names) *
-                                      sizeof(*g_rdt->proc_pids));
+    proc_pids_t **proc_pids = realloc(g_rdt->proc_pids,
+                                      (g_rdt->num_proc_pids + ng->num_names) *
+                                          sizeof(*g_rdt->proc_pids));
     if (NULL == proc_pids) {
       ERROR(RDT_PLUGIN ": Alloc error\n");
       continue;

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -145,7 +145,7 @@ static void rdt_dump_cgroups(void) {
     memset(cores, 0, sizeof(cores));
     for (size_t j = 0; j < cgroup->num_cores; j++) {
       ssnprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
-               cgroup->cores[j]);
+                cgroup->cores[j]);
     }
 
     DEBUG(RDT_PLUGIN ":  group[%zu]:", i);
@@ -172,7 +172,7 @@ static void rdt_dump_ngroups(void) {
     memset(names, 0, sizeof(names));
     for (size_t j = 0; j < g_rdt->ngroups[i].num_names; j++)
       ssnprintf(names + strlen(names), sizeof(names) - strlen(names) - 1, " %s",
-               g_rdt->ngroups[i].names[j]);
+                g_rdt->ngroups[i].names[j]);
 
     DEBUG(RDT_PLUGIN ":  group[%d]:", (int)i);
     DEBUG(RDT_PLUGIN ":    description: %s", g_rdt->ngroups[i].desc);
@@ -250,7 +250,7 @@ static void rdt_dump_pids_data(void) {
       pids_list_t *list = g_rdt->ngroups[i].proc_pids[j]->curr;
       for (size_t k = 0; k < list->size; k++)
         ssnprintf(pids + strlen(pids), sizeof(pids) - strlen(pids) - 1, " %u",
-                 list->pids[k]);
+                  list->pids[k]);
     }
     DEBUG(RDT_PLUGIN ":  [%s] %s", g_rdt->ngroups[i].desc, pids);
   }
@@ -851,9 +851,9 @@ static void rdt_init_pids_monitoring() {
     }
 
     /* update global proc_pids table */
-    proc_pids_t **proc_pids = realloc(g_rdt->proc_pids,
-                                      (g_rdt->num_proc_pids + ng->num_names) *
-                                          sizeof(*g_rdt->proc_pids));
+    proc_pids_t **proc_pids =
+        realloc(g_rdt->proc_pids, (g_rdt->num_proc_pids + ng->num_names) *
+                                      sizeof(*g_rdt->proc_pids));
     if (NULL == proc_pids) {
       ERROR(RDT_PLUGIN ": Alloc error\n");
       continue;

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -851,9 +851,9 @@ static void rdt_init_pids_monitoring() {
     }
 
     /* update global proc_pids table */
-    proc_pids_t **proc_pids = realloc(g_rdt->proc_pids,
-                                      (g_rdt->num_proc_pids + ng->num_names) *
-                                          sizeof(*g_rdt->proc_pids));
+    proc_pids_t **proc_pids =
+        realloc(g_rdt->proc_pids, (g_rdt->num_proc_pids + ng->num_names) *
+                                      sizeof(*g_rdt->proc_pids));
     if (NULL == proc_pids) {
       ERROR(RDT_PLUGIN ": Alloc error\n");
       continue;

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -105,7 +105,7 @@ static void rdt_submit_derive(const char *cgroup, const char *type,
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, RDT_PLUGIN, sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
   sstrncpy(vl.type, type, sizeof(vl.type));
   if (type_instance)
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
@@ -121,7 +121,7 @@ static void rdt_submit_gauge(const char *cgroup, const char *type,
   vl.values_len = 1;
 
   sstrncpy(vl.plugin, RDT_PLUGIN, sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s", cgroup);
   sstrncpy(vl.type, type, sizeof(vl.type));
   if (type_instance)
     sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
@@ -144,7 +144,7 @@ static void rdt_dump_cgroups(void) {
 
     memset(cores, 0, sizeof(cores));
     for (size_t j = 0; j < cgroup->num_cores; j++) {
-      snprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
+      ssnprintf(cores + strlen(cores), sizeof(cores) - strlen(cores) - 1, " %d",
                cgroup->cores[j]);
     }
 
@@ -171,7 +171,7 @@ static void rdt_dump_ngroups(void) {
   for (size_t i = 0; i < g_rdt->num_ngroups; i++) {
     memset(names, 0, sizeof(names));
     for (size_t j = 0; j < g_rdt->ngroups[i].num_names; j++)
-      snprintf(names + strlen(names), sizeof(names) - strlen(names) - 1, " %s",
+      ssnprintf(names + strlen(names), sizeof(names) - strlen(names) - 1, " %s",
                g_rdt->ngroups[i].names[j]);
 
     DEBUG(RDT_PLUGIN ":  group[%d]:", (int)i);
@@ -249,7 +249,7 @@ static void rdt_dump_pids_data(void) {
     for (size_t j = 0; j < g_rdt->ngroups[i].num_names; ++j) {
       pids_list_t *list = g_rdt->ngroups[i].proc_pids[j]->curr;
       for (size_t k = 0; k < list->size; k++)
-        snprintf(pids + strlen(pids), sizeof(pids) - strlen(pids) - 1, " %u",
+        ssnprintf(pids + strlen(pids), sizeof(pids) - strlen(pids) - 1, " %u",
                  list->pids[k]);
     }
     DEBUG(RDT_PLUGIN ":  [%s] %s", g_rdt->ngroups[i].desc, pids);
@@ -922,7 +922,7 @@ static int rdt_default_cgroups(void) {
     cgroup->num_cores = 1;
     cgroup->cores[0] = i;
 
-    snprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
+    ssnprintf(desc, sizeof(desc), "%d", g_rdt->pqos_cpu->cores[i].lcore);
     cgroup->desc = strdup(desc);
     if (cgroup->desc == NULL) {
       ERROR(RDT_PLUGIN ": Error allocating core group description");

--- a/src/intel_rdt_test.c
+++ b/src/intel_rdt_test.c
@@ -122,7 +122,8 @@ DEF_TEST(rdt_config_ngroups__one_process) {
       {.value.string = "proc1", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -147,7 +148,8 @@ DEF_TEST(rdt_config_ngroups__two_groups) {
       {.value.string = "proc21,proc22,proc23", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -178,7 +180,8 @@ DEF_TEST(rdt_config_ngroups__too_long_proc_name) {
       {.value.string = "_seventeen_chars_", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -200,7 +203,8 @@ DEF_TEST(rdt_config_ngroups__duplicate_proc_name_between_groups) {
       {.value.string = "proc21,proc,proc23", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -221,7 +225,8 @@ DEF_TEST(rdt_config_ngroups__duplicate_proc_name_in_group) {
       {.value.string = "proc11,proc,proc,proc14", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -244,7 +249,8 @@ DEF_TEST(rdt_config_ngroups__empty_group) {
 
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */
@@ -265,7 +271,8 @@ DEF_TEST(rdt_config_ngroups__empty_proc_name) {
       {.value.string = "proc11,,proc13", .type = OCONFIG_TYPE_STRING},
   };
   oconfig_item_t config_item = {
-      .values = values, .values_num = STATIC_ARRAY_SIZE(values),
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
   };
 
   /* check */

--- a/src/interface.c
+++ b/src/interface.c
@@ -82,9 +82,7 @@ static int pnif;
  * (Module-)Global variables
  */
 static const char *config_keys[] = {
-    "Interface",
-    "IgnoreSelected",
-    "ReportInactive",
+    "Interface", "IgnoreSelected", "ReportInactive",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -162,8 +160,7 @@ static void if_submit(const char *dev, const char *type, derive_t rx,
                       derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx},
-      {.derive = tx},
+      {.derive = rx}, {.derive = tx},
   };
 
   if (ignorelist_match(ignorelist, dev) != 0)
@@ -191,7 +188,7 @@ static int interface_read(void) {
 #define IFA_TX_PACKT ifi_opackets
 #define IFA_RX_ERROR ifi_ierrors
 #define IFA_TX_ERROR ifi_oerrors
-  /* #endif HAVE_STRUCT_IF_DATA */
+/* #endif HAVE_STRUCT_IF_DATA */
 
 #elif HAVE_STRUCT_NET_DEVICE_STATS
 #define IFA_DATA net_device_stats
@@ -229,7 +226,7 @@ static int interface_read(void) {
   }
 
   freeifaddrs(if_list);
-  /* #endif HAVE_GETIFADDRS */
+/* #endif HAVE_GETIFADDRS */
 
 #elif KERNEL_LINUX
   FILE *fh;
@@ -285,7 +282,7 @@ static int interface_read(void) {
   }
 
   fclose(fh);
-  /* #endif KERNEL_LINUX */
+/* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
   derive_t rx;
@@ -335,7 +332,7 @@ static int interface_read(void) {
     if ((rx != -1LL) || (tx != -1LL))
       if_submit(iname, "if_errors", rx, tx);
   }
-  /* #endif HAVE_LIBKSTAT */
+/* #endif HAVE_LIBKSTAT */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_network_io_stats *ios;
@@ -348,7 +345,7 @@ static int interface_read(void) {
       continue;
     if_submit(ios[i].interface_name, "if_octets", ios[i].rx, ios[i].tx);
   }
-  /* #endif HAVE_LIBSTATGRAB */
+/* #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT)
   perfstat_id_t id;

--- a/src/interface.c
+++ b/src/interface.c
@@ -82,7 +82,9 @@ static int pnif;
  * (Module-)Global variables
  */
 static const char *config_keys[] = {
-    "Interface", "IgnoreSelected", "ReportInactive",
+    "Interface",
+    "IgnoreSelected",
+    "ReportInactive",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -160,7 +162,8 @@ static void if_submit(const char *dev, const char *type, derive_t rx,
                       derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   if (ignorelist_match(ignorelist, dev) != 0)
@@ -188,7 +191,7 @@ static int interface_read(void) {
 #define IFA_TX_PACKT ifi_opackets
 #define IFA_RX_ERROR ifi_ierrors
 #define IFA_TX_ERROR ifi_oerrors
-/* #endif HAVE_STRUCT_IF_DATA */
+  /* #endif HAVE_STRUCT_IF_DATA */
 
 #elif HAVE_STRUCT_NET_DEVICE_STATS
 #define IFA_DATA net_device_stats
@@ -226,7 +229,7 @@ static int interface_read(void) {
   }
 
   freeifaddrs(if_list);
-/* #endif HAVE_GETIFADDRS */
+  /* #endif HAVE_GETIFADDRS */
 
 #elif KERNEL_LINUX
   FILE *fh;
@@ -282,7 +285,7 @@ static int interface_read(void) {
   }
 
   fclose(fh);
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
   derive_t rx;
@@ -298,7 +301,7 @@ static int interface_read(void) {
 
     if (unique_name)
       ssnprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
-               ksp[i]->ks_instance, ksp[i]->ks_name);
+                ksp[i]->ks_instance, ksp[i]->ks_name);
     else
       sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));
 
@@ -332,7 +335,7 @@ static int interface_read(void) {
     if ((rx != -1LL) || (tx != -1LL))
       if_submit(iname, "if_errors", rx, tx);
   }
-/* #endif HAVE_LIBKSTAT */
+  /* #endif HAVE_LIBKSTAT */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_network_io_stats *ios;
@@ -345,7 +348,7 @@ static int interface_read(void) {
       continue;
     if_submit(ios[i].interface_name, "if_octets", ios[i].rx, ios[i].tx);
   }
-/* #endif HAVE_LIBSTATGRAB */
+  /* #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT)
   perfstat_id_t id;

--- a/src/interface.c
+++ b/src/interface.c
@@ -297,7 +297,7 @@ static int interface_read(void) {
       continue;
 
     if (unique_name)
-      snprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
+      ssnprintf(iname, sizeof(iname), "%s_%d_%s", ksp[i]->ks_module,
                ksp[i]->ks_instance, ksp[i]->ks_name);
     else
       sstrncpy(iname, ksp[i]->ks_name, sizeof(iname));

--- a/src/interface.c
+++ b/src/interface.c
@@ -82,7 +82,9 @@ static int pnif;
  * (Module-)Global variables
  */
 static const char *config_keys[] = {
-    "Interface", "IgnoreSelected", "ReportInactive",
+    "Interface",
+    "IgnoreSelected",
+    "ReportInactive",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -160,7 +162,8 @@ static void if_submit(const char *dev, const char *type, derive_t rx,
                       derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   if (ignorelist_match(ignorelist, dev) != 0)
@@ -188,7 +191,7 @@ static int interface_read(void) {
 #define IFA_TX_PACKT ifi_opackets
 #define IFA_RX_ERROR ifi_ierrors
 #define IFA_TX_ERROR ifi_oerrors
-/* #endif HAVE_STRUCT_IF_DATA */
+  /* #endif HAVE_STRUCT_IF_DATA */
 
 #elif HAVE_STRUCT_NET_DEVICE_STATS
 #define IFA_DATA net_device_stats
@@ -226,7 +229,7 @@ static int interface_read(void) {
   }
 
   freeifaddrs(if_list);
-/* #endif HAVE_GETIFADDRS */
+  /* #endif HAVE_GETIFADDRS */
 
 #elif KERNEL_LINUX
   FILE *fh;
@@ -282,7 +285,7 @@ static int interface_read(void) {
   }
 
   fclose(fh);
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
   derive_t rx;
@@ -332,7 +335,7 @@ static int interface_read(void) {
     if ((rx != -1LL) || (tx != -1LL))
       if_submit(iname, "if_errors", rx, tx);
   }
-/* #endif HAVE_LIBKSTAT */
+    /* #endif HAVE_LIBKSTAT */
 
 #elif defined(HAVE_LIBSTATGRAB)
   sg_network_io_stats *ios;
@@ -345,7 +348,7 @@ static int interface_read(void) {
       continue;
     if_submit(ios[i].interface_name, "if_octets", ios[i].rx, ios[i].tx);
   }
-/* #endif HAVE_LIBSTATGRAB */
+    /* #endif HAVE_LIBSTATGRAB */
 
 #elif defined(HAVE_PERFSTAT)
   perfstat_id_t id;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -173,8 +173,8 @@ static int ipc_init(void) /* {{{ */
   pagesize_g = sysconf(_SC_PAGESIZE);
   return 0;
 }
-/* }}} */
-/* #endif KERNEL_LINUX */
+  /* }}} */
+  /* #endif KERNEL_LINUX */
 
 #elif KERNEL_AIX
 static caddr_t ipc_get_info(cid_t cid, int cmd, int version, int stsize,

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -202,7 +202,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
                    sizeof(n.type_instance));
           sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
           ssnprintf(n.message, sizeof(n.message), "sensor %s not present",
-                   list_item->sensor_name);
+                    list_item->sensor_name);
 
           plugin_dispatch_notification(&n);
         }
@@ -255,7 +255,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
                sizeof(n.type_instance));
       sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
       ssnprintf(n.message, sizeof(n.message), "sensor %s present",
-               list_item->sensor_name);
+                list_item->sensor_name);
 
       plugin_dispatch_notification(&n);
     }
@@ -313,7 +313,8 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
   temp[sizeof(temp) - 1] = '\0';
 
   if (entity_id_string != NULL && strlen(temp))
-    ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", temp, entity_id_string);
+    ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", temp,
+              entity_id_string);
   else if (entity_id_string != NULL)
     sstrncpy(sensor_name, entity_id_string, sizeof(sensor_name));
   else
@@ -339,7 +340,7 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
       if (sensor_id_ptr != NULL) {
         /* `sensor_id_ptr' now points to "(123)". */
         ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
-                 sensor_id_ptr);
+                  sensor_id_ptr);
       }
       /* else: don't touch sensor_name. */
     }
@@ -494,7 +495,7 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
      and add the `percent` to the type instance of the reported value */
   if (ipmi_sensor_get_percentage(sensor)) {
     ssnprintf(list_item->type_instance, sizeof(list_item->type_instance),
-             "percent-%s", sensor_name_ptr);
+              "percent-%s", sensor_name_ptr);
     type = "percent";
   } else {
     /* use type instance as a name of the sensor */
@@ -515,7 +516,7 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
     ssnprintf(n.message, sizeof(n.message), "sensor %s added",
-             list_item->sensor_name);
+              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }
@@ -562,7 +563,7 @@ static int sensor_list_remove(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
     ssnprintf(n.message, sizeof(n.message), "sensor %s removed",
-             list_item->sensor_name);
+              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
   }
@@ -675,12 +676,12 @@ static int sensor_threshold_event_handler(
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
   if (value_present != IPMI_NO_VALUES_PRESENT)
     ssnprintf(n.message, sizeof(n.message),
-             "sensor %s received event: %s, value is %f", n.type_instance,
-             event_state, value);
+              "sensor %s received event: %s, value is %f", n.type_instance,
+              event_state, value);
   else
     ssnprintf(n.message, sizeof(n.message),
-             "sensor %s received event: %s, value not provided",
-             n.type_instance, event_state);
+              "sensor %s received event: %s, value not provided",
+              n.type_instance, event_state);
 
   DEBUG("Threshold event received for sensor %s", n.type_instance);
 
@@ -742,7 +743,7 @@ static int sensor_discrete_event_handler(ipmi_sensor_t *sensor,
       ipmi_get_reading_name(event_type, sensor_type, offset);
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
   ssnprintf(n.message, sizeof(n.message), "sensor %s received event: %s",
-           n.type_instance, event_state);
+            n.type_instance, event_state);
 
   DEBUG("Discrete event received for sensor %s", n.type_instance);
 

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -111,7 +111,7 @@ static void c_ipmi_error(c_ipmi_instance_t *st, const char *func, int status) {
   }
 
   if (errbuf[0] == 0) {
-    snprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
+    ssnprintf(errbuf, sizeof(errbuf), "Unknown error %#x", status);
   }
   errbuf[sizeof(errbuf) - 1] = '\0';
 
@@ -201,7 +201,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
           sstrncpy(n.type_instance, list_item->type_instance,
                    sizeof(n.type_instance));
           sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-          snprintf(n.message, sizeof(n.message), "sensor %s not present",
+          ssnprintf(n.message, sizeof(n.message), "sensor %s not present",
                    list_item->sensor_name);
 
           plugin_dispatch_notification(&n);
@@ -254,7 +254,7 @@ static void sensor_read_handler(ipmi_sensor_t *sensor, int err,
       sstrncpy(n.type_instance, list_item->type_instance,
                sizeof(n.type_instance));
       sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-      snprintf(n.message, sizeof(n.message), "sensor %s present",
+      ssnprintf(n.message, sizeof(n.message), "sensor %s present",
                list_item->sensor_name);
 
       plugin_dispatch_notification(&n);
@@ -313,7 +313,7 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
   temp[sizeof(temp) - 1] = '\0';
 
   if (entity_id_string != NULL && strlen(temp))
-    snprintf(sensor_name, sizeof(sensor_name), "%s %s", temp, entity_id_string);
+    ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", temp, entity_id_string);
   else if (entity_id_string != NULL)
     sstrncpy(sensor_name, entity_id_string, sizeof(sensor_name));
   else
@@ -338,7 +338,7 @@ static void sensor_get_name(ipmi_sensor_t *sensor, char *buffer, int buf_len) {
       sensor_id_ptr = strstr(temp, "(");
       if (sensor_id_ptr != NULL) {
         /* `sensor_id_ptr' now points to "(123)". */
-        snprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
+        ssnprintf(sensor_name, sizeof(sensor_name), "%s %s", sensor_name_ptr,
                  sensor_id_ptr);
       }
       /* else: don't touch sensor_name. */
@@ -493,7 +493,7 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
   /* if sensor provides the percentage value, use "percent" collectd type
      and add the `percent` to the type instance of the reported value */
   if (ipmi_sensor_get_percentage(sensor)) {
-    snprintf(list_item->type_instance, sizeof(list_item->type_instance),
+    ssnprintf(list_item->type_instance, sizeof(list_item->type_instance),
              "percent-%s", sensor_name_ptr);
     type = "percent";
   } else {
@@ -514,7 +514,7 @@ static int sensor_list_add(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->type_instance,
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    snprintf(n.message, sizeof(n.message), "sensor %s added",
+    ssnprintf(n.message, sizeof(n.message), "sensor %s added",
              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
@@ -561,7 +561,7 @@ static int sensor_list_remove(c_ipmi_instance_t *st, ipmi_sensor_t *sensor) {
     sstrncpy(n.type_instance, list_item->type_instance,
              sizeof(n.type_instance));
     sstrncpy(n.type, list_item->sensor_type, sizeof(n.type));
-    snprintf(n.message, sizeof(n.message), "sensor %s removed",
+    ssnprintf(n.message, sizeof(n.message), "sensor %s removed",
              list_item->sensor_name);
 
     plugin_dispatch_notification(&n);
@@ -674,11 +674,11 @@ static int sensor_threshold_event_handler(
       ipmi_get_reading_name(event_type, sensor_type, offset);
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
   if (value_present != IPMI_NO_VALUES_PRESENT)
-    snprintf(n.message, sizeof(n.message),
+    ssnprintf(n.message, sizeof(n.message),
              "sensor %s received event: %s, value is %f", n.type_instance,
              event_state, value);
   else
-    snprintf(n.message, sizeof(n.message),
+    ssnprintf(n.message, sizeof(n.message),
              "sensor %s received event: %s, value not provided",
              n.type_instance, event_state);
 
@@ -699,7 +699,7 @@ static int sensor_threshold_event_handler(
   /* both values present, so fall-through to add raw value too */
   case IPMI_RAW_VALUE_PRESENT: {
     char buf[DATA_MAX_NAME_LEN] = {0};
-    snprintf(buf, sizeof(buf), "0x%2.2x", raw_value);
+    ssnprintf(buf, sizeof(buf), "0x%2.2x", raw_value);
     plugin_notification_meta_add_string(&n, "raw", buf);
   } break;
   default:
@@ -741,7 +741,7 @@ static int sensor_discrete_event_handler(ipmi_sensor_t *sensor,
   const char *event_state =
       ipmi_get_reading_name(event_type, sensor_type, offset);
   sensor_get_name(sensor, n.type_instance, sizeof(n.type_instance));
-  snprintf(n.message, sizeof(n.message), "sensor %s received event: %s",
+  ssnprintf(n.message, sizeof(n.message), "sensor %s received event: %s",
            n.type_instance, event_state);
 
   DEBUG("Discrete event received for sensor %s", n.type_instance);
@@ -1253,7 +1253,7 @@ static int c_ipmi_init(void) {
     /* The `st->name` is used as "domain name" for ipmi_open_domain().
      * That value should be unique, so we do plugin_register_complex_read()
      * at first as it checks the uniqueness. */
-    snprintf(callback_name, sizeof(callback_name), "ipmi/%s", st->name);
+    ssnprintf(callback_name, sizeof(callback_name), "ipmi/%s", st->name);
 
     user_data_t ud = {
         .data = st,

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -221,7 +221,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
 
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
 
-  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
@@ -230,7 +230,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
@@ -269,7 +269,7 @@ static int submit_match(const struct ipt_entry_match *match,
 
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
 
-  status = snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
@@ -278,7 +278,7 @@ static int submit_match(const struct ipt_entry_match *match,
     sstrncpy(vl.type_instance, chain->name, sizeof(vl.type_instance));
   } else {
     if (chain->rule_type == RTYPE_NUM)
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));

--- a/src/iptables.c
+++ b/src/iptables.c
@@ -222,7 +222,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   sstrncpy(vl.plugin, "ip6tables", sizeof(vl.plugin));
 
   status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                    chain->table, chain->chain);
+                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -231,7 +231,7 @@ static int submit6_match(const struct ip6t_entry_match *match,
   } else {
     if (chain->rule_type == RTYPE_NUM)
       ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-               chain->rule.num);
+                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }
@@ -270,7 +270,7 @@ static int submit_match(const struct ipt_entry_match *match,
   sstrncpy(vl.plugin, "iptables", sizeof(vl.plugin));
 
   status = ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-                    chain->table, chain->chain);
+                     chain->table, chain->chain);
   if ((status < 1) || ((unsigned int)status >= sizeof(vl.plugin_instance)))
     return 0;
 
@@ -279,7 +279,7 @@ static int submit_match(const struct ipt_entry_match *match,
   } else {
     if (chain->rule_type == RTYPE_NUM)
       ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%i",
-               chain->rule.num);
+                chain->rule.num);
     else
       sstrncpy(vl.type_instance, (char *)match->data, sizeof(vl.type_instance));
   }

--- a/src/ipvs.c
+++ b/src/ipvs.c
@@ -207,7 +207,8 @@ static void cipvs_submit_connections(const char *pi, const char *ti,
 static void cipvs_submit_if(const char *pi, const char *t, const char *ti,
                             derive_t rx, derive_t tx) {
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
   value_list_t vl = VALUE_LIST_INIT;
 

--- a/src/java.c
+++ b/src/java.c
@@ -1306,7 +1306,8 @@ static jint JNICALL cjni_api_register_read(JNIEnv *jvm_env, /* {{{ */
       /* group = */ NULL, cbi->name, cjni_read,
       /* interval = */ 0,
       &(user_data_t){
-          .data = cbi, .free_func = cjni_callback_info_destroy,
+          .data = cbi,
+          .free_func = cjni_callback_info_destroy,
       });
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_read);
@@ -1325,11 +1326,11 @@ static jint JNICALL cjni_api_register_write(JNIEnv *jvm_env, /* {{{ */
 
   DEBUG("java plugin: Registering new write callback: %s", cbi->name);
 
-  plugin_register_write(
-      cbi->name, cjni_write,
-      &(user_data_t){
-          .data = cbi, .free_func = cjni_callback_info_destroy,
-      });
+  plugin_register_write(cbi->name, cjni_write,
+                        &(user_data_t){
+                            .data = cbi,
+                            .free_func = cjni_callback_info_destroy,
+                        });
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_write);
 
@@ -1347,11 +1348,11 @@ static jint JNICALL cjni_api_register_flush(JNIEnv *jvm_env, /* {{{ */
 
   DEBUG("java plugin: Registering new flush callback: %s", cbi->name);
 
-  plugin_register_flush(
-      cbi->name, cjni_flush,
-      &(user_data_t){
-          .data = cbi, .free_func = cjni_callback_info_destroy,
-      });
+  plugin_register_flush(cbi->name, cjni_flush,
+                        &(user_data_t){
+                            .data = cbi,
+                            .free_func = cjni_callback_info_destroy,
+                        });
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_flush);
 
@@ -1377,7 +1378,8 @@ static jint JNICALL cjni_api_register_log(JNIEnv *jvm_env, /* {{{ */
 
   plugin_register_log(cbi->name, cjni_log,
                       &(user_data_t){
-                          .data = cbi, .free_func = cjni_callback_info_destroy,
+                          .data = cbi,
+                          .free_func = cjni_callback_info_destroy,
                       });
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_log);
@@ -1397,11 +1399,11 @@ static jint JNICALL cjni_api_register_notification(JNIEnv *jvm_env, /* {{{ */
 
   DEBUG("java plugin: Registering new notification callback: %s", cbi->name);
 
-  plugin_register_notification(
-      cbi->name, cjni_notification,
-      &(user_data_t){
-          .data = cbi, .free_func = cjni_callback_info_destroy,
-      });
+  plugin_register_notification(cbi->name, cjni_notification,
+                               &(user_data_t){
+                                   .data = cbi,
+                                   .free_func = cjni_callback_info_destroy,
+                               });
 
   (*jvm_env)->DeleteLocalRef(jvm_env, o_notification);
 
@@ -1543,16 +1545,19 @@ static JNINativeMethod jni_api_functions[] = /* {{{ */
          "(Ljava/lang/String;Lorg/collectd/api/CollectdLogInterface;)I",
          cjni_api_register_log},
 
-        {"registerNotification", "(Ljava/lang/String;Lorg/collectd/api/"
-                                 "CollectdNotificationInterface;)I",
+        {"registerNotification",
+         "(Ljava/lang/String;Lorg/collectd/api/"
+         "CollectdNotificationInterface;)I",
          cjni_api_register_notification},
 
-        {"registerMatch", "(Ljava/lang/String;Lorg/collectd/api/"
-                          "CollectdMatchFactoryInterface;)I",
+        {"registerMatch",
+         "(Ljava/lang/String;Lorg/collectd/api/"
+         "CollectdMatchFactoryInterface;)I",
          cjni_api_register_match},
 
-        {"registerTarget", "(Ljava/lang/String;Lorg/collectd/api/"
-                           "CollectdTargetFactoryInterface;)I",
+        {"registerTarget",
+         "(Ljava/lang/String;Lorg/collectd/api/"
+         "CollectdTargetFactoryInterface;)I",
          cjni_api_register_target},
 
         {"log", "(ILjava/lang/String;)V", cjni_api_log},

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -147,7 +147,7 @@ static char *sstrerror(int errnum, char *buf, size_t buflen) {
 
 #if !HAVE_STRERROR_R
   snprintf(buf, buflen, "Error #%i; strerror_r is not available.", errnum);
-/* #endif !HAVE_STRERROR_R */
+  /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -157,17 +157,19 @@ static char *sstrerror(int errnum, char *buf, size_t buflen) {
       if ((temp != NULL) && (temp != buf) && (temp[0] != 0))
         strncpy(buf, temp, buflen);
       else
-        strncpy(buf, "strerror_r did not return "
-                     "an error message",
+        strncpy(buf,
+                "strerror_r did not return "
+                "an error message",
                 buflen);
     }
   }
-/* #endif STRERROR_R_CHAR_P */
+    /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
-    snprintf(buf, buflen, "Error #%i; "
-                          "Additionally, strerror_r failed.",
+    snprintf(buf, buflen,
+             "Error #%i; "
+             "Additionally, strerror_r failed.",
              errnum);
   }
 #endif /* STRERROR_R_CHAR_P */

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -293,7 +293,8 @@ static double ntohd(double val) /* {{{ */
 static int parse_values(void *payload, size_t payload_size,
                         lcc_value_list_t *state) {
   buffer_t *b = &(buffer_t){
-      .data = payload, .len = payload_size,
+      .data = payload,
+      .len = payload_size,
   };
 
   uint16_t n;
@@ -401,7 +402,8 @@ static int parse_sign_sha256(void *signature, size_t signature_len,
   }
 
   buffer_t *b = &(buffer_t){
-      .data = signature, .len = signature_len,
+      .data = signature,
+      .len = signature_len,
   };
 
   uint8_t hash[32];
@@ -459,7 +461,8 @@ static int parse_encrypt_aes256(void *data, size_t data_size,
   }
 
   buffer_t *b = &(buffer_t){
-      .data = data, .len = data_size,
+      .data = data,
+      .len = data_size,
   };
 
   uint16_t username_len;
@@ -508,7 +511,8 @@ static int parse_encrypt_aes256(void *data, size_t data_size,
 static int network_parse(void *data, size_t data_size, lcc_security_level_t sl,
                          lcc_network_parse_options_t const *opts) {
   buffer_t *b = &(buffer_t){
-      .data = data, .len = data_size,
+      .data = data,
+      .len = data_size,
   };
 
   lcc_value_list_t state = {0};

--- a/src/libcollectdclient/network_parse_test.c
+++ b/src/libcollectdclient/network_parse_test.c
@@ -245,16 +245,17 @@ static int test_network_parse() {
     uint8_t buffer[LCC_NETWORK_BUFFER_SIZE_DEFAULT];
     size_t buffer_size = sizeof(buffer);
     if (decode_string(raw_packet_data[i], buffer, &buffer_size)) {
-      fprintf(stderr, "lcc_network_parse(raw_packet_data[%" PRIsz "]):"
-                      " decoding string failed\n",
+      fprintf(stderr,
+              "lcc_network_parse(raw_packet_data[%" PRIsz "]):"
+              " decoding string failed\n",
               i);
       return -1;
     }
 
-    int status =
-        lcc_network_parse(buffer, buffer_size, (lcc_network_parse_options_t){
-                                                   .writer = nop_writer,
-                                               });
+    int status = lcc_network_parse(buffer, buffer_size,
+                                   (lcc_network_parse_options_t){
+                                       .writer = nop_writer,
+                                   });
     if (status != 0) {
       fprintf(stderr,
               "lcc_network_parse(raw_packet_data[%" PRIsz "]) = %d, want 0\n",
@@ -466,7 +467,8 @@ static int test_decrypt_aes256() {
 
   int status = decrypt_aes256(
       &(buffer_t){
-          .data = ciphertext, .len = ciphertext_len,
+          .data = ciphertext,
+          .len = ciphertext_len,
       },
       iv, iv_len, "admin");
   if (status != 0) {

--- a/src/liboconfig/aux_types.h
+++ b/src/liboconfig/aux_types.h
@@ -1,17 +1,15 @@
 #ifndef AUX_TYPES_H
 #define AUX_TYPES_H 1
 
-struct statement_list_s
-{
-	oconfig_item_t *statement;
-	int             statement_num;
+struct statement_list_s {
+  oconfig_item_t *statement;
+  int statement_num;
 };
 typedef struct statement_list_s statement_list_t;
 
-struct argument_list_s
-{
-	oconfig_value_t *argument;
-	int              argument_num;
+struct argument_list_s {
+  oconfig_value_t *argument;
+  int argument_num;
 };
 typedef struct argument_list_s argument_list_t;
 

--- a/src/lpar.c
+++ b/src/lpar.c
@@ -224,10 +224,10 @@ static int lpar_read(void) {
     if (pool_busy_cpus < 0.0)
       pool_busy_cpus = 0.0;
 
-    snprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
+    ssnprintf(typinst, sizeof(typinst), "pool-%X-busy", lparstats.pool_id);
     lpar_submit(typinst, pool_busy_cpus);
 
-    snprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
+    ssnprintf(typinst, sizeof(typinst), "pool-%X-idle", lparstats.pool_id);
     lpar_submit(typinst, pool_idle_cpus);
   }
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -28,10 +28,10 @@
  *   Ruben Kerkhof <ruben at rubenkerkhof.com>
  **/
 
-#include "collectd.h"
 #include "plugin.h"
 #include "utils/common/common.h"
 #include "utils_lua.h"
+#include "collectd.h"
 
 /* Include the Lua API header files. */
 #include <lauxlib.h>

--- a/src/lua.c
+++ b/src/lua.c
@@ -28,10 +28,10 @@
  *   Ruben Kerkhof <ruben at rubenkerkhof.com>
  **/
 
+#include "collectd.h"
 #include "plugin.h"
 #include "utils/common/common.h"
 #include "utils_lua.h"
-#include "collectd.h"
 
 /* Include the Lua API header files. */
 #include <lauxlib.h>
@@ -322,14 +322,14 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   pthread_mutex_init(&cb->lock, NULL);
 
   if (PLUGIN_READ == type) {
-    int status = plugin_register_complex_read(/* group = */ "lua",
-                                              /* name      = */ function_name,
-                                              /* callback  = */ clua_read,
-                                              /* interval  = */ 0,
-                                              &(user_data_t){
-                                                  .data = cb,
-                                                  .free_func = lua_cb_free,
-                                              });
+    int status =
+        plugin_register_complex_read(/* group = */ "lua",
+                                     /* name      = */ function_name,
+                                     /* callback  = */ clua_read,
+                                     /* interval  = */ 0,
+                                     &(user_data_t){
+                                         .data = cb, .free_func = lua_cb_free,
+                                     });
 
     if (status != 0)
       return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -338,8 +338,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
     int status = plugin_register_write(/* name = */ function_name,
                                        /* callback  = */ clua_write,
                                        &(user_data_t){
-                                           .data = cb,
-                                           .free_func = lua_cb_free,
+                                           .data = cb, .free_func = lua_cb_free,
                                        });
 
     if (status != 0)

--- a/src/lua.c
+++ b/src/lua.c
@@ -322,14 +322,14 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   pthread_mutex_init(&cb->lock, NULL);
 
   if (PLUGIN_READ == type) {
-    int status =
-        plugin_register_complex_read(/* group = */ "lua",
-                                     /* name      = */ function_name,
-                                     /* callback  = */ clua_read,
-                                     /* interval  = */ 0,
-                                     &(user_data_t){
-                                         .data = cb, .free_func = lua_cb_free,
-                                     });
+    int status = plugin_register_complex_read(/* group = */ "lua",
+                                              /* name      = */ function_name,
+                                              /* callback  = */ clua_read,
+                                              /* interval  = */ 0,
+                                              &(user_data_t){
+                                                  .data = cb,
+                                                  .free_func = lua_cb_free,
+                                              });
 
     if (status != 0)
       return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -338,7 +338,8 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
     int status = plugin_register_write(/* name = */ function_name,
                                        /* callback  = */ clua_write,
                                        &(user_data_t){
-                                           .data = cb, .free_func = lua_cb_free,
+                                           .data = cb,
+                                           .free_func = lua_cb_free,
                                        });
 
     if (status != 0)

--- a/src/lua.c
+++ b/src/lua.c
@@ -299,7 +299,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   lua_getfield(L, LUA_REGISTRYINDEX, "collectd:script_path");
   char function_name[DATA_MAX_NAME_LEN];
   ssnprintf(function_name, sizeof(function_name), "lua/%s/%s",
-           lua_tostring(L, -1), subname);
+            lua_tostring(L, -1), subname);
   lua_pop(L, 1);
 
   int callback_id = clua_store_callback(L, 1);
@@ -322,14 +322,14 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   pthread_mutex_init(&cb->lock, NULL);
 
   if (PLUGIN_READ == type) {
-    int status =
-        plugin_register_complex_read(/* group = */ "lua",
-                                     /* name      = */ function_name,
-                                     /* callback  = */ clua_read,
-                                     /* interval  = */ 0,
-                                     &(user_data_t){
-                                         .data = cb, .free_func = lua_cb_free,
-                                     });
+    int status = plugin_register_complex_read(/* group = */ "lua",
+                                              /* name      = */ function_name,
+                                              /* callback  = */ clua_read,
+                                              /* interval  = */ 0,
+                                              &(user_data_t){
+                                                  .data = cb,
+                                                  .free_func = lua_cb_free,
+                                              });
 
     if (status != 0)
       return luaL_error(L, "%s", "plugin_register_complex_read failed");
@@ -338,7 +338,8 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
     int status = plugin_register_write(/* name = */ function_name,
                                        /* callback  = */ clua_write,
                                        &(user_data_t){
-                                           .data = cb, .free_func = lua_cb_free,
+                                           .data = cb,
+                                           .free_func = lua_cb_free,
                                        });
 
     if (status != 0)

--- a/src/lua.c
+++ b/src/lua.c
@@ -278,7 +278,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   char subname[DATA_MAX_NAME_LEN];
   if (!lua_isfunction(L, 1) && lua_isstring(L, 1)) {
     const char *fname = lua_tostring(L, 1);
-    snprintf(subname, sizeof(subname), "%s()", fname);
+    ssnprintf(subname, sizeof(subname), "%s()", fname);
 
     lua_getglobal(L, fname); // Push function into stack
     lua_remove(L, 1);        // Remove string from stack
@@ -288,7 +288,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
   } else {
     lua_getfield(L, LUA_REGISTRYINDEX, "collectd:callback_num");
     int tmp = lua_tointeger(L, -1);
-    snprintf(subname, sizeof(subname), "callback_%d", tmp);
+    ssnprintf(subname, sizeof(subname), "callback_%d", tmp);
     lua_pop(L, 1); // Remove old value from stack
     lua_pushinteger(L, tmp + 1);
     lua_setfield(L, LUA_REGISTRYINDEX, "collectd:callback_num"); // pops value
@@ -298,7 +298,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
 
   lua_getfield(L, LUA_REGISTRYINDEX, "collectd:script_path");
   char function_name[DATA_MAX_NAME_LEN];
-  snprintf(function_name, sizeof(function_name), "lua/%s/%s",
+  ssnprintf(function_name, sizeof(function_name), "lua/%s/%s",
            lua_tostring(L, -1), subname);
   lua_pop(L, 1);
 
@@ -530,7 +530,7 @@ static int lua_config_script(const oconfig_item_t *ci) /* {{{ */
   if (base_path[0] == '\0')
     sstrncpy(abs_path, rel_path, sizeof(abs_path));
   else
-    snprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
+    ssnprintf(abs_path, sizeof(abs_path), "%s/%s", base_path, rel_path);
 
   DEBUG("Lua plugin: abs_path = \"%s\";", abs_path);
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -81,7 +81,7 @@ static void report_lv_utilization(lv_t lv, char const *vg_name,
     return;
   used_bytes = lv_size * (used_percent_unscaled * PERCENT_SCALE_FACTOR);
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name, lv_name);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name, lv_name);
   lvm_submit(plugin_instance, "used", used_bytes);
   lvm_submit(plugin_instance, "free", lv_size - used_bytes);
 }

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -81,7 +81,8 @@ static void report_lv_utilization(lv_t lv, char const *vg_name,
     return;
   used_bytes = lv_size * (used_percent_unscaled * PERCENT_SCALE_FACTOR);
 
-  ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name, lv_name);
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "%s-%s", vg_name,
+            lv_name);
   lvm_submit(plugin_instance, "used", used_bytes);
   lvm_submit(plugin_instance, "free", lv_size - used_bytes);
 }

--- a/src/madwifi.c
+++ b/src/madwifi.c
@@ -534,7 +534,8 @@ static void submit_derive(const char *dev, const char *type, const char *ti1,
 static void submit_derive2(const char *dev, const char *type, const char *ti1,
                            const char *ti2, derive_t val1, derive_t val2) {
   value_t values[] = {
-      {.derive = val1}, {.derive = val2},
+      {.derive = val1},
+      {.derive = val2},
   };
 
   submit(dev, type, ti1, ti2, values, STATIC_ARRAY_SIZE(values));

--- a/src/madwifi.h
+++ b/src/madwifi.h
@@ -36,166 +36,165 @@
 #ifndef MADWIFI_H
 #define MADWIFI_H
 
-#define	IEEE80211_ADDR_LEN		6		/* size of 802.11 address */
-#define	IEEE80211_RATE_VAL		0x7f
-#define	IEEE80211_RATE_SIZE		8		/* 802.11 standard */
-#define	IEEE80211_RATE_MAXSIZE		15		/* max rates we'll handle */
-
+#define IEEE80211_ADDR_LEN 6 /* size of 802.11 address */
+#define IEEE80211_RATE_VAL 0x7f
+#define IEEE80211_RATE_SIZE 8     /* 802.11 standard */
+#define IEEE80211_RATE_MAXSIZE 15 /* max rates we'll handle */
 
 /*
  * Per/node (station) statistics available when operating as an AP.
  */
 struct ieee80211_nodestats {
-	u_int32_t ns_rx_data;		/* rx data frames */
-	u_int32_t ns_rx_mgmt;		/* rx management frames */
-	u_int32_t ns_rx_ctrl;		/* rx control frames */
-	u_int32_t ns_rx_ucast;		/* rx unicast frames */
-	u_int32_t ns_rx_mcast;		/* rx multi/broadcast frames */
-	u_int64_t ns_rx_bytes;		/* rx data count (bytes) */
-	u_int64_t ns_rx_beacons;	/* rx beacon frames */
-	u_int32_t ns_rx_proberesp;	/* rx probe response frames */
+  u_int32_t ns_rx_data;      /* rx data frames */
+  u_int32_t ns_rx_mgmt;      /* rx management frames */
+  u_int32_t ns_rx_ctrl;      /* rx control frames */
+  u_int32_t ns_rx_ucast;     /* rx unicast frames */
+  u_int32_t ns_rx_mcast;     /* rx multi/broadcast frames */
+  u_int64_t ns_rx_bytes;     /* rx data count (bytes) */
+  u_int64_t ns_rx_beacons;   /* rx beacon frames */
+  u_int32_t ns_rx_proberesp; /* rx probe response frames */
 
-	u_int32_t ns_rx_dup;		/* rx discard because it's a dup */
-	u_int32_t ns_rx_noprivacy;	/* rx w/ wep but privacy off */
-	u_int32_t ns_rx_wepfail;	/* rx wep processing failed */
-	u_int32_t ns_rx_demicfail;	/* rx demic failed */
-	u_int32_t ns_rx_decap;		/* rx decapsulation failed */
-	u_int32_t ns_rx_defrag;		/* rx defragmentation failed */
-	u_int32_t ns_rx_disassoc;	/* rx disassociation */
-	u_int32_t ns_rx_deauth;		/* rx deauthentication */
-	u_int32_t ns_rx_decryptcrc;	/* rx decrypt failed on crc */
-	u_int32_t ns_rx_unauth;		/* rx on unauthorized port */
-	u_int32_t ns_rx_unencrypted;	/* rx unecrypted w/ privacy */
+  u_int32_t ns_rx_dup;         /* rx discard because it's a dup */
+  u_int32_t ns_rx_noprivacy;   /* rx w/ wep but privacy off */
+  u_int32_t ns_rx_wepfail;     /* rx wep processing failed */
+  u_int32_t ns_rx_demicfail;   /* rx demic failed */
+  u_int32_t ns_rx_decap;       /* rx decapsulation failed */
+  u_int32_t ns_rx_defrag;      /* rx defragmentation failed */
+  u_int32_t ns_rx_disassoc;    /* rx disassociation */
+  u_int32_t ns_rx_deauth;      /* rx deauthentication */
+  u_int32_t ns_rx_decryptcrc;  /* rx decrypt failed on crc */
+  u_int32_t ns_rx_unauth;      /* rx on unauthorized port */
+  u_int32_t ns_rx_unencrypted; /* rx unecrypted w/ privacy */
 
-	u_int32_t ns_tx_data;		/* tx data frames */
-	u_int32_t ns_tx_mgmt;		/* tx management frames */
-	u_int32_t ns_tx_ucast;		/* tx unicast frames */
-	u_int32_t ns_tx_mcast;		/* tx multi/broadcast frames */
-	u_int64_t ns_tx_bytes;		/* tx data count (bytes) */
-	u_int32_t ns_tx_probereq;	/* tx probe request frames */
-	u_int32_t ns_tx_uapsd;		/* tx on uapsd queue */
+  u_int32_t ns_tx_data;     /* tx data frames */
+  u_int32_t ns_tx_mgmt;     /* tx management frames */
+  u_int32_t ns_tx_ucast;    /* tx unicast frames */
+  u_int32_t ns_tx_mcast;    /* tx multi/broadcast frames */
+  u_int64_t ns_tx_bytes;    /* tx data count (bytes) */
+  u_int32_t ns_tx_probereq; /* tx probe request frames */
+  u_int32_t ns_tx_uapsd;    /* tx on uapsd queue */
 
-	u_int32_t ns_tx_novlantag;	/* tx discard due to no tag */
-	u_int32_t ns_tx_vlanmismatch;	/* tx discard due to of bad tag */
+  u_int32_t ns_tx_novlantag;    /* tx discard due to no tag */
+  u_int32_t ns_tx_vlanmismatch; /* tx discard due to of bad tag */
 
-	u_int32_t ns_tx_eosplost;	/* uapsd EOSP retried out */
+  u_int32_t ns_tx_eosplost; /* uapsd EOSP retried out */
 
-	u_int32_t ns_ps_discard;	/* ps discard due to of age */
+  u_int32_t ns_ps_discard; /* ps discard due to of age */
 
-	u_int32_t ns_uapsd_triggers;	/* uapsd triggers */
+  u_int32_t ns_uapsd_triggers; /* uapsd triggers */
 
-	/* MIB-related state */
-	u_int32_t ns_tx_assoc;		/* [re]associations */
-	u_int32_t ns_tx_assoc_fail;	/* [re]association failures */
-	u_int32_t ns_tx_auth;		/* [re]authentications */
-	u_int32_t ns_tx_auth_fail;	/* [re]authentication failures*/
-	u_int32_t ns_tx_deauth;		/* deauthentications */
-	u_int32_t ns_tx_deauth_code;	/* last deauth reason */
-	u_int32_t ns_tx_disassoc;	/* disassociations */
-	u_int32_t ns_tx_disassoc_code;	/* last disassociation reason */
-	u_int32_t ns_psq_drops;		/* power save queue drops */
+  /* MIB-related state */
+  u_int32_t ns_tx_assoc;         /* [re]associations */
+  u_int32_t ns_tx_assoc_fail;    /* [re]association failures */
+  u_int32_t ns_tx_auth;          /* [re]authentications */
+  u_int32_t ns_tx_auth_fail;     /* [re]authentication failures*/
+  u_int32_t ns_tx_deauth;        /* deauthentications */
+  u_int32_t ns_tx_deauth_code;   /* last deauth reason */
+  u_int32_t ns_tx_disassoc;      /* disassociations */
+  u_int32_t ns_tx_disassoc_code; /* last disassociation reason */
+  u_int32_t ns_psq_drops;        /* power save queue drops */
 };
 
 /*
  * Summary statistics.
  */
 struct ieee80211_stats {
-	u_int32_t is_rx_badversion;	/* rx frame with bad version */
-	u_int32_t is_rx_tooshort;	/* rx frame too short */
-	u_int32_t is_rx_wrongbss;	/* rx from wrong bssid */
-	u_int32_t is_rx_dup;		/* rx discard due to it's a dup */
-	u_int32_t is_rx_wrongdir;	/* rx w/ wrong direction */
-	u_int32_t is_rx_mcastecho;	/* rx discard due to of mcast echo */
-	u_int32_t is_rx_notassoc;	/* rx discard due to sta !assoc */
-	u_int32_t is_rx_noprivacy;	/* rx w/ wep but privacy off */
-	u_int32_t is_rx_unencrypted;	/* rx w/o wep and privacy on */
-	u_int32_t is_rx_wepfail;	/* rx wep processing failed */
-	u_int32_t is_rx_decap;		/* rx decapsulation failed */
-	u_int32_t is_rx_mgtdiscard;	/* rx discard mgt frames */
-	u_int32_t is_rx_ctl;		/* rx discard ctrl frames */
-	u_int32_t is_rx_beacon;		/* rx beacon frames */
-	u_int32_t is_rx_rstoobig;	/* rx rate set truncated */
-	u_int32_t is_rx_elem_missing;	/* rx required element missing*/
-	u_int32_t is_rx_elem_toobig;	/* rx element too big */
-	u_int32_t is_rx_elem_toosmall;	/* rx element too small */
-	u_int32_t is_rx_elem_unknown;	/* rx element unknown */
-	u_int32_t is_rx_badchan;	/* rx frame w/ invalid chan */
-	u_int32_t is_rx_chanmismatch;	/* rx frame chan mismatch */
-	u_int32_t is_rx_nodealloc;	/* rx frame dropped */
-	u_int32_t is_rx_ssidmismatch;	/* rx frame ssid mismatch  */
-	u_int32_t is_rx_auth_unsupported;/* rx w/ unsupported auth alg */
-	u_int32_t is_rx_auth_fail;	/* rx sta auth failure */
-	u_int32_t is_rx_auth_countermeasures;/* rx auth discard due to CM */
-	u_int32_t is_rx_assoc_bss;	/* rx assoc from wrong bssid */
-	u_int32_t is_rx_assoc_notauth;	/* rx assoc w/o auth */
-	u_int32_t is_rx_assoc_capmismatch;/* rx assoc w/ cap mismatch */
-	u_int32_t is_rx_assoc_norate;	/* rx assoc w/ no rate match */
-	u_int32_t is_rx_assoc_badwpaie;	/* rx assoc w/ bad WPA IE */
-	u_int32_t is_rx_deauth;		/* rx deauthentication */
-	u_int32_t is_rx_disassoc;	/* rx disassociation */
-	u_int32_t is_rx_badsubtype;	/* rx frame w/ unknown subtype*/
-	u_int32_t is_rx_nobuf;		/* rx failed for lack of buf */
-	u_int32_t is_rx_decryptcrc;	/* rx decrypt failed on crc */
-	u_int32_t is_rx_ahdemo_mgt;	/* rx discard ahdemo mgt frame*/
-	u_int32_t is_rx_bad_auth;	/* rx bad auth request */
-	u_int32_t is_rx_unauth;		/* rx on unauthorized port */
-	u_int32_t is_rx_badkeyid;	/* rx w/ incorrect keyid */
-	u_int32_t is_rx_ccmpreplay;	/* rx seq# violation (CCMP) */
-	u_int32_t is_rx_ccmpformat;	/* rx format bad (CCMP) */
-	u_int32_t is_rx_ccmpmic;	/* rx MIC check failed (CCMP) */
-	u_int32_t is_rx_tkipreplay;	/* rx seq# violation (TKIP) */
-	u_int32_t is_rx_tkipformat;	/* rx format bad (TKIP) */
-	u_int32_t is_rx_tkipmic;	/* rx MIC check failed (TKIP) */
-	u_int32_t is_rx_tkipicv;	/* rx ICV check failed (TKIP) */
-	u_int32_t is_rx_badcipher;	/* rx failed due to of key type */
-	u_int32_t is_rx_nocipherctx;	/* rx failed due to key !setup */
-	u_int32_t is_rx_acl;		/* rx discard due to of acl policy */
-	u_int32_t is_rx_ffcnt;		/* rx fast frames */
-	u_int32_t is_rx_badathtnl;	/* driver key alloc failed */
-	u_int32_t is_tx_nobuf;		/* tx failed for lack of buf */
-	u_int32_t is_tx_nonode;		/* tx failed for no node */
-	u_int32_t is_tx_unknownmgt;	/* tx of unknown mgt frame */
-	u_int32_t is_tx_badcipher;	/* tx failed due to of key type */
-	u_int32_t is_tx_nodefkey;	/* tx failed due to no defkey */
-	u_int32_t is_tx_noheadroom;	/* tx failed due to no space */
-	u_int32_t is_tx_ffokcnt;	/* tx fast frames sent success */
-	u_int32_t is_tx_fferrcnt;	/* tx fast frames sent success */
-	u_int32_t is_scan_active;	/* active scans started */
-	u_int32_t is_scan_passive;	/* passive scans started */
-	u_int32_t is_node_timeout;	/* nodes timed out inactivity */
-	u_int32_t is_crypto_nomem;	/* no memory for crypto ctx */
-	u_int32_t is_crypto_tkip;	/* tkip crypto done in s/w */
-	u_int32_t is_crypto_tkipenmic;	/* tkip en-MIC done in s/w */
-	u_int32_t is_crypto_tkipdemic;	/* tkip de-MIC done in s/w */
-	u_int32_t is_crypto_tkipcm;	/* tkip counter measures */
-	u_int32_t is_crypto_ccmp;	/* ccmp crypto done in s/w */
-	u_int32_t is_crypto_wep;	/* wep crypto done in s/w */
-	u_int32_t is_crypto_setkey_cipher;/* cipher rejected key */
-	u_int32_t is_crypto_setkey_nokey;/* no key index for setkey */
-	u_int32_t is_crypto_delkey;	/* driver key delete failed */
-	u_int32_t is_crypto_badcipher;	/* unknown cipher */
-	u_int32_t is_crypto_nocipher;	/* cipher not available */
-	u_int32_t is_crypto_attachfail;	/* cipher attach failed */
-	u_int32_t is_crypto_swfallback;	/* cipher fallback to s/w */
-	u_int32_t is_crypto_keyfail;	/* driver key alloc failed */
-	u_int32_t is_crypto_enmicfail;	/* en-MIC failed */
-	u_int32_t is_ibss_capmismatch;	/* merge failed-cap mismatch */
-	u_int32_t is_ibss_norate;	/* merge failed-rate mismatch */
-	u_int32_t is_ps_unassoc;	/* ps-poll for unassoc. sta */
-	u_int32_t is_ps_badaid;		/* ps-poll w/ incorrect aid */
-	u_int32_t is_ps_qempty;		/* ps-poll w/ nothing to send */
+  u_int32_t is_rx_badversion;           /* rx frame with bad version */
+  u_int32_t is_rx_tooshort;             /* rx frame too short */
+  u_int32_t is_rx_wrongbss;             /* rx from wrong bssid */
+  u_int32_t is_rx_dup;                  /* rx discard due to it's a dup */
+  u_int32_t is_rx_wrongdir;             /* rx w/ wrong direction */
+  u_int32_t is_rx_mcastecho;            /* rx discard due to of mcast echo */
+  u_int32_t is_rx_notassoc;             /* rx discard due to sta !assoc */
+  u_int32_t is_rx_noprivacy;            /* rx w/ wep but privacy off */
+  u_int32_t is_rx_unencrypted;          /* rx w/o wep and privacy on */
+  u_int32_t is_rx_wepfail;              /* rx wep processing failed */
+  u_int32_t is_rx_decap;                /* rx decapsulation failed */
+  u_int32_t is_rx_mgtdiscard;           /* rx discard mgt frames */
+  u_int32_t is_rx_ctl;                  /* rx discard ctrl frames */
+  u_int32_t is_rx_beacon;               /* rx beacon frames */
+  u_int32_t is_rx_rstoobig;             /* rx rate set truncated */
+  u_int32_t is_rx_elem_missing;         /* rx required element missing*/
+  u_int32_t is_rx_elem_toobig;          /* rx element too big */
+  u_int32_t is_rx_elem_toosmall;        /* rx element too small */
+  u_int32_t is_rx_elem_unknown;         /* rx element unknown */
+  u_int32_t is_rx_badchan;              /* rx frame w/ invalid chan */
+  u_int32_t is_rx_chanmismatch;         /* rx frame chan mismatch */
+  u_int32_t is_rx_nodealloc;            /* rx frame dropped */
+  u_int32_t is_rx_ssidmismatch;         /* rx frame ssid mismatch  */
+  u_int32_t is_rx_auth_unsupported;     /* rx w/ unsupported auth alg */
+  u_int32_t is_rx_auth_fail;            /* rx sta auth failure */
+  u_int32_t is_rx_auth_countermeasures; /* rx auth discard due to CM */
+  u_int32_t is_rx_assoc_bss;            /* rx assoc from wrong bssid */
+  u_int32_t is_rx_assoc_notauth;        /* rx assoc w/o auth */
+  u_int32_t is_rx_assoc_capmismatch;    /* rx assoc w/ cap mismatch */
+  u_int32_t is_rx_assoc_norate;         /* rx assoc w/ no rate match */
+  u_int32_t is_rx_assoc_badwpaie;       /* rx assoc w/ bad WPA IE */
+  u_int32_t is_rx_deauth;               /* rx deauthentication */
+  u_int32_t is_rx_disassoc;             /* rx disassociation */
+  u_int32_t is_rx_badsubtype;           /* rx frame w/ unknown subtype*/
+  u_int32_t is_rx_nobuf;                /* rx failed for lack of buf */
+  u_int32_t is_rx_decryptcrc;           /* rx decrypt failed on crc */
+  u_int32_t is_rx_ahdemo_mgt;           /* rx discard ahdemo mgt frame*/
+  u_int32_t is_rx_bad_auth;             /* rx bad auth request */
+  u_int32_t is_rx_unauth;               /* rx on unauthorized port */
+  u_int32_t is_rx_badkeyid;             /* rx w/ incorrect keyid */
+  u_int32_t is_rx_ccmpreplay;           /* rx seq# violation (CCMP) */
+  u_int32_t is_rx_ccmpformat;           /* rx format bad (CCMP) */
+  u_int32_t is_rx_ccmpmic;              /* rx MIC check failed (CCMP) */
+  u_int32_t is_rx_tkipreplay;           /* rx seq# violation (TKIP) */
+  u_int32_t is_rx_tkipformat;           /* rx format bad (TKIP) */
+  u_int32_t is_rx_tkipmic;              /* rx MIC check failed (TKIP) */
+  u_int32_t is_rx_tkipicv;              /* rx ICV check failed (TKIP) */
+  u_int32_t is_rx_badcipher;            /* rx failed due to of key type */
+  u_int32_t is_rx_nocipherctx;          /* rx failed due to key !setup */
+  u_int32_t is_rx_acl;                  /* rx discard due to of acl policy */
+  u_int32_t is_rx_ffcnt;                /* rx fast frames */
+  u_int32_t is_rx_badathtnl;            /* driver key alloc failed */
+  u_int32_t is_tx_nobuf;                /* tx failed for lack of buf */
+  u_int32_t is_tx_nonode;               /* tx failed for no node */
+  u_int32_t is_tx_unknownmgt;           /* tx of unknown mgt frame */
+  u_int32_t is_tx_badcipher;            /* tx failed due to of key type */
+  u_int32_t is_tx_nodefkey;             /* tx failed due to no defkey */
+  u_int32_t is_tx_noheadroom;           /* tx failed due to no space */
+  u_int32_t is_tx_ffokcnt;              /* tx fast frames sent success */
+  u_int32_t is_tx_fferrcnt;             /* tx fast frames sent success */
+  u_int32_t is_scan_active;             /* active scans started */
+  u_int32_t is_scan_passive;            /* passive scans started */
+  u_int32_t is_node_timeout;            /* nodes timed out inactivity */
+  u_int32_t is_crypto_nomem;            /* no memory for crypto ctx */
+  u_int32_t is_crypto_tkip;             /* tkip crypto done in s/w */
+  u_int32_t is_crypto_tkipenmic;        /* tkip en-MIC done in s/w */
+  u_int32_t is_crypto_tkipdemic;        /* tkip de-MIC done in s/w */
+  u_int32_t is_crypto_tkipcm;           /* tkip counter measures */
+  u_int32_t is_crypto_ccmp;             /* ccmp crypto done in s/w */
+  u_int32_t is_crypto_wep;              /* wep crypto done in s/w */
+  u_int32_t is_crypto_setkey_cipher;    /* cipher rejected key */
+  u_int32_t is_crypto_setkey_nokey;     /* no key index for setkey */
+  u_int32_t is_crypto_delkey;           /* driver key delete failed */
+  u_int32_t is_crypto_badcipher;        /* unknown cipher */
+  u_int32_t is_crypto_nocipher;         /* cipher not available */
+  u_int32_t is_crypto_attachfail;       /* cipher attach failed */
+  u_int32_t is_crypto_swfallback;       /* cipher fallback to s/w */
+  u_int32_t is_crypto_keyfail;          /* driver key alloc failed */
+  u_int32_t is_crypto_enmicfail;        /* en-MIC failed */
+  u_int32_t is_ibss_capmismatch;        /* merge failed-cap mismatch */
+  u_int32_t is_ibss_norate;             /* merge failed-rate mismatch */
+  u_int32_t is_ps_unassoc;              /* ps-poll for unassoc. sta */
+  u_int32_t is_ps_badaid;               /* ps-poll w/ incorrect aid */
+  u_int32_t is_ps_qempty;               /* ps-poll w/ nothing to send */
 };
 
 /*
  * Retrieve per-node statistics.
  */
 struct ieee80211req_sta_stats {
-	union {
-		/* NB: explicitly force 64-bit alignment */
-		u_int8_t macaddr[IEEE80211_ADDR_LEN];
-		u_int64_t pad;
-	} is_u;
-	struct ieee80211_nodestats is_stats;
+  union {
+    /* NB: explicitly force 64-bit alignment */
+    u_int8_t macaddr[IEEE80211_ADDR_LEN];
+    u_int64_t pad;
+  } is_u;
+  struct ieee80211_nodestats is_stats;
 };
 
 /*
@@ -203,105 +202,103 @@ struct ieee80211req_sta_stats {
  * to retrieve other data like stats, unicast key, etc.
  */
 struct ieee80211req_sta_info {
-	u_int16_t isi_len;		/* length (mult of 4) */
-	u_int16_t isi_freq;		/* MHz */
-	u_int16_t isi_flags;		/* channel flags */
-	u_int16_t isi_state;		/* state flags */
-	u_int8_t isi_authmode;		/* authentication algorithm */
-	u_int8_t isi_rssi;
-	u_int16_t isi_capinfo;		/* capabilities */
-	u_int8_t isi_athflags;		/* Atheros capabilities */
-	u_int8_t isi_erp;		/* ERP element */
-	u_int8_t isi_macaddr[IEEE80211_ADDR_LEN];
-	u_int8_t isi_nrates;		/* negotiated rates */
-	u_int8_t isi_rates[IEEE80211_RATE_MAXSIZE];
-	u_int8_t isi_txrate;		/* index to isi_rates[] */
-	u_int16_t isi_ie_len;		/* IE length */
-	u_int16_t isi_associd;		/* assoc response */
-	u_int16_t isi_txpower;		/* current tx power */
-	u_int16_t isi_vlan;		/* vlan tag */
-	u_int16_t isi_txseqs[17];	/* seq to be transmitted */
-	u_int16_t isi_rxseqs[17];	/* seq previous for qos frames*/
-	u_int16_t isi_inact;		/* inactivity timer */
-	u_int8_t isi_uapsd;		/* UAPSD queues */
-	u_int8_t isi_opmode;		/* sta operating mode */
+  u_int16_t isi_len;     /* length (mult of 4) */
+  u_int16_t isi_freq;    /* MHz */
+  u_int16_t isi_flags;   /* channel flags */
+  u_int16_t isi_state;   /* state flags */
+  u_int8_t isi_authmode; /* authentication algorithm */
+  u_int8_t isi_rssi;
+  u_int16_t isi_capinfo; /* capabilities */
+  u_int8_t isi_athflags; /* Atheros capabilities */
+  u_int8_t isi_erp;      /* ERP element */
+  u_int8_t isi_macaddr[IEEE80211_ADDR_LEN];
+  u_int8_t isi_nrates; /* negotiated rates */
+  u_int8_t isi_rates[IEEE80211_RATE_MAXSIZE];
+  u_int8_t isi_txrate;      /* index to isi_rates[] */
+  u_int16_t isi_ie_len;     /* IE length */
+  u_int16_t isi_associd;    /* assoc response */
+  u_int16_t isi_txpower;    /* current tx power */
+  u_int16_t isi_vlan;       /* vlan tag */
+  u_int16_t isi_txseqs[17]; /* seq to be transmitted */
+  u_int16_t isi_rxseqs[17]; /* seq previous for qos frames*/
+  u_int16_t isi_inact;      /* inactivity timer */
+  u_int8_t isi_uapsd;       /* UAPSD queues */
+  u_int8_t isi_opmode;      /* sta operating mode */
 
-	/* XXX frag state? */
-	/* variable length IE data */
+  /* XXX frag state? */
+  /* variable length IE data */
 };
-
 
 struct ath_stats {
-	u_int32_t ast_watchdog;		/* device reset by watchdog */
-	u_int32_t ast_hardware;		/* fatal hardware error interrupts */
-	u_int32_t ast_bmiss;		/* beacon miss interrupts */
-	u_int32_t ast_rxorn;		/* rx overrun interrupts */
-	u_int32_t ast_rxeol;		/* rx eol interrupts */
-	u_int32_t ast_txurn;		/* tx underrun interrupts */
-	u_int32_t ast_mib;		/* mib interrupts */
-	u_int32_t ast_tx_packets;	/* packet sent on the interface */
-	u_int32_t ast_tx_mgmt;		/* management frames transmitted */
-	u_int32_t ast_tx_discard;	/* frames discarded prior to assoc */
-	u_int32_t ast_tx_invalid;	/* frames discarded due to is device gone */
-	u_int32_t ast_tx_qstop;		/* tx queue stopped because it's full */
-	u_int32_t ast_tx_encap;		/* tx encapsulation failed */
-	u_int32_t ast_tx_nonode;	/* tx failed due to of no node */
-	u_int32_t ast_tx_nobuf;		/* tx failed due to of no tx buffer (data) */
-	u_int32_t ast_tx_nobufmgt;	/* tx failed due to of no tx buffer (mgmt)*/
-	u_int32_t ast_tx_xretries;	/* tx failed due to of too many retries */
-	u_int32_t ast_tx_fifoerr;	/* tx failed due to of FIFO underrun */
-	u_int32_t ast_tx_filtered;	/* tx failed due to xmit filtered */
-	u_int32_t ast_tx_shortretry;	/* tx on-chip retries (short) */
-	u_int32_t ast_tx_longretry;	/* tx on-chip retries (long) */
-	u_int32_t ast_tx_badrate;	/* tx failed due to of bogus xmit rate */
-	u_int32_t ast_tx_noack;		/* tx frames with no ack marked */
-	u_int32_t ast_tx_rts;		/* tx frames with rts enabled */
-	u_int32_t ast_tx_cts;		/* tx frames with cts enabled */
-	u_int32_t ast_tx_shortpre;	/* tx frames with short preamble */
-	u_int32_t ast_tx_altrate;	/* tx frames with alternate rate */
-	u_int32_t ast_tx_protect;	/* tx frames with protection */
-	u_int32_t ast_rx_orn;		/* rx failed due to of desc overrun */
-	u_int32_t ast_rx_crcerr;	/* rx failed due to of bad CRC */
-	u_int32_t ast_rx_fifoerr;	/* rx failed due to of FIFO overrun */
-	u_int32_t ast_rx_badcrypt;	/* rx failed due to of decryption */
-	u_int32_t ast_rx_badmic;	/* rx failed due to of MIC failure */
-	u_int32_t ast_rx_phyerr;	/* rx PHY error summary count */
-	u_int32_t ast_rx_phy[32];	/* rx PHY error per-code counts */
-	u_int32_t ast_rx_tooshort;	/* rx discarded due to frame too short */
-	u_int32_t ast_rx_toobig;	/* rx discarded due to frame too large */
-	u_int32_t ast_rx_nobuf;		/* rx setup failed due to of no skbuff */
-	u_int32_t ast_rx_packets;	/* packet recv on the interface */
-	u_int32_t ast_rx_mgt;		/* management frames received */
-	u_int32_t ast_rx_ctl;		/* control frames received */
-	int8_t ast_tx_rssi;		/* tx rssi of last ack */
-	int8_t ast_rx_rssi;		/* rx rssi from histogram */
-	u_int32_t ast_be_xmit;		/* beacons transmitted */
-	u_int32_t ast_be_nobuf;		/* no skbuff available for beacon */
-	u_int32_t ast_per_cal;		/* periodic calibration calls */
-	u_int32_t ast_per_calfail;	/* periodic calibration failed */
-	u_int32_t ast_per_rfgain;	/* periodic calibration rfgain reset */
-	u_int32_t ast_rate_calls;	/* rate control checks */
-	u_int32_t ast_rate_raise;	/* rate control raised xmit rate */
-	u_int32_t ast_rate_drop;	/* rate control dropped xmit rate */
-	u_int32_t ast_ant_defswitch;	/* rx/default antenna switches */
-	u_int32_t ast_ant_txswitch;	/* tx antenna switches */
-	u_int32_t ast_ant_rx[8];	/* rx frames with antenna */
-	u_int32_t ast_ant_tx[8];	/* tx frames with antenna */
+  u_int32_t ast_watchdog;      /* device reset by watchdog */
+  u_int32_t ast_hardware;      /* fatal hardware error interrupts */
+  u_int32_t ast_bmiss;         /* beacon miss interrupts */
+  u_int32_t ast_rxorn;         /* rx overrun interrupts */
+  u_int32_t ast_rxeol;         /* rx eol interrupts */
+  u_int32_t ast_txurn;         /* tx underrun interrupts */
+  u_int32_t ast_mib;           /* mib interrupts */
+  u_int32_t ast_tx_packets;    /* packet sent on the interface */
+  u_int32_t ast_tx_mgmt;       /* management frames transmitted */
+  u_int32_t ast_tx_discard;    /* frames discarded prior to assoc */
+  u_int32_t ast_tx_invalid;    /* frames discarded due to is device gone */
+  u_int32_t ast_tx_qstop;      /* tx queue stopped because it's full */
+  u_int32_t ast_tx_encap;      /* tx encapsulation failed */
+  u_int32_t ast_tx_nonode;     /* tx failed due to of no node */
+  u_int32_t ast_tx_nobuf;      /* tx failed due to of no tx buffer (data) */
+  u_int32_t ast_tx_nobufmgt;   /* tx failed due to of no tx buffer (mgmt)*/
+  u_int32_t ast_tx_xretries;   /* tx failed due to of too many retries */
+  u_int32_t ast_tx_fifoerr;    /* tx failed due to of FIFO underrun */
+  u_int32_t ast_tx_filtered;   /* tx failed due to xmit filtered */
+  u_int32_t ast_tx_shortretry; /* tx on-chip retries (short) */
+  u_int32_t ast_tx_longretry;  /* tx on-chip retries (long) */
+  u_int32_t ast_tx_badrate;    /* tx failed due to of bogus xmit rate */
+  u_int32_t ast_tx_noack;      /* tx frames with no ack marked */
+  u_int32_t ast_tx_rts;        /* tx frames with rts enabled */
+  u_int32_t ast_tx_cts;        /* tx frames with cts enabled */
+  u_int32_t ast_tx_shortpre;   /* tx frames with short preamble */
+  u_int32_t ast_tx_altrate;    /* tx frames with alternate rate */
+  u_int32_t ast_tx_protect;    /* tx frames with protection */
+  u_int32_t ast_rx_orn;        /* rx failed due to of desc overrun */
+  u_int32_t ast_rx_crcerr;     /* rx failed due to of bad CRC */
+  u_int32_t ast_rx_fifoerr;    /* rx failed due to of FIFO overrun */
+  u_int32_t ast_rx_badcrypt;   /* rx failed due to of decryption */
+  u_int32_t ast_rx_badmic;     /* rx failed due to of MIC failure */
+  u_int32_t ast_rx_phyerr;     /* rx PHY error summary count */
+  u_int32_t ast_rx_phy[32];    /* rx PHY error per-code counts */
+  u_int32_t ast_rx_tooshort;   /* rx discarded due to frame too short */
+  u_int32_t ast_rx_toobig;     /* rx discarded due to frame too large */
+  u_int32_t ast_rx_nobuf;      /* rx setup failed due to of no skbuff */
+  u_int32_t ast_rx_packets;    /* packet recv on the interface */
+  u_int32_t ast_rx_mgt;        /* management frames received */
+  u_int32_t ast_rx_ctl;        /* control frames received */
+  int8_t ast_tx_rssi;          /* tx rssi of last ack */
+  int8_t ast_rx_rssi;          /* rx rssi from histogram */
+  u_int32_t ast_be_xmit;       /* beacons transmitted */
+  u_int32_t ast_be_nobuf;      /* no skbuff available for beacon */
+  u_int32_t ast_per_cal;       /* periodic calibration calls */
+  u_int32_t ast_per_calfail;   /* periodic calibration failed */
+  u_int32_t ast_per_rfgain;    /* periodic calibration rfgain reset */
+  u_int32_t ast_rate_calls;    /* rate control checks */
+  u_int32_t ast_rate_raise;    /* rate control raised xmit rate */
+  u_int32_t ast_rate_drop;     /* rate control dropped xmit rate */
+  u_int32_t ast_ant_defswitch; /* rx/default antenna switches */
+  u_int32_t ast_ant_txswitch;  /* tx antenna switches */
+  u_int32_t ast_ant_rx[8];     /* rx frames with antenna */
+  u_int32_t ast_ant_tx[8];     /* tx frames with antenna */
 };
 
-#define	SIOCGATHSTATS			(SIOCDEVPRIVATE+0)
-#define	SIOCGATHDIAG			(SIOCDEVPRIVATE+1)
-#define	SIOCGATHRADARSIG		(SIOCDEVPRIVATE+2)
-#define	SIOCGATHHALDIAG			(SIOCDEVPRIVATE+3)
-#define	SIOCG80211STATS			(SIOCDEVPRIVATE+2)
+#define SIOCGATHSTATS (SIOCDEVPRIVATE + 0)
+#define SIOCGATHDIAG (SIOCDEVPRIVATE + 1)
+#define SIOCGATHRADARSIG (SIOCDEVPRIVATE + 2)
+#define SIOCGATHHALDIAG (SIOCDEVPRIVATE + 3)
+#define SIOCG80211STATS (SIOCDEVPRIVATE + 2)
 /* NB: require in+out parameters so cannot use wireless extensions, yech */
-#define	IEEE80211_IOCTL_GETKEY		(SIOCDEVPRIVATE+3)
-#define	IEEE80211_IOCTL_GETWPAIE	(SIOCDEVPRIVATE+4)
-#define	IEEE80211_IOCTL_STA_STATS	(SIOCDEVPRIVATE+5)
-#define	IEEE80211_IOCTL_STA_INFO	(SIOCDEVPRIVATE+6)
-#define	SIOC80211IFCREATE		(SIOCDEVPRIVATE+7)
-#define	SIOC80211IFDESTROY	 	(SIOCDEVPRIVATE+8)
-#define	IEEE80211_IOCTL_SCAN_RESULTS	(SIOCDEVPRIVATE+9)
-
+#define IEEE80211_IOCTL_GETKEY (SIOCDEVPRIVATE + 3)
+#define IEEE80211_IOCTL_GETWPAIE (SIOCDEVPRIVATE + 4)
+#define IEEE80211_IOCTL_STA_STATS (SIOCDEVPRIVATE + 5)
+#define IEEE80211_IOCTL_STA_INFO (SIOCDEVPRIVATE + 6)
+#define SIOC80211IFCREATE (SIOCDEVPRIVATE + 7)
+#define SIOC80211IFDESTROY (SIOCDEVPRIVATE + 8)
+#define IEEE80211_IOCTL_SCAN_RESULTS (SIOCDEVPRIVATE + 9)
 
 #endif

--- a/src/match_empty_counter.c
+++ b/src/match_empty_counter.c
@@ -73,9 +73,9 @@ static int mec_match(__attribute__((unused)) const data_set_t *ds, /* {{{ */
 } /* }}} int mec_match */
 
 void module_register(void) {
-  fc_register_match(
-      "empty_counter",
-      (match_proc_t){
-          .create = mec_create, .destroy = mec_destroy, .match = mec_match,
-      });
+  fc_register_match("empty_counter", (match_proc_t){
+                                         .create = mec_create,
+                                         .destroy = mec_destroy,
+                                         .match = mec_match,
+                                     });
 } /* module_register */

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -90,14 +90,16 @@ static int socket_reinit(socket_adapter_t *self);
 static int socket_receive(socket_adapter_t *self, FILE **p_file);
 
 static mcelog_config_t g_mcelog_config = {
-    .logfile = "/var/log/mcelog", .persist = false,
+    .logfile = "/var/log/mcelog",
+    .persist = false,
 };
 
 static socket_adapter_t socket_adapter = {
     .sock_fd = -1,
     .unix_sock =
         {
-            .sun_family = AF_UNIX, .sun_path = "/var/run/mcelog-client",
+            .sun_family = AF_UNIX,
+            .sun_path = "/var/run/mcelog-client",
         },
     .lock = PTHREAD_RWLOCK_INITIALIZER,
     .close = socket_close,
@@ -523,7 +525,8 @@ static int socket_receive(socket_adapter_t *self, FILE **pp_file) {
   int res = -1;
   pthread_rwlock_rdlock(&self->lock);
   struct pollfd poll_fd = {
-      .fd = self->sock_fd, .events = POLLIN | POLLPRI,
+      .fd = self->sock_fd,
+      .events = POLLIN | POLLPRI,
   };
 
   if ((res = poll(&poll_fd, 1, MCELOG_POLL_TIMEOUT)) <= 0) {

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -171,7 +171,8 @@ static int memcached_connect_inet(memcached_t *st) {
 
     /* Wait until connection establishes */
     struct pollfd pollfd = {
-        .fd = fd, .events = POLLOUT,
+        .fd = fd,
+        .events = POLLOUT,
     };
     do
       status = poll(&pollfd, 1, MEMCACHED_CONNECT_TIMEOUT);
@@ -226,7 +227,8 @@ static int memcached_query_daemon(char *buffer, size_t buffer_size,
   }
 
   struct pollfd pollfd = {
-      .fd = st->fd, .events = POLLOUT,
+      .fd = st->fd,
+      .events = POLLOUT,
   };
 
   do
@@ -346,7 +348,8 @@ static void submit_derive2(const char *type, const char *type_inst,
                            derive_t value0, derive_t value1, memcached_t *st) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = value0}, {.derive = value1},
+      {.derive = value0},
+      {.derive = value1},
   };
 
   memcached_init_vl(&vl, st);
@@ -377,7 +380,8 @@ static void submit_gauge2(const char *type, const char *type_inst,
                           gauge_t value0, gauge_t value1, memcached_t *st) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.gauge = value0}, {.gauge = value1},
+      {.gauge = value0},
+      {.gauge = value1},
   };
 
   memcached_init_vl(&vl, st);
@@ -692,7 +696,8 @@ static int memcached_add_read_callback(memcached_t *st) {
       /* callback  = */ memcached_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = st, .free_func = memcached_free,
+          .data = st,
+          .free_func = memcached_free,
       });
 } /* int memcached_add_read_callback */
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -118,7 +118,7 @@ static int memory_init(void) {
 #if HAVE_HOST_STATISTICS
   port_host = mach_host_self();
   host_page_size(port_host, &pagesize);
-/* #endif HAVE_HOST_STATISTICS */
+  /* #endif HAVE_HOST_STATISTICS */
 
 #elif HAVE_SYSCTLBYNAME
 /* no init stuff */
@@ -140,7 +140,7 @@ static int memory_init(void) {
     return -1;
   }
 
-/* #endif HAVE_LIBKSTAT */
+    /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYSCTL
   pagesize = getpagesize();
@@ -148,7 +148,7 @@ static int memory_init(void) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
     return -1;
   }
-/* #endif HAVE_SYSCTL */
+    /* #endif HAVE_SYSCTL */
 
 #elif HAVE_LIBSTATGRAB
 /* no init stuff */
@@ -218,7 +218,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   MEMORY_SUBMIT("wired", wired, "active", active, "inactive", inactive, "free",
                 free);
-/* #endif HAVE_HOST_STATISTICS */
+  /* #endif HAVE_HOST_STATISTICS */
 
 #elif HAVE_SYSCTLBYNAME
   /*
@@ -259,7 +259,7 @@ static int memory_read_internal(value_list_t *vl) {
                 (gauge_t)sysctl_vals[3], "active", (gauge_t)sysctl_vals[4],
                 "inactive", (gauge_t)sysctl_vals[5], "cache",
                 (gauge_t)sysctl_vals[6]);
-/* #endif HAVE_SYSCTLBYNAME */
+  /* #endif HAVE_SYSCTLBYNAME */
 
 #elif KERNEL_LINUX
   FILE *fh;
@@ -334,7 +334,7 @@ static int memory_read_internal(value_list_t *vl) {
   else
     MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
                   mem_cached, "free", mem_free, "slab", mem_slab_total);
-/* #endif KERNEL_LINUX */
+    /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
   /* Most of the additions here were taken as-is from the k9toolkit from
@@ -406,7 +406,7 @@ static int memory_read_internal(value_list_t *vl) {
   MEMORY_SUBMIT("used", (gauge_t)mem_used, "free", (gauge_t)mem_free, "locked",
                 (gauge_t)mem_lock, "kernel", (gauge_t)mem_kern, "arc",
                 (gauge_t)arcsize, "unusable", (gauge_t)mem_unus);
-/* #endif HAVE_LIBKSTAT */
+  /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYSCTL
   int mib[] = {CTL_VM, VM_METER};
@@ -430,7 +430,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   MEMORY_SUBMIT("active", mem_active, "inactive", mem_inactive, "free",
                 mem_free);
-/* #endif HAVE_SYSCTL */
+  /* #endif HAVE_SYSCTL */
 
 #elif HAVE_LIBSTATGRAB
   sg_mem_stats *ios;
@@ -441,7 +441,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   MEMORY_SUBMIT("used", (gauge_t)ios->used, "cached", (gauge_t)ios->cache,
                 "free", (gauge_t)ios->free);
-/* #endif HAVE_LIBSTATGRAB */
+  /* #endif HAVE_LIBSTATGRAB */
 
 #elif HAVE_PERFSTAT
   perfstat_memory_total_t pmemory = {0};

--- a/src/mic.c
+++ b/src/mic.c
@@ -209,7 +209,7 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
     ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   else /* per-core statistics */
     ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
-             micnumber, core);
+              micnumber, core);
   strncpy(vl.type, "cpu", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 

--- a/src/mic.c
+++ b/src/mic.c
@@ -132,7 +132,7 @@ static void mic_submit_memory_use(int micnumber, const char *type_instance,
   vl.values_len = 1;
 
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, "memory", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 
@@ -164,7 +164,7 @@ static void mic_submit_temp(int micnumber, const char *type, gauge_t value) {
   vl.values_len = 1;
 
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, "temperature", sizeof(vl.type));
   strncpy(vl.type_instance, type, sizeof(vl.type_instance));
 
@@ -206,9 +206,9 @@ static void mic_submit_cpu(int micnumber, const char *type_instance, int core,
 
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
   if (core < 0) /* global aggregation */
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   else /* per-core statistics */
-    snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
+    ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i-cpu-%i",
              micnumber, core);
   strncpy(vl.type, "cpu", sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
@@ -258,7 +258,7 @@ static void mic_submit_power(int micnumber, const char *type,
   vl.values_len = 1;
 
   strncpy(vl.plugin, "mic", sizeof(vl.plugin));
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%i", micnumber);
   strncpy(vl.type, type, sizeof(vl.type));
   strncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1078,7 +1078,8 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
                                  /* callback = */ mb_read,
                                  /* interval = */ interval,
                                  &(user_data_t){
-                                     .data = host, .free_func = host_free,
+                                     .data = host,
+                                     .free_func = host_free,
                                  });
   } else {
     host_free(host);

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -259,7 +259,7 @@ static int mb_submit(mb_host_t *host, mb_slave_t *slave, /* {{{ */
     return EINVAL;
 
   if (slave->instance[0] == 0)
-    snprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
+    ssnprintf(slave->instance, sizeof(slave->instance), "slave_%i", slave->id);
 
   vl.values = &value;
   vl.values_len = 1;
@@ -1072,7 +1072,7 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char name[1024];
 
-    snprintf(name, sizeof(name), "modbus-%s", host->host);
+    ssnprintf(name, sizeof(name), "modbus-%s", host->host);
 
     plugin_register_complex_read(/* group = */ NULL, name,
                                  /* callback = */ mb_read,

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -341,7 +341,7 @@ static int mb_init_connection(mb_host_t *host) /* {{{ */
   host->is_connected = true;
   return 0;
 } /* }}} int mb_init_connection */
-/* #endif LEGACY_LIBMODBUS */
+  /* #endif LEGACY_LIBMODBUS */
 
 #else /* if !LEGACY_LIBMODBUS */
 /* Version 2.9.2 */
@@ -1078,7 +1078,8 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
                                  /* callback = */ mb_read,
                                  /* interval = */ interval,
                                  &(user_data_t){
-                                     .data = host, .free_func = host_free,
+                                     .data = host,
+                                     .free_func = host_free,
                                  });
   } else {
     host_free(host);

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1078,8 +1078,7 @@ static int mb_config_add_host(oconfig_item_t *ci) /* {{{ */
                                  /* callback = */ mb_read,
                                  /* interval = */ interval,
                                  &(user_data_t){
-                                     .data = host,
-                                     .free_func = host_free,
+                                     .data = host, .free_func = host_free,
                                  });
   } else {
     host_free(host);

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -462,7 +462,7 @@ static int format_topic(char *buf, size_t buf_len, data_set_t const *ds,
   if (status != 0)
     return status;
 
-  status = snprintf(buf, buf_len, "%s/%s", conf->topic_prefix, name);
+  status = ssnprintf(buf, buf_len, "%s/%s", conf->topic_prefix, name);
   if ((status < 0) || (((size_t)status) >= buf_len))
     return ENOMEM;
 
@@ -599,7 +599,7 @@ static int mqtt_config_publisher(oconfig_item_t *ci) {
       ERROR("mqtt plugin: Unknown config option: %s", child->key);
   }
 
-  snprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
+  ssnprintf(cb_name, sizeof(cb_name), "mqtt/%s", conf->name);
   plugin_register_write(cb_name, mqtt_write,
                         &(user_data_t){
                             .data = conf,

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -225,8 +225,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
     plugin_register_complex_read(
         /* group = */ NULL, cb_name, mysql_read, /* interval = */ 0,
         &(user_data_t){
-            .data = db,
-            .free_func = mysql_database_free,
+            .data = db, .free_func = mysql_database_free,
         });
   } else {
     mysql_database_free(db);
@@ -355,8 +354,7 @@ static void derive_submit(const char *type, const char *type_instance,
 
 static void traffic_submit(derive_t rx, derive_t tx, mysql_database_t *db) {
   value_t values[] = {
-      {.derive = rx},
-      {.derive = tx},
+      {.derive = rx}, {.derive = tx},
   };
 
   submit("mysql_octets", NULL, values, STATIC_ARRAY_SIZE(values), db);

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -218,7 +218,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
           (db->database != NULL) ? db->database : "<default>");
 
     if (db->instance != NULL)
-      snprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
+      ssnprintf(cb_name, sizeof(cb_name), "mysql-%s", db->instance);
     else
       sstrncpy(cb_name, "mysql", sizeof(cb_name));
 
@@ -500,14 +500,14 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((io == NULL) || (strcasecmp(io, "yes") != 0)) &&
         (db->slave_io_running)) {
       n.severity = NOTIF_WARNING;
-      snprintf(n.message, sizeof(n.message),
+      ssnprintf(n.message, sizeof(n.message),
                "slave I/O thread not started or not connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = false;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                (!db->slave_io_running)) {
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message),
+      ssnprintf(n.message, sizeof(n.message),
                "slave I/O thread started and connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = true;
@@ -516,13 +516,13 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     if (((sql == NULL) || (strcasecmp(sql, "yes") != 0)) &&
         (db->slave_sql_running)) {
       n.severity = NOTIF_WARNING;
-      snprintf(n.message, sizeof(n.message), "slave SQL thread not started");
+      ssnprintf(n.message, sizeof(n.message), "slave SQL thread not started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = false;
     } else if (((sql != NULL) && (strcasecmp(sql, "yes") == 0)) &&
                (!db->slave_sql_running)) {
       n.severity = NOTIF_OKAY;
-      snprintf(n.message, sizeof(n.message), "slave SQL thread started");
+      ssnprintf(n.message, sizeof(n.message), "slave SQL thread started");
       plugin_dispatch_notification(&n);
       db->slave_sql_running = true;
     }

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -225,7 +225,8 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
     plugin_register_complex_read(
         /* group = */ NULL, cb_name, mysql_read, /* interval = */ 0,
         &(user_data_t){
-            .data = db, .free_func = mysql_database_free,
+            .data = db,
+            .free_func = mysql_database_free,
         });
   } else {
     mysql_database_free(db);
@@ -354,7 +355,8 @@ static void derive_submit(const char *type, const char *type_instance,
 
 static void traffic_submit(derive_t rx, derive_t tx, mysql_database_t *db) {
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   submit("mysql_octets", NULL, values, STATIC_ARRAY_SIZE(values), db);
@@ -501,14 +503,14 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
         (db->slave_io_running)) {
       n.severity = NOTIF_WARNING;
       ssnprintf(n.message, sizeof(n.message),
-               "slave I/O thread not started or not connected to master");
+                "slave I/O thread not started or not connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = false;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
                (!db->slave_io_running)) {
       n.severity = NOTIF_OKAY;
       ssnprintf(n.message, sizeof(n.message),
-               "slave I/O thread started and connected to master");
+                "slave I/O thread started and connected to master");
       plugin_dispatch_notification(&n);
       db->slave_io_running = true;
     }

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -225,7 +225,8 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
     plugin_register_complex_read(
         /* group = */ NULL, cb_name, mysql_read, /* interval = */ 0,
         &(user_data_t){
-            .data = db, .free_func = mysql_database_free,
+            .data = db,
+            .free_func = mysql_database_free,
         });
   } else {
     mysql_database_free(db);
@@ -354,7 +355,8 @@ static void derive_submit(const char *type, const char *type_instance,
 
 static void traffic_submit(derive_t rx, derive_t tx, mysql_database_t *db) {
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   submit("mysql_octets", NULL, values, STATIC_ARRAY_SIZE(values), db);

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -773,7 +773,7 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   if ((hostname == NULL) || (old_data == NULL) || (new_data == NULL))
     return -1;
 
-  snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
+  ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
            old_data->name);
 
   /* Check for and submit disk-octet values */
@@ -1404,7 +1404,7 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
     uint64_t snap_reserve_free = v->snap_reserved;
     uint64_t snap_norm_used = v->snap_used;
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
     if (HAS_ALL_FLAGS(v->flags,
                       HAVE_VOLUME_USAGE_SNAP_USED |
@@ -1498,11 +1498,11 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
 
   if ((v->flags & IS_VOLUME_USAGE_OFFLINE) != 0) {
     n.severity = NOTIF_OKAY;
-    snprintf(n.message, sizeof(n.message), "Volume %s is now online.", v->name);
+    ssnprintf(n.message, sizeof(n.message), "Volume %s is now online.", v->name);
     v->flags &= ~IS_VOLUME_USAGE_OFFLINE;
   } else {
     n.severity = NOTIF_WARNING;
-    snprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
+    ssnprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
              v->name);
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
@@ -1832,7 +1832,7 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
     if (volume_name == NULL)
       continue;
 
-    snprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
              volume_name, tree_name);
 
     value = na_child_get_uint64(elem_quota, "disk-used", UINT64_MAX);
@@ -1945,7 +1945,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
       continue;
 
     /* possible TODO: make plugin instance configurable */
-    snprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
+    ssnprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
              dest_path);
     submit_double(hostname, plugin_instance, /* type = */ "delay", NULL,
                   (double)value, /* timestamp = */ 0, interval);
@@ -2787,10 +2787,10 @@ static int cna_register_host(host_config_t *host) /* {{{ */
   char cb_name[256];
 
   if (host->vfiler)
-    snprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
+    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
              host->vfiler);
   else
-    snprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
+    ssnprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
 
   plugin_register_complex_read(
       /* group = */ NULL, cb_name,

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -643,7 +643,8 @@ static int submit_two_derive(const char *host,
                              derive_t val0, derive_t val1, cdtime_t timestamp,
                              cdtime_t interval) {
   value_t values[] = {
-      {.derive = val0}, {.derive = val1},
+      {.derive = val0},
+      {.derive = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -666,7 +667,8 @@ static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
                             gauge_t val0, gauge_t val1, cdtime_t timestamp,
                             cdtime_t interval) {
   value_t values[] = {
-      {.gauge = val0}, {.gauge = val1},
+      {.gauge = val0},
+      {.gauge = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -774,13 +776,12 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
     return -1;
 
   ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s",
-           old_data->name);
+            old_data->name);
 
   /* Check for and submit disk-octet values */
   if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_IO) &&
-      HAS_ALL_FLAGS(new_data->flags,
-                    HAVE_VOLUME_PERF_BYTES_READ |
-                        HAVE_VOLUME_PERF_BYTES_WRITE)) {
+      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_BYTES_READ |
+                                         HAVE_VOLUME_PERF_BYTES_WRITE)) {
     submit_two_derive(
         hostname, plugin_instance, "disk_octets", /* type instance = */ NULL,
         (derive_t)new_data->read_bytes, (derive_t)new_data->write_bytes,
@@ -798,15 +799,15 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   }
 
   /* Check for, calculate and submit disk-latency values */
-  if (HAS_ALL_FLAGS(old_data->flags,
-                    CFG_VOLUME_PERF_LATENCY | HAVE_VOLUME_PERF_OPS_READ |
-                        HAVE_VOLUME_PERF_OPS_WRITE |
-                        HAVE_VOLUME_PERF_LATENCY_READ |
-                        HAVE_VOLUME_PERF_LATENCY_WRITE) &&
-      HAS_ALL_FLAGS(new_data->flags,
-                    HAVE_VOLUME_PERF_OPS_READ | HAVE_VOLUME_PERF_OPS_WRITE |
-                        HAVE_VOLUME_PERF_LATENCY_READ |
-                        HAVE_VOLUME_PERF_LATENCY_WRITE)) {
+  if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_LATENCY |
+                                         HAVE_VOLUME_PERF_OPS_READ |
+                                         HAVE_VOLUME_PERF_OPS_WRITE |
+                                         HAVE_VOLUME_PERF_LATENCY_READ |
+                                         HAVE_VOLUME_PERF_LATENCY_WRITE) &&
+      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_OPS_READ |
+                                         HAVE_VOLUME_PERF_OPS_WRITE |
+                                         HAVE_VOLUME_PERF_LATENCY_READ |
+                                         HAVE_VOLUME_PERF_LATENCY_WRITE)) {
     gauge_t latency_per_op_read;
     gauge_t latency_per_op_write;
 
@@ -1406,9 +1407,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_SNAP_USED |
-                          HAVE_VOLUME_USAGE_SNAP_RSVD)) {
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_RSVD)) {
       if (v->snap_reserved > v->snap_used) {
         snap_reserve_free = v->snap_reserved - v->snap_used;
         snap_reserve_used = v->snap_used;
@@ -1422,9 +1422,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     /* The space used by snapshots but not reserved for them is included in
      * both, norm_used and snap_norm_used. If possible, subtract this here. */
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_NORM_USED |
-                          HAVE_VOLUME_USAGE_SNAP_USED)) {
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_NORM_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_USED)) {
       if (norm_used >= snap_norm_used)
         norm_used -= snap_norm_used;
       else {
@@ -1466,9 +1465,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
                     "df_complex", "snap_reserved", (double)snap_reserve_free,
                     /* timestamp = */ 0, interval);
 
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_SNAP_USED |
-                          HAVE_VOLUME_USAGE_SNAP_RSVD))
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_RSVD))
       submit_double(hostname, /* plugin instance = */ plugin_instance,
                     "df_complex", "snap_reserve_used",
                     (double)snap_reserve_used, /* timestamp = */ 0, interval);
@@ -1498,12 +1496,13 @@ static int cna_change_volume_status(const char *hostname, /* {{{ */
 
   if ((v->flags & IS_VOLUME_USAGE_OFFLINE) != 0) {
     n.severity = NOTIF_OKAY;
-    ssnprintf(n.message, sizeof(n.message), "Volume %s is now online.", v->name);
+    ssnprintf(n.message, sizeof(n.message), "Volume %s is now online.",
+              v->name);
     v->flags &= ~IS_VOLUME_USAGE_OFFLINE;
   } else {
     n.severity = NOTIF_WARNING;
     ssnprintf(n.message, sizeof(n.message), "Volume %s is now offline.",
-             v->name);
+              v->name);
     v->flags |= IS_VOLUME_USAGE_OFFLINE;
   }
 
@@ -1833,7 +1832,7 @@ static int cna_handle_quota_data(const host_config_t *host, /* {{{ */
       continue;
 
     ssnprintf(plugin_instance, sizeof(plugin_instance), "quota-%s-%s",
-             volume_name, tree_name);
+              volume_name, tree_name);
 
     value = na_child_get_uint64(elem_quota, "disk-used", UINT64_MAX);
     if (value != UINT64_MAX) {
@@ -1946,7 +1945,7 @@ static int cna_handle_snapvault_data(const char *hostname, /* {{{ */
 
     /* possible TODO: make plugin instance configurable */
     ssnprintf(plugin_instance, sizeof(plugin_instance), "snapvault-%s",
-             dest_path);
+              dest_path);
     submit_double(hostname, plugin_instance, /* type = */ "delay", NULL,
                   (double)value, /* timestamp = */ 0, interval);
 
@@ -2788,7 +2787,7 @@ static int cna_register_host(host_config_t *host) /* {{{ */
 
   if (host->vfiler)
     ssnprintf(cb_name, sizeof(cb_name), "netapp-%s-%s", host->name,
-             host->vfiler);
+              host->vfiler);
   else
     ssnprintf(cb_name, sizeof(cb_name), "netapp-%s", host->name);
 
@@ -2797,7 +2796,8 @@ static int cna_register_host(host_config_t *host) /* {{{ */
       /* callback  = */ cna_read,
       /* interval  = */ host->interval,
       &(user_data_t){
-          .data = host, .free_func = (void *)free_host_config,
+          .data = host,
+          .free_func = (void *)free_host_config,
       });
 
   return 0;

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -643,8 +643,7 @@ static int submit_two_derive(const char *host,
                              derive_t val0, derive_t val1, cdtime_t timestamp,
                              cdtime_t interval) {
   value_t values[] = {
-      {.derive = val0},
-      {.derive = val1},
+      {.derive = val0}, {.derive = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -667,8 +666,7 @@ static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
                             gauge_t val0, gauge_t val1, cdtime_t timestamp,
                             cdtime_t interval) {
   value_t values[] = {
-      {.gauge = val0},
-      {.gauge = val1},
+      {.gauge = val0}, {.gauge = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -780,8 +778,9 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
 
   /* Check for and submit disk-octet values */
   if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_IO) &&
-      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_BYTES_READ |
-                                         HAVE_VOLUME_PERF_BYTES_WRITE)) {
+      HAS_ALL_FLAGS(new_data->flags,
+                    HAVE_VOLUME_PERF_BYTES_READ |
+                        HAVE_VOLUME_PERF_BYTES_WRITE)) {
     submit_two_derive(
         hostname, plugin_instance, "disk_octets", /* type instance = */ NULL,
         (derive_t)new_data->read_bytes, (derive_t)new_data->write_bytes,
@@ -799,15 +798,15 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   }
 
   /* Check for, calculate and submit disk-latency values */
-  if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_LATENCY |
-                                         HAVE_VOLUME_PERF_OPS_READ |
-                                         HAVE_VOLUME_PERF_OPS_WRITE |
-                                         HAVE_VOLUME_PERF_LATENCY_READ |
-                                         HAVE_VOLUME_PERF_LATENCY_WRITE) &&
-      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_OPS_READ |
-                                         HAVE_VOLUME_PERF_OPS_WRITE |
-                                         HAVE_VOLUME_PERF_LATENCY_READ |
-                                         HAVE_VOLUME_PERF_LATENCY_WRITE)) {
+  if (HAS_ALL_FLAGS(old_data->flags,
+                    CFG_VOLUME_PERF_LATENCY | HAVE_VOLUME_PERF_OPS_READ |
+                        HAVE_VOLUME_PERF_OPS_WRITE |
+                        HAVE_VOLUME_PERF_LATENCY_READ |
+                        HAVE_VOLUME_PERF_LATENCY_WRITE) &&
+      HAS_ALL_FLAGS(new_data->flags,
+                    HAVE_VOLUME_PERF_OPS_READ | HAVE_VOLUME_PERF_OPS_WRITE |
+                        HAVE_VOLUME_PERF_LATENCY_READ |
+                        HAVE_VOLUME_PERF_LATENCY_WRITE)) {
     gauge_t latency_per_op_read;
     gauge_t latency_per_op_write;
 
@@ -1407,8 +1406,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_RSVD)) {
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_SNAP_USED |
+                          HAVE_VOLUME_USAGE_SNAP_RSVD)) {
       if (v->snap_reserved > v->snap_used) {
         snap_reserve_free = v->snap_reserved - v->snap_used;
         snap_reserve_used = v->snap_used;
@@ -1422,8 +1422,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     /* The space used by snapshots but not reserved for them is included in
      * both, norm_used and snap_norm_used. If possible, subtract this here. */
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_NORM_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_USED)) {
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_NORM_USED |
+                          HAVE_VOLUME_USAGE_SNAP_USED)) {
       if (norm_used >= snap_norm_used)
         norm_used -= snap_norm_used;
       else {
@@ -1465,8 +1466,9 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
                     "df_complex", "snap_reserved", (double)snap_reserve_free,
                     /* timestamp = */ 0, interval);
 
-    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
-                                    HAVE_VOLUME_USAGE_SNAP_RSVD))
+    if (HAS_ALL_FLAGS(v->flags,
+                      HAVE_VOLUME_USAGE_SNAP_USED |
+                          HAVE_VOLUME_USAGE_SNAP_RSVD))
       submit_double(hostname, /* plugin instance = */ plugin_instance,
                     "df_complex", "snap_reserve_used",
                     (double)snap_reserve_used, /* timestamp = */ 0, interval);
@@ -2796,8 +2798,7 @@ static int cna_register_host(host_config_t *host) /* {{{ */
       /* callback  = */ cna_read,
       /* interval  = */ host->interval,
       &(user_data_t){
-          .data = host,
-          .free_func = (void *)free_host_config,
+          .data = host, .free_func = (void *)free_host_config,
       });
 
   return 0;

--- a/src/netapp.c
+++ b/src/netapp.c
@@ -643,7 +643,8 @@ static int submit_two_derive(const char *host,
                              derive_t val0, derive_t val1, cdtime_t timestamp,
                              cdtime_t interval) {
   value_t values[] = {
-      {.derive = val0}, {.derive = val1},
+      {.derive = val0},
+      {.derive = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -666,7 +667,8 @@ static int submit_two_gauge(const char *host, const char *plugin_inst, /* {{{ */
                             gauge_t val0, gauge_t val1, cdtime_t timestamp,
                             cdtime_t interval) {
   value_t values[] = {
-      {.gauge = val0}, {.gauge = val1},
+      {.gauge = val0},
+      {.gauge = val1},
   };
 
   return submit_values(host, plugin_inst, type, type_inst, values,
@@ -778,9 +780,8 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
 
   /* Check for and submit disk-octet values */
   if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_IO) &&
-      HAS_ALL_FLAGS(new_data->flags,
-                    HAVE_VOLUME_PERF_BYTES_READ |
-                        HAVE_VOLUME_PERF_BYTES_WRITE)) {
+      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_BYTES_READ |
+                                         HAVE_VOLUME_PERF_BYTES_WRITE)) {
     submit_two_derive(
         hostname, plugin_instance, "disk_octets", /* type instance = */ NULL,
         (derive_t)new_data->read_bytes, (derive_t)new_data->write_bytes,
@@ -798,15 +799,15 @@ static int submit_volume_perf_data(const char *hostname, /* {{{ */
   }
 
   /* Check for, calculate and submit disk-latency values */
-  if (HAS_ALL_FLAGS(old_data->flags,
-                    CFG_VOLUME_PERF_LATENCY | HAVE_VOLUME_PERF_OPS_READ |
-                        HAVE_VOLUME_PERF_OPS_WRITE |
-                        HAVE_VOLUME_PERF_LATENCY_READ |
-                        HAVE_VOLUME_PERF_LATENCY_WRITE) &&
-      HAS_ALL_FLAGS(new_data->flags,
-                    HAVE_VOLUME_PERF_OPS_READ | HAVE_VOLUME_PERF_OPS_WRITE |
-                        HAVE_VOLUME_PERF_LATENCY_READ |
-                        HAVE_VOLUME_PERF_LATENCY_WRITE)) {
+  if (HAS_ALL_FLAGS(old_data->flags, CFG_VOLUME_PERF_LATENCY |
+                                         HAVE_VOLUME_PERF_OPS_READ |
+                                         HAVE_VOLUME_PERF_OPS_WRITE |
+                                         HAVE_VOLUME_PERF_LATENCY_READ |
+                                         HAVE_VOLUME_PERF_LATENCY_WRITE) &&
+      HAS_ALL_FLAGS(new_data->flags, HAVE_VOLUME_PERF_OPS_READ |
+                                         HAVE_VOLUME_PERF_OPS_WRITE |
+                                         HAVE_VOLUME_PERF_LATENCY_READ |
+                                         HAVE_VOLUME_PERF_LATENCY_WRITE)) {
     gauge_t latency_per_op_read;
     gauge_t latency_per_op_write;
 
@@ -1406,9 +1407,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     ssnprintf(plugin_instance, sizeof(plugin_instance), "volume-%s", v->name);
 
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_SNAP_USED |
-                          HAVE_VOLUME_USAGE_SNAP_RSVD)) {
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_RSVD)) {
       if (v->snap_reserved > v->snap_used) {
         snap_reserve_free = v->snap_reserved - v->snap_used;
         snap_reserve_used = v->snap_used;
@@ -1422,9 +1422,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
 
     /* The space used by snapshots but not reserved for them is included in
      * both, norm_used and snap_norm_used. If possible, subtract this here. */
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_NORM_USED |
-                          HAVE_VOLUME_USAGE_SNAP_USED)) {
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_NORM_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_USED)) {
       if (norm_used >= snap_norm_used)
         norm_used -= snap_norm_used;
       else {
@@ -1466,9 +1465,8 @@ static int cna_submit_volume_usage_data(const char *hostname, /* {{{ */
                     "df_complex", "snap_reserved", (double)snap_reserve_free,
                     /* timestamp = */ 0, interval);
 
-    if (HAS_ALL_FLAGS(v->flags,
-                      HAVE_VOLUME_USAGE_SNAP_USED |
-                          HAVE_VOLUME_USAGE_SNAP_RSVD))
+    if (HAS_ALL_FLAGS(v->flags, HAVE_VOLUME_USAGE_SNAP_USED |
+                                    HAVE_VOLUME_USAGE_SNAP_RSVD))
       submit_double(hostname, /* plugin instance = */ plugin_instance,
                     "df_complex", "snap_reserve_used",
                     (double)snap_reserve_used, /* timestamp = */ 0, interval);
@@ -2798,7 +2796,8 @@ static int cna_register_host(host_config_t *host) /* {{{ */
       /* callback  = */ cna_read,
       /* interval  = */ host->interval,
       &(user_data_t){
-          .data = host, .free_func = (void *)free_host_config,
+          .data = host,
+          .free_func = (void *)free_host_config,
       });
 
   return 0;

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -198,8 +198,7 @@ static void submit_two(const char *dev, const char *type,
                        const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx},
-      {.derive = tx},
+      {.derive = rx}, {.derive = tx},
   };
 
   vl.values = values;

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -198,7 +198,8 @@ static void submit_two(const char *dev, const char *type,
                        const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;
@@ -510,7 +511,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       numberic_id = tm->tcm_parent;
 
     ssnprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
-             numberic_id & 0x0000FFFF);
+              numberic_id & 0x0000FFFF);
   }
 
   DEBUG("netlink plugin: qos_filter_cb: got %s for %s (%i).", tc_type, dev,
@@ -542,7 +543,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       stats_submitted = true;
 
       int r = ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
-                       tc_inst);
+                        tc_inst);
       if ((size_t)r >= sizeof(type_instance)) {
         ERROR("netlink plugin: type_instance truncated to %zu bytes, need %d",
               sizeof(type_instance), r);
@@ -581,7 +582,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
       char type_instance[DATA_MAX_NAME_LEN];
 
       int r = ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
-                       tc_inst);
+                        tc_inst);
       if ((size_t)r >= sizeof(type_instance)) {
         ERROR("netlink plugin: type_instance truncated to %zu bytes, need %d",
               sizeof(type_instance), r);

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -198,7 +198,8 @@ static void submit_two(const char *dev, const char *type,
                        const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -509,7 +509,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (strcmp(tc_type, "filter") == 0)
       numberic_id = tm->tcm_parent;
 
-    snprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
+    ssnprintf(tc_inst, sizeof(tc_inst), "%s-%x:%x", kind, numberic_id >> 16,
              numberic_id & 0x0000FFFF);
   }
 
@@ -541,7 +541,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
 
       stats_submitted = true;
 
-      int r = snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
+      int r = ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                        tc_inst);
       if ((size_t)r >= sizeof(type_instance)) {
         ERROR("netlink plugin: type_instance truncated to %zu bytes, need %d",
@@ -580,7 +580,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
     if (!stats_submitted && ts != NULL) {
       char type_instance[DATA_MAX_NAME_LEN];
 
-      int r = snprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
+      int r = ssnprintf(type_instance, sizeof(type_instance), "%s-%s", tc_type,
                        tc_inst);
       if ((size_t)r >= sizeof(type_instance)) {
         ERROR("netlink plugin: type_instance truncated to %zu bytes, need %d",

--- a/src/network.c
+++ b/src/network.c
@@ -1108,7 +1108,7 @@ static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
 
   return 0;
 } /* }}} int parse_part_sign_sha256 */
-/* #endif HAVE_GCRYPT_H */
+  /* #endif HAVE_GCRYPT_H */
 
 #else  /* if !HAVE_GCRYPT_H */
 static int parse_part_sign_sha256(sockent_t *se, /* {{{ */
@@ -1263,7 +1263,7 @@ static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
 
   return 0;
 } /* }}} int parse_part_encr_aes256 */
-/* #endif HAVE_GCRYPT_H */
+  /* #endif HAVE_GCRYPT_H */
 
 #else  /* if !HAVE_GCRYPT_H */
 static int parse_part_encr_aes256(sockent_t *se, /* {{{ */
@@ -1668,7 +1668,7 @@ static int network_set_interface(const sockent_t *se,
       ERROR("network plugin: setsockopt (bind-if): %s", STRERRNO);
       return -1;
     }
-/* #endif HAVE_IF_INDEXTONAME && SO_BINDTODEVICE */
+      /* #endif HAVE_IF_INDEXTONAME && SO_BINDTODEVICE */
 
 #else
     WARNING("network plugin: Cannot set the interface on a unicast "

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -322,7 +322,7 @@ static int nfs_config(const char *key, const char *value) {
 
 #if KERNEL_LINUX
 static int nfs_init(void) { return 0; }
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
 static int nfs_init(void) {
@@ -594,7 +594,7 @@ static int nfs_read(void) {
 
   return 0;
 }
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
 static int nfs_read(void) {

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -122,7 +122,7 @@ static int init(void) {
     curl_easy_setopt(curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
 #else
     static char credentials[1024];
-    int status = snprintf(credentials, sizeof(credentials), "%s:%s", user,
+    int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
                           pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -123,7 +123,7 @@ static int init(void) {
 #else
     static char credentials[1024];
     int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
-                          pass == NULL ? "" : pass);
+                           pass == NULL ? "" : pass);
     if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
       ERROR("nginx plugin: Credentials would have been truncated.");
       return -1;

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -93,7 +93,7 @@ static int c_notify(const notification_t *n,
     timeout = fail_timeout;
   }
 
-  snprintf(summary, sizeof(summary), "collectd %s notification",
+  ssnprintf(summary, sizeof(summary), "collectd %s notification",
            (NOTIF_FAILURE == n->severity)
                ? "FAILURE"
                : (NOTIF_WARNING == n->severity)

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -102,7 +102,7 @@ static int c_notify(const notification_t *n,
 
   notification = notify_notification_new(summary, n->message, NULL
 #if NOTIFY_CHECK_VERSION(0, 7, 0)
-                                         );
+  );
 #else
                                          ,
                                          NULL);

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -102,7 +102,7 @@ static int c_notify(const notification_t *n,
 
   notification = notify_notification_new(summary, n->message, NULL
 #if NOTIFY_CHECK_VERSION(0, 7, 0)
-  );
+                                         );
 #else
                                          ,
                                          NULL);

--- a/src/notify_desktop.c
+++ b/src/notify_desktop.c
@@ -94,15 +94,15 @@ static int c_notify(const notification_t *n,
   }
 
   ssnprintf(summary, sizeof(summary), "collectd %s notification",
-           (NOTIF_FAILURE == n->severity)
-               ? "FAILURE"
-               : (NOTIF_WARNING == n->severity)
-                     ? "WARNING"
-                     : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
+            (NOTIF_FAILURE == n->severity)
+                ? "FAILURE"
+                : (NOTIF_WARNING == n->severity)
+                      ? "WARNING"
+                      : (NOTIF_OKAY == n->severity) ? "OKAY" : "UNKNOWN");
 
   notification = notify_notification_new(summary, n->message, NULL
 #if NOTIFY_CHECK_VERSION(0, 7, 0)
-                                         );
+  );
 #else
                                          ,
                                          NULL);

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -105,7 +105,7 @@ static int notify_email_init(void) {
   char server[MAXSTRING];
 
   ssnprintf(server, sizeof(server), "%s:%i",
-           (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
+            (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
 
   pthread_mutex_lock(&session_lock);
 
@@ -215,15 +215,15 @@ static int notify_email_notification(const notification_t *n,
   int buf_len = sizeof(buf);
 
   ssnprintf(severity, sizeof(severity), "%s",
-           (n->severity == NOTIF_FAILURE)
-               ? "FAILURE"
-               : ((n->severity == NOTIF_WARNING)
-                      ? "WARNING"
-                      : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
+            (n->severity == NOTIF_FAILURE)
+                ? "FAILURE"
+                : ((n->severity == NOTIF_WARNING)
+                       ? "WARNING"
+                       : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
 
   ssnprintf(subject, sizeof(subject),
-           (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
-           severity, n->host);
+            (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
+            severity, n->host);
 
   localtime_r(&CDTIME_T_TO_TIME_T(n->time), &timestamp_tm);
   strftime(timestamp_str, sizeof(timestamp_str), "%Y-%m-%d %H:%M:%S",
@@ -232,14 +232,14 @@ static int notify_email_notification(const notification_t *n,
 
   /* Let's make RFC822 message text with \r\n EOLs */
   int status = ssnprintf(buf, buf_len,
-                        "MIME-Version: 1.0\r\n"
-                        "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
-                        "Content-Transfer-Encoding: 8bit\r\n"
-                        "Subject: %s\r\n"
-                        "\r\n"
-                        "%s - %s@%s\r\n"
-                        "\r\n",
-                        subject, timestamp_str, severity, n->host);
+                         "MIME-Version: 1.0\r\n"
+                         "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
+                         "Content-Transfer-Encoding: 8bit\r\n"
+                         "Subject: %s\r\n"
+                         "\r\n"
+                         "%s - %s@%s\r\n"
+                         "\r\n",
+                         subject, timestamp_str, severity, n->host);
 
   if (status > 0) {
     buf_ptr += status;
@@ -248,7 +248,7 @@ static int notify_email_notification(const notification_t *n,
 
 #define APPEND(format, value)                                                  \
   if ((buf_len > 0) && (strlen(value) > 0)) {                                  \
-    status = ssnprintf(buf_ptr, buf_len, format "\r\n", value);                 \
+    status = ssnprintf(buf_ptr, buf_len, format "\r\n", value);                \
     if (status > 0) {                                                          \
       buf_ptr += status;                                                       \
       buf_len -= status;                                                       \

--- a/src/notify_email.c
+++ b/src/notify_email.c
@@ -104,7 +104,7 @@ static void monitor_cb(const char *buf, int buflen, int writing,
 static int notify_email_init(void) {
   char server[MAXSTRING];
 
-  snprintf(server, sizeof(server), "%s:%i",
+  ssnprintf(server, sizeof(server), "%s:%i",
            (smtp_host == NULL) ? DEFAULT_SMTP_HOST : smtp_host, smtp_port);
 
   pthread_mutex_lock(&session_lock);
@@ -214,14 +214,14 @@ static int notify_email_notification(const notification_t *n,
   char *buf_ptr = buf;
   int buf_len = sizeof(buf);
 
-  snprintf(severity, sizeof(severity), "%s",
+  ssnprintf(severity, sizeof(severity), "%s",
            (n->severity == NOTIF_FAILURE)
                ? "FAILURE"
                : ((n->severity == NOTIF_WARNING)
                       ? "WARNING"
                       : ((n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN")));
 
-  snprintf(subject, sizeof(subject),
+  ssnprintf(subject, sizeof(subject),
            (email_subject == NULL) ? DEFAULT_SMTP_SUBJECT : email_subject,
            severity, n->host);
 
@@ -231,7 +231,7 @@ static int notify_email_notification(const notification_t *n,
   timestamp_str[sizeof(timestamp_str) - 1] = '\0';
 
   /* Let's make RFC822 message text with \r\n EOLs */
-  int status = snprintf(buf, buf_len,
+  int status = ssnprintf(buf, buf_len,
                         "MIME-Version: 1.0\r\n"
                         "Content-Type: text/plain; charset=\"US-ASCII\"\r\n"
                         "Content-Transfer-Encoding: 8bit\r\n"
@@ -248,7 +248,7 @@ static int notify_email_notification(const notification_t *n,
 
 #define APPEND(format, value)                                                  \
   if ((buf_len > 0) && (strlen(value) > 0)) {                                  \
-    status = snprintf(buf_ptr, buf_len, format "\r\n", value);                 \
+    status = ssnprintf(buf_ptr, buf_len, format "\r\n", value);                 \
     if (status > 0) {                                                          \
       buf_ptr += status;                                                       \
       buf_len -= status;                                                       \

--- a/src/nut.c
+++ b/src/nut.c
@@ -100,8 +100,10 @@ static int nut_add_ups(const char *name) {
       /* name      = */ cb_name,
       /* callback  = */ nut_read,
       /* interval  = */ 0,
-      /* user_data = */ &(user_data_t){
-          .data = ups, .free_func = free_nut_ups_t,
+      /* user_data = */
+      &(user_data_t){
+          .data = ups,
+          .free_func = free_nut_ups_t,
       });
 
   sfree(cb_name);

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -297,7 +297,7 @@ static int cow_read_values(const char *path, const char *name,
     char file[4096];
     char *endptr;
 
-    snprintf(file, sizeof(file), "%s/%s", path,
+    ssnprintf(file, sizeof(file), "%s/%s", path,
              family_info->features[i].filename);
     file[sizeof(file) - 1] = '\0';
 
@@ -348,11 +348,11 @@ static int cow_read_ds2409(const char *path) {
   char subpath[4096];
   int status;
 
-  status = snprintf(subpath, sizeof(subpath), "%s/main", path);
+  status = ssnprintf(subpath, sizeof(subpath), "%s/main", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
-  status = snprintf(subpath, sizeof(subpath), "%s/aux", path);
+  status = ssnprintf(subpath, sizeof(subpath), "%s/aux", path);
   if ((status > 0) && (status < (int)sizeof(subpath)))
     cow_read_bus(subpath);
 
@@ -384,9 +384,9 @@ static int cow_read_bus(const char *path) {
     dummy = NULL;
 
     if (strcmp("/", path) == 0)
-      status = snprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
+      status = ssnprintf(subpath, sizeof(subpath), "/%s", buffer_ptr);
     else
-      status = snprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
+      status = ssnprintf(subpath, sizeof(subpath), "%s/%s", path, buffer_ptr);
     if ((status <= 0) || (status >= (int)sizeof(subpath)))
       continue;
 

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -298,7 +298,7 @@ static int cow_read_values(const char *path, const char *name,
     char *endptr;
 
     ssnprintf(file, sizeof(file), "%s/%s", path,
-             family_info->features[i].filename);
+              family_info->features[i].filename);
     file[sizeof(file) - 1] = '\0';
 
     buffer = NULL;

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -472,7 +472,8 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
                                       /* callback  = */ cldap_read_host,
                                       /* interval  = */ 0,
                                       &(user_data_t){
-                                          .data = st, .free_func = cldap_free,
+                                          .data = st,
+                                          .free_func = cldap_free,
                                       });
 } /* }}} int cldap_config_add */
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -472,8 +472,7 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
                                       /* callback  = */ cldap_read_host,
                                       /* interval  = */ 0,
                                       &(user_data_t){
-                                          .data = st,
-                                          .free_func = cldap_free,
+                                          .data = st, .free_func = cldap_free,
                                       });
 } /* }}} int cldap_config_add */
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -306,7 +306,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list =
                  ldap_get_values_len(st->ld, e, "olmBDBEntryCache")) != NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
+          ssnprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
@@ -316,7 +316,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBDNCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbdncache-%s", nc_data.bv_val);
+          ssnprintf(typeinst, sizeof(typeinst), "bdbdncache-%s", nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -325,7 +325,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBIDLCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          snprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
+          ssnprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
@@ -462,7 +462,7 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
 
   char callback_name[3 * DATA_MAX_NAME_LEN] = {0};
 
-  snprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
+  ssnprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
            (st->host != NULL) ? st->host : hostname_g,
            (st->name != NULL) ? st->name : "default");
 

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -307,7 +307,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
                  ldap_get_values_len(st->ld, e, "olmBDBEntryCache")) != NULL) {
           olmbdb_data = *olmbdb_list[0];
           ssnprintf(typeinst, sizeof(typeinst), "bdbentrycache-%s",
-                   nc_data.bv_val);
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -316,7 +316,8 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
         if ((olmbdb_list = ldap_get_values_len(st->ld, e, "olmBDBDNCache")) !=
             NULL) {
           olmbdb_data = *olmbdb_list[0];
-          ssnprintf(typeinst, sizeof(typeinst), "bdbdncache-%s", nc_data.bv_val);
+          ssnprintf(typeinst, sizeof(typeinst), "bdbdncache-%s",
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -326,7 +327,7 @@ static int cldap_read_host(user_data_t *ud) /* {{{ */
             NULL) {
           olmbdb_data = *olmbdb_list[0];
           ssnprintf(typeinst, sizeof(typeinst), "bdbidlcache-%s",
-                   nc_data.bv_val);
+                    nc_data.bv_val);
           cldap_submit_gauge("cache_size", typeinst, atoll(olmbdb_data.bv_val),
                              st);
           ldap_value_free_len(olmbdb_list);
@@ -463,15 +464,16 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
   char callback_name[3 * DATA_MAX_NAME_LEN] = {0};
 
   ssnprintf(callback_name, sizeof(callback_name), "openldap/%s/%s",
-           (st->host != NULL) ? st->host : hostname_g,
-           (st->name != NULL) ? st->name : "default");
+            (st->host != NULL) ? st->host : hostname_g,
+            (st->name != NULL) ? st->name : "default");
 
   return plugin_register_complex_read(/* group = */ NULL,
                                       /* name      = */ callback_name,
                                       /* callback  = */ cldap_read_host,
                                       /* interval  = */ 0,
                                       &(user_data_t){
-                                          .data = st, .free_func = cldap_free,
+                                          .data = st,
+                                          .free_func = cldap_free,
                                       });
 } /* }}} int cldap_config_add */
 

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -640,7 +640,7 @@ static int o_read_database(o_database_t *db) /* {{{ */
     if ((status != OCI_SUCCESS) && (status != OCI_SUCCESS_WITH_INFO)) {
       char errfunc[256];
 
-      snprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
+      ssnprintf(errfunc, sizeof(errfunc), "OCILogon(\"%s\")", db->connect_id);
 
       o_report_error("o_read_database", db->name, NULL, errfunc, oci_error);
       DEBUG("oracle plugin: OCILogon (%s): db->oci_service_context = %p;",

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -158,7 +158,7 @@ static char *ovs_events_get_select_params() {
       return NULL;
     }
     opt_buff = new_buff;
-    int ret = snprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
+    int ret = ssnprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
                        iface->name);
     if (ret < 0) {
       sfree(opt_buff);
@@ -339,7 +339,7 @@ ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifinfo) {
   }
 
   /* fill the notification data */
-  snprintf(n.message, sizeof(n.message),
+  ssnprintf(n.message, sizeof(n.message),
            "link state of \"%s\" interface has been changed to \"%s\"",
            ifinfo->name, msg_link_status);
   sstrncpy(n.host, hostname_g, sizeof(n.host));

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -159,7 +159,7 @@ static char *ovs_events_get_select_params() {
     }
     opt_buff = new_buff;
     int ret = ssnprintf(opt_buff + buff_off, buff_size - buff_off, option_fmt,
-                       iface->name);
+                        iface->name);
     if (ret < 0) {
       sfree(opt_buff);
       return NULL;
@@ -340,8 +340,8 @@ ovs_events_dispatch_notification(const ovs_events_iface_info_t *ifinfo) {
 
   /* fill the notification data */
   ssnprintf(n.message, sizeof(n.message),
-           "link state of \"%s\" interface has been changed to \"%s\"",
-           ifinfo->name, msg_link_status);
+            "link state of \"%s\" interface has been changed to \"%s\"",
+            ifinfo->name, msg_link_status);
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   sstrncpy(n.plugin_instance, ifinfo->name, sizeof(n.plugin_instance));
   sstrncpy(n.type, "gauge", sizeof(n.type));

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -394,16 +394,16 @@ static void ovs_stats_submit_port(port_list_t *port) {
 
     for (interface_list_t *iface = port->iface; iface != NULL;
          iface = iface->next) {
-      snprintf(key_str, sizeof(key_str), "uuid%d", i);
+      ssnprintf(key_str, sizeof(key_str), "uuid%d", i);
       meta_data_add_string(meta, key_str, iface->iface_uuid);
 
       if (strlen(iface->ex_vm_id)) {
-        snprintf(key_str, sizeof(key_str), "vm-uuid%d", i);
+        ssnprintf(key_str, sizeof(key_str), "vm-uuid%d", i);
         meta_data_add_string(meta, key_str, iface->ex_vm_id);
       }
 
       if (strlen(iface->ex_iface_id)) {
-        snprintf(key_str, sizeof(key_str), "iface-id%d", i);
+        ssnprintf(key_str, sizeof(key_str), "iface-id%d", i);
         meta_data_add_string(meta, key_str, iface->ex_iface_id);
       }
 
@@ -411,7 +411,7 @@ static void ovs_stats_submit_port(port_list_t *port) {
     }
   }
   bridge_list_t *bridge = port->br;
-  snprintf(devname, sizeof(devname), "%s.%s", bridge->name, port->name);
+  ssnprintf(devname, sizeof(devname), "%s.%s", bridge->name, port->name);
   ovs_stats_submit_one(devname, "if_collisions", NULL,
                        ovs_stats_get_port_stat_value(port, collisions), meta);
   ovs_stats_submit_two(devname, "if_dropped", NULL,

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -282,9 +282,7 @@ static void ovs_stats_submit_interfaces(port_list_t *port) {
     }
     strjoin(devname, sizeof(devname),
             (char *[]){
-                bridge->name,
-                port->name,
-                iface->name,
+                bridge->name, port->name, iface->name,
             },
             3, ".");
     ovs_stats_submit_one(devname, "if_collisions", NULL,

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -282,7 +282,9 @@ static void ovs_stats_submit_interfaces(port_list_t *port) {
     }
     strjoin(devname, sizeof(devname),
             (char *[]){
-                bridge->name, port->name, iface->name,
+                bridge->name,
+                port->name,
+                iface->name,
             },
             3, ".");
     ovs_stats_submit_one(devname, "if_collisions", NULL,

--- a/src/pcie_errors.c
+++ b/src/pcie_errors.c
@@ -492,7 +492,7 @@ static void pcie_dispatch_uncorrectable_errors(pcie_device_t *dev,
 /* Find offset of PCI Express Capability Structure
  * in PCI configuration space.
  * Returns offset, -1 if not found.
-**/
+ **/
 static int pcie_find_cap_exp(pcie_device_t *dev) {
   int pos = pcie_read8(dev, PCI_CAPABILITY_LIST) & ~3;
 
@@ -515,7 +515,7 @@ static int pcie_find_cap_exp(pcie_device_t *dev) {
 
 /* Find offset of Advanced Error Reporting Capability.
  * Returns AER offset, -1 if not found.
-**/
+ **/
 static int pcie_find_ecap_aer(pcie_device_t *dev) {
   int pos = PCIE_ECAP_OFFSET;
   uint32_t header = pcie_read32(dev, pos);

--- a/src/perl.c
+++ b/src/perl.c
@@ -863,9 +863,9 @@ static int oconfig_item2hv(pTHX_ oconfig_item_t *ci, HV *hash) {
 static char *get_module_name(char *buf, size_t buf_len, const char *module) {
   int status = 0;
   if (base_name[0] == '\0')
-    status = snprintf(buf, buf_len, "%s", module);
+    status = ssnprintf(buf, buf_len, "%s", module);
   else
-    status = snprintf(buf, buf_len, "%s::%s", base_name, module);
+    status = ssnprintf(buf, buf_len, "%s::%s", base_name, module);
   if ((status < 0) || ((unsigned int)status >= buf_len))
     return NULL;
   return buf;

--- a/src/perl.c
+++ b/src/perl.c
@@ -33,8 +33,8 @@
 /* do not automatically get the thread specific Perl interpreter */
 #define PERL_NO_GET_CONTEXT
 
-#include "collectd.h"
 #include <stdbool.h>
+#include "collectd.h"
 
 #include <EXTERN.h>
 #include <perl.h>

--- a/src/perl.c
+++ b/src/perl.c
@@ -33,8 +33,8 @@
 /* do not automatically get the thread specific Perl interpreter */
 #define PERL_NO_GET_CONTEXT
 
-#include <stdbool.h>
 #include "collectd.h"
+#include <stdbool.h>
 
 #include <EXTERN.h>
 #include <perl.h>

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
+    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -323,7 +323,7 @@ static int c_psql_connect(c_psql_database_t *db) {
   if ((!db) || (!db->database))
     return -1;
 
-  status = snprintf(buf, buf_len, "dbname = '%s'", db->database);
+  status = ssnprintf(buf, buf_len, "dbname = '%s'", db->database);
   if (0 < status) {
     buf += status;
     buf_len -= status;
@@ -426,7 +426,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
       params[i] = db->user;
       break;
     case C_PSQL_PARAM_INTERVAL:
-      snprintf(interval, sizeof(interval), "%.3f",
+      ssnprintf(interval, sizeof(interval), "%.3f",
                CDTIME_T_TO_DOUBLE(plugin_get_interval()));
       params[i] = interval;
       break;
@@ -632,7 +632,7 @@ static char *values_name_to_sqlarray(const data_set_t *ds, char *string,
   str_len = string_len;
 
   for (size_t i = 0; i < ds->ds_num; ++i) {
-    int status = snprintf(str_ptr, str_len, ",'%s'", ds->ds[i].name);
+    int status = ssnprintf(str_ptr, str_len, ",'%s'", ds->ds[i].name);
 
     if (status < 1)
       return NULL;
@@ -670,9 +670,9 @@ static char *values_type_to_sqlarray(const data_set_t *ds, char *string,
     int status;
 
     if (store_rates)
-      status = snprintf(str_ptr, str_len, ",'gauge'");
+      status = ssnprintf(str_ptr, str_len, ",'gauge'");
     else
-      status = snprintf(str_ptr, str_len, ",'%s'",
+      status = ssnprintf(str_ptr, str_len, ",'%s'",
                         DS_TYPE_TO_STRING(ds->ds[i].type));
 
     if (status < 1) {
@@ -725,7 +725,7 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       status =
-          snprintf(str_ptr, str_len, "," GAUGE_FORMAT, vl->values[i].gauge);
+          ssnprintf(str_ptr, str_len, "," GAUGE_FORMAT, vl->values[i].gauge);
     else if (store_rates) {
       if (rates == NULL)
         rates = uc_get_rate(ds, vl);
@@ -735,14 +735,14 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
         return NULL;
       }
 
-      status = snprintf(str_ptr, str_len, ",%lf", rates[i]);
+      status = ssnprintf(str_ptr, str_len, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = snprintf(str_ptr, str_len, ",%" PRIu64,
+      status = ssnprintf(str_ptr, str_len, ",%" PRIu64,
                         (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      status = snprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
+      status = ssnprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)
-      status = snprintf(str_ptr, str_len, ",%" PRIu64, vl->values[i].absolute);
+      status = ssnprintf(str_ptr, str_len, ",%" PRIu64, vl->values[i].absolute);
 
     if (status < 1) {
       str_len = 0;
@@ -940,7 +940,7 @@ static int c_psql_shutdown(void) {
 
     if (db->writers_num > 0) {
       char cb_name[DATA_MAX_NAME_LEN];
-      snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
+      ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->database);
 
       if (!had_flush) {
         plugin_unregister_flush("postgresql");
@@ -1199,7 +1199,7 @@ static int c_psql_config_database(oconfig_item_t *ci) {
     }
   }
 
-  snprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
+  ssnprintf(cb_name, sizeof(cb_name), "postgresql-%s", db->instance);
 
   user_data_t ud = {.data = db, .free_func = c_psql_database_delete};
 

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
+    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -427,7 +427,7 @@ static PGresult *c_psql_exec_query_params(c_psql_database_t *db, udb_query_t *q,
       break;
     case C_PSQL_PARAM_INTERVAL:
       ssnprintf(interval, sizeof(interval), "%.3f",
-               CDTIME_T_TO_DOUBLE(plugin_get_interval()));
+                CDTIME_T_TO_DOUBLE(plugin_get_interval()));
       params[i] = interval;
       break;
     case C_PSQL_PARAM_INSTANCE:
@@ -673,7 +673,7 @@ static char *values_type_to_sqlarray(const data_set_t *ds, char *string,
       status = ssnprintf(str_ptr, str_len, ",'gauge'");
     else
       status = ssnprintf(str_ptr, str_len, ",'%s'",
-                        DS_TYPE_TO_STRING(ds->ds[i].type));
+                         DS_TYPE_TO_STRING(ds->ds[i].type));
 
     if (status < 1) {
       str_len = 0;
@@ -738,7 +738,7 @@ static char *values_to_sqlarray(const data_set_t *ds, const value_list_t *vl,
       status = ssnprintf(str_ptr, str_len, ",%lf", rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
       status = ssnprintf(str_ptr, str_len, ",%" PRIu64,
-                        (uint64_t)vl->values[i].counter);
+                         (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       status = ssnprintf(str_ptr, str_len, ",%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)

--- a/src/processes.c
+++ b/src/processes.c
@@ -757,7 +757,7 @@ static int ps_init(void) {
     pset_list_len = 0;
     return -1;
   }
-/* #endif HAVE_THREAD_INFO */
+    /* #endif HAVE_THREAD_INFO */
 
 #elif KERNEL_LINUX
   pagesize_g = sysconf(_SC_PAGESIZE);
@@ -771,13 +771,13 @@ static int ps_init(void) {
     }
   }
 #endif
-/* #endif KERNEL_LINUX */
+    /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKVM_GETPROCS &&                                                  \
     (HAVE_STRUCT_KINFO_PROC_FREEBSD || HAVE_STRUCT_KINFO_PROC_OPENBSD)
   pagesize = getpagesize();
-/* #endif HAVE_LIBKVM_GETPROCS && (HAVE_STRUCT_KINFO_PROC_FREEBSD ||
- * HAVE_STRUCT_KINFO_PROC_OPENBSD) */
+  /* #endif HAVE_LIBKVM_GETPROCS && (HAVE_STRUCT_KINFO_PROC_FREEBSD ||
+   * HAVE_STRUCT_KINFO_PROC_OPENBSD) */
 
 #elif HAVE_PROCINFO_H
   pagesize = getpagesize();
@@ -1681,7 +1681,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   /*
    * TODO: context switch counters for Solaris
-*/
+   */
   ps->cswitch_vol = -1;
   ps->cswitch_invol = -1;
 
@@ -2013,7 +2013,7 @@ static int ps_read(void) {
 
   for (ps = list_head_g; ps != NULL; ps = ps->next)
     ps_submit_proc_list(ps);
-/* #endif HAVE_THREAD_INFO */
+    /* #endif HAVE_THREAD_INFO */
 
 #elif KERNEL_LINUX
   int running = 0;
@@ -2095,7 +2095,7 @@ static int ps_read(void) {
     ps_submit_proc_list(ps_ptr);
 
   read_fork_rate();
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_FREEBSD
   int running = 0;
@@ -2250,7 +2250,7 @@ static int ps_read(void) {
 
   for (procstat_t *ps_ptr = list_head_g; ps_ptr != NULL; ps_ptr = ps_ptr->next)
     ps_submit_proc_list(ps_ptr);
-/* #endif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_FREEBSD */
+    /* #endif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_FREEBSD */
 
 #elif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_OPENBSD
   int running = 0;
@@ -2394,7 +2394,7 @@ static int ps_read(void) {
 
   for (procstat_t *ps_ptr = list_head_g; ps_ptr != NULL; ps_ptr = ps_ptr->next)
     ps_submit_proc_list(ps_ptr);
-/* #endif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_OPENBSD */
+    /* #endif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_OPENBSD */
 
 #elif HAVE_PROCINFO_H
   /* AIX */
@@ -2533,7 +2533,7 @@ static int ps_read(void) {
 
   for (procstat_t *ps = list_head_g; ps != NULL; ps = ps->next)
     ps_submit_proc_list(ps);
-/* #endif HAVE_PROCINFO_H */
+    /* #endif HAVE_PROCINFO_H */
 
 #elif KERNEL_SOLARIS
   /*

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -41,8 +41,7 @@
  * Global variables
  */
 static const char *config_keys[] = {
-    "Value",
-    "IgnoreSelected",
+    "Value", "IgnoreSelected",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -154,7 +154,7 @@ static int read_file(const char *path) {
       if (values_list != NULL) {
         char match_name[2 * DATA_MAX_NAME_LEN];
 
-        snprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
+        ssnprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
                  key_fields[i]);
 
         if (ignorelist_match(values_list, match_name))

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -41,7 +41,8 @@
  * Global variables
  */
 static const char *config_keys[] = {
-    "Value", "IgnoreSelected",
+    "Value",
+    "IgnoreSelected",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -41,7 +41,8 @@
  * Global variables
  */
 static const char *config_keys[] = {
-    "Value", "IgnoreSelected",
+    "Value",
+    "IgnoreSelected",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -155,7 +156,7 @@ static int read_file(const char *path) {
         char match_name[2 * DATA_MAX_NAME_LEN];
 
         ssnprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
-                 key_fields[i]);
+                  key_fields[i]);
 
         if (ignorelist_match(values_list, match_name))
           continue;

--- a/src/python.c
+++ b/src/python.c
@@ -703,9 +703,8 @@ static PyObject *cpy_get_dataset(PyObject *self, PyObject *args) {
   for (size_t i = 0; i < ds->ds_num; ++i) {
     tuple = PyTuple_New(4);
     PyTuple_SET_ITEM(tuple, 0, cpy_string_to_unicode_or_bytes(ds->ds[i].name));
-    PyTuple_SET_ITEM(
-        tuple, 1,
-        cpy_string_to_unicode_or_bytes(DS_TYPE_TO_STRING(ds->ds[i].type)));
+    PyTuple_SET_ITEM(tuple, 1, cpy_string_to_unicode_or_bytes(
+                                   DS_TYPE_TO_STRING(ds->ds[i].type)));
     PyTuple_SET_ITEM(tuple, 2, float_or_none(ds->ds[i].min));
     PyTuple_SET_ITEM(tuple, 3, float_or_none(ds->ds[i].max));
     PyList_SET_ITEM(list, i, tuple);
@@ -775,8 +774,7 @@ static PyObject *cpy_register_generic_userdata(void *reg, void *handler,
 
   register_function(buf, handler,
                     &(user_data_t){
-                        .data = c,
-                        .free_func = cpy_destroy_user_data,
+                        .data = c, .free_func = cpy_destroy_user_data,
                     });
 
   ++cpy_num_callbacks;
@@ -819,8 +817,7 @@ static PyObject *cpy_register_read(PyObject *self, PyObject *args,
       /* group = */ "python", buf, cpy_read_callback,
       DOUBLE_TO_CDTIME_T(interval),
       &(user_data_t){
-          .data = c,
-          .free_func = cpy_destroy_user_data,
+          .data = c, .free_func = cpy_destroy_user_data,
       });
   ++cpy_num_callbacks;
   return cpy_string_to_unicode_or_bytes(buf);
@@ -1204,9 +1201,8 @@ static PyObject *cpy_oconfig_to_pyconfig(oconfig_item_t *ci, PyObject *parent) {
   values = PyTuple_New(ci->values_num); /* New reference. */
   for (int i = 0; i < ci->values_num; ++i) {
     if (ci->values[i].type == OCONFIG_TYPE_STRING) {
-      PyTuple_SET_ITEM(
-          values, i,
-          cpy_string_to_unicode_or_bytes(ci->values[i].value.string));
+      PyTuple_SET_ITEM(values, i, cpy_string_to_unicode_or_bytes(
+                                      ci->values[i].value.string));
     } else if (ci->values[i].type == OCONFIG_TYPE_NUMBER) {
       PyTuple_SET_ITEM(values, i,
                        PyFloat_FromDouble(ci->values[i].value.number));

--- a/src/python.c
+++ b/src/python.c
@@ -285,7 +285,7 @@ static void cpy_build_name(char *buf, size_t size, PyObject *callback,
   PyObject *mod = NULL;
 
   if (name != NULL) {
-    snprintf(buf, size, "python.%s", name);
+    ssnprintf(buf, size, "python.%s", name);
     return;
   }
 
@@ -294,14 +294,14 @@ static void cpy_build_name(char *buf, size_t size, PyObject *callback,
     module = cpy_unicode_or_bytes_to_string(&mod);
 
   if (module != NULL) {
-    snprintf(buf, size, "python.%s", module);
+    ssnprintf(buf, size, "python.%s", module);
     Py_XDECREF(mod);
     PyErr_Clear();
     return;
   }
   Py_XDECREF(mod);
 
-  snprintf(buf, size, "python.%p", callback);
+  ssnprintf(buf, size, "python.%p", callback);
   PyErr_Clear();
 }
 

--- a/src/python.c
+++ b/src/python.c
@@ -703,8 +703,9 @@ static PyObject *cpy_get_dataset(PyObject *self, PyObject *args) {
   for (size_t i = 0; i < ds->ds_num; ++i) {
     tuple = PyTuple_New(4);
     PyTuple_SET_ITEM(tuple, 0, cpy_string_to_unicode_or_bytes(ds->ds[i].name));
-    PyTuple_SET_ITEM(tuple, 1, cpy_string_to_unicode_or_bytes(
-                                   DS_TYPE_TO_STRING(ds->ds[i].type)));
+    PyTuple_SET_ITEM(
+        tuple, 1,
+        cpy_string_to_unicode_or_bytes(DS_TYPE_TO_STRING(ds->ds[i].type)));
     PyTuple_SET_ITEM(tuple, 2, float_or_none(ds->ds[i].min));
     PyTuple_SET_ITEM(tuple, 3, float_or_none(ds->ds[i].max));
     PyList_SET_ITEM(list, i, tuple);
@@ -774,7 +775,8 @@ static PyObject *cpy_register_generic_userdata(void *reg, void *handler,
 
   register_function(buf, handler,
                     &(user_data_t){
-                        .data = c, .free_func = cpy_destroy_user_data,
+                        .data = c,
+                        .free_func = cpy_destroy_user_data,
                     });
 
   ++cpy_num_callbacks;
@@ -817,7 +819,8 @@ static PyObject *cpy_register_read(PyObject *self, PyObject *args,
       /* group = */ "python", buf, cpy_read_callback,
       DOUBLE_TO_CDTIME_T(interval),
       &(user_data_t){
-          .data = c, .free_func = cpy_destroy_user_data,
+          .data = c,
+          .free_func = cpy_destroy_user_data,
       });
   ++cpy_num_callbacks;
   return cpy_string_to_unicode_or_bytes(buf);
@@ -1201,8 +1204,9 @@ static PyObject *cpy_oconfig_to_pyconfig(oconfig_item_t *ci, PyObject *parent) {
   values = PyTuple_New(ci->values_num); /* New reference. */
   for (int i = 0; i < ci->values_num; ++i) {
     if (ci->values[i].type == OCONFIG_TYPE_STRING) {
-      PyTuple_SET_ITEM(values, i, cpy_string_to_unicode_or_bytes(
-                                      ci->values[i].value.string));
+      PyTuple_SET_ITEM(
+          values, i,
+          cpy_string_to_unicode_or_bytes(ci->values[i].value.string));
     } else if (ci->values[i].type == OCONFIG_TYPE_NUMBER) {
       PyTuple_SET_ITEM(values, i,
                        PyFloat_FromDouble(ci->values[i].value.number));

--- a/src/redis.c
+++ b/src/redis.c
@@ -123,7 +123,8 @@ static int redis_node_add(redis_node_t *rn) /* {{{ */
       /* callback  = */ redis_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = rn, .free_func = redis_node_free,
+          .data = rn,
+          .free_func = redis_node_free,
       });
 } /* }}} */
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -115,7 +115,7 @@ static int redis_node_add(redis_node_t *rn) /* {{{ */
   redis_have_instances = true;
 
   char cb_name[sizeof("redis/") + DATA_MAX_NAME_LEN];
-  snprintf(cb_name, sizeof(cb_name), "redis/%s", rn->name);
+  ssnprintf(cb_name, sizeof(cb_name), "redis/%s", rn->name);
 
   return plugin_register_complex_read(
       /* group = */ "redis",
@@ -486,7 +486,7 @@ static int redis_db_stats(const char *node, char const *info_line) /* {{{ */
     char *str;
     int i;
 
-    snprintf(field_name, sizeof(field_name), "db%d:keys=", db);
+    ssnprintf(field_name, sizeof(field_name), "db%d:keys=", db);
 
     str = strstr(info_line, field_name);
     if (!str)
@@ -502,7 +502,7 @@ static int redis_db_stats(const char *node, char const *info_line) /* {{{ */
       return -1;
     }
 
-    snprintf(db_id, sizeof(db_id), "%d", db);
+    ssnprintf(db_id, sizeof(db_id), "%d", db);
     redis_submit(node, "records", db_id, val);
   }
   return 0;

--- a/src/redis.c
+++ b/src/redis.c
@@ -123,8 +123,7 @@ static int redis_node_add(redis_node_t *rn) /* {{{ */
       /* callback  = */ redis_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = rn,
-          .free_func = redis_node_free,
+          .data = rn, .free_func = redis_node_free,
       });
 } /* }}} */
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -150,7 +150,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
     name = "default";
 
   /*** RX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
@@ -159,7 +159,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->rx_ccq);
 
   /*** TX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
@@ -168,7 +168,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
   cr_submit_gauge(rd, "signal_quality", type_instance, (gauge_t)r->tx_ccq);
 
   /*** RX / TX ***/
-  snprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface, name);
+  ssnprintf(type_instance, sizeof(type_instance), "%s-%s", r->interface, name);
   cr_submit_io(rd, "if_octets", type_instance, (derive_t)r->rx_bytes,
                (derive_t)r->tx_bytes);
   cr_submit_gauge(rd, "snr", type_instance, (gauge_t)r->signal_to_noise);
@@ -438,7 +438,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
     return status;
   }
 
-  snprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
+  ssnprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
   return plugin_register_complex_read(
       /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
       &(user_data_t){

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -53,7 +53,8 @@ static void cr_submit_io(cr_data_t *rd, const char *type, /* {{{ */
                          const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;
@@ -151,7 +152,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** RX ***/
   ssnprintf(type_instance, sizeof(type_instance), "%s-%s-rx", r->interface,
-           name);
+            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->rx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -160,7 +161,7 @@ static void submit_regtable(cr_data_t *rd, /* {{{ */
 
   /*** TX ***/
   ssnprintf(type_instance, sizeof(type_instance), "%s-%s-tx", r->interface,
-           name);
+            name);
   cr_submit_gauge(rd, "bitrate", type_instance,
                   (gauge_t)(1000000.0 * r->tx_rate));
   cr_submit_gauge(rd, "signal_power", type_instance,
@@ -442,7 +443,8 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
   return plugin_register_complex_read(
       /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
       &(user_data_t){
-          .data = router_data, .free_func = (void *)cr_free_data,
+          .data = router_data,
+          .free_func = (void *)cr_free_data,
       });
 } /* }}} int cr_config_router */
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -53,8 +53,7 @@ static void cr_submit_io(cr_data_t *rd, const char *type, /* {{{ */
                          const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx},
-      {.derive = tx},
+      {.derive = rx}, {.derive = tx},
   };
 
   vl.values = values;
@@ -443,8 +442,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
   return plugin_register_complex_read(
       /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
       &(user_data_t){
-          .data = router_data,
-          .free_func = (void *)cr_free_data,
+          .data = router_data, .free_func = (void *)cr_free_data,
       });
 } /* }}} int cr_config_router */
 

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -53,7 +53,8 @@ static void cr_submit_io(cr_data_t *rd, const char *type, /* {{{ */
                          const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;
@@ -442,7 +443,8 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
   return plugin_register_complex_read(
       /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
       &(user_data_t){
-          .data = router_data, .free_func = (void *)cr_free_data,
+          .data = router_data,
+          .free_func = (void *)cr_free_data,
       });
 } /* }}} int cr_config_router */
 

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -426,8 +426,7 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
   }
 
   char *values_array[2] = {
-      [0] = values,
-      [1] = NULL,
+          [0] = values, [1] = NULL,
   };
 
   while (42) {

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -426,7 +426,8 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
   }
 
   char *values_array[2] = {
-          [0] = values, [1] = NULL,
+      [0] = values,
+      [1] = NULL,
   };
 
   while (42) {

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -67,7 +67,7 @@ static int value_list_to_string(char *buffer, int buffer_len,
   memset(buffer, '\0', buffer_len);
 
   int status =
-      snprintf(buffer, buffer_len, "%.6f", CDTIME_T_TO_DOUBLE(vl->time));
+      ssnprintf(buffer, buffer_len, "%.6f", CDTIME_T_TO_DOUBLE(vl->time));
   if ((status < 1) || (status >= buffer_len))
     return -1;
   int offset = status;
@@ -80,16 +80,16 @@ static int value_list_to_string(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                         (uint64_t)vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_GAUGE) {
-      status = snprintf(buffer + offset, buffer_len - offset, ":%f",
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%f",
                         vl->values[i].gauge);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
                         vl->values[i].derive);
     } else /* if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */ {
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                         vl->values[i].absolute);
     }
 
@@ -461,9 +461,9 @@ static int rc_flush(__attribute__((unused)) cdtime_t timeout, /* {{{ */
   char filename[PATH_MAX + 1];
 
   if (datadir != NULL)
-    snprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
+    ssnprintf(filename, sizeof(filename), "%s/%s.rrd", datadir, identifier);
   else
-    snprintf(filename, sizeof(filename), "%s.rrd", identifier);
+    ssnprintf(filename, sizeof(filename), "%s.rrd", identifier);
 
   rrd_clear_error();
   int status = rrdc_connect(daemon_address);

--- a/src/rrdcached.c
+++ b/src/rrdcached.c
@@ -81,16 +81,16 @@ static int value_list_to_string(char *buffer, int buffer_len,
 
     if (ds->ds[i].type == DS_TYPE_COUNTER) {
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                        (uint64_t)vl->values[i].counter);
+                         (uint64_t)vl->values[i].counter);
     } else if (ds->ds[i].type == DS_TYPE_GAUGE) {
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%f",
-                        vl->values[i].gauge);
+                         vl->values[i].gauge);
     } else if (ds->ds[i].type == DS_TYPE_DERIVE) {
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
-                        vl->values[i].derive);
+                         vl->values[i].derive);
     } else /* if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */ {
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                        vl->values[i].absolute);
+                         vl->values[i].absolute);
     }
 
     if ((status < 1) || (status >= (buffer_len - offset)))
@@ -426,7 +426,8 @@ static int rc_write(const data_set_t *ds, const value_list_t *vl,
   }
 
   char *values_array[2] = {
-          [0] = values, [1] = NULL,
+      [0] = values,
+      [1] = NULL,
   };
 
   while (42) {

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -187,16 +187,16 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                        (uint64_t)vl->values[i].counter);
+                         (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)
       status = ssnprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
-                        vl->values[i].gauge);
+                         vl->values[i].gauge);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
-                        vl->values[i].derive);
+                         vl->values[i].derive);
     else /*if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */
       status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
-                        vl->values[i].absolute);
+                         vl->values[i].absolute);
 
     if ((status < 1) || (status >= (buffer_len - offset)))
       return -1;
@@ -219,19 +219,19 @@ static int value_list_to_string(char *buffer, int buffer_len,
   switch (ds->ds[0].type) {
   case DS_TYPE_DERIVE:
     status = ssnprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
-                      vl->values[0].derive);
+                       vl->values[0].derive);
     break;
   case DS_TYPE_GAUGE:
     status = ssnprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
-                      vl->values[0].gauge);
+                       vl->values[0].gauge);
     break;
   case DS_TYPE_COUNTER:
     status = ssnprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
-                      (uint64_t)vl->values[0].counter);
+                       (uint64_t)vl->values[0].counter);
     break;
   case DS_TYPE_ABSOLUTE:
     status = ssnprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
-                      vl->values[0].absolute);
+                       vl->values[0].absolute);
     break;
   default:
     return EINVAL;

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -173,7 +173,7 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
   memset(buffer, '\0', buffer_len);
 
   tt = CDTIME_T_TO_TIME_T(vl->time);
-  status = snprintf(buffer, buffer_len, "%u", (unsigned int)tt);
+  status = ssnprintf(buffer, buffer_len, "%u", (unsigned int)tt);
   if ((status < 1) || (status >= buffer_len))
     return -1;
   offset = status;
@@ -186,16 +186,16 @@ static int value_list_to_string_multiple(char *buffer, int buffer_len,
       return -1;
 
     if (ds->ds[i].type == DS_TYPE_COUNTER)
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                         (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_GAUGE)
-      status = snprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":" GAUGE_FORMAT,
                         vl->values[i].gauge);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIi64,
                         vl->values[i].derive);
     else /*if (ds->ds[i].type == DS_TYPE_ABSOLUTE) */
-      status = snprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
+      status = ssnprintf(buffer + offset, buffer_len - offset, ":%" PRIu64,
                         vl->values[i].absolute);
 
     if ((status < 1) || (status >= (buffer_len - offset)))
@@ -218,19 +218,19 @@ static int value_list_to_string(char *buffer, int buffer_len,
   tt = CDTIME_T_TO_TIME_T(vl->time);
   switch (ds->ds[0].type) {
   case DS_TYPE_DERIVE:
-    status = snprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
+    status = ssnprintf(buffer, buffer_len, "%u:%" PRIi64, (unsigned)tt,
                       vl->values[0].derive);
     break;
   case DS_TYPE_GAUGE:
-    status = snprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
+    status = ssnprintf(buffer, buffer_len, "%u:" GAUGE_FORMAT, (unsigned)tt,
                       vl->values[0].gauge);
     break;
   case DS_TYPE_COUNTER:
-    status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
+    status = ssnprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
                       (uint64_t)vl->values[0].counter);
     break;
   case DS_TYPE_ABSOLUTE:
-    status = snprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
+    status = ssnprintf(buffer, buffer_len, "%u:%" PRIu64, (unsigned)tt,
                       vl->values[0].absolute);
     break;
   default:
@@ -566,9 +566,9 @@ static int rrd_cache_flush_identifier(cdtime_t timeout,
   now = cdtime();
 
   if (datadir == NULL)
-    snprintf(key, sizeof(key), "%s.rrd", identifier);
+    ssnprintf(key, sizeof(key), "%s.rrd", identifier);
   else
-    snprintf(key, sizeof(key), "%s/%s.rrd", datadir, identifier);
+    ssnprintf(key, sizeof(key), "%s/%s.rrd", datadir, identifier);
   key[sizeof(key) - 1] = '\0';
 
   status = c_avl_get(cache, key, (void *)&rc);

--- a/src/rrdtool.c
+++ b/src/rrdtool.c
@@ -120,7 +120,7 @@ static int srrd_update(char *filename, char *template, int argc,
 
   return status;
 } /* int srrd_update */
-/* #endif HAVE_THREADSAFE_LIBRRD */
+  /* #endif HAVE_THREADSAFE_LIBRRD */
 
 #else  /* !HAVE_THREADSAFE_LIBRRD */
 static int srrd_update(char *filename, char *template, int argc,

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -230,7 +230,7 @@ static int sensors_load_conf(void) {
       last_feature = fl;
     } /* while sensors_get_all_features */
   }   /* while sensors_get_detected_chips */
-    /* #endif SENSORS_API_VERSION < 0x400 */
+      /* #endif SENSORS_API_VERSION < 0x400 */
 
 #elif (SENSORS_API_VERSION >= 0x400)
   chip_num = 0;

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -230,7 +230,7 @@ static int sensors_load_conf(void) {
       last_feature = fl;
     } /* while sensors_get_all_features */
   }   /* while sensors_get_detected_chips */
-/* #endif SENSORS_API_VERSION < 0x400 */
+    /* #endif SENSORS_API_VERSION < 0x400 */
 
 #elif (SENSORS_API_VERSION >= 0x400)
   chip_num = 0;
@@ -368,7 +368,7 @@ static int sensors_read(void) {
     sensors_submit(plugin_instance, sensor_type_name_map[fl->type],
                    type_instance, value);
   } /* for fl = first_feature .. NULL */
-/* #endif SENSORS_API_VERSION < 0x400 */
+    /* #endif SENSORS_API_VERSION < 0x400 */
 
 #elif (SENSORS_API_VERSION >= 0x400)
   for (featurelist_t *fl = first_feature; fl != NULL; fl = fl->next) {

--- a/src/serial.c
+++ b/src/serial.c
@@ -33,7 +33,8 @@
 static void serial_submit(const char *type_instance, derive_t rx, derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -247,7 +247,7 @@ static int sigrok_init_driver(struct config_device *cfdev,
   }
   cfdev->sdi = devlist->data;
   g_slist_free(devlist);
-  snprintf(hwident, sizeof(hwident), "%s %s %s",
+  ssnprintf(hwident, sizeof(hwident), "%s %s %s",
            cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
            cfdev->sdi->model ? cfdev->sdi->model : "",
            cfdev->sdi->version ? cfdev->sdi->version : "");

--- a/src/sigrok.c
+++ b/src/sigrok.c
@@ -248,9 +248,9 @@ static int sigrok_init_driver(struct config_device *cfdev,
   cfdev->sdi = devlist->data;
   g_slist_free(devlist);
   ssnprintf(hwident, sizeof(hwident), "%s %s %s",
-           cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
-           cfdev->sdi->model ? cfdev->sdi->model : "",
-           cfdev->sdi->version ? cfdev->sdi->version : "");
+            cfdev->sdi->vendor ? cfdev->sdi->vendor : "",
+            cfdev->sdi->model ? cfdev->sdi->model : "",
+            cfdev->sdi->version ? cfdev->sdi->version : "");
   INFO("sigrok plugin: Device \"%s\" is a %s", cfdev->name, hwident);
 
   if (sr_dev_open(cfdev->sdi) != SR_OK)

--- a/src/smart.c
+++ b/src/smart.c
@@ -116,7 +116,7 @@ static void handle_attribute(SkDisk *d, const SkSmartAttributeParsedData *a,
     sstrncpy(notif.host, hostname_g, sizeof(notif.host));
     sstrncpy(notif.plugin_instance, name, sizeof(notif.plugin_instance));
     sstrncpy(notif.type_instance, a->name, sizeof(notif.type_instance));
-    snprintf(notif.message, sizeof(notif.message),
+    ssnprintf(notif.message, sizeof(notif.message),
              "attribute %s is below allowed threshold (%d < %d)", a->name,
              a->current_value, a->threshold);
     plugin_dispatch_notification(&notif);

--- a/src/smart.c
+++ b/src/smart.c
@@ -117,8 +117,8 @@ static void handle_attribute(SkDisk *d, const SkSmartAttributeParsedData *a,
     sstrncpy(notif.plugin_instance, name, sizeof(notif.plugin_instance));
     sstrncpy(notif.type_instance, a->name, sizeof(notif.type_instance));
     ssnprintf(notif.message, sizeof(notif.message),
-             "attribute %s is below allowed threshold (%d < %d)", a->name,
-             a->current_value, a->threshold);
+              "attribute %s is below allowed threshold (%d < %d)", a->name,
+              a->current_value, a->threshold);
     plugin_dispatch_notification(&notif);
   }
 }

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -171,7 +171,7 @@ static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -871,7 +871,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
         "= %i }",
         hd->name, hd->address, hd->community, hd->version);
 
-  snprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
+  ssnprintf(cb_name, sizeof(cb_name), "snmp-%s", hd->name);
 
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, interval,
@@ -1140,7 +1140,7 @@ static int csnmp_strvbcopy_hexstring(char *dst, /* {{{ */
   for (size_t i = 0; i < vb->val_len; i++) {
     int status;
 
-    status = snprintf(buffer_ptr, buffer_free, (i == 0) ? "%02x" : ":%02x",
+    status = ssnprintf(buffer_ptr, buffer_free, (i == 0) ? "%02x" : ":%02x",
                       (unsigned int)vb->val.bitstring[i]);
     assert(status >= 0);
 
@@ -1173,7 +1173,7 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
   else if (vb->type == ASN_BIT_STR)
     src = (char *)vb->val.bitstring;
   else if (vb->type == ASN_IPADDRESS) {
-    return snprintf(dst, dst_size,
+    return ssnprintf(dst, dst_size,
                     "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
                     (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
                     (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
@@ -1234,7 +1234,7 @@ static csnmp_cell_char_t *csnmp_get_char_cell(const struct variable_list *vb,
     value_t val = csnmp_value_list_to_value(
         vb, DS_TYPE_COUNTER,
         /* scale = */ 1.0, /* shift = */ 0.0, hd->name, dd->name);
-    snprintf(il->value, sizeof(il->value), "%" PRIu64, (uint64_t)val.counter);
+    ssnprintf(il->value, sizeof(il->value), "%" PRIu64, (uint64_t)val.counter);
   }
 
   return il;
@@ -1479,7 +1479,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->host.prefix == NULL)
         sstrncpy(vl.host, temp, sizeof(vl.host));
       else
-        snprintf(vl.host, sizeof(vl.host), "%s%s", data->host.prefix, temp);
+        ssnprintf(vl.host, sizeof(vl.host), "%s%s", data->host.prefix, temp);
     } else {
       sstrncpy(vl.host, host->name, sizeof(vl.host));
     }
@@ -1495,7 +1495,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->type_instance.prefix == NULL)
         sstrncpy(vl.type_instance, temp, sizeof(vl.type_instance));
       else
-        snprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
+        ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
                  data->type_instance.prefix, temp);
     } else if (data->type_instance.value) {
       sstrncpy(vl.type_instance, data->type_instance.value,
@@ -1513,7 +1513,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
       if (data->plugin_instance.prefix == NULL)
         sstrncpy(vl.plugin_instance, temp, sizeof(vl.plugin_instance));
       else
-        snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s%s",
+        ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s%s",
                  data->plugin_instance.prefix, temp);
     } else if (data->plugin_instance.value) {
       sstrncpy(vl.plugin_instance, data->plugin_instance.value,

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -876,7 +876,8 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, interval,
       &(user_data_t){
-          .data = hd, .free_func = csnmp_host_definition_destroy,
+          .data = hd,
+          .free_func = csnmp_host_definition_destroy,
       });
   if (status != 0) {
     ERROR("snmp plugin: Registering complex read function failed.");

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -876,8 +876,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, interval,
       &(user_data_t){
-          .data = hd,
-          .free_func = csnmp_host_definition_destroy,
+          .data = hd, .free_func = csnmp_host_definition_destroy,
       });
   if (status != 0) {
     ERROR("snmp plugin: Registering complex read function failed.");

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -876,7 +876,8 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
   status = plugin_register_complex_read(
       /* group = */ NULL, cb_name, csnmp_read_host, interval,
       &(user_data_t){
-          .data = hd, .free_func = csnmp_host_definition_destroy,
+          .data = hd,
+          .free_func = csnmp_host_definition_destroy,
       });
   if (status != 0) {
     ERROR("snmp plugin: Registering complex read function failed.");
@@ -1141,7 +1142,7 @@ static int csnmp_strvbcopy_hexstring(char *dst, /* {{{ */
     int status;
 
     status = ssnprintf(buffer_ptr, buffer_free, (i == 0) ? "%02x" : ":%02x",
-                      (unsigned int)vb->val.bitstring[i]);
+                       (unsigned int)vb->val.bitstring[i]);
     assert(status >= 0);
 
     if (((size_t)status) >= buffer_free) /* truncated */
@@ -1174,9 +1175,9 @@ static int csnmp_strvbcopy(char *dst, /* {{{ */
     src = (char *)vb->val.bitstring;
   else if (vb->type == ASN_IPADDRESS) {
     return ssnprintf(dst, dst_size,
-                    "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
-                    (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
-                    (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
+                     "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8 "",
+                     (uint8_t)vb->val.string[0], (uint8_t)vb->val.string[1],
+                     (uint8_t)vb->val.string[2], (uint8_t)vb->val.string[3]);
   } else {
     dst[0] = 0;
     return EINVAL;
@@ -1496,7 +1497,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
         sstrncpy(vl.type_instance, temp, sizeof(vl.type_instance));
       else
         ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s%s",
-                 data->type_instance.prefix, temp);
+                  data->type_instance.prefix, temp);
     } else if (data->type_instance.value) {
       sstrncpy(vl.type_instance, data->type_instance.value,
                sizeof(vl.type_instance));
@@ -1514,7 +1515,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
         sstrncpy(vl.plugin_instance, temp, sizeof(vl.plugin_instance));
       else
         ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s%s",
-                 data->plugin_instance.prefix, temp);
+                  data->plugin_instance.prefix, temp);
     } else if (data->plugin_instance.value) {
       sstrncpy(vl.plugin_instance, data->plugin_instance.value,
                sizeof(vl.plugin_instance));

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -29,11 +29,11 @@
 
 #include "collectd.h"
 
-#include <regex.h>
 #include "utils/avltree/avltree.h"
 #include "utils/common/common.h"
 #include "utils_cache.h"
 #include "utils_llist.h"
+#include <regex.h>
 
 #include <net-snmp/net-snmp-config.h>
 

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -29,11 +29,11 @@
 
 #include "collectd.h"
 
+#include <regex.h>
 #include "utils/avltree/avltree.h"
 #include "utils/common/common.h"
 #include "utils_cache.h"
 #include "utils_llist.h"
-#include <regex.h>
 
 #include <net-snmp/net-snmp-config.h>
 

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -742,7 +742,8 @@ static void snmp_agent_table_data_remove(data_definition_t *dd,
       .severity = NOTIF_WARNING, .time = cdtime(), .plugin = PLUGIN_NAME};
   sstrncpy(n.host, hostname_g, sizeof(n.host));
   ssnprintf(n.message, sizeof(n.message),
-           "Removed data row from table %s with index %s", td->name, index_str);
+            "Removed data row from table %s with index %s", td->name,
+            index_str);
   DEBUG(PLUGIN_NAME ": %s", n.message);
   plugin_dispatch_notification(&n);
 
@@ -2001,7 +2002,7 @@ static int snmp_agent_update_index(data_definition_t *dd,
         .severity = NOTIF_OKAY, .time = cdtime(), .plugin = PLUGIN_NAME};
     sstrncpy(n.host, hostname_g, sizeof(n.host));
     ssnprintf(n.message, sizeof(n.message),
-             "Data added to table %s with index %s", td->name, index_str);
+              "Data added to table %s with index %s", td->name, index_str);
     DEBUG(PLUGIN_NAME ": %s", n.message);
 
     plugin_dispatch_notification(&n);

--- a/src/snmp_agent.c
+++ b/src/snmp_agent.c
@@ -172,7 +172,7 @@ static int snmp_agent_oid_to_string(char *buf, size_t buf_size,
   char *oid_str_ptr[MAX_OID_LEN];
 
   for (size_t i = 0; i < o->oid_len; i++) {
-    snprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
+    ssnprintf(oid_str[i], sizeof(oid_str[i]), "%lu", (unsigned long)o->oid[i]);
     oid_str_ptr[i] = oid_str[i];
   }
 
@@ -736,12 +736,12 @@ static void snmp_agent_table_data_remove(data_definition_t *dd,
   if (index == NULL)
     snmp_agent_oid_to_string(index_str, sizeof(index_str), index_oid);
   else
-    snprintf(index_str, sizeof(index_str), "%d", *index);
+    ssnprintf(index_str, sizeof(index_str), "%d", *index);
 
   notification_t n = {
       .severity = NOTIF_WARNING, .time = cdtime(), .plugin = PLUGIN_NAME};
   sstrncpy(n.host, hostname_g, sizeof(n.host));
-  snprintf(n.message, sizeof(n.message),
+  ssnprintf(n.message, sizeof(n.message),
            "Removed data row from table %s with index %s", td->name, index_str);
   DEBUG(PLUGIN_NAME ": %s", n.message);
   plugin_dispatch_notification(&n);
@@ -960,7 +960,7 @@ static int snmp_agent_build_name(char **name, c_avl_tree_t *tokens) {
     strncat(out, tok->str, DATA_MAX_NAME_LEN - strlen(out) - 1);
     if (tok->key != NULL) {
       if (tok->key->type == ASN_INTEGER) {
-        snprintf(str, sizeof(str), "%ld", *tok->key->val.integer);
+        ssnprintf(str, sizeof(str), "%ld", *tok->key->val.integer);
         strncat(out, str, DATA_MAX_NAME_LEN - strlen(out) - 1);
       } else /* OCTET_STR */
         strncat(out, (char *)tok->key->val.string,
@@ -1013,7 +1013,7 @@ static int snmp_agent_format_name(char *name, int name_len,
         }
 
         if (td->index_keys[i].type == ASN_INTEGER) {
-          snprintf(str, sizeof(str), "%ld", *key->val.integer);
+          ssnprintf(str, sizeof(str), "%ld", *key->val.integer);
           fields[source] = str;
         } else /* OCTET_STR */
           fields[source] = (char *)key->val.string;
@@ -1836,7 +1836,7 @@ static int snmp_agent_set_vardata(void *data, size_t *data_len, u_char asn_type,
   case ASN_OCTET_STR:
     if (type == DS_TYPE_GAUGE) {
       char buf[DATA_MAX_NAME_LEN];
-      snprintf(buf, sizeof(buf), "%.2f", val->gauge);
+      ssnprintf(buf, sizeof(buf), "%.2f", val->gauge);
       if (*data_len < strlen(buf))
         return -EINVAL;
       *data_len = strlen(buf);
@@ -1995,12 +1995,12 @@ static int snmp_agent_update_index(data_definition_t *dd,
     if (index == NULL)
       snmp_agent_oid_to_string(index_str, sizeof(index_str), index_oid);
     else
-      snprintf(index_str, sizeof(index_str), "%d", *index);
+      ssnprintf(index_str, sizeof(index_str), "%d", *index);
 
     notification_t n = {
         .severity = NOTIF_OKAY, .time = cdtime(), .plugin = PLUGIN_NAME};
     sstrncpy(n.host, hostname_g, sizeof(n.host));
-    snprintf(n.message, sizeof(n.message),
+    ssnprintf(n.message, sizeof(n.message),
              "Data added to table %s with index %s", td->name, index_str);
     DEBUG(PLUGIN_NAME ": %s", n.message);
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -606,9 +606,8 @@ static int statsd_config_timer_percentile(oconfig_item_t *ci) /* {{{ */
     return ERANGE;
   }
 
-  tmp =
-      realloc(conf_timer_percentile,
-              sizeof(*conf_timer_percentile) * (conf_timer_percentile_num + 1));
+  tmp = realloc(conf_timer_percentile, sizeof(*conf_timer_percentile) *
+                                           (conf_timer_percentile_num + 1));
   if (tmp == NULL) {
     ERROR("statsd plugin: realloc failed.");
     return ENOMEM;

--- a/src/swap.c
+++ b/src/swap.c
@@ -150,12 +150,12 @@ static int swap_init(void) /* {{{ */
 {
 #if KERNEL_LINUX
   pagesize = (derive_t)sysconf(_SC_PAGESIZE);
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_SWAPCTL && HAVE_SWAPCTL_TWO_ARGS
   /* getpagesize(3C) tells me this does not fail.. */
   pagesize = (derive_t)getpagesize();
-/* #endif HAVE_SWAPCTL */
+  /* #endif HAVE_SWAPCTL */
 
 #elif defined(VM_SWAPUSAGE)
 /* No init stuff */
@@ -177,7 +177,7 @@ static int swap_init(void) /* {{{ */
     ERROR("swap plugin: kvm_openfiles failed, %s", errbuf);
     return -1;
   }
-/* #endif HAVE_LIBKVM_GETSWAPINFO */
+    /* #endif HAVE_LIBKVM_GETSWAPINFO */
 
 #elif HAVE_LIBSTATGRAB
 /* No init stuff */

--- a/src/tail_csv.c
+++ b/src/tail_csv.c
@@ -482,7 +482,8 @@ static int tcsv_config_add_file(oconfig_item_t *ci) {
   status = plugin_register_complex_read(
       NULL, cb_name, tcsv_read, interval,
       &(user_data_t){
-          .data = id, .free_func = tcsv_instance_definition_destroy,
+          .data = id,
+          .free_func = tcsv_instance_definition_destroy,
       });
   if (status != 0) {
     ERROR("tail_csv plugin: Registering complex read function failed.");

--- a/src/tape.c
+++ b/src/tape.c
@@ -63,7 +63,8 @@ static void tape_submit(const char *plugin_instance, const char *type,
                         derive_t read, derive_t write) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = read}, {.derive = write},
+      {.derive = read},
+      {.derive = write},
   };
 
   vl.values = values;

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -413,7 +413,7 @@ static int conn_handle_ports(uint16_t port_local, uint16_t port_remote,
 #if TCP_STATE_MIN > 0
       || (state < TCP_STATE_MIN)
 #endif
-          ) {
+  ) {
     NOTICE("tcpconns plugin: Ignoring connection with "
            "unknown state 0x%02" PRIx8 ".",
            state);
@@ -630,10 +630,10 @@ static int conn_read_file(const char *file) {
 
   return 0;
 } /* int conn_read_file */
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_SYSCTLBYNAME
-/* #endif HAVE_SYSCTLBYNAME */
+  /* #endif HAVE_SYSCTLBYNAME */
 
 #elif HAVE_LIBKVM_NLIST
 #endif /* HAVE_LIBKVM_NLIST */
@@ -729,7 +729,7 @@ static int conn_read(void) {
 
   return 0;
 } /* int conn_read */
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_SYSCTLBYNAME
 static int conn_read(void) {
@@ -848,8 +848,8 @@ static int conn_read(void) {
 
   return 0;
 }
-/* int conn_read */
-/* #endif HAVE_KVM_GETFILES */
+  /* int conn_read */
+  /* #endif HAVE_KVM_GETFILES */
 
 #elif HAVE_LIBKVM_NLIST
 static int kread(u_long addr, void *buf, int size) {
@@ -966,7 +966,7 @@ static int conn_read(void) {
 
   return 0;
 }
-/* #endif HAVE_LIBKVM_NLIST */
+  /* #endif HAVE_LIBKVM_NLIST */
 
 #elif KERNEL_AIX
 

--- a/src/teamspeak2.c
+++ b/src/teamspeak2.c
@@ -132,7 +132,8 @@ static void tss2_submit_io(const char *plugin_instance, const char *type,
    */
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -367,9 +367,10 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
     if (state_old == STATE_MISSING)
       ssnprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      ssnprintf(buf, bufsize, ": All data sources are within range again. "
-                             "Current value of \"%s\" is %f.",
-               ds->ds[ds_index].name, values[ds_index]);
+      ssnprintf(buf, bufsize,
+                ": All data sources are within range again. "
+                "Current value of \"%s\" is %f.",
+                ds->ds[ds_index].name, values[ds_index]);
   } else if (state == STATE_UNKNOWN) {
     ERROR("ut_report_state: metric transition to UNKNOWN from a different "
           "state. This shouldn't happen.");
@@ -384,20 +385,21 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
     if (th->flags & UT_FLAG_INVERT) {
       if (!isnan(min) && !isnan(max)) {
         ssnprintf(buf, bufsize,
-                 ": Data source \"%s\" is currently "
-                 "%f. That is within the %s region of %f%s and %f%s.",
-                 ds->ds[ds_index].name, values[ds_index],
-                 (state == STATE_ERROR) ? "failure" : "warning", min,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+                  ": Data source \"%s\" is currently "
+                  "%f. That is within the %s region of %f%s and %f%s.",
+                  ds->ds[ds_index].name, values[ds_index],
+                  (state == STATE_ERROR) ? "failure" : "warning", min,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                               "%f. That is %s the %s threshold of %f%s.",
-                 ds->ds[ds_index].name, values[ds_index],
-                 isnan(min) ? "below" : "above",
-                 (state == STATE_ERROR) ? "failure" : "warning",
-                 isnan(min) ? max : min,
-                 ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
+        ssnprintf(buf, bufsize,
+                  ": Data source \"%s\" is currently "
+                  "%f. That is %s the %s threshold of %f%s.",
+                  ds->ds[ds_index].name, values[ds_index],
+                  isnan(min) ? "below" : "above",
+                  (state == STATE_ERROR) ? "failure" : "warning",
+                  isnan(min) ? max : min,
+                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       }
     } else if (th->flags & UT_FLAG_PERCENTAGE) {
       gauge_t value;
@@ -417,20 +419,21 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
         value = 100.0 * values[ds_index] / sum;
 
       ssnprintf(buf, bufsize,
-               ": Data source \"%s\" is currently "
-               "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
-               ds->ds[ds_index].name, values[ds_index], value,
-               (value < min) ? "below" : "above",
-               (state == STATE_ERROR) ? "failure" : "warning",
-               (value < min) ? min : max);
+                ": Data source \"%s\" is currently "
+                "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
+                ds->ds[ds_index].name, values[ds_index], value,
+                (value < min) ? "below" : "above",
+                (state == STATE_ERROR) ? "failure" : "warning",
+                (value < min) ? min : max);
     } else /* is not inverted */
     {
-      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                             "%f. That is %s the %s threshold of %f.",
-               ds->ds[ds_index].name, values[ds_index],
-               (values[ds_index] < min) ? "below" : "above",
-               (state == STATE_ERROR) ? "failure" : "warning",
-               (values[ds_index] < min) ? min : max);
+      ssnprintf(buf, bufsize,
+                ": Data source \"%s\" is currently "
+                "%f. That is %s the %s threshold of %f.",
+                ds->ds[ds_index].name, values[ds_index],
+                (values[ds_index] < min) ? "below" : "above",
+                (state == STATE_ERROR) ? "failure" : "warning",
+                (values[ds_index] < min) ? min : max);
     }
   }
 
@@ -690,8 +693,8 @@ static int ut_missing(const value_list_t *vl,
 
   NOTIFICATION_INIT_VL(&n, vl);
   ssnprintf(n.message, sizeof(n.message),
-           "%s has not been updated for %.3f seconds.", identifier,
-           CDTIME_T_TO_DOUBLE(missing_time));
+            "%s has not been updated for %.3f seconds.", identifier,
+            CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;
 
   plugin_dispatch_notification(&n);

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -335,22 +335,22 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
   n.time = vl->time;
 
-  status = snprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
+  status = ssnprintf(buf, bufsize, "Host %s, plugin %s", vl->host, vl->plugin);
   buf += status;
   bufsize -= status;
 
   if (vl->plugin_instance[0] != '\0') {
-    status = snprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
+    status = ssnprintf(buf, bufsize, " (instance %s)", vl->plugin_instance);
     buf += status;
     bufsize -= status;
   }
 
-  status = snprintf(buf, bufsize, " type %s", vl->type);
+  status = ssnprintf(buf, bufsize, " type %s", vl->type);
   buf += status;
   bufsize -= status;
 
   if (vl->type_instance[0] != '\0') {
-    status = snprintf(buf, bufsize, " (instance %s)", vl->type_instance);
+    status = ssnprintf(buf, bufsize, " (instance %s)", vl->type_instance);
     buf += status;
     bufsize -= status;
   }
@@ -365,9 +365,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
   /* Send an okay notification */
   if (state == STATE_OKAY) {
     if (state_old == STATE_MISSING)
-      snprintf(buf, bufsize, ": Value is no longer missing.");
+      ssnprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      snprintf(buf, bufsize, ": All data sources are within range again. "
+      ssnprintf(buf, bufsize, ": All data sources are within range again. "
                              "Current value of \"%s\" is %f.",
                ds->ds[ds_index].name, values[ds_index]);
   } else if (state == STATE_UNKNOWN) {
@@ -383,7 +383,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
     if (th->flags & UT_FLAG_INVERT) {
       if (!isnan(min) && !isnan(max)) {
-        snprintf(buf, bufsize,
+        ssnprintf(buf, bufsize,
                  ": Data source \"%s\" is currently "
                  "%f. That is within the %s region of %f%s and %f%s.",
                  ds->ds[ds_index].name, values[ds_index],
@@ -391,7 +391,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
                  ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        snprintf(buf, bufsize, ": Data source \"%s\" is currently "
+        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
                                "%f. That is %s the %s threshold of %f%s.",
                  ds->ds[ds_index].name, values[ds_index],
                  isnan(min) ? "below" : "above",
@@ -416,7 +416,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
       else
         value = 100.0 * values[ds_index] / sum;
 
-      snprintf(buf, bufsize,
+      ssnprintf(buf, bufsize,
                ": Data source \"%s\" is currently "
                "%g (%.2f%%). That is %s the %s threshold of %.2f%%.",
                ds->ds[ds_index].name, values[ds_index], value,
@@ -425,7 +425,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                (value < min) ? min : max);
     } else /* is not inverted */
     {
-      snprintf(buf, bufsize, ": Data source \"%s\" is currently "
+      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
                              "%f. That is %s the %s threshold of %f.",
                ds->ds[ds_index].name, values[ds_index],
                (values[ds_index] < min) ? "below" : "above",
@@ -689,7 +689,7 @@ static int ut_missing(const value_list_t *vl,
   FORMAT_VL(identifier, sizeof(identifier), vl);
 
   NOTIFICATION_INIT_VL(&n, vl);
-  snprintf(n.message, sizeof(n.message),
+  ssnprintf(n.message, sizeof(n.message),
            "%s has not been updated for %.3f seconds.", identifier,
            CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -367,9 +367,8 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
     if (state_old == STATE_MISSING)
       ssnprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      ssnprintf(buf, bufsize,
-                ": All data sources are within range again. "
-                "Current value of \"%s\" is %f.",
+      ssnprintf(buf, bufsize, ": All data sources are within range again. "
+                              "Current value of \"%s\" is %f.",
                 ds->ds[ds_index].name, values[ds_index]);
   } else if (state == STATE_UNKNOWN) {
     ERROR("ut_report_state: metric transition to UNKNOWN from a different "
@@ -392,9 +391,8 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        ssnprintf(buf, bufsize,
-                  ": Data source \"%s\" is currently "
-                  "%f. That is %s the %s threshold of %f%s.",
+        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+                                "%f. That is %s the %s threshold of %f%s.",
                   ds->ds[ds_index].name, values[ds_index],
                   isnan(min) ? "below" : "above",
                   (state == STATE_ERROR) ? "failure" : "warning",
@@ -427,9 +425,8 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                 (value < min) ? min : max);
     } else /* is not inverted */
     {
-      ssnprintf(buf, bufsize,
-                ": Data source \"%s\" is currently "
-                "%f. That is %s the %s threshold of %f.",
+      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
+                              "%f. That is %s the %s threshold of %f.",
                 ds->ds[ds_index].name, values[ds_index],
                 (values[ds_index] < min) ? "below" : "above",
                 (state == STATE_ERROR) ? "failure" : "warning",

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -367,8 +367,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
     if (state_old == STATE_MISSING)
       ssnprintf(buf, bufsize, ": Value is no longer missing.");
     else
-      ssnprintf(buf, bufsize, ": All data sources are within range again. "
-                              "Current value of \"%s\" is %f.",
+      ssnprintf(buf, bufsize,
+                ": All data sources are within range again. "
+                "Current value of \"%s\" is %f.",
                 ds->ds[ds_index].name, values[ds_index]);
   } else if (state == STATE_UNKNOWN) {
     ERROR("ut_report_state: metric transition to UNKNOWN from a different "
@@ -391,8 +392,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "", max,
                   ((th->flags & UT_FLAG_PERCENTAGE) != 0) ? "%" : "");
       } else {
-        ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                                "%f. That is %s the %s threshold of %f%s.",
+        ssnprintf(buf, bufsize,
+                  ": Data source \"%s\" is currently "
+                  "%f. That is %s the %s threshold of %f%s.",
                   ds->ds[ds_index].name, values[ds_index],
                   isnan(min) ? "below" : "above",
                   (state == STATE_ERROR) ? "failure" : "warning",
@@ -425,8 +427,9 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
                 (value < min) ? min : max);
     } else /* is not inverted */
     {
-      ssnprintf(buf, bufsize, ": Data source \"%s\" is currently "
-                              "%f. That is %s the %s threshold of %f.",
+      ssnprintf(buf, bufsize,
+                ": Data source \"%s\" is currently "
+                "%f. That is %s the %s threshold of %f.",
                 ds->ds[ds_index].name, values[ds_index],
                 (values[ds_index] < min) ? "below" : "above",
                 (state == STATE_ERROR) ? "failure" : "warning",

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1434,9 +1434,9 @@ static void free_all_buffers(void) {
   package_delta = NULL;
 }
 
-/**********************
- * Collectd functions *
- **********************/
+  /**********************
+   * Collectd functions *
+   **********************/
 
 #define DO_OR_GOTO_ERR(something)                                              \
   do {                                                                         \

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -96,7 +96,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
   }
 
   result = (time_t)info.uptime;
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT
   kstat_t *ksp;
@@ -136,7 +136,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
   }
 
   result = time(NULL) - (time_t)knp->value.ui32;
-/* #endif HAVE_LIBKSTAT */
+  /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYS_SYSCTL_H
   struct timeval boottv = {0};
@@ -161,7 +161,7 @@ static time_t uptime_get_sys(void) { /* {{{ */
   }
 
   result = time(NULL) - boottv.tv_sec;
-/* #endif HAVE_SYS_SYSCTL_H */
+  /* #endif HAVE_SYS_SYSCTL_H */
 
 #elif HAVE_PERFSTAT
   int status;

--- a/src/users.c
+++ b/src/users.c
@@ -71,7 +71,7 @@ static int users_read(void) {
   endutxent();
 
   users_submit(users);
-/* #endif HAVE_GETUTXENT */
+  /* #endif HAVE_GETUTXENT */
 
 #elif HAVE_GETUTENT
   unsigned int users = 0;
@@ -89,7 +89,7 @@ static int users_read(void) {
   endutent();
 
   users_submit(users);
-/* #endif HAVE_GETUTENT */
+  /* #endif HAVE_GETUTENT */
 
 #elif HAVE_LIBSTATGRAB
   sg_user_stats *us;
@@ -109,7 +109,7 @@ static int users_read(void) {
 #else
                    us->num_entries);
 #endif
-/* #endif HAVE_LIBSTATGRAB */
+  /* #endif HAVE_LIBSTATGRAB */
 
 #else
 #error "No applicable input method."

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -196,7 +196,7 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    snprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
+    ssnprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
                                                "%d (type=%d [%s]); want %d "
                                                "(type=%d [%s])",
              parse_data[i].input, parse_data[i].opts, status, cmd.type,

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -196,13 +196,14 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    ssnprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
-                                                "%d (type=%d [%s]); want %d "
-                                                "(type=%d [%s])",
-              parse_data[i].input, parse_data[i].opts, status, cmd.type,
-              CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
-              parse_data[i].expected_type,
-              CMD_TO_STRING(parse_data[i].expected_type));
+    ssnprintf(description, sizeof(description),
+             "cmd_parse (\"%s\", opts=%p) = "
+             "%d (type=%d [%s]); want %d "
+             "(type=%d [%s])",
+             parse_data[i].input, parse_data[i].opts, status, cmd.type,
+             CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
+             parse_data[i].expected_type,
+             CMD_TO_STRING(parse_data[i].expected_type));
     result = (status == parse_data[i].expected_status) &&
              (cmd.type == parse_data[i].expected_type);
     LOG(result, description);

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -51,201 +51,114 @@ static struct {
 } parse_data[] = {
     /* Valid FLUSH commands. */
     {
-        "FLUSH",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH", NULL, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH identifier=myhost/magic/MAGIC",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH identifier=myhost/magic/MAGIC", NULL, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH identifier=magic/MAGIC",
-        &default_host_opts,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH identifier=magic/MAGIC", &default_host_opts, CMD_OK, CMD_FLUSH,
     },
     {
-        "FLUSH timeout=123 plugin=\"A\"",
-        NULL,
-        CMD_OK,
-        CMD_FLUSH,
+        "FLUSH timeout=123 plugin=\"A\"", NULL, CMD_OK, CMD_FLUSH,
     },
     /* Invalid FLUSH commands. */
     {
         /* Missing hostname; no default. */
-        "FLUSH identifier=magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH identifier=magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Missing 'identifier' key. */
-        "FLUSH myhost/magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid timeout. */
-        "FLUSH timeout=A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH timeout=A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid identifier. */
-        "FLUSH identifier=invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH identifier=invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
         /* Invalid option. */
-        "FLUSH invalid=option",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "FLUSH invalid=option", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid GETVAL commands. */
     {
-        "GETVAL myhost/magic/MAGIC",
-        NULL,
-        CMD_OK,
-        CMD_GETVAL,
+        "GETVAL myhost/magic/MAGIC", NULL, CMD_OK, CMD_GETVAL,
     },
     {
-        "GETVAL magic/MAGIC",
-        &default_host_opts,
-        CMD_OK,
-        CMD_GETVAL,
+        "GETVAL magic/MAGIC", &default_host_opts, CMD_OK, CMD_GETVAL,
     },
 
     /* Invalid GETVAL commands. */
     {
-        "GETVAL magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "GETVAL",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "GETVAL invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "GETVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid LISTVAL commands. */
     {
-        "LISTVAL",
-        NULL,
-        CMD_OK,
-        CMD_LISTVAL,
+        "LISTVAL", NULL, CMD_OK, CMD_LISTVAL,
     },
 
     /* Invalid LISTVAL commands. */
     {
-        "LISTVAL invalid",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "LISTVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
 
     /* Valid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42",
-        &default_host_opts,
-        CMD_OK,
+        "PUTVAL magic/MAGIC N:42", &default_host_opts, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC N:42", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23", NULL, CMD_OK, CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42", NULL, CMD_OK,
         CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC N:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23", NULL,
+        CMD_OK, CMD_PUTVAL,
     },
 
     /* Invalid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL magic/MAGIC N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL invalid N:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL invalid N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC A:42",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC A:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL 1234:A",
-        NULL,
-        CMD_PARSE_ERROR,
-        CMD_UNKNOWN,
+        "PUTVAL 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/UNKNOWN 1234:42",
-        NULL,
-        CMD_PARSE_ERROR,
+        "PUTVAL myhost/magic/UNKNOWN 1234:42", NULL, CMD_PARSE_ERROR,
         CMD_UNKNOWN,
     },
     /*
@@ -260,16 +173,10 @@ static struct {
 
     /* Invalid commands. */
     {
-        "INVALID",
-        NULL,
-        CMD_UNKNOWN_COMMAND,
-        CMD_UNKNOWN,
+        "INVALID", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
     },
     {
-        "INVALID interval=2",
-        NULL,
-        CMD_UNKNOWN_COMMAND,
-        CMD_UNKNOWN,
+        "INVALID interval=2", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
     },
 };
 
@@ -289,10 +196,9 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    ssnprintf(description, sizeof(description),
-              "cmd_parse (\"%s\", opts=%p) = "
-              "%d (type=%d [%s]); want %d "
-              "(type=%d [%s])",
+    ssnprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
+                                                "%d (type=%d [%s]); want %d "
+                                                "(type=%d [%s])",
               parse_data[i].input, parse_data[i].opts, status, cmd.type,
               CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
               parse_data[i].expected_type,

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -51,114 +51,201 @@ static struct {
 } parse_data[] = {
     /* Valid FLUSH commands. */
     {
-        "FLUSH", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=myhost/magic/MAGIC", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=magic/MAGIC", &default_host_opts, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH timeout=123 plugin=\"A\"", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH timeout=123 plugin=\"A\"",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     /* Invalid FLUSH commands. */
     {
         /* Missing hostname; no default. */
-        "FLUSH identifier=magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Missing 'identifier' key. */
-        "FLUSH myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid timeout. */
-        "FLUSH timeout=A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH timeout=A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid identifier. */
-        "FLUSH identifier=invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid option. */
-        "FLUSH invalid=option", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH invalid=option",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid GETVAL commands. */
     {
-        "GETVAL myhost/magic/MAGIC", NULL, CMD_OK, CMD_GETVAL,
+        "GETVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_GETVAL,
     },
     {
-        "GETVAL magic/MAGIC", &default_host_opts, CMD_OK, CMD_GETVAL,
+        "GETVAL magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_GETVAL,
     },
 
     /* Invalid GETVAL commands. */
     {
-        "GETVAL magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid LISTVAL commands. */
     {
-        "LISTVAL", NULL, CMD_OK, CMD_LISTVAL,
+        "LISTVAL",
+        NULL,
+        CMD_OK,
+        CMD_LISTVAL,
     },
 
     /* Invalid LISTVAL commands. */
     {
-        "LISTVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "LISTVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", &default_host_opts, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC N:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42", NULL, CMD_OK,
+        "PUTVAL magic/MAGIC N:42",
+        &default_host_opts,
+        CMD_OK,
         CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23", NULL,
-        CMD_OK, CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC N:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
     },
 
     /* Invalid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL magic/MAGIC N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL invalid N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL invalid N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC A:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC A:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/UNKNOWN 1234:42", NULL, CMD_PARSE_ERROR,
+        "PUTVAL myhost/magic/UNKNOWN 1234:42",
+        NULL,
+        CMD_PARSE_ERROR,
         CMD_UNKNOWN,
     },
     /*
@@ -173,10 +260,16 @@ static struct {
 
     /* Invalid commands. */
     {
-        "INVALID", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
     {
-        "INVALID interval=2", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID interval=2",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
 };
 
@@ -196,13 +289,14 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    ssnprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
-                                               "%d (type=%d [%s]); want %d "
-                                               "(type=%d [%s])",
-             parse_data[i].input, parse_data[i].opts, status, cmd.type,
-             CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
-             parse_data[i].expected_type,
-             CMD_TO_STRING(parse_data[i].expected_type));
+    ssnprintf(description, sizeof(description),
+              "cmd_parse (\"%s\", opts=%p) = "
+              "%d (type=%d [%s]); want %d "
+              "(type=%d [%s])",
+              parse_data[i].input, parse_data[i].opts, status, cmd.type,
+              CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
+              parse_data[i].expected_type,
+              CMD_TO_STRING(parse_data[i].expected_type));
     result = (status == parse_data[i].expected_status) &&
              (cmd.type == parse_data[i].expected_type);
     LOG(result, description);

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -89,6 +89,22 @@ char *sstrncpy(char *dest, const char *src, size_t n) {
   return dest;
 } /* char *sstrncpy */
 
+/* ssnprintf returns zero on success, one if truncation occurred
+   and a negative integer onerror. */
+int ssnprintf(char *str, size_t sz, const char *format, ...) {
+  va_list ap;
+  va_start(ap, format);
+
+  int ret = vsnprintf(str, sz, format, ap);
+
+  va_end(ap);
+
+  if (ret < 0) {
+    return ret;
+  }
+  return (size_t)ret >= sz;
+} /* int ssnprintf */
+
 char *ssnprintf_alloc(char const *format, ...) /* {{{ */
 {
   char static_buffer[1024] = "";

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -181,7 +181,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
     pthread_mutex_unlock(&strerror_r_lock);
   }
-/* #endif !HAVE_STRERROR_R */
+    /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -191,17 +191,19 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
       if ((temp != NULL) && (temp != buf) && (temp[0] != '\0'))
         sstrncpy(buf, temp, buflen);
       else
-        sstrncpy(buf, "strerror_r did not return "
-                      "an error message",
+        sstrncpy(buf,
+                 "strerror_r did not return "
+                 "an error message",
                  buflen);
     }
   }
-/* #endif STRERROR_R_CHAR_P */
+    /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
-    snprintf(buf, buflen, "Error #%i; "
-                          "Additionally, strerror_r failed.",
+    snprintf(buf, buflen,
+             "Error #%i; "
+             "Additionally, strerror_r failed.",
              errnum);
   }
 #endif /* STRERROR_R_CHAR_P */
@@ -767,8 +769,8 @@ unsigned long long htonll(unsigned long long n) {
 #endif /* HAVE_HTONLL */
 
 #if FP_LAYOUT_NEED_NOTHING
-/* Well, we need nothing.. */
-/* #endif FP_LAYOUT_NEED_NOTHING */
+  /* Well, we need nothing.. */
+  /* #endif FP_LAYOUT_NEED_NOTHING */
 
 #elif FP_LAYOUT_NEED_ENDIANFLIP || FP_LAYOUT_NEED_INTSWAP
 #if FP_LAYOUT_NEED_ENDIANFLIP

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -25,7 +25,7 @@
  *   Niki W. Waibel <niki.waibel@gmx.net>
  *   Sebastian Harl <sh at tokkee.org>
  *   Michał Mirosław <mirq-linux at rere.qmqm.pl>
-**/
+ **/
 
 #include "collectd.h"
 
@@ -181,7 +181,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
     pthread_mutex_unlock(&strerror_r_lock);
   }
-/* #endif !HAVE_STRERROR_R */
+  /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -191,17 +191,19 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
       if ((temp != NULL) && (temp != buf) && (temp[0] != '\0'))
         sstrncpy(buf, temp, buflen);
       else
-        sstrncpy(buf, "strerror_r did not return "
-                      "an error message",
+        sstrncpy(buf,
+                 "strerror_r did not return "
+                 "an error message",
                  buflen);
     }
   }
-/* #endif STRERROR_R_CHAR_P */
+  /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
-    snprintf(buf, buflen, "Error #%i; "
-                          "Additionally, strerror_r failed.",
+    snprintf(buf, buflen,
+             "Error #%i; "
+             "Additionally, strerror_r failed.",
              errnum);
   }
 #endif /* STRERROR_R_CHAR_P */
@@ -737,9 +739,8 @@ long long get_kstat_value(kstat_t *ksp, char *name) {
   else if (kn->data_type == KSTAT_DATA_UINT32)
     retval = (long long)kn->value.ui32;
   else if (kn->data_type == KSTAT_DATA_INT64)
-    retval =
-        (long long)kn->value.i64; /* According to ANSI C99 `long long' must hold
-                                     at least 64 bits */
+    retval = (long long)kn->value.i64; /* According to ANSI C99 `long long' must
+                                          hold at least 64 bits */
   else if (kn->data_type == KSTAT_DATA_UINT64)
     retval = (long long)kn->value.ui64; /* XXX: Might overflow! */
   else

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -181,7 +181,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
     pthread_mutex_unlock(&strerror_r_lock);
   }
-  /* #endif !HAVE_STRERROR_R */
+/* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -191,19 +191,17 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
       if ((temp != NULL) && (temp != buf) && (temp[0] != '\0'))
         sstrncpy(buf, temp, buflen);
       else
-        sstrncpy(buf,
-                 "strerror_r did not return "
-                 "an error message",
+        sstrncpy(buf, "strerror_r did not return "
+                      "an error message",
                  buflen);
     }
   }
-  /* #endif STRERROR_R_CHAR_P */
+/* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
-    snprintf(buf, buflen,
-             "Error #%i; "
-             "Additionally, strerror_r failed.",
+    snprintf(buf, buflen, "Error #%i; "
+                          "Additionally, strerror_r failed.",
              errnum);
   }
 #endif /* STRERROR_R_CHAR_P */

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -23,7 +23,7 @@
  * Authors:
  *   Florian octo Forster <octo at collectd.org>
  *   Niki W. Waibel <niki.waibel@gmx.net>
-**/
+ **/
 
 #ifndef COMMON_H
 #define COMMON_H

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -66,6 +66,9 @@ typedef struct value_to_rate_state_s value_to_rate_state_t;
 
 char *sstrncpy(char *dest, const char *src, size_t n);
 
+__attribute__((format(printf, 3, 4))) int ssnprintf(char *str, size_t size,
+                                                    char const *format, ...);
+
 __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
                                                             ...);
 

--- a/src/utils/config_cores/config_cores.c
+++ b/src/utils/config_cores/config_cores.c
@@ -254,7 +254,7 @@ int config_cores_parse(const oconfig_item_t *ci, core_groups_list_t *cgl) {
     } else {
       for (size_t j = 0; j < n && cg_idx < STATIC_ARRAY_SIZE(cgroups); j++) {
         char desc[DATA_MAX_NAME_LEN];
-        snprintf(desc, sizeof(desc), "%u", cores[j]);
+        ssnprintf(desc, sizeof(desc), "%u", cores[j]);
 
         cgroups[cg_idx].desc = strdup(desc);
         if (cgroups[cg_idx].desc == NULL) {
@@ -313,7 +313,7 @@ int config_cores_default(int num_cores, core_groups_list_t *cgl) {
 
   for (int i = 0; i < num_cores; i++) {
     char desc[DATA_MAX_NAME_LEN];
-    snprintf(desc, sizeof(desc), "%d", i);
+    ssnprintf(desc, sizeof(desc), "%d", i);
 
     cgl->cgroups[i].cores = calloc(1, sizeof(*(cgl->cgroups[i].cores)));
     if (cgl->cgroups[i].cores == NULL) {

--- a/src/utils/db_query/db_query.c
+++ b/src/utils/db_query/db_query.c
@@ -229,7 +229,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
       tmp[sizeof(tmp) - 1] = '\0';
 
       ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s",
-               r->instance_prefix, tmp);
+                r->instance_prefix, tmp);
     }
   }
   vl.type_instance[sizeof(vl.type_instance) - 1] = '\0';

--- a/src/utils/db_query/db_query.c
+++ b/src/utils/db_query/db_query.c
@@ -228,7 +228,7 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
       }
       tmp[sizeof(tmp) - 1] = '\0';
 
-      snprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s",
+      ssnprintf(vl.type_instance, sizeof(vl.type_instance), "%s-%s",
                r->instance_prefix, tmp);
     }
   }

--- a/src/utils/dns/dns.c
+++ b/src/utils/dns/dns.c
@@ -912,7 +912,7 @@ const char *qtype_str(int t) {
     return "ANY"; /* ... 255 */
 #endif /* __BIND >= 19950621 */
   default:
-    snprintf(buf, sizeof(buf), "#%i", t);
+    ssnprintf(buf, sizeof(buf), "#%i", t);
     return buf;
   } /* switch (t) */
 }
@@ -931,7 +931,7 @@ const char *opcode_str(int o) {
   case 5:
     return "Update";
   default:
-    snprintf(buf, sizeof(buf), "Opcode%d", o);
+    ssnprintf(buf, sizeof(buf), "Opcode%d", o);
     return buf;
   }
 }
@@ -998,7 +998,7 @@ const char *rcode_str(int rcode) {
 #endif /* RFC2136 rcodes */
 #endif /* __BIND >= 19950621 */
   default:
-    snprintf(buf, sizeof(buf), "RCode%i", rcode);
+    ssnprintf(buf, sizeof(buf), "RCode%i", rcode);
     return buf;
   }
 } /* const char *rcode_str (int rcode) */

--- a/src/utils/dns/dns.c
+++ b/src/utils/dns/dns.c
@@ -466,7 +466,7 @@ static int handle_ipv6(struct ip6_hdr *ipv6, int len) {
 
   return 1; /* Success */
 } /* int handle_ipv6 */
-/* #endif HAVE_IPV6 */
+  /* #endif HAVE_IPV6 */
 
 #else  /* if !HAVE_IPV6 */
 static int handle_ipv6(__attribute__((unused)) void *pkg,

--- a/src/utils/dpdk/dpdk.c
+++ b/src/utils/dpdk/dpdk.c
@@ -110,9 +110,9 @@ static void dpdk_helper_config_default(dpdk_helper_ctx_t *phc) {
 
   DPDK_HELPER_TRACE(phc->shm_name);
 
-  snprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
-  snprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
-  snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
+  ssnprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
+  ssnprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
+  ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
            DPDK_DEFAULT_RTE_CONFIG);
 }
 
@@ -189,10 +189,10 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
       status = cf_util_get_string_buffer(child, prefix, sizeof(prefix));
       if (status == 0) {
 #if RTE_VERSION <= RTE_VERSION_NUM(18, 5, 0, 0)
-        snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
+        ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
                  "/var/run/.%s_config", prefix);
 #else
-        snprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
+        ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
                  "/var/run/dpdk/%s/config", prefix);
 #endif
         DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);

--- a/src/utils/dpdk/dpdk.c
+++ b/src/utils/dpdk/dpdk.c
@@ -113,7 +113,7 @@ static void dpdk_helper_config_default(dpdk_helper_ctx_t *phc) {
   ssnprintf(phc->eal_config.coremask, DATA_MAX_NAME_LEN, "%s", "0xf");
   ssnprintf(phc->eal_config.memory_channels, DATA_MAX_NAME_LEN, "%s", "1");
   ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN, "%s",
-           DPDK_DEFAULT_RTE_CONFIG);
+            DPDK_DEFAULT_RTE_CONFIG);
 }
 
 int dpdk_helper_eal_config_set(dpdk_helper_ctx_t *phc, dpdk_eal_config_t *ec) {
@@ -190,10 +190,10 @@ int dpdk_helper_eal_config_parse(dpdk_helper_ctx_t *phc, oconfig_item_t *ci) {
       if (status == 0) {
 #if RTE_VERSION <= RTE_VERSION_NUM(18, 5, 0, 0)
         ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
-                 "/var/run/.%s_config", prefix);
+                  "/var/run/.%s_config", prefix);
 #else
         ssnprintf(phc->eal_config.file_prefix, DATA_MAX_NAME_LEN,
-                 "/var/run/dpdk/%s/config", prefix);
+                  "/var/run/dpdk/%s/config", prefix);
 #endif
         DEBUG("dpdk_common: EAL:File prefix %s", phc->eal_config.file_prefix);
       }
@@ -304,8 +304,8 @@ int dpdk_helper_init(const char *name, size_t data_size,
   DPDK_HELPER_TRACE(name);
 
   /* Allocate dpdk_helper_ctx_t and
-  * initialize a POSIX SHared Memory (SHM) object.
-  */
+   * initialize a POSIX SHared Memory (SHM) object.
+   */
   int err = dpdk_shm_init(name, shm_size, (void **)&phc);
   if (err != 0) {
     return -errno;
@@ -704,7 +704,8 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
 
   /* non blocking check on helper logging pipe */
   struct pollfd fds = {
-      .fd = phc->pipes[0], .events = POLLIN,
+      .fd = phc->pipes[0],
+      .events = POLLIN,
   };
   int data_avail = poll(&fds, 1, 0);
   DEBUG("%s:dpdk_helper_check_pipe: poll data_avail=%d", phc->shm_name,

--- a/src/utils/dpdk/dpdk.c
+++ b/src/utils/dpdk/dpdk.c
@@ -704,7 +704,8 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
 
   /* non blocking check on helper logging pipe */
   struct pollfd fds = {
-      .fd = phc->pipes[0], .events = POLLIN,
+      .fd = phc->pipes[0],
+      .events = POLLIN,
   };
   int data_avail = poll(&fds, 1, 0);
   DEBUG("%s:dpdk_helper_check_pipe: poll data_avail=%d", phc->shm_name,

--- a/src/utils/dpdk/dpdk.c
+++ b/src/utils/dpdk/dpdk.c
@@ -704,8 +704,7 @@ static void dpdk_helper_check_pipe(dpdk_helper_ctx_t *phc) {
 
   /* non blocking check on helper logging pipe */
   struct pollfd fds = {
-      .fd = phc->pipes[0],
-      .events = POLLIN,
+      .fd = phc->pipes[0], .events = POLLIN,
   };
   int data_avail = poll(&fds, 1, 0);
   DEBUG("%s:dpdk_helper_check_pipe: poll data_avail=%d", phc->shm_name,

--- a/src/utils/format_graphite/format_graphite_test.c
+++ b/src/utils/format_graphite/format_graphite_test.c
@@ -154,7 +154,7 @@ DEF_TEST(metric_name) {
     };
 
     char want[1024];
-    snprintf(want, sizeof(want), "%s 42 1480063672\r\n", cases[i].want_name);
+    ssnprintf(want, sizeof(want), "%s 42 1480063672\r\n", cases[i].want_name);
 
     if (cases[i].plugin_instance != NULL)
       sstrncpy(vl.plugin_instance, cases[i].plugin_instance,

--- a/src/utils/format_json/format_json.c
+++ b/src/utils/format_json/format_json.c
@@ -578,12 +578,11 @@ static int format_alert(yajl_gen g, notification_t const *n) /* {{{ */
   }
 
   JSON_ADD(g, "severity");
-  JSON_ADD(g,
-           (n->severity == NOTIF_FAILURE)
-               ? "FAILURE"
-               : (n->severity == NOTIF_WARNING)
-                     ? "WARNING"
-                     : (n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN");
+  JSON_ADD(g, (n->severity == NOTIF_FAILURE)
+                  ? "FAILURE"
+                  : (n->severity == NOTIF_WARNING)
+                        ? "WARNING"
+                        : (n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN");
 
   JSON_ADD(g, "service");
   JSON_ADD(g, "collectd");

--- a/src/utils/format_json/format_json_test.c
+++ b/src/utils/format_json/format_json_test.c
@@ -131,7 +131,8 @@ static int test_string(void *ctx, unsigned char const *value,
 
 static int expect_json_labels(char *json, label_t *labels, size_t labels_num) {
   yajl_callbacks funcs = {
-      .yajl_string = test_string, .yajl_map_key = test_map_key,
+      .yajl_string = test_string,
+      .yajl_map_key = test_map_key,
   };
 
   test_case_t c = {labels, labels_num, NULL};

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -144,16 +144,16 @@ static int format_typed_value(yajl_gen gen, int ds_type, value_t v,
   }
   case DS_TYPE_DERIVE: {
     derive_t diff = v.derive - (derive_t)start_value;
-    snprintf(integer, sizeof(integer), "%" PRIi64, diff);
+    ssnprintf(integer, sizeof(integer), "%" PRIi64, diff);
     break;
   }
   case DS_TYPE_COUNTER: {
     counter_t diff = counter_diff((counter_t)start_value, v.counter);
-    snprintf(integer, sizeof(integer), "%llu", diff);
+    ssnprintf(integer, sizeof(integer), "%llu", diff);
     break;
   }
   case DS_TYPE_ABSOLUTE: {
-    snprintf(integer, sizeof(integer), "%" PRIu64, v.absolute);
+    ssnprintf(integer, sizeof(integer), "%" PRIu64, v.absolute);
     break;
   }
   default: {
@@ -210,10 +210,10 @@ static int metric_type(char *buffer, size_t buffer_size, data_set_t const *ds,
 
 #define GCM_PREFIX "custom.googleapis.com/collectd/"
   if ((ds_index != 0) || strcmp("value", ds_name) != 0) {
-    snprintf(buffer, buffer_size, GCM_PREFIX "%s/%s_%s", vl->plugin, vl->type,
+    ssnprintf(buffer, buffer_size, GCM_PREFIX "%s/%s_%s", vl->plugin, vl->type,
              ds_name);
   } else {
-    snprintf(buffer, buffer_size, GCM_PREFIX "%s/%s", vl->plugin, vl->type);
+    ssnprintf(buffer, buffer_size, GCM_PREFIX "%s/%s", vl->plugin, vl->type);
   }
 
   char const *whitelist = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -280,7 +280,7 @@ static int read_cumulative_state(data_set_t const *ds, value_list_t const *vl,
   }
 
   char start_value_key[DATA_MAX_NAME_LEN];
-  snprintf(start_value_key, sizeof(start_value_key),
+  ssnprintf(start_value_key, sizeof(start_value_key),
            "stackdriver:start_value[%d]", ds_index);
 
   int status =

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -177,7 +177,7 @@ static int format_typed_value(yajl_gen gen, int ds_type, value_t v,
  *   "CUMULATIVE",
  *   "GAUGE"
  * )
-*/
+ */
 static int format_metric_kind(yajl_gen gen, int ds_type) {
   switch (ds_type) {
   case DS_TYPE_GAUGE:
@@ -198,7 +198,7 @@ static int format_metric_kind(yajl_gen gen, int ds_type) {
  *   "DOUBLE",
  *   "INT64"
  * )
-*/
+ */
 static int format_value_type(yajl_gen gen, int ds_type) {
   return json_string(gen, (ds_type == DS_TYPE_GAUGE) ? "DOUBLE" : "INT64");
 }
@@ -211,7 +211,7 @@ static int metric_type(char *buffer, size_t buffer_size, data_set_t const *ds,
 #define GCM_PREFIX "custom.googleapis.com/collectd/"
   if ((ds_index != 0) || strcmp("value", ds_name) != 0) {
     ssnprintf(buffer, buffer_size, GCM_PREFIX "%s/%s_%s", vl->plugin, vl->type,
-             ds_name);
+              ds_name);
   } else {
     ssnprintf(buffer, buffer_size, GCM_PREFIX "%s/%s", vl->plugin, vl->type);
   }
@@ -281,7 +281,7 @@ static int read_cumulative_state(data_set_t const *ds, value_list_t const *vl,
 
   char start_value_key[DATA_MAX_NAME_LEN];
   ssnprintf(start_value_key, sizeof(start_value_key),
-           "stackdriver:start_value[%d]", ds_index);
+            "stackdriver:start_value[%d]", ds_index);
 
   int status =
       uc_meta_data_get_signed_int(vl, start_value_key, ret_start_value);

--- a/src/utils/format_stackdriver/format_stackdriver_test.c
+++ b/src/utils/format_stackdriver/format_stackdriver_test.c
@@ -27,7 +27,9 @@
 
 DEF_TEST(sd_format_metric_descriptor) {
   value_list_t vl = {
-      .host = "example.com", .plugin = "unit-test", .type = "example",
+      .host = "example.com",
+      .plugin = "unit-test",
+      .type = "example",
   };
   char got[1024];
 
@@ -36,7 +38,10 @@ DEF_TEST(sd_format_metric_descriptor) {
       .ds_num = 1,
       .ds =
           &(data_source_t){
-              .name = "value", .type = DS_TYPE_GAUGE, .min = NAN, .max = NAN,
+              .name = "value",
+              .type = DS_TYPE_GAUGE,
+              .min = NAN,
+              .max = NAN,
           },
   };
   EXPECT_EQ_INT(

--- a/src/utils/gce/gce.c
+++ b/src/utils/gce/gce.c
@@ -227,7 +227,7 @@ char *gce_scope(char const *email) /* {{{ */
 {
   char url[1024];
 
-  snprintf(url, sizeof(url), GCE_SCOPE_URL_FORMAT,
+  ssnprintf(url, sizeof(url), GCE_SCOPE_URL_FORMAT,
            (email != NULL) ? email : GCE_DEFAULT_SERVICE_ACCOUNT);
 
   return read_url(url);
@@ -252,7 +252,7 @@ int gce_access_token(char const *email, char *buffer,
     return 0;
   }
 
-  snprintf(url, sizeof(url), GCE_TOKEN_URL_FORMAT, email);
+  ssnprintf(url, sizeof(url), GCE_TOKEN_URL_FORMAT, email);
   json = read_url(url);
   if (json == NULL) {
     pthread_mutex_unlock(&token_lock);

--- a/src/utils/gce/gce.c
+++ b/src/utils/gce/gce.c
@@ -228,7 +228,7 @@ char *gce_scope(char const *email) /* {{{ */
   char url[1024];
 
   ssnprintf(url, sizeof(url), GCE_SCOPE_URL_FORMAT,
-           (email != NULL) ? email : GCE_DEFAULT_SERVICE_ACCOUNT);
+            (email != NULL) ? email : GCE_DEFAULT_SERVICE_ACCOUNT);
 
   return read_url(url);
 } /* }}} char *gce_scope */

--- a/src/utils/latency/latency.c
+++ b/src/utils/latency/latency.c
@@ -56,22 +56,22 @@ struct latency_counter_s {
 };
 
 /*
-* Histogram represents the distribution of data, it has a list of "bins".
-* Each bin represents an interval and has a count (frequency) of
-* number of values fall within its interval.
-*
-* Histogram's range is determined by the number of bins and the bin width,
-* There are 1000 bins and all bins have the same width of default 1 millisecond.
-* When a value above this range is added, Histogram's range is increased by
-* increasing the bin width (note that number of bins remains always at 1000).
-* This operation of increasing bin width is little expensive as each bin need
-* to be visited to update its count. To reduce frequent change of bin width,
-* new bin width will be the next nearest power of 2. Example: 2, 4, 8, 16, 32,
-* 64, 128, 256, 512, 1024, 2048, 5086, ...
-*
-* So, if the required bin width is 300, then new bin width will be 512 as it is
-* the next nearest power of 2.
-*/
+ * Histogram represents the distribution of data, it has a list of "bins".
+ * Each bin represents an interval and has a count (frequency) of
+ * number of values fall within its interval.
+ *
+ * Histogram's range is determined by the number of bins and the bin width,
+ * There are 1000 bins and all bins have the same width of default 1
+ * millisecond. When a value above this range is added, Histogram's range is
+ * increased by increasing the bin width (note that number of bins remains
+ * always at 1000). This operation of increasing bin width is little expensive
+ * as each bin need to be visited to update its count. To reduce frequent change
+ * of bin width, new bin width will be the next nearest power of 2. Example: 2,
+ * 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 5086, ...
+ *
+ * So, if the required bin width is 300, then new bin width will be 512 as it is
+ * the next nearest power of 2.
+ */
 static void change_bin_width(latency_counter_t *lc, cdtime_t latency) /* {{{ */
 {
   /* This function is called because the new value is above histogram's range.

--- a/src/utils/latency/latency_config.c
+++ b/src/utils/latency/latency_config.c
@@ -124,7 +124,8 @@ int latency_config(latency_config_t *conf, oconfig_item_t *ci) {
 
 int latency_config_copy(latency_config_t *dst, const latency_config_t src) {
   *dst = (latency_config_t){
-      .percentile_num = src.percentile_num, .buckets_num = src.buckets_num,
+      .percentile_num = src.percentile_num,
+      .buckets_num = src.buckets_num,
   };
 
   dst->percentile = calloc(dst->percentile_num, sizeof(*dst->percentile));

--- a/src/utils/latency/latency_test.c
+++ b/src/utils/latency/latency_test.c
@@ -159,58 +159,75 @@ DEF_TEST(get_rate) {
   } cases[] = {
       {
           // bucket 6 is zero
-          DOUBLE_TO_CDTIME_T_STATIC(0.750), DOUBLE_TO_CDTIME_T_STATIC(0.875),
+          DOUBLE_TO_CDTIME_T_STATIC(0.750),
+          DOUBLE_TO_CDTIME_T_STATIC(0.875),
           0.00,
       },
       {
           // bucket 7 contains the t=1 update
-          DOUBLE_TO_CDTIME_T_STATIC(0.875), DOUBLE_TO_CDTIME_T_STATIC(1.000),
+          DOUBLE_TO_CDTIME_T_STATIC(0.875),
+          DOUBLE_TO_CDTIME_T_STATIC(1.000),
           1.00,
       },
       {
           // range: bucket 7 - bucket 15; contains the t=1 and t=2 updates
-          DOUBLE_TO_CDTIME_T_STATIC(0.875), DOUBLE_TO_CDTIME_T_STATIC(2.000),
+          DOUBLE_TO_CDTIME_T_STATIC(0.875),
+          DOUBLE_TO_CDTIME_T_STATIC(2.000),
           2.00,
       },
       {
           // lower bucket is only partially applied
           DOUBLE_TO_CDTIME_T_STATIC(0.875 + (0.125 / 4)),
-          DOUBLE_TO_CDTIME_T_STATIC(2.000), 1.75,
+          DOUBLE_TO_CDTIME_T_STATIC(2.000),
+          1.75,
       },
       {
           // upper bucket is only partially applied
           DOUBLE_TO_CDTIME_T_STATIC(0.875),
-          DOUBLE_TO_CDTIME_T_STATIC(2.000 - (0.125 / 4)), 1.75,
+          DOUBLE_TO_CDTIME_T_STATIC(2.000 - (0.125 / 4)),
+          1.75,
       },
       {
           // both buckets are only partially applied
           DOUBLE_TO_CDTIME_T_STATIC(0.875 + (0.125 / 4)),
-          DOUBLE_TO_CDTIME_T_STATIC(2.000 - (0.125 / 4)), 1.50,
+          DOUBLE_TO_CDTIME_T_STATIC(2.000 - (0.125 / 4)),
+          1.50,
       },
       {
           // lower bound is unspecified
-          0, DOUBLE_TO_CDTIME_T_STATIC(2.000), 2.00,
+          0,
+          DOUBLE_TO_CDTIME_T_STATIC(2.000),
+          2.00,
       },
       {
           // upper bound is unspecified
-          DOUBLE_TO_CDTIME_T_STATIC(125.000 - 0.125), 0, 1.00,
+          DOUBLE_TO_CDTIME_T_STATIC(125.000 - 0.125),
+          0,
+          1.00,
       },
       {
           // overflow test: upper >> longest latency
-          DOUBLE_TO_CDTIME_T_STATIC(1.000), DOUBLE_TO_CDTIME_T_STATIC(999999),
+          DOUBLE_TO_CDTIME_T_STATIC(1.000),
+          DOUBLE_TO_CDTIME_T_STATIC(999999),
           124.00,
       },
       {
           // overflow test: lower > longest latency
-          DOUBLE_TO_CDTIME_T_STATIC(130), 0, 0.00,
+          DOUBLE_TO_CDTIME_T_STATIC(130),
+          0,
+          0.00,
       },
       {
           // lower > upper => error
-          DOUBLE_TO_CDTIME_T_STATIC(10), DOUBLE_TO_CDTIME_T_STATIC(9), NAN,
+          DOUBLE_TO_CDTIME_T_STATIC(10),
+          DOUBLE_TO_CDTIME_T_STATIC(9),
+          NAN,
       },
       {
           // lower == upper => zero
-          DOUBLE_TO_CDTIME_T_STATIC(9), DOUBLE_TO_CDTIME_T_STATIC(9), 0.00,
+          DOUBLE_TO_CDTIME_T_STATIC(9),
+          DOUBLE_TO_CDTIME_T_STATIC(9),
+          0.00,
       },
   };
 

--- a/src/utils/mount/mount.c
+++ b/src/utils/mount/mount.c
@@ -18,7 +18,7 @@
  *
  * Author:
  *   Niki W. Waibel <niki.waibel@gmx.net>
-**/
+ **/
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -250,14 +250,14 @@ static void uuidcache_init(void) {
 
       if (isdigit((int)s[-1])) {
         /*
-        * Note: this is a heuristic only - there is no reason
-        * why these devices should live in /dev.
-        * Perhaps this directory should be specifiable by option.
-        * One might for example have /devlabel with links to /dev
-        * for the devices that may be accessed in this way.
-        * (This is useful, if the cdrom on /dev/hdc must not
-        * be accessed.)
-        */
+         * Note: this is a heuristic only - there is no reason
+         * why these devices should live in /dev.
+         * Perhaps this directory should be specifiable by option.
+         * One might for example have /devlabel with links to /dev
+         * for the devices that may be accessed in this way.
+         * (This is useful, if the cdrom on /dev/hdc must not
+         * be accessed.)
+         */
         snprintf(device, sizeof(device), "%s/%s", DEVLABELDIR, ptname);
         if (!get_label_uuid(device, &label, uuid)) {
           uuidcache_addentry(sstrdup(device), label, uuid);
@@ -522,7 +522,7 @@ static cu_mount_t *cu_mount_gen_getmntent(void) {
 
 #elif HAVE_SEQ_GETMNTENT
 #warn "This version of `getmntent' hat not yet been implemented!"
-/* #endif HAVE_SEQ_GETMNTENT */
+  /* #endif HAVE_SEQ_GETMNTENT */
 
 #elif HAVE_GETMNTENT_R
 static cu_mount_t *cu_mount_getmntent(void) {

--- a/src/utils/mount/mount.h
+++ b/src/utils/mount/mount.h
@@ -18,7 +18,7 @@
  *
  * Author:
  *   Niki W. Waibel <niki.waibel@gmx.net>
-**/
+ **/
 
 /* See below for instructions how to use the public functions. */
 

--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -531,7 +531,8 @@ oauth_google_t oauth_create_google_json(char const *buffer, char const *scope) {
   }
 
   oauth_google_t ret = {
-      .project_id = strdup(project_id), .oauth = oauth,
+      .project_id = strdup(project_id),
+      .oauth = oauth,
   };
 
   yajl_tree_free(root);

--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -184,9 +184,9 @@ static int get_claim(oauth_t *auth, char *buffer, size_t buffer_size) /* {{{ */
 
   /* create the claim set */
   status =
-      ssnprintf(claim, sizeof(claim), OAUTH_CLAIM_FORMAT, auth->iss, auth->scope,
-               auth->aud, (unsigned long)CDTIME_T_TO_TIME_T(exp),
-               (unsigned long)CDTIME_T_TO_TIME_T(iat));
+      ssnprintf(claim, sizeof(claim), OAUTH_CLAIM_FORMAT, auth->iss,
+                auth->scope, auth->aud, (unsigned long)CDTIME_T_TO_TIME_T(exp),
+                (unsigned long)CDTIME_T_TO_TIME_T(iat));
   if (status < 1)
     return -1;
   else if ((size_t)status >= sizeof(claim))
@@ -351,7 +351,7 @@ static int new_token(oauth_t *auth) /* {{{ */
   }
 
   ssnprintf(post_data, sizeof(post_data), "grant_type=%s&assertion=%s",
-           OAUTH_GRANT_TYPE, assertion);
+            OAUTH_GRANT_TYPE, assertion);
 
   curl = curl_easy_init();
   if (curl == NULL) {
@@ -531,7 +531,8 @@ oauth_google_t oauth_create_google_json(char const *buffer, char const *scope) {
   }
 
   oauth_google_t ret = {
-      .project_id = strdup(project_id), .oauth = oauth,
+      .project_id = strdup(project_id),
+      .oauth = oauth,
   };
 
   yajl_tree_free(root);
@@ -590,7 +591,7 @@ oauth_google_t oauth_create_google_default(char const *scope) {
   if ((home = getenv("HOME")) != NULL) {
     char path[PATH_MAX];
     ssnprintf(path, sizeof(path),
-             "%s/.config/gcloud/application_default_credentials.json", home);
+              "%s/.config/gcloud/application_default_credentials.json", home);
 
     oauth_google_t ret = oauth_create_google_file(path, scope);
     if (ret.oauth != NULL) {

--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -184,7 +184,7 @@ static int get_claim(oauth_t *auth, char *buffer, size_t buffer_size) /* {{{ */
 
   /* create the claim set */
   status =
-      snprintf(claim, sizeof(claim), OAUTH_CLAIM_FORMAT, auth->iss, auth->scope,
+      ssnprintf(claim, sizeof(claim), OAUTH_CLAIM_FORMAT, auth->iss, auth->scope,
                auth->aud, (unsigned long)CDTIME_T_TO_TIME_T(exp),
                (unsigned long)CDTIME_T_TO_TIME_T(iat));
   if (status < 1)
@@ -209,7 +209,7 @@ static int get_signature(char *buffer, size_t buffer_size, /* {{{ */
   int status;
 
   /* Make the string to sign */
-  payload_len = snprintf(payload, sizeof(payload), "%s.%s", header, claim);
+  payload_len = ssnprintf(payload, sizeof(payload), "%s.%s", header, claim);
   if (payload_len < 1) {
     return -1;
   } else if (payload_len >= sizeof(payload)) {
@@ -277,7 +277,7 @@ static int get_assertion(oauth_t *auth, char *buffer,
   if (status != 0)
     return -1;
 
-  status = snprintf(buffer, buffer_size, "%s.%s.%s", header, claim, signature);
+  status = ssnprintf(buffer, buffer_size, "%s.%s.%s", header, claim, signature);
   if (status < 1)
     return -1;
   else if ((size_t)status >= buffer_size)
@@ -350,7 +350,7 @@ static int new_token(oauth_t *auth) /* {{{ */
     return -1;
   }
 
-  snprintf(post_data, sizeof(post_data), "grant_type=%s&assertion=%s",
+  ssnprintf(post_data, sizeof(post_data), "grant_type=%s&assertion=%s",
            OAUTH_GRANT_TYPE, assertion);
 
   curl = curl_easy_init();
@@ -589,7 +589,7 @@ oauth_google_t oauth_create_google_default(char const *scope) {
   char const *home;
   if ((home = getenv("HOME")) != NULL) {
     char path[PATH_MAX];
-    snprintf(path, sizeof(path),
+    ssnprintf(path, sizeof(path),
              "%s/.config/gcloud/application_default_credentials.json", home);
 
     oauth_google_t ret = oauth_create_google_file(path, scope);

--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -531,8 +531,7 @@ oauth_google_t oauth_create_google_json(char const *buffer, char const *scope) {
   }
 
   oauth_google_t ret = {
-      .project_id = strdup(project_id),
-      .oauth = oauth,
+      .project_id = strdup(project_id), .oauth = oauth,
   };
 
   yajl_tree_free(root);

--- a/src/utils/oauth/oauth_test.c
+++ b/src/utils/oauth/oauth_test.c
@@ -35,21 +35,29 @@ struct {
 } cases[] = {
     {
         "{\"access_token\":\"MaeC6kaePhie1ree\",\"expires_in\":3600}",
-        /* status = */ 0, "MaeC6kaePhie1ree", TIME_T_TO_CDTIME_T_STATIC(3600),
+        /* status = */ 0,
+        "MaeC6kaePhie1ree",
+        TIME_T_TO_CDTIME_T_STATIC(3600),
     },
     {
         "{\"token_type\":\"Bearer\",\"expires_in\":1800,\"access_token\":"
         "\"aeThiebee2gushuY\"}",
-        /* status = */ 0, "aeThiebee2gushuY", TIME_T_TO_CDTIME_T_STATIC(1800),
+        /* status = */ 0,
+        "aeThiebee2gushuY",
+        TIME_T_TO_CDTIME_T_STATIC(1800),
     },
     {
         "{\"ignored_key\":\"uaph5aewaeghi1Ge\",\"expires_in\":3600}",
-        /* status = */ -1, NULL, 0,
+        /* status = */ -1,
+        NULL,
+        0,
     },
     {
         /* expires_in missing */
         "{\"access_token\":\"shaephohbie9Ahch\"}",
-        /* status = */ -1, NULL, 0,
+        /* status = */ -1,
+        NULL,
+        0,
     },
 };
 

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -785,9 +785,7 @@ static void *ovs_poll_worker(void *arg) {
   ovs_db_t *pdb = (ovs_db_t *)arg; /* pointer to OVS DB */
   ovs_json_reader_t *jreader = NULL;
   struct pollfd poll_fd = {
-      .fd = pdb->sock,
-      .events = POLLIN | POLLPRI,
-      .revents = 0,
+      .fd = pdb->sock, .events = POLLIN | POLLPRI, .revents = 0,
   };
 
   /* create JSON reader instance */

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -1117,7 +1117,7 @@ int ovs_db_send_request(ovs_db_t *pdb, const char *method, const char *params,
   /* generate id field */
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, "id");
   uid = ovs_uid_generate();
-  snprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
+  ssnprintf(uid_buff, sizeof(uid_buff), "%" PRIX64, uid);
   OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_buff);
 
   OVS_YAJL_CALL(yajl_gen_map_close, jgen);
@@ -1203,7 +1203,7 @@ int ovs_db_table_cb_register(ovs_db_t *pdb, const char *tb_name,
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, OVS_DB_DEFAULT_DB_NAME);
 
     /* uid string <json-value> */
-    snprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
+    ssnprintf(uid_str, sizeof(uid_str), "%" PRIX64, new_cb->uid);
     OVS_YAJL_CALL(ovs_yajl_gen_tstring, jgen, uid_str);
 
     /* <monitor-requests> */

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -785,7 +785,9 @@ static void *ovs_poll_worker(void *arg) {
   ovs_db_t *pdb = (ovs_db_t *)arg; /* pointer to OVS DB */
   ovs_json_reader_t *jreader = NULL;
   struct pollfd poll_fd = {
-      .fd = pdb->sock, .events = POLLIN | POLLPRI, .revents = 0,
+      .fd = pdb->sock,
+      .events = POLLIN | POLLPRI,
+      .revents = 0,
   };
 
   /* create JSON reader instance */

--- a/src/utils/proc_pids/proc_pids.c
+++ b/src/utils/proc_pids/proc_pids.c
@@ -140,7 +140,7 @@ int pids_list_contains_pid(pids_list_t *list, const pid_t pid) {
  * RETURN VALUE
  *   On success, the number of read bytes (includes stripped \n).
  *   -1 on file open error
-*/
+ */
 static int read_proc_name(const char *procfs_path,
                           const struct dirent *pid_entry, char *name,
                           const size_t out_size) {

--- a/src/utils/rrdcreate/rrdcreate.c
+++ b/src/utils/rrdcreate/rrdcreate.c
@@ -343,7 +343,7 @@ static int srrd_create(const char *filename, /* {{{ */
 
   return status;
 } /* }}} int srrd_create */
-/* #endif HAVE_THREADSAFE_LIBRRD */
+  /* #endif HAVE_THREADSAFE_LIBRRD */
 
 #else  /* !HAVE_THREADSAFE_LIBRRD */
 static int srrd_create(const char *filename, /* {{{ */

--- a/src/utils/rrdcreate/rrdcreate.c
+++ b/src/utils/rrdcreate/rrdcreate.c
@@ -208,7 +208,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
       if (rra_num >= rra_max)
         break;
 
-      status = snprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
+      status = ssnprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
                         rra_types[j], cfg->xff, cdp_len, cdp_num);
 
       if ((status < 0) || ((size_t)status >= sizeof(buffer))) {
@@ -278,14 +278,14 @@ static int ds_get(char ***ret, /* {{{ */
     if (isnan(d->min)) {
       sstrncpy(min, "U", sizeof(min));
     } else
-      snprintf(min, sizeof(min), "%f", d->min);
+      ssnprintf(min, sizeof(min), "%f", d->min);
 
     if (isnan(d->max)) {
       sstrncpy(max, "U", sizeof(max));
     } else
-      snprintf(max, sizeof(max), "%f", d->max);
+      ssnprintf(max, sizeof(max), "%f", d->max);
 
-    status = snprintf(
+    status = ssnprintf(
         buffer, sizeof(buffer), "DS:%s:%s:%i:%s:%s", d->name, type,
         (cfg->heartbeat > 0) ? cfg->heartbeat
                              : (int)CDTIME_T_TO_TIME_T(2 * vl->interval),
@@ -367,8 +367,8 @@ static int srrd_create(const char *filename, /* {{{ */
   if (last_up == 0)
     last_up = time(NULL) - 10;
 
-  snprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
-  snprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
+  ssnprintf(pdp_step_str, sizeof(pdp_step_str), "%lu", pdp_step);
+  ssnprintf(last_up_str, sizeof(last_up_str), "%lu", (unsigned long)last_up);
 
   new_argv[0] = "create";
   new_argv[1] = (void *)filename;
@@ -496,7 +496,7 @@ static void *srrd_create_thread(void *targs) /* {{{ */
     return 0;
   }
 
-  snprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
+  ssnprintf(tmpfile, sizeof(tmpfile), "%s.async", args->filename);
 
   status = srrd_create(tmpfile, args->pdp_step, args->last_up, args->argc,
                        (void *)args->argv);

--- a/src/utils/rrdcreate/rrdcreate.c
+++ b/src/utils/rrdcreate/rrdcreate.c
@@ -209,7 +209,7 @@ static int rra_get(char ***ret, const value_list_t *vl, /* {{{ */
         break;
 
       status = ssnprintf(buffer, sizeof(buffer), "RRA:%s:%.10f:%u:%u",
-                        rra_types[j], cfg->xff, cdp_len, cdp_num);
+                         rra_types[j], cfg->xff, cdp_len, cdp_num);
 
       if ((status < 0) || ((size_t)status >= sizeof(buffer))) {
         P_ERROR("rra_get: Buffer would have been truncated.");

--- a/src/utils/taskstats/taskstats.c
+++ b/src/utils/taskstats/taskstats.c
@@ -188,7 +188,8 @@ static int get_family_id(ts_t *ts) {
 
   struct genlmsghdr *genh = mnl_nlmsg_put_extra_header(nlh, sizeof(*genh));
   *genh = (struct genlmsghdr){
-      .cmd = CTRL_CMD_GETFAMILY, .version = 0x01,
+      .cmd = CTRL_CMD_GETFAMILY,
+      .version = 0x01,
   };
 
   mnl_attr_put_strz(nlh, CTRL_ATTR_FAMILY_NAME, TASKSTATS_GENL_NAME);

--- a/src/utils_tail_match.h
+++ b/src/utils_tail_match.h
@@ -131,5 +131,5 @@ int tail_match_add_match_simple(cu_tail_match_t *obj, const char *regex,
  *
  * RETURN VALUE
  *   Zero on success, nonzero on failure.
-*/
+ */
 int tail_match_read(cu_tail_match_t *obj);

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -1546,7 +1546,8 @@ static int varnish_init(void) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf, .free_func = varnish_config_free,
+          .data = conf,
+          .free_func = varnish_config_free,
       });
 
   return 0;
@@ -1751,7 +1752,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
 #endif
-      ) {
+  ) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);
@@ -1768,7 +1769,8 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf, .free_func = varnish_config_free,
+          .data = conf,
+          .free_func = varnish_config_free,
       });
 
   have_instance = true;

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -1546,8 +1546,7 @@ static int varnish_init(void) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf,
-          .free_func = varnish_config_free,
+          .data = conf, .free_func = varnish_config_free,
       });
 
   return 0;
@@ -1752,7 +1751,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
 #endif
-  ) {
+      ) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);
@@ -1769,8 +1768,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf,
-          .free_func = varnish_config_free,
+          .data = conf, .free_func = varnish_config_free,
       });
 
   have_instance = true;

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -107,7 +107,7 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
 
   if (plugin_instance == NULL)
     plugin_instance = "default";
-  snprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
+  ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
            plugin_instance, category);
 
   sstrncpy(vl.type, type, sizeof(vl.type));
@@ -1759,7 +1759,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     return EINVAL;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "varnish/%s",
+  ssnprintf(callback_name, sizeof(callback_name), "varnish/%s",
            (conf->instance == NULL) ? "localhost" : conf->instance);
 
   plugin_register_complex_read(

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -108,7 +108,7 @@ static int varnish_submit(const char *plugin_instance, /* {{{ */
   if (plugin_instance == NULL)
     plugin_instance = "default";
   ssnprintf(vl.plugin_instance, sizeof(vl.plugin_instance), "%s-%s",
-           plugin_instance, category);
+            plugin_instance, category);
 
   sstrncpy(vl.type, type, sizeof(vl.type));
 
@@ -1546,7 +1546,8 @@ static int varnish_init(void) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf, .free_func = varnish_config_free,
+          .data = conf,
+          .free_func = varnish_config_free,
       });
 
   return 0;
@@ -1751,7 +1752,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
 #endif
-      ) {
+  ) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);
@@ -1760,7 +1761,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
   }
 
   ssnprintf(callback_name, sizeof(callback_name), "varnish/%s",
-           (conf->instance == NULL) ? "localhost" : conf->instance);
+            (conf->instance == NULL) ? "localhost" : conf->instance);
 
   plugin_register_complex_read(
       /* group = */ "varnish",
@@ -1768,7 +1769,8 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       /* callback  = */ varnish_read,
       /* interval  = */ 0,
       &(user_data_t){
-          .data = conf, .free_func = varnish_config_free,
+          .data = conf,
+          .free_func = varnish_config_free,
       });
 
   have_instance = true;

--- a/src/virt.c
+++ b/src/virt.c
@@ -131,16 +131,16 @@ static bool report_network_interfaces = true;
 static virt_notif_thread_t notif_thread;
 
 const char *domain_states[] = {
-        [VIR_DOMAIN_NOSTATE] = "no state",
-        [VIR_DOMAIN_RUNNING] = "the domain is running",
-        [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
-        [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
-        [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
-        [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
-        [VIR_DOMAIN_CRASHED] = "the domain is crashed",
+    [VIR_DOMAIN_NOSTATE] = "no state",
+    [VIR_DOMAIN_RUNNING] = "the domain is running",
+    [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
+    [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
+    [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
+    [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
+    [VIR_DOMAIN_CRASHED] = "the domain is crashed",
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-        [VIR_DOMAIN_PMSUSPENDED] =
-            "the domain is suspended by guest power management",
+    [VIR_DOMAIN_PMSUSPENDED] =
+        "the domain is suspended by guest power management",
 #endif
 };
 
@@ -352,107 +352,99 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
 
 #define DOMAIN_STATE_REASON_MAX_SIZE 20
 const char *domain_reasons[][DOMAIN_STATE_REASON_MAX_SIZE] = {
-        [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] = "the reason is unknown",
 
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
-            "normal startup from boot",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
-            "migrated from another host",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
-            "restored from a state file",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
-            "restored from snapshot",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
-            "returned from paused state",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
-            "returned from migration",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
-            "returned from failed save process",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
+        "normal startup from boot",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
+        "migrated from another host",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
+        "restored from a state file",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
+        "restored from snapshot",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
+        "returned from paused state",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
+        "returned from migration",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
+        "returned from failed save process",
 #ifdef HAVE_DOM_REASON_RUNNING_WAKEUP
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
-            "returned from pmsuspended due to wakeup event",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
+        "returned from pmsuspended due to wakeup event",
 #endif
 #ifdef HAVE_DOM_REASON_CRASHED
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] =
-            "resumed from crashed",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] = "resumed from crashed",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
-            "running in post-copy migration mode",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
+        "running in post-copy migration mode",
 #endif
-        [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] = "the reason is unknown",
 
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
-            "paused for offline migration",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
-            "paused for offline core dump",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
-            "paused due to a disk I/O error",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
-            "paused due to a watchdog event",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
-            "paused after restoring from snapshot",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
+        "paused for offline migration",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
+        "paused for offline core dump",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
+        "paused due to a disk I/O error",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
+        "paused due to a watchdog event",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
+        "paused after restoring from snapshot",
 #ifdef HAVE_DOM_REASON_PAUSED_SHUTTING_DOWN
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
-            "paused during shutdown process",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
+        "paused during shutdown process",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_SNAPSHOT
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
-            "paused while creating a snapshot",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
+        "paused while creating a snapshot",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_CRASHED
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
-            "paused due to a guest crash",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
+        "paused due to a guest crash",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_STARTING_UP
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
-            "the domain is being started",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
+        "the domain is being started",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
-            "paused for post-copy migration",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
-            "paused after failed post-copy",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
+        "paused for post-copy migration",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
+        "paused after failed post-copy",
 #endif
-        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
-            "shutting down on user request",
+    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
+        "the reason is unknown",
+    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
+        "shutting down on user request",
 
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
-            "migrated to another host",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] =
-            "domain failed to start",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
-            "restored from a snapshot which was taken while domain was shutoff",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
+        "migrated to another host",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] = "domain failed to start",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
+        "restored from a snapshot which was taken while domain was shutoff",
 #ifdef HAVE_DOM_REASON_SHUTOFF_DAEMON
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
-            "daemon decides to kill domain during reconnection processing",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
+        "daemon decides to kill domain during reconnection processing",
 #endif
 
-        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] = "the reason is unknown",
 #ifdef VIR_DOMAIN_CRASHED_PANICKED
-        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
+    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
 #endif
 
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-        [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
+        "the reason is unknown",
 #endif
 };
 #endif /* HAVE_DOM_REASON */
@@ -742,7 +734,8 @@ static char *metadata_get_hostname(virDomainPtr dom) {
   const char *namespace = NULL;
   if (hm_ns == NULL) {
     namespace = "http://openstack.org/xmlns/libvirt/nova/1.0";
-  } else {
+  } // namespace =hm_ns;
+  else {
     namespace = hm_ns;
   }
 
@@ -957,7 +950,8 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
 static void submit_derive2(const char *type, derive_t v0, derive_t v1,
                            virDomainPtr dom, const char *devname) {
   value_t values[] = {
-      {.derive = v0}, {.derive = v1},
+      {.derive = v0},
+      {.derive = v1},
   };
 
   submit(dom, type, devname, values, STATIC_ARRAY_SIZE(values));
@@ -1718,7 +1712,8 @@ static int submit_domain_state(virDomainPtr domain) {
   }
 
   value_t values[] = {
-      {.gauge = (gauge_t)domain_state}, {.gauge = (gauge_t)domain_reason},
+      {.gauge = (gauge_t)domain_state},
+      {.gauge = (gauge_t)domain_reason},
   };
 
   submit(domain, "domain_state", NULL, values, STATIC_ARRAY_SIZE(values));
@@ -1802,7 +1797,8 @@ static int get_memory_stats(virDomainPtr domain) {
 
   if (min_flt > 0 || maj_flt > 0) {
     value_t values[] = {
-        {.gauge = (gauge_t)min_flt}, {.gauge = (gauge_t)maj_flt},
+        {.gauge = (gauge_t)min_flt},
+        {.gauge = (gauge_t)maj_flt},
     };
     submit(domain, "ps_pagefaults", NULL, values, STATIC_ARRAY_SIZE(values));
   }

--- a/src/virt.c
+++ b/src/virt.c
@@ -131,16 +131,16 @@ static bool report_network_interfaces = true;
 static virt_notif_thread_t notif_thread;
 
 const char *domain_states[] = {
-        [VIR_DOMAIN_NOSTATE] = "no state",
-        [VIR_DOMAIN_RUNNING] = "the domain is running",
-        [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
-        [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
-        [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
-        [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
-        [VIR_DOMAIN_CRASHED] = "the domain is crashed",
+    [VIR_DOMAIN_NOSTATE] = "no state",
+    [VIR_DOMAIN_RUNNING] = "the domain is running",
+    [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
+    [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
+    [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
+    [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
+    [VIR_DOMAIN_CRASHED] = "the domain is crashed",
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-        [VIR_DOMAIN_PMSUSPENDED] =
-            "the domain is suspended by guest power management",
+    [VIR_DOMAIN_PMSUSPENDED] =
+        "the domain is suspended by guest power management",
 #endif
 };
 
@@ -352,107 +352,99 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
 
 #define DOMAIN_STATE_REASON_MAX_SIZE 20
 const char *domain_reasons[][DOMAIN_STATE_REASON_MAX_SIZE] = {
-        [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] = "the reason is unknown",
 
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
-            "normal startup from boot",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
-            "migrated from another host",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
-            "restored from a state file",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
-            "restored from snapshot",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
-            "returned from paused state",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
-            "returned from migration",
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
-            "returned from failed save process",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
+        "normal startup from boot",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
+        "migrated from another host",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
+        "restored from a state file",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
+        "restored from snapshot",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
+        "returned from paused state",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
+        "returned from migration",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
+        "returned from failed save process",
 #ifdef HAVE_DOM_REASON_RUNNING_WAKEUP
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
-            "returned from pmsuspended due to wakeup event",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
+        "returned from pmsuspended due to wakeup event",
 #endif
 #ifdef HAVE_DOM_REASON_CRASHED
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] =
-            "resumed from crashed",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] = "resumed from crashed",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
-            "running in post-copy migration mode",
+    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
+        "running in post-copy migration mode",
 #endif
-        [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] = "the reason is unknown",
 
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
-            "paused for offline migration",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
-            "paused for offline core dump",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
-            "paused due to a disk I/O error",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
-            "paused due to a watchdog event",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
-            "paused after restoring from snapshot",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
+        "paused for offline migration",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
+        "paused for offline core dump",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
+        "paused due to a disk I/O error",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
+        "paused due to a watchdog event",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
+        "paused after restoring from snapshot",
 #ifdef HAVE_DOM_REASON_PAUSED_SHUTTING_DOWN
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
-            "paused during shutdown process",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
+        "paused during shutdown process",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_SNAPSHOT
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
-            "paused while creating a snapshot",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
+        "paused while creating a snapshot",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_CRASHED
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
-            "paused due to a guest crash",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
+        "paused due to a guest crash",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_STARTING_UP
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
-            "the domain is being started",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
+        "the domain is being started",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
-            "paused for post-copy migration",
-        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
-            "paused after failed post-copy",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
+        "paused for post-copy migration",
+    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
+        "paused after failed post-copy",
 #endif
-        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
-            "shutting down on user request",
+    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
+        "the reason is unknown",
+    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
+        "shutting down on user request",
 
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] =
-            "the reason is unknown",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
-            "migrated to another host",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] =
-            "domain failed to start",
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
-            "restored from a snapshot which was taken while domain was shutoff",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] = "the reason is unknown",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
+        "migrated to another host",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] = "domain failed to start",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
+        "restored from a snapshot which was taken while domain was shutoff",
 #ifdef HAVE_DOM_REASON_SHUTOFF_DAEMON
-        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
-            "daemon decides to kill domain during reconnection processing",
+    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
+        "daemon decides to kill domain during reconnection processing",
 #endif
 
-        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] = "the reason is unknown",
 #ifdef VIR_DOMAIN_CRASHED_PANICKED
-        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
+    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
 #endif
 
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-        [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
-            "the reason is unknown",
+    [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
+        "the reason is unknown",
 #endif
 };
 #endif /* HAVE_DOM_REASON */
@@ -952,7 +944,8 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
 static void submit_derive2(const char *type, derive_t v0, derive_t v1,
                            virDomainPtr dom, const char *devname) {
   value_t values[] = {
-      {.derive = v0}, {.derive = v1},
+      {.derive = v0},
+      {.derive = v1},
   };
 
   submit(dom, type, devname, values, STATIC_ARRAY_SIZE(values));
@@ -1027,7 +1020,7 @@ static void disk_block_stats_submit(struct lv_block_stats *bstats,
 
   char flush_type_instance[DATA_MAX_NAME_LEN];
   ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
-           type_instance);
+            type_instance);
 
   if ((bstats->bi.rd_req != -1) && (bstats->bi.wr_req != -1))
     submit_derive2("disk_ops", (derive_t)bstats->bi.rd_req,
@@ -1131,7 +1124,7 @@ static void domain_state_submit_notif(virDomainPtr dom, int state, int reason) {
 #endif
 
   ssnprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
-           reason_str);
+            reason_str);
 
   int severity;
   switch (state) {
@@ -1578,7 +1571,8 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
     char type_instance[DATA_MAX_NAME_LEN];
     bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu);
 
-    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
+    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu,
+              cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
   }
 }
@@ -1677,7 +1671,8 @@ static int submit_domain_state(virDomainPtr domain) {
   }
 
   value_t values[] = {
-      {.gauge = (gauge_t)domain_state}, {.gauge = (gauge_t)domain_reason},
+      {.gauge = (gauge_t)domain_state},
+      {.gauge = (gauge_t)domain_reason},
   };
 
   submit(domain, "domain_state", NULL, values, STATIC_ARRAY_SIZE(values));
@@ -1753,7 +1748,8 @@ static int get_memory_stats(virDomainPtr domain) {
 
   if (min_flt > 0 || maj_flt > 0) {
     value_t values[] = {
-        {.gauge = (gauge_t)min_flt}, {.gauge = (gauge_t)maj_flt},
+        {.gauge = (gauge_t)min_flt},
+        {.gauge = (gauge_t)maj_flt},
     };
     submit(domain, "ps_pagefaults", NULL, values, STATIC_ARRAY_SIZE(values));
   }
@@ -2467,7 +2463,7 @@ static int lv_domain_get_tag(xmlXPathContextPtr xpath_ctx, const char *dom_name,
   }
 
   ssnprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
-           METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
+            METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
   xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
   if (xpath_obj == NULL) {
     ERROR(PLUGIN_NAME " plugin: xmlXPathEval(%s) failed on domain %s",

--- a/src/virt.c
+++ b/src/virt.c
@@ -1004,7 +1004,7 @@ static void vcpu_submit(derive_t value, virDomainPtr dom, int vcpu_nr,
                         const char *type) {
   char type_instance[DATA_MAX_NAME_LEN];
 
-  snprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
+  ssnprintf(type_instance, sizeof(type_instance), "%d", vcpu_nr);
   submit(dom, type, type_instance, &(value_t){.derive = value}, 1);
 }
 
@@ -1026,7 +1026,7 @@ static void disk_block_stats_submit(struct lv_block_stats *bstats,
   }
 
   char flush_type_instance[DATA_MAX_NAME_LEN];
-  snprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
+  ssnprintf(flush_type_instance, sizeof(flush_type_instance), "flush-%s",
            type_instance);
 
   if ((bstats->bi.rd_req != -1) && (bstats->bi.wr_req != -1))
@@ -1130,7 +1130,7 @@ static void domain_state_submit_notif(virDomainPtr dom, int state, int reason) {
   const char *reason_str = "N/A";
 #endif
 
-  snprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
+  ssnprintf(msg, sizeof(msg), "Domain state: %s. Reason: %s", state_str,
            reason_str);
 
   int severity;
@@ -1578,7 +1578,7 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
     char type_instance[DATA_MAX_NAME_LEN];
     bool is_set = VIR_CPU_USABLE(cpu_maps, cpu_map_len, vcpu, cpu);
 
-    snprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
+    ssnprintf(type_instance, sizeof(type_instance), "vcpu_%d-cpu_%d", vcpu, cpu);
     submit(dom, "cpu_affinity", type_instance, &(value_t){.gauge = is_set}, 1);
   }
 }
@@ -2402,7 +2402,7 @@ static int lv_init_instance(size_t i, plugin_read_cb callback) {
 
   memset(lv_ud, 0, sizeof(*lv_ud));
 
-  snprintf(inst->tag, sizeof(inst->tag), "%s-%" PRIsz, PLUGIN_NAME, i);
+  ssnprintf(inst->tag, sizeof(inst->tag), "%s-%" PRIsz, PLUGIN_NAME, i);
   inst->id = i;
 
   user_data_t *ud = &(lv_ud->ud);
@@ -2472,7 +2472,7 @@ static int lv_domain_get_tag(xmlXPathContextPtr xpath_ctx, const char *dom_name,
     goto done;
   }
 
-  snprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
+  ssnprintf(xpath_str, sizeof(xpath_str), "/domain/metadata/%s:%s/text()",
            METADATA_VM_PARTITION_PREFIX, METADATA_VM_PARTITION_ELEMENT);
   xpath_obj = xmlXPathEvalExpression((xmlChar *)xpath_str, xpath_ctx);
   if (xpath_obj == NULL) {
@@ -2675,7 +2675,7 @@ static void lv_add_network_interfaces(struct lv_read_state *state,
       break;
     case if_number: {
       char number_string[4];
-      snprintf(number_string, sizeof(number_string), "%d", itf_number);
+      ssnprintf(number_string, sizeof(number_string), "%d", itf_number);
       if (ignore_device_match(il_interface_devices, domname, number_string) !=
           0)
         device_ignored = true;
@@ -2976,7 +2976,7 @@ static int add_interface_device(struct lv_read_state *state, virDomainPtr dom,
   }
 
   char number_string[21];
-  snprintf(number_string, sizeof(number_string), "interface-%u", number);
+  ssnprintf(number_string, sizeof(number_string), "interface-%u", number);
   char *number_copy = strdup(number_string);
   if (!number_copy) {
     sfree(path_copy);
@@ -3015,7 +3015,7 @@ static int ignore_device_match(ignorelist_t *il, const char *domname,
     ERROR(PLUGIN_NAME " plugin: malloc failed.");
     return 0;
   }
-  snprintf(name, n, "%s:%s", domname, devpath);
+  ssnprintf(name, n, "%s:%s", domname, devpath);
   int r = ignorelist_match(il, name);
   sfree(name);
   return r;

--- a/src/virt.c
+++ b/src/virt.c
@@ -131,16 +131,16 @@ static bool report_network_interfaces = true;
 static virt_notif_thread_t notif_thread;
 
 const char *domain_states[] = {
-    [VIR_DOMAIN_NOSTATE] = "no state",
-    [VIR_DOMAIN_RUNNING] = "the domain is running",
-    [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
-    [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
-    [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
-    [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
-    [VIR_DOMAIN_CRASHED] = "the domain is crashed",
+        [VIR_DOMAIN_NOSTATE] = "no state",
+        [VIR_DOMAIN_RUNNING] = "the domain is running",
+        [VIR_DOMAIN_BLOCKED] = "the domain is blocked on resource",
+        [VIR_DOMAIN_PAUSED] = "the domain is paused by user",
+        [VIR_DOMAIN_SHUTDOWN] = "the domain is being shut down",
+        [VIR_DOMAIN_SHUTOFF] = "the domain is shut off",
+        [VIR_DOMAIN_CRASHED] = "the domain is crashed",
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-    [VIR_DOMAIN_PMSUSPENDED] =
-        "the domain is suspended by guest power management",
+        [VIR_DOMAIN_PMSUSPENDED] =
+            "the domain is suspended by guest power management",
 #endif
 };
 
@@ -352,99 +352,107 @@ static int map_domain_event_detail_to_reason(int event, int detail) {
 
 #define DOMAIN_STATE_REASON_MAX_SIZE 20
 const char *domain_reasons[][DOMAIN_STATE_REASON_MAX_SIZE] = {
-    [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] = "the reason is unknown",
+        [VIR_DOMAIN_NOSTATE][VIR_DOMAIN_NOSTATE_UNKNOWN] =
+            "the reason is unknown",
 
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] = "the reason is unknown",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
-        "normal startup from boot",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
-        "migrated from another host",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
-        "restored from a state file",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
-        "restored from snapshot",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
-        "returned from paused state",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
-        "returned from migration",
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
-        "returned from failed save process",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_BOOTED] =
+            "normal startup from boot",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATED] =
+            "migrated from another host",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_RESTORED] =
+            "restored from a state file",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_FROM_SNAPSHOT] =
+            "restored from snapshot",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_UNPAUSED] =
+            "returned from paused state",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_MIGRATION_CANCELED] =
+            "returned from migration",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_SAVE_CANCELED] =
+            "returned from failed save process",
 #ifdef HAVE_DOM_REASON_RUNNING_WAKEUP
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
-        "returned from pmsuspended due to wakeup event",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_WAKEUP] =
+            "returned from pmsuspended due to wakeup event",
 #endif
 #ifdef HAVE_DOM_REASON_CRASHED
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] = "resumed from crashed",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_CRASHED] =
+            "resumed from crashed",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-    [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
-        "running in post-copy migration mode",
+        [VIR_DOMAIN_RUNNING][VIR_DOMAIN_RUNNING_POSTCOPY] =
+            "running in post-copy migration mode",
 #endif
-    [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] = "the reason is unknown",
+        [VIR_DOMAIN_BLOCKED][VIR_DOMAIN_BLOCKED_UNKNOWN] =
+            "the reason is unknown",
 
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] = "the reason is unknown",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
-        "paused for offline migration",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
-        "paused for offline core dump",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
-        "paused due to a disk I/O error",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
-        "paused due to a watchdog event",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
-        "paused after restoring from snapshot",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_USER] = "paused on user request",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_MIGRATION] =
+            "paused for offline migration",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SAVE] = "paused for save",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_DUMP] =
+            "paused for offline core dump",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_IOERROR] =
+            "paused due to a disk I/O error",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_WATCHDOG] =
+            "paused due to a watchdog event",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_FROM_SNAPSHOT] =
+            "paused after restoring from snapshot",
 #ifdef HAVE_DOM_REASON_PAUSED_SHUTTING_DOWN
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
-        "paused during shutdown process",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SHUTTING_DOWN] =
+            "paused during shutdown process",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_SNAPSHOT
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
-        "paused while creating a snapshot",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_SNAPSHOT] =
+            "paused while creating a snapshot",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_CRASHED
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
-        "paused due to a guest crash",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_CRASHED] =
+            "paused due to a guest crash",
 #endif
 #ifdef HAVE_DOM_REASON_PAUSED_STARTING_UP
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
-        "the domain is being started",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_STARTING_UP] =
+            "the domain is being started",
 #endif
 #ifdef HAVE_DOM_REASON_POSTCOPY
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
-        "paused for post-copy migration",
-    [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
-        "paused after failed post-copy",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY] =
+            "paused for post-copy migration",
+        [VIR_DOMAIN_PAUSED][VIR_DOMAIN_PAUSED_POSTCOPY_FAILED] =
+            "paused after failed post-copy",
 #endif
-    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
-        "the reason is unknown",
-    [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
-        "shutting down on user request",
+        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_SHUTDOWN][VIR_DOMAIN_SHUTDOWN_USER] =
+            "shutting down on user request",
 
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] = "the reason is unknown",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
-        "migrated to another host",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] = "domain failed to start",
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
-        "restored from a snapshot which was taken while domain was shutoff",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_UNKNOWN] =
+            "the reason is unknown",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SHUTDOWN] = "normal shutdown",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DESTROYED] = "forced poweroff",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_CRASHED] = "domain crashed",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_MIGRATED] =
+            "migrated to another host",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_SAVED] = "saved to a file",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FAILED] =
+            "domain failed to start",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_FROM_SNAPSHOT] =
+            "restored from a snapshot which was taken while domain was shutoff",
 #ifdef HAVE_DOM_REASON_SHUTOFF_DAEMON
-    [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
-        "daemon decides to kill domain during reconnection processing",
+        [VIR_DOMAIN_SHUTOFF][VIR_DOMAIN_SHUTOFF_DAEMON] =
+            "daemon decides to kill domain during reconnection processing",
 #endif
 
-    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] = "the reason is unknown",
+        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_UNKNOWN] =
+            "the reason is unknown",
 #ifdef VIR_DOMAIN_CRASHED_PANICKED
-    [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
+        [VIR_DOMAIN_CRASHED][VIR_DOMAIN_CRASHED_PANICKED] = "domain panicked",
 #endif
 
 #ifdef HAVE_DOM_STATE_PMSUSPENDED
-    [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
-        "the reason is unknown",
+        [VIR_DOMAIN_PMSUSPENDED][VIR_DOMAIN_PMSUSPENDED_UNKNOWN] =
+            "the reason is unknown",
 #endif
 };
 #endif /* HAVE_DOM_REASON */
@@ -944,8 +952,7 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
 static void submit_derive2(const char *type, derive_t v0, derive_t v1,
                            virDomainPtr dom, const char *devname) {
   value_t values[] = {
-      {.derive = v0},
-      {.derive = v1},
+      {.derive = v0}, {.derive = v1},
   };
 
   submit(dom, type, devname, values, STATIC_ARRAY_SIZE(values));
@@ -1671,8 +1678,7 @@ static int submit_domain_state(virDomainPtr domain) {
   }
 
   value_t values[] = {
-      {.gauge = (gauge_t)domain_state},
-      {.gauge = (gauge_t)domain_reason},
+      {.gauge = (gauge_t)domain_state}, {.gauge = (gauge_t)domain_reason},
   };
 
   submit(domain, "domain_state", NULL, values, STATIC_ARRAY_SIZE(values));
@@ -1748,8 +1754,7 @@ static int get_memory_stats(virDomainPtr domain) {
 
   if (min_flt > 0 || maj_flt > 0) {
     value_t values[] = {
-        {.gauge = (gauge_t)min_flt},
-        {.gauge = (gauge_t)maj_flt},
+        {.gauge = (gauge_t)min_flt}, {.gauge = (gauge_t)maj_flt},
     };
     submit(domain, "ps_pagefaults", NULL, values, STATIC_ARRAY_SIZE(values));
   }

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -60,7 +60,8 @@ static void submit(const char *plugin_instance, const char *type,
 static void submit_two(const char *plugin_instance, const char *type,
                        const char *type_instance, derive_t c0, derive_t c1) {
   value_t values[] = {
-      {.derive = c0}, {.derive = c1},
+      {.derive = c0},
+      {.derive = c1},
   };
 
   submit(plugin_instance, type, type_instance, values,

--- a/src/vserver.c
+++ b/src/vserver.c
@@ -57,7 +57,8 @@ static void traffic_submit(const char *plugin_instance,
                            derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   vl.values = values;
@@ -74,7 +75,9 @@ static void load_submit(const char *plugin_instance, gauge_t snum, gauge_t mnum,
                         gauge_t lnum) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.gauge = snum}, {.gauge = mnum}, {.gauge = lnum},
+      {.gauge = snum},
+      {.gauge = mnum},
+      {.gauge = lnum},
   };
 
   vl.values = values;

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -552,7 +552,8 @@ static int wg_config_node(oconfig_item_t *ci) {
 
   plugin_register_write(callback_name, wg_write,
                         &(user_data_t){
-                            .data = cb, .free_func = wg_callback_free,
+                            .data = cb,
+                            .free_func = wg_callback_free,
                         });
 
   plugin_register_flush(callback_name, wg_flush, &(user_data_t){.data = cb});

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -815,7 +815,8 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
         callback_name, cb->location);
 
   user_data_t user_data = {
-      .data = cb, .free_func = wh_callback_free,
+      .data = cb,
+      .free_func = wh_callback_free,
   };
 
   if (cb->send_metrics) {

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -411,13 +411,13 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   rd_kafka_topic_conf_set_opaque(tctx->conf, tctx);
 
   ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
-           tctx->topic_name);
+            tctx->topic_name);
 
-  status = plugin_register_write(
-      callback_name, kafka_write,
-      &(user_data_t){
-          .data = tctx, .free_func = kafka_topic_context_free,
-      });
+  status = plugin_register_write(callback_name, kafka_write,
+                                 &(user_data_t){
+                                     .data = tctx,
+                                     .free_func = kafka_topic_context_free,
+                                 });
   if (status != 0) {
     WARNING("write_kafka plugin: plugin_register_write (\"%s\") "
             "failed with status %i.",

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -413,11 +413,11 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
             tctx->topic_name);
 
-  status = plugin_register_write(callback_name, kafka_write,
-                                 &(user_data_t){
-                                     .data = tctx,
-                                     .free_func = kafka_topic_context_free,
-                                 });
+  status = plugin_register_write(
+      callback_name, kafka_write,
+      &(user_data_t){
+          .data = tctx, .free_func = kafka_topic_context_free,
+      });
   if (status != 0) {
     WARNING("write_kafka plugin: plugin_register_write (\"%s\") "
             "failed with status %i.",

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -97,7 +97,7 @@ static uint32_t kafka_hash(const char *keydata, size_t keylen) {
 #define KAFKA_RANDOM_KEY_BUFFER                                                \
   (char[KAFKA_RANDOM_KEY_SIZE]) { "" }
 static char *kafka_random_key(char buffer[static KAFKA_RANDOM_KEY_SIZE]) {
-  snprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
+  ssnprintf(buffer, KAFKA_RANDOM_KEY_SIZE, "%08" PRIX32, cdrand_u());
   return buffer;
 }
 
@@ -410,7 +410,7 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   rd_kafka_topic_conf_set_partitioner_cb(tctx->conf, kafka_partition);
   rd_kafka_topic_conf_set_opaque(tctx->conf, tctx);
 
-  snprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
+  ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
            tctx->topic_name);
 
   status = plugin_register_write(

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -413,11 +413,11 @@ static void kafka_config_topic(rd_kafka_conf_t *conf,
   ssnprintf(callback_name, sizeof(callback_name), "write_kafka/%s",
             tctx->topic_name);
 
-  status = plugin_register_write(
-      callback_name, kafka_write,
-      &(user_data_t){
-          .data = tctx, .free_func = kafka_topic_context_free,
-      });
+  status = plugin_register_write(callback_name, kafka_write,
+                                 &(user_data_t){
+                                     .data = tctx,
+                                     .free_func = kafka_topic_context_free,
+                                 });
   if (status != 0) {
     WARNING("write_kafka plugin: plugin_register_write (\"%s\") "
             "failed with status %i.",

--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -370,11 +370,11 @@ static int wm_config_node(oconfig_item_t *ci) /* {{{ */
 
     snprintf(cb_name, sizeof(cb_name), "write_mongodb/%s", node->name);
 
-    status =
-        plugin_register_write(cb_name, wm_write,
-                              &(user_data_t){
-                                  .data = node, .free_func = wm_config_free,
-                              });
+    status = plugin_register_write(cb_name, wm_write,
+                                   &(user_data_t){
+                                       .data = node,
+                                       .free_func = wm_config_free,
+                                   });
     INFO("write_mongodb plugin: registered write plugin %s %d", cb_name,
          status);
   }

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -156,8 +156,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
 #define LABEL_BUFFER_SIZE (LABEL_KEY_SIZE + LABEL_VALUE_SIZE + 4)
 
   char *labels[3] = {
-      (char[LABEL_BUFFER_SIZE]){0},
-      (char[LABEL_BUFFER_SIZE]){0},
+      (char[LABEL_BUFFER_SIZE]){0}, (char[LABEL_BUFFER_SIZE]){0},
       (char[LABEL_BUFFER_SIZE]){0},
   };
 

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -164,7 +164,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
    * know that they are sane. */
   for (size_t i = 0; i < m->n_label; i++) {
     char value[LABEL_VALUE_SIZE];
-    snprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
+    ssnprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
              escape_label_value(value, sizeof(value), m->label[i]->value));
   }
 
@@ -183,10 +183,10 @@ static void format_text(ProtobufCBuffer *buffer) {
   while (c_avl_iterator_next(iter, (void *)&unused_name, (void *)&fam) == 0) {
     char line[1024]; /* 4x DATA_MAX_NAME_LEN? */
 
-    snprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
+    ssnprintf(line, sizeof(line), "# HELP %s %s\n", fam->name, fam->help);
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
-    snprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
+    ssnprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
              (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
                  ? "gauge"
                  : "counter");
@@ -199,15 +199,15 @@ static void format_text(ProtobufCBuffer *buffer) {
 
       char timestamp_ms[24] = "";
       if (m->has_timestamp_ms)
-        snprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
+        ssnprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
                  m->timestamp_ms);
 
       if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-        snprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
+        ssnprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
                  format_labels(labels, sizeof(labels), m), m->gauge->value,
                  timestamp_ms);
       else /* if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__COUNTER) */
-        snprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
+        ssnprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
                  format_labels(labels, sizeof(labels), m), m->counter->value,
                  timestamp_ms);
 
@@ -217,7 +217,7 @@ static void format_text(ProtobufCBuffer *buffer) {
   c_avl_iterator_destroy(iter);
 
   char server[1024];
-  snprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
+  ssnprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
            PACKAGE_VERSION, hostname_g);
   buffer->append(buffer, strlen(server), (uint8_t *)server);
 
@@ -635,7 +635,7 @@ metric_family_create(char *name, data_set_t const *ds, value_list_t const *vl,
   msg->name = name;
 
   char help[1024];
-  snprintf(
+  ssnprintf(
       help, sizeof(help),
       "write_prometheus plugin: '%s' Type: '%s', Dstype: '%s', Dsname: '%s'",
       vl->plugin, vl->type, DS_TYPE_TO_STRING(ds->ds[ds_index].type),
@@ -744,7 +744,7 @@ static void prom_logger(__attribute__((unused)) void *arg, char const *fmt,
 static int prom_open_socket(int addrfamily) {
   /* {{{ */
   char service[NI_MAXSERV];
-  snprintf(service, sizeof(service), "%hu", httpd_port);
+  ssnprintf(service, sizeof(service), "%hu", httpd_port);
 
   struct addrinfo *res;
   int status = getaddrinfo(httpd_host, service,

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -156,7 +156,8 @@ static char *format_labels(char *buffer, size_t buffer_size,
 #define LABEL_BUFFER_SIZE (LABEL_KEY_SIZE + LABEL_VALUE_SIZE + 4)
 
   char *labels[3] = {
-      (char[LABEL_BUFFER_SIZE]){0}, (char[LABEL_BUFFER_SIZE]){0},
+      (char[LABEL_BUFFER_SIZE]){0},
+      (char[LABEL_BUFFER_SIZE]){0},
       (char[LABEL_BUFFER_SIZE]){0},
   };
 
@@ -165,7 +166,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
   for (size_t i = 0; i < m->n_label; i++) {
     char value[LABEL_VALUE_SIZE];
     ssnprintf(labels[i], LABEL_BUFFER_SIZE, "%s=\"%s\"", m->label[i]->name,
-             escape_label_value(value, sizeof(value), m->label[i]->value));
+              escape_label_value(value, sizeof(value), m->label[i]->value));
   }
 
   strjoin(buffer, buffer_size, labels, m->n_label, ",");
@@ -187,9 +188,9 @@ static void format_text(ProtobufCBuffer *buffer) {
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
     ssnprintf(line, sizeof(line), "# TYPE %s %s\n", fam->name,
-             (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
-                 ? "gauge"
-                 : "counter");
+              (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
+                  ? "gauge"
+                  : "counter");
     buffer->append(buffer, strlen(line), (uint8_t *)line);
 
     for (size_t i = 0; i < fam->n_metric; i++) {
@@ -200,16 +201,16 @@ static void format_text(ProtobufCBuffer *buffer) {
       char timestamp_ms[24] = "";
       if (m->has_timestamp_ms)
         ssnprintf(timestamp_ms, sizeof(timestamp_ms), " %" PRIi64,
-                 m->timestamp_ms);
+                  m->timestamp_ms);
 
       if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__GAUGE)
         ssnprintf(line, sizeof(line), "%s{%s} " GAUGE_FORMAT "%s\n", fam->name,
-                 format_labels(labels, sizeof(labels), m), m->gauge->value,
-                 timestamp_ms);
+                  format_labels(labels, sizeof(labels), m), m->gauge->value,
+                  timestamp_ms);
       else /* if (fam->type == IO__PROMETHEUS__CLIENT__METRIC_TYPE__COUNTER) */
         ssnprintf(line, sizeof(line), "%s{%s} %.0f%s\n", fam->name,
-                 format_labels(labels, sizeof(labels), m), m->counter->value,
-                 timestamp_ms);
+                  format_labels(labels, sizeof(labels), m), m->counter->value,
+                  timestamp_ms);
 
       buffer->append(buffer, strlen(line), (uint8_t *)line);
     }
@@ -218,7 +219,7 @@ static void format_text(ProtobufCBuffer *buffer) {
 
   char server[1024];
   ssnprintf(server, sizeof(server), "\n# collectd/write_prometheus %s at %s\n",
-           PACKAGE_VERSION, hostname_g);
+            PACKAGE_VERSION, hostname_g);
   buffer->append(buffer, strlen(server), (uint8_t *)server);
 
   pthread_mutex_unlock(&metrics_lock);

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -156,7 +156,8 @@ static char *format_labels(char *buffer, size_t buffer_size,
 #define LABEL_BUFFER_SIZE (LABEL_KEY_SIZE + LABEL_VALUE_SIZE + 4)
 
   char *labels[3] = {
-      (char[LABEL_BUFFER_SIZE]){0}, (char[LABEL_BUFFER_SIZE]){0},
+      (char[LABEL_BUFFER_SIZE]){0},
+      (char[LABEL_BUFFER_SIZE]){0},
       (char[LABEL_BUFFER_SIZE]){0},
   };
 

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -71,9 +71,9 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   status = FORMAT_VL(ident, sizeof(ident), vl);
   if (status != 0)
     return status;
-  snprintf(key, sizeof(key), "%s%s",
+  ssnprintf(key, sizeof(key), "%s%s",
            (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX, ident);
-  snprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
+  ssnprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   value_size = sizeof(value);
   value_ptr = &value[0];
@@ -239,7 +239,7 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
   if (status == 0) {
     char cb_name[sizeof("write_redis/") + DATA_MAX_NAME_LEN];
 
-    snprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
+    ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
     status =
         plugin_register_write(cb_name, wr_write,

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -242,11 +242,11 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
 
     ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
-    status = plugin_register_write(cb_name, wr_write,
-                                   &(user_data_t){
-                                       .data = node,
-                                       .free_func = wr_config_free,
-                                   });
+    status =
+        plugin_register_write(cb_name, wr_write,
+                              &(user_data_t){
+                                  .data = node, .free_func = wr_config_free,
+                              });
   }
 
   if (status != 0)

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -72,7 +72,8 @@ static int wr_write(const data_set_t *ds, /* {{{ */
   if (status != 0)
     return status;
   ssnprintf(key, sizeof(key), "%s%s",
-           (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX, ident);
+            (node->prefix != NULL) ? node->prefix : REDIS_DEFAULT_PREFIX,
+            ident);
   ssnprintf(time, sizeof(time), "%.9f", CDTIME_T_TO_DOUBLE(vl->time));
 
   value_size = sizeof(value);
@@ -241,11 +242,11 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
 
     ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
-    status =
-        plugin_register_write(cb_name, wr_write,
-                              &(user_data_t){
-                                  .data = node, .free_func = wr_config_free,
-                              });
+    status = plugin_register_write(cb_name, wr_write,
+                                   &(user_data_t){
+                                       .data = node,
+                                       .free_func = wr_config_free,
+                                   });
   }
 
   if (status != 0)

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -242,11 +242,11 @@ static int wr_config_node(oconfig_item_t *ci) /* {{{ */
 
     ssnprintf(cb_name, sizeof(cb_name), "write_redis/%s", node->name);
 
-    status =
-        plugin_register_write(cb_name, wr_write,
-                              &(user_data_t){
-                                  .data = node, .free_func = wr_config_free,
-                              });
+    status = plugin_register_write(cb_name, wr_write,
+                                   &(user_data_t){
+                                       .data = node,
+                                       .free_func = wr_config_free,
+                                   });
   }
 
   if (status != 0)

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -291,16 +291,16 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
               vl->type_instance);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      snprintf(service_buffer, sizeof(service_buffer), "%s/%s", &name_buffer[1],
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s/%s", &name_buffer[1],
                ds->ds[index].name);
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
                host->event_service_prefix, &name_buffer[1], ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, &name_buffer[1], sizeof(service_buffer));
     else
-      snprintf(service_buffer, sizeof(service_buffer), "%s%s",
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
                host->event_service_prefix, &name_buffer[1]);
   }
 
@@ -349,7 +349,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   if ((ds->ds[index].type != DS_TYPE_GAUGE) && (rates != NULL)) {
     char ds_type[DATA_MAX_NAME_LEN];
 
-    snprintf(ds_type, sizeof(ds_type), "%s:rate",
+    ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
              DS_TYPE_TO_STRING(ds->ds[index].type));
     riemann_event_string_attribute_add(event, "ds_type", ds_type);
   } else {
@@ -360,7 +360,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
   {
     char ds_index[DATA_MAX_NAME_LEN];
 
-    snprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
+    ssnprintf(ds_index, sizeof(ds_index), "%" PRIsz, index);
     riemann_event_string_attribute_add(event, "ds_index", ds_index);
   }
 
@@ -777,7 +777,7 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
     return status;
   }
 
-  snprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
+  ssnprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
            host->name);
 
   user_data_t ud = {.data = host, .free_func = wrr_free};

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -291,17 +291,18 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
               vl->type_instance);
   if (host->always_append_ds || (ds->ds_num > 1)) {
     if (host->event_service_prefix == NULL)
-      ssnprintf(service_buffer, sizeof(service_buffer), "%s/%s", &name_buffer[1],
-               ds->ds[index].name);
+      ssnprintf(service_buffer, sizeof(service_buffer), "%s/%s",
+                &name_buffer[1], ds->ds[index].name);
     else
       ssnprintf(service_buffer, sizeof(service_buffer), "%s%s/%s",
-               host->event_service_prefix, &name_buffer[1], ds->ds[index].name);
+                host->event_service_prefix, &name_buffer[1],
+                ds->ds[index].name);
   } else {
     if (host->event_service_prefix == NULL)
       sstrncpy(service_buffer, &name_buffer[1], sizeof(service_buffer));
     else
       ssnprintf(service_buffer, sizeof(service_buffer), "%s%s",
-               host->event_service_prefix, &name_buffer[1]);
+                host->event_service_prefix, &name_buffer[1]);
   }
 
   riemann_event_set(
@@ -350,7 +351,7 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
     char ds_type[DATA_MAX_NAME_LEN];
 
     ssnprintf(ds_type, sizeof(ds_type), "%s:rate",
-             DS_TYPE_TO_STRING(ds->ds[index].type));
+              DS_TYPE_TO_STRING(ds->ds[index].type));
     riemann_event_string_attribute_add(event, "ds_type", ds_type);
   } else {
     riemann_event_string_attribute_add(event, "ds_type",
@@ -778,7 +779,7 @@ static int wrr_config_node(oconfig_item_t *ci) /* {{{ */
   }
 
   ssnprintf(callback_name, sizeof(callback_name), "write_riemann/%s",
-           host->name);
+            host->name);
 
   user_data_t ud = {.data = host, .free_func = wrr_free};
 

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -109,7 +109,7 @@ static char *wg_get_authorization_header(wg_callback_t *cb) { /* {{{ */
     return NULL;
   }
 
-  status = snprintf(authorization_header, sizeof(authorization_header),
+  status = ssnprintf(authorization_header, sizeof(authorization_header),
                     "Authorization: Bearer %s", access_token);
   if ((status < 1) || ((size_t)status >= sizeof(authorization_header)))
     return NULL;
@@ -160,9 +160,9 @@ static char *api_error_string(api_error_t *err, char *buffer,
   if (err == NULL) {
     strncpy(buffer, "Unknown error (API error is NULL)", buffer_size);
   } else if (err->message == NULL) {
-    snprintf(buffer, buffer_size, "API error %d", err->code);
+    ssnprintf(buffer, buffer_size, "API error %d", err->code);
   } else {
-    snprintf(buffer, buffer_size, "API error %d: %s", err->code, err->message);
+    ssnprintf(buffer, buffer_size, "API error %d: %s", err->code, err->message);
   }
 
   return buffer;
@@ -251,7 +251,7 @@ static int do_post(wg_callback_t *cb, char const *url, void const *payload,
 static int wg_call_metricdescriptor_create(wg_callback_t *cb,
                                            char const *payload) {
   char url[1024];
-  snprintf(url, sizeof(url), "%s/projects/%s/metricDescriptors", cb->url,
+  ssnprintf(url, sizeof(url), "%s/projects/%s/metricDescriptors", cb->url,
            cb->project);
   wg_memory_t response = {0};
 
@@ -273,7 +273,7 @@ static int wg_call_metricdescriptor_create(wg_callback_t *cb,
 
 static int wg_call_timeseries_write(wg_callback_t *cb, char const *payload) {
   char url[1024];
-  snprintf(url, sizeof(url), "%s/projects/%s/timeSeries", cb->url, cb->project);
+  ssnprintf(url, sizeof(url), "%s/projects/%s/timeSeries", cb->url, cb->project);
   wg_memory_t response = {0};
 
   int status = do_post(cb, url, payload, &response);

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -110,7 +110,7 @@ static char *wg_get_authorization_header(wg_callback_t *cb) { /* {{{ */
   }
 
   status = ssnprintf(authorization_header, sizeof(authorization_header),
-                    "Authorization: Bearer %s", access_token);
+                     "Authorization: Bearer %s", access_token);
   if ((status < 1) || ((size_t)status >= sizeof(authorization_header)))
     return NULL;
 
@@ -252,7 +252,7 @@ static int wg_call_metricdescriptor_create(wg_callback_t *cb,
                                            char const *payload) {
   char url[1024];
   ssnprintf(url, sizeof(url), "%s/projects/%s/metricDescriptors", cb->url,
-           cb->project);
+            cb->project);
   wg_memory_t response = {0};
 
   int status = do_post(cb, url, payload, &response);
@@ -273,7 +273,8 @@ static int wg_call_metricdescriptor_create(wg_callback_t *cb,
 
 static int wg_call_timeseries_write(wg_callback_t *cb, char const *payload) {
   char url[1024];
-  ssnprintf(url, sizeof(url), "%s/projects/%s/timeSeries", cb->url, cb->project);
+  ssnprintf(url, sizeof(url), "%s/projects/%s/timeSeries", cb->url,
+            cb->project);
   wg_memory_t response = {0};
 
   int status = do_post(cb, url, payload, &response);

--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -127,7 +127,7 @@ static long long get_zfs_value(kstat_t *dummy __attribute__((unused)),
   size_t valuelen = sizeof(value);
   int rv;
 
-  snprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
+  ssnprintf(buffer, sizeof(buffer), "%s%s", zfs_arcstat, name);
   rv = sysctlbyname(buffer, (void *)&value, &valuelen,
                     /* new value = */ NULL, /* new length = */ (size_t)0);
   if (rv == 0)


### PR DESCRIPTION
ChangeLog: Add ssnprintf wrapper function to 67 *.c and _ssnprintf to 1 file, to stop GCC 8.2/3 Truncation Warnings

Added ssnprintf wrapper function to all *.c files which report with truncation warnings from GCC 8.2/3 toolset. Update tested with Ubuntu 19.04 / GCC 8.3.
Completes work started under issue: https://github.com/collectd/collectd/pull/2895
And allow clean Debian/Ubuntu build of collectd

The following files auto edited to add wrapper function:
```
collectd/src/aquaero.c
collectd/src/ascent.c
collectd/src/ceph.c
collectd/src/collectd.c
collectd/src/daemon/configfile.c
collectd/src/disk.c
collectd/src/dpdkevents.c
collectd/src/dpdkstat.c
collectd/src/gmond.c
collectd/src/intel_pmu.c
collectd/src/intel_rdt.c
collectd/src/interface.c
collectd/src/ipmi.c
collectd/src/iptables.c
collectd/src/lpar.c
collectd/src/lua.c
collectd/src/lvm.c
collectd/src/mic.c
collectd/src/modbus.c
collectd/src/mqtt.c
collectd/src/mysql.c
collectd/src/netapp.c
collectd/src/netlink.c
collectd/src/nginx.c
collectd/src/notify_desktop.c
collectd/src/notify_email.c
collectd/src/onewire.c
collectd/src/openldap.c
collectd/src/oracle.c
collectd/src/ovs_events.c
collectd/src/ovs_stats.c
collectd/src/perl.c
collectd/src/postgresql.c
collectd/src/protocols.c
collectd/src/python.c
collectd/src/redis.c
collectd/src/routeros.c
collectd/src/rrdcached.c
collectd/src/rrdtool.c
collectd/src/sigrok.c
collectd/src/smart.c
collectd/src/snmp_agent.c
collectd/src/snmp.c
collectd/src/threshold.c
collectd/src/utils/cmds/cmds_test.c
collectd/src/utils/config_cores/config_cores.c
collectd/src/utils/db_query/db_query.c
collectd/src/utils/dns/dns.c
collectd/src/utils/dpdk/dpdk.c
collectd/src/utils/format_graphite/format_graphite_test.c
collectd/src/utils/format_stackdriver/format_stackdriver.c
collectd/src/utils/gce/gce.c
collectd/src/utils/oauth/oauth.c
collectd/src/utils/ovs/ovs.c
collectd/src/utils/rrdcreate/rrdcreate.c
collectd/src/varnish.c
collectd/src/virt.c
collectd/src/write_kafka.c
collectd/src/write_prometheus.c
collectd/src/write_redis.c
collectd/src/write_riemann.c
collectd/src/write_stackdriver.c
collectd/src/zfs_arc.c
collectd/src/zone.c
```

Auto edit via sed, where file: auto-sed-03.txt is file list above:
```
find collectd -name "*.c" -exec sh -c "( grep '{}' auto-sed-03.txt && mv '{}' '{}'.sed.bak && cat '{}'.sed.bak | sed 's/ snprintf(/ ssnprintf(/g' > '{}')" \;
```

Hand edited the following 3 special case files:
```
src/collectdctl.c - added static special wrapper _ssnprintf
src/utils/common/common.c/.h - added ssnprintf wrapper function
```

Code compiled with all modules except the following:
```
    apple_sensors . . . . no
    aquaero . . . . . . . no (libaquaero5.h not found)
    gpu_nvidia  . . . . . no
    grpc  . . . . . . . . no (protoc3 not found)
    intel_pmu . . . . . . no (jevents.h not found)
    java  . . . . . . . . no (jar not found)
    lpar  . . . . . . . . no (AIX only)
    mic . . . . . . . . . no (MicAccessApi not found)
    mysql . . . . . . . . no (mysql_config failed)
    netapp  . . . . . . . no (netapp_api.h not found)
    oracle  . . . . . . . no (ORACLE_HOME is not set)
    pf  . . . . . . . . . no
    python  . . . . . . . no
    routeros  . . . . . . no (routeros_api.h not found)
    sigrok  . . . . . . . no (pkg-config could not find libsigrok)
    tape  . . . . . . . . no
    xmms  . . . . . . . . no
    zone  . . . . . . . . no
```
NOTE: lvm module compiles with error due to "deprecated warning" in /usr/include/lvm2app.h

```
#warning "liblvm2app is deprecated, use D-Bus API instead."
```
I commented out warning in system header file to get around warning.
see: https://github.com/collectd/collectd/issues/2820