### PR TITLE
Travis CI: Added tests to check against Power architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ matrix:
     - os: linux
       dist: xenial
       compiler: gcc
+    - os: linux-ppc64le
+      dist: xenial
+      compiler: gcc
+    - os: linux-ppc64le
+      dist: xenial
+      compiler: clang
 
 before_install:
   # When building the coverity_scan branch, allow only the first job to continue to avoid travis-ci/travis-ci#1975.

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ addons:
     - libupsclient-dev
     - libvarnish-dev
     - libvirt-dev
-    - libxen-dev
     - libxml2-dev
     - libyajl-dev
     - linux-libc-dev


### PR DESCRIPTION
ChangeLog: Travis CI: Added tests to check against Power architecture

Two tests have been added to .travis.yml to allow for testing on Power architecture with both gcc and clang. `libxen-dev` was removed from the list of packages to allow for this because it is not available for xenial on Power and Travis will only run xenial on Power, not trusty.