### PR TITLE
Fix return value or loglevel for several plugins

### DIFF
--- a/src/barometer.c
+++ b/src/barometer.c
@@ -1309,7 +1309,7 @@ static int collectd_barometer_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "Normalization") == 0) {
     int normalize_tmp = atoi(value);
     if (normalize_tmp < 0 || normalize_tmp > 2) {
-      WARNING("barometer: collectd_barometer_config: invalid normalization: %d",
+      ERROR("barometer: collectd_barometer_config: invalid normalization: %d",
               normalize_tmp);
       return 1;
     }

--- a/src/barometer.c
+++ b/src/barometer.c
@@ -1310,7 +1310,7 @@ static int collectd_barometer_config(const char *key, const char *value) {
     int normalize_tmp = atoi(value);
     if (normalize_tmp < 0 || normalize_tmp > 2) {
       ERROR("barometer: collectd_barometer_config: invalid normalization: %d",
-              normalize_tmp);
+            normalize_tmp);
       return 1;
     }
     config_normalize = normalize_tmp;

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -267,7 +267,8 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
   /* default to the global interval set before loading this plugin */
   plugin_ctx_t ctx = {
-      .interval = cf_get_default_interval(), .name = strdup(name),
+      .interval = cf_get_default_interval(),
+      .name = strdup(name),
   };
   if (ctx.name == NULL)
     return ENOMEM;
@@ -413,10 +414,11 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
   /* Hm, no complex plugin found. Dispatch the values one by one */
   for (int i = 0, ret = 0; i < ci->children_num; i++) {
     if (ci->children[i].children == NULL) {
-      oconfig_item_t *child = ci -> children + i;
+      oconfig_item_t *child = ci->children + i;
       ret = dispatch_value_plugin(name, child);
       if (ret != 0) {
-        ERROR("Plugin %s failed to handle option %s, return code: %i", name, child -> key, ret);
+        ERROR("Plugin %s failed to handle option %s, return code: %i", name,
+              child->key, ret);
         return ret;
       }
     } else {
@@ -478,9 +480,9 @@ static int cf_ci_replace_child(oconfig_item_t *dst, oconfig_item_t *src,
     return 0;
   }
 
-  temp = realloc(dst->children,
-                 sizeof(oconfig_item_t) *
-                     (dst->children_num + src->children_num - 1));
+  temp =
+      realloc(dst->children, sizeof(oconfig_item_t) *
+                                 (dst->children_num + src->children_num - 1));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -519,9 +521,8 @@ static int cf_ci_append_children(oconfig_item_t *dst, oconfig_item_t *src) {
   if ((src == NULL) || (src->children_num == 0))
     return 0;
 
-  temp =
-      realloc(dst->children,
-              sizeof(oconfig_item_t) * (dst->children_num + src->children_num));
+  temp = realloc(dst->children, sizeof(oconfig_item_t) *
+                                    (dst->children_num + src->children_num));
   if (temp == NULL) {
     ERROR("configfile: realloc failed.");
     return -1;
@@ -809,7 +810,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
   return root;
 } /* oconfig_item_t *cf_read_generic */
-/* #endif HAVE_WORDEXP_H */
+  /* #endif HAVE_WORDEXP_H */
 
 #else  /* if !HAVE_WORDEXP_H */
 static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -413,9 +413,10 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
   /* Hm, no complex plugin found. Dispatch the values one by one */
   for (int i = 0, ret = 0; i < ci->children_num; i++) {
     if (ci->children[i].children == NULL) {
-      ret = dispatch_value_plugin(name, ci->children + i);
+      oconfig_item_t *child = ci -> children + i;
+      ret = dispatch_value_plugin(name, child);
       if (ret != 0) {
-        ERROR("dispatch for plugin %s returned non-zero code : %i", name, ret);
+        ERROR("Plugin %s failed to handle option %s, return code: %i", name, child -> key, ret);
         return ret;
       }
     } else {

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -414,8 +414,10 @@ static int dispatch_block_plugin(oconfig_item_t *ci) {
   for (int i = 0, ret = 0; i < ci->children_num; i++) {
     if (ci->children[i].children == NULL) {
       ret = dispatch_value_plugin(name, ci->children + i);
-      if (ret != 0)
+      if (ret != 0) {
+        ERROR("dispatch for plugin %s returned non-zero code : %i", name, ret);
         return ret;
+      }
     } else {
       WARNING("There is a `%s' block within the "
               "configuration for the %s plugin. "

--- a/src/load.c
+++ b/src/load.c
@@ -91,7 +91,9 @@ static void load_submit(gauge_t snum, gauge_t mnum, gauge_t lnum) {
 
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.gauge = snum}, {.gauge = mnum}, {.gauge = lnum},
+      {.gauge = snum},
+      {.gauge = mnum},
+      {.gauge = lnum},
   };
 
   vl.values = values;
@@ -116,7 +118,7 @@ static int load_read(void) {
   else {
     WARNING("load: getloadavg failed: %s", STRERRNO);
   }
-/* #endif HAVE_GETLOADAVG */
+    /* #endif HAVE_GETLOADAVG */
 
 #elif defined(KERNEL_LINUX)
   gauge_t snum, mnum, lnum;
@@ -151,7 +153,7 @@ static int load_read(void) {
   lnum = atof(fields[2]);
 
   load_submit(snum, mnum, lnum);
-/* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBSTATGRAB
   gauge_t snum, mnum, lnum;
@@ -164,7 +166,7 @@ static int load_read(void) {
   mnum = ls->min5;
   lnum = ls->min15;
   load_submit(snum, mnum, lnum);
-/* #endif HAVE_LIBSTATGRAB */
+  /* #endif HAVE_LIBSTATGRAB */
 
 #elif HAVE_PERFSTAT
   gauge_t snum, mnum, lnum;
@@ -180,7 +182,7 @@ static int load_read(void) {
   mnum = (float)cputotal.loadavg[1] / (float)(1 << SBITS);
   lnum = (float)cputotal.loadavg[2] / (float)(1 << SBITS);
   load_submit(snum, mnum, lnum);
-/* #endif HAVE_PERFSTAT */
+  /* #endif HAVE_PERFSTAT */
 
 #else
 #error "No applicable input method."

--- a/src/load.c
+++ b/src/load.c
@@ -61,7 +61,7 @@ static const char *config_keys[] = {"ReportRelative"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static int load_config(const char *key, const char *value) {
-  if (strcasecmp(key, "ReportRelative") == 0)
+  if (strcasecmp(key, "ReportRelative") == 0) {
 #ifdef _SC_NPROCESSORS_ONLN
     report_relative_load = IS_TRUE(value);
 #else
@@ -69,6 +69,8 @@ static int load_config(const char *key, const char *value) {
             "is not available, because I can't determine the "
             "number of CPUS on this system. Sorry.");
 #endif
+    return 0;
+  }
   return -1;
 }
 static void load_submit(gauge_t snum, gauge_t mnum, gauge_t lnum) {

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -52,8 +52,8 @@ static int logfile_config(const char *key, const char *value) {
     log_level = parse_log_severity(value);
     if (log_level < 0) {
       log_level = LOG_INFO;
-      ERROR("logfile: invalid loglevel [%s] defaulting to 'info'", value);
-      return 1;
+      WARNING("logfile: invalid loglevel [%s] defaulting to 'info'", value);
+      return 0;
     }
   } else if (0 == strcasecmp(key, "File")) {
     sfree(log_file);

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -506,7 +506,7 @@ static int openvpn_config(const char *key, const char *value) {
         });
 
     if (status == EINVAL) {
-      WARNING("openvpn plugin: status filename \"%s\" "
+      ERROR("openvpn plugin: status filename \"%s\" "
               "already used, please choose a "
               "different one.",
               status_name);

--- a/src/openvpn.c
+++ b/src/openvpn.c
@@ -139,7 +139,8 @@ static void iostats_submit(const char *pinst, const char *tinst, derive_t rx,
                            derive_t tx) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = rx}, {.derive = tx},
+      {.derive = rx},
+      {.derive = tx},
   };
 
   /* NOTE ON THE NEW NAMING SCHEMA:
@@ -165,7 +166,8 @@ static void compression_submit(const char *pinst, const char *tinst,
                                derive_t uncompressed, derive_t compressed) {
   value_list_t vl = VALUE_LIST_INIT;
   value_t values[] = {
-      {.derive = uncompressed}, {.derive = compressed},
+      {.derive = uncompressed},
+      {.derive = compressed},
   };
 
   vl.values = values;
@@ -502,14 +504,15 @@ static int openvpn_config(const char *key, const char *value) {
         /* callback  = */ openvpn_read,
         /* interval  = */ 0,
         &(user_data_t){
-            .data = instance, .free_func = openvpn_free,
+            .data = instance,
+            .free_func = openvpn_free,
         });
 
     if (status == EINVAL) {
       ERROR("openvpn plugin: status filename \"%s\" "
-              "already used, please choose a "
-              "different one.",
-              status_name);
+            "already used, please choose a "
+            "different one.",
+            status_name);
       return -1;
     }
 

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -41,7 +41,8 @@ static int log_level = LOG_INFO;
 static int notif_severity;
 
 static const char *config_keys[] = {
-    "LogLevel", "NotifyLevel",
+    "LogLevel",
+    "NotifyLevel",
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -57,7 +58,7 @@ static int sl_config(const char *key, const char *value) {
     notif_severity = parse_notif_severity(value);
     if (notif_severity < 0)
       ERROR("syslog: invalid notification severity [%s]", value);
-      return 1;
+    return 1;
   }
 
   return 0;

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -56,6 +56,7 @@ static int sl_config(const char *key, const char *value) {
   } else if (strcasecmp(key, "NotifyLevel") == 0) {
     notif_severity = parse_notif_severity(value);
     if (notif_severity < 0)
+      ERROR("syslog: invalid notification severity [%s]", value);
       return 1;
   }
 

--- a/src/ted.c
+++ b/src/ted.c
@@ -243,7 +243,7 @@ static int ted_config(const char *key, const char *value) {
 
     tmp = atoi(value);
     if (tmp < 0) {
-      WARNING("ted plugin: Invalid retry count: %i", tmp);
+      ERROR("ted plugin: Invalid retry count: %i", tmp);
       return 1;
     }
     conf_retries = tmp;


### PR DESCRIPTION
Some plugins' RC was != 0 and started to fail due to stricter verification introduced by 3b9c7b2.
This commit fixes those return values. For some plugins, fix verbosity of error message: non-zero rc
should be error, not warning.

Fixes #3180

What I chose to do:

* fix RC when I judged it to be non-fatal (load, logfile)
*  fix loglevel from WARNING to ERROR in other cases (barometer, openvpn, ted)
* add log message (syslog)

ChangeLog: fix incorrect return codes or log level for several plugin config callbacks