### PR TITLE
Add Python 3.8 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4771,7 +4771,7 @@ if test "$PYTHON_CONFIG" != ""; then
   if test $? -ne 0; then
     with_libpython="no"
   fi
-  LIBPYTHON_LIBS="`${PYTHON_CONFIG} --libs`"
+  LIBPYTHON_LIBS="`${PYTHON_CONFIG} --libs --embed`" || LIBPYTHON_LIBS="`${PYTHON_CONFIG} --libs`"
   if test $? -ne 0; then
     with_libpython="no"
   fi


### PR DESCRIPTION
From Python 3.8 and onwards C extensions are no longer
linked to libpython so in order to embed python within
an application the --embed flag needs to be added to
python3-config --libs. A fall back is provided as the
command will error out on previous python versions.

References: https://bugs.python.org/issue36721

Resolves: #3166 

ChangeLog: Add Python 3.8 compatibility