### PR TITLE
virt plugin: improvements

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1684,7 +1684,7 @@
 #	InterfaceFormat name
 #	PluginInstanceFormat name
 #	Instances 1
-#	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpupin disk_physical disk_allocation disk_capacity"
+#	ExtraStats "cpu_util disk disk_err domain_state fs_info job_stats_background pcpu perf vcpu vcpupin disk_physical disk_allocation disk_capacity memory"
 #	PersistentNotification false
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9520,6 +9520,9 @@ Requires libvirt API version I<1.2.9> or later.
 a domain. Only one type of job statistics can be collected at the same time.
 Requires libvirt API version I<1.2.9> or later.
 
+=item B<memory>: report statistics about memory usage details, provided
+by libvirt virDomainMemoryStats() function.
+
 =item B<pcpu>: report the physical user/system cpu time consumed by the hypervisor, per-vm.
 Requires libvirt API version I<0.9.11> or later.
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9531,6 +9531,8 @@ metrics they must be enabled for domain and supported by the platform. Requires
 libvirt API version I<1.3.3> or later.
 B<Note>: I<perf> metrics can't be collected if I<intel_rdt> plugin is enabled.
 
+=item B<vcpu>: report domain virtual CPUs utilisation.
+
 =item B<vcpupin>: report pinning of domain VCPUs to host physical CPUs.
 
 =item B<disk_physical>: report 'disk_physical' statistic for disk device.

--- a/src/virt.c
+++ b/src/virt.c
@@ -1589,7 +1589,6 @@ static void vcpu_pin_submit(virDomainPtr dom, int max_cpus, int vcpu,
 
 static int get_vcpu_stats(virDomainPtr domain, unsigned short nr_virt_cpu) {
   int max_cpus = VIR_NODEINFO_MAXCPUS(nodeinfo);
-  int cpu_map_len = VIR_CPU_MAPLEN(max_cpus);
 
   virVcpuInfoPtr vinfo = calloc(nr_virt_cpu, sizeof(*vinfo));
   if (vinfo == NULL) {
@@ -1597,11 +1596,17 @@ static int get_vcpu_stats(virDomainPtr domain, unsigned short nr_virt_cpu) {
     return -1;
   }
 
-  unsigned char *cpumaps = calloc(nr_virt_cpu, cpu_map_len);
-  if (cpumaps == NULL) {
-    ERROR(PLUGIN_NAME " plugin: calloc failed.");
-    sfree(vinfo);
-    return -1;
+  int cpu_map_len = 0;
+  unsigned char *cpumaps = NULL;
+  if (extra_stats & ex_stats_vcpupin) {
+    cpu_map_len = VIR_CPU_MAPLEN(max_cpus);
+    cpumaps = calloc(nr_virt_cpu, cpu_map_len);
+
+    if (cpumaps == NULL) {
+      ERROR(PLUGIN_NAME " plugin: calloc failed.");
+      sfree(vinfo);
+      return -1;
+    }
   }
 
   int status =

--- a/src/virt.c
+++ b/src/virt.c
@@ -2418,6 +2418,21 @@ static int lv_read(user_data_t *ud) {
     return 0;
   }
 
+  int ret = virConnectIsAlive(conn);
+  if (ret == 0) { /* Connection lost */
+    if (inst->id == 0) {
+      c_complain(LOG_ERR, &conn_complain,
+                 PLUGIN_NAME " plugin: Lost connection.");
+
+      if (!persistent_notification)
+        stop_event_loop(&notif_thread);
+
+      lv_disconnect();
+      last_refresh = 0;
+    }
+    return -1;
+  }
+
   time_t t;
   time(&t);
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -976,7 +976,7 @@ static double cpu_ns_to_percent(unsigned int node_cpus,
   }
 
   DEBUG(PLUGIN_NAME " plugin: node_cpus=%u cpu_time_old=%" PRIu64
-                    " cpu_time_new=%" PRIu64 "cpu_time_diff=%" PRIu64
+                    " cpu_time_new=%" PRIu64 " cpu_time_diff=%" PRIu64
                     " time_diff_sec=%f percent=%f",
         node_cpus, (uint64_t)cpu_time_old, (uint64_t)cpu_time_new,
         (uint64_t)cpu_time_diff, time_diff_sec, percent);
@@ -1523,8 +1523,8 @@ static int lv_domain_block_stats(virDomainPtr dom, const char *path,
 
   virTypedParameterPtr params = calloc(nparams, sizeof(*params));
   if (params == NULL) {
-    ERROR("virt plugin: alloc(%i) for block=%s parameters failed.", nparams,
-          path);
+    ERROR(PLUGIN_NAME " plugin: alloc(%i) for block=%s parameters failed.",
+          nparams, path);
     return -1;
   }
 
@@ -1564,7 +1564,8 @@ static int get_perf_events(virDomainPtr domain) {
   int status =
       virDomainListGetStats(domain_array, VIR_DOMAIN_STATS_PERF, &stats, 0);
   if (status == -1) {
-    ERROR("virt plugin: virDomainListGetStats failed with status %i.", status);
+    ERROR(PLUGIN_NAME " plugin: virDomainListGetStats failed with status %i.",
+          status);
     return status;
   }
 
@@ -1718,14 +1719,14 @@ static int get_memory_stats(virDomainPtr domain) {
   virDomainMemoryStatPtr minfo =
       calloc(VIR_DOMAIN_MEMORY_STAT_NR, sizeof(*minfo));
   if (minfo == NULL) {
-    ERROR("virt plugin: calloc failed.");
+    ERROR(PLUGIN_NAME " plugin: calloc failed.");
     return -1;
   }
 
   int mem_stats =
       virDomainMemoryStats(domain, minfo, VIR_DOMAIN_MEMORY_STAT_NR, 0);
   if (mem_stats < 0) {
-    ERROR("virt plugin: virDomainMemoryStats failed with mem_stats %i.",
+    ERROR(PLUGIN_NAME " plugin: virDomainMemoryStats failed with mem_stats %i.",
           mem_stats);
     sfree(minfo);
     return mem_stats;

--- a/src/virt.c
+++ b/src/virt.c
@@ -610,7 +610,8 @@ enum ex_stats {
 #endif
   ex_stats_disk_allocation = 1 << 10,
   ex_stats_disk_capacity = 1 << 11,
-  ex_stats_disk_physical = 1 << 12
+  ex_stats_disk_physical = 1 << 12,
+  ex_stats_memory = 1 << 13
 };
 
 static unsigned int extra_stats = ex_stats_none;
@@ -641,6 +642,7 @@ static const struct ex_stats_item ex_stats_table[] = {
     {"disk_allocation", ex_stats_disk_allocation},
     {"disk_capacity", ex_stats_disk_capacity},
     {"disk_physical", ex_stats_disk_physical},
+    {"memory", ex_stats_memory},
     {NULL, ex_stats_none},
 };
 
@@ -2019,7 +2021,8 @@ static int get_domain_metrics(domain_t *domain) {
   memory_submit(domain->ptr, (gauge_t)info.memory * 1024);
 
   GET_STATS(get_vcpu_stats, "vcpu stats", domain->ptr, info.nrVirtCpu);
-  GET_STATS(get_memory_stats, "memory stats", domain->ptr);
+  if (extra_stats & ex_stats_memory)
+    GET_STATS(get_memory_stats, "memory stats", domain->ptr);
 
 #ifdef HAVE_PERF_STATS
   if (extra_stats & ex_stats_perf)

--- a/src/virt.c
+++ b/src/virt.c
@@ -946,7 +946,8 @@ static void memory_stats_submit(gauge_t value, virDomainPtr dom,
                                "last_update",    "disk_caches"};
 
   if ((tag_index < 0) || (tag_index >= (int)STATIC_ARRAY_SIZE(tags))) {
-    ERROR("virt plugin: Array index out of bounds: tag_index = %d", tag_index);
+    ERROR(PLUGIN_NAME " plugin: Array index out of bounds: tag_index = %d",
+          tag_index);
     return;
   }
 

--- a/src/virt.c
+++ b/src/virt.c
@@ -1568,7 +1568,7 @@ static int get_perf_events(virDomainPtr domain) {
     ERROR(PLUGIN_NAME " plugin: virDomainListGetStats failed with status %i.",
           status);
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     if (err->code == VIR_ERR_NO_SUPPORT) {
       ERROR(PLUGIN_NAME
             " plugin: Disabled unsupported ExtraStats selector: perf");
@@ -1625,7 +1625,7 @@ static int get_vcpu_stats(virDomainPtr domain, unsigned short nr_virt_cpu) {
     ERROR(PLUGIN_NAME " plugin: virDomainGetVcpus failed with status %i.",
           status);
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     if (err->code == VIR_ERR_NO_SUPPORT) {
       if (extra_stats & ex_stats_vcpu)
         ERROR(PLUGIN_NAME
@@ -1659,7 +1659,7 @@ static int get_pcpu_stats(virDomainPtr dom) {
   if (nparams < 0) {
     VIRT_ERROR(conn, "getting the CPU params count");
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     if (err->code == VIR_ERR_NO_SUPPORT) {
       ERROR(PLUGIN_NAME
             " plugin: Disabled unsupported ExtraStats selector: pcpu");
@@ -1759,7 +1759,7 @@ static int get_memory_stats(virDomainPtr domain) {
           mem_stats);
     sfree(minfo);
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     if (err->code == VIR_ERR_NO_SUPPORT) {
       ERROR(PLUGIN_NAME
             " plugin: Disabled unsupported ExtraStats selector: memory");
@@ -1824,7 +1824,7 @@ static int get_disk_err(virDomainPtr domain) {
     ERROR(PLUGIN_NAME
           " plugin: failed to get preferred size of disk errors array");
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
 
     if (err->code == VIR_ERR_NO_SUPPORT) {
       ERROR(PLUGIN_NAME
@@ -1879,7 +1879,7 @@ static int get_block_device_stats(struct block_device *block_dev) {
         ERROR(PLUGIN_NAME " plugin: virDomainGetBlockInfo failed for path: %s",
               block_dev->path);
 
-        virErrorPtr err = virConnGetLastError(conn);
+        virErrorPtr err = virGetLastError();
         if (err->code == VIR_ERR_NO_SUPPORT) {
 
           if (extra_stats & ex_stats_disk_allocation)
@@ -1983,7 +1983,7 @@ static int get_fs_info(virDomainPtr domain) {
     ERROR(PLUGIN_NAME " plugin: virDomainGetFSInfo failed: %d",
           mount_points_cnt);
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     if (err->code == VIR_ERR_NO_SUPPORT) {
       ERROR(PLUGIN_NAME
             " plugin: Disabled unsupported ExtraStats selector: fs_info");
@@ -2048,7 +2048,7 @@ static int get_job_stats(virDomainPtr domain) {
   if (ret != 0) {
     ERROR(PLUGIN_NAME " plugin: virDomainGetJobStats failed: %d", ret);
 
-    virErrorPtr err = virConnGetLastError(conn);
+    virErrorPtr err = virGetLastError();
     // VIR_ERR_INVALID_ARG returned when VIR_DOMAIN_JOB_STATS_COMPLETED flag is
     // not supported by driver
     if (err->code == VIR_ERR_NO_SUPPORT || err->code == VIR_ERR_INVALID_ARG) {


### PR DESCRIPTION
Changelog: virt plugin: improvements and fixes.

1)
```
virt plugin: Added ExtraStats selector 'memory' 
This allows to disable virDomainMemoryStats calls when hypervisor/drivers
does not supports that function or it does not provide additional details.
```

2)
```
virt plugin: Added ExtraStats selector 'vcpu'  
This allows to disable virDomainGetVcpus calls when hypervisor/driver
does not supports that function.
```

3)
```
virt plugin: Do not request cpu maps when not required
```

4)
```
virt plugin: Disable ExtraStats selectors when unsupported by libvirt 
When function is not supported by driver, log filled by continuous messages like:

libvirt: Domain Config error : this function is not supported by the connection driver: virDomainGetDiskErrors

libvirt API allows us to detect such cases and disable unsupported calls.
```

5)
```
virt plugin: Added timeout to event_loop thread
As per virEventRunDefaultImpl() documentation, this function will block
forever if there are no registered event handlers.

This leads to Collectd is unable to correctly stop event_loop thread
if libvirtd was restarted.
```
https://libvirt.org/html/libvirt-libvirt-event.html#virEventRunDefaultImpl

6)
```
virt plugin: Added connection state check via virConnectIsAlive()

Before this fix, if libvirt daemon was stopped, Collectd starts to spam logs with lot of "failed" messages.
With this fix it correctly re-establishes connection.
```

7)
```
virt plugin: Fixed typos and inconsistencies
```

![image](https://user-images.githubusercontent.com/13328211/58323413-1700fb80-7e4e-11e9-93dc-0256423ac56b.png)
