### PR TITLE
battery plugin: read linux sysfs charge files

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -336,7 +336,7 @@ static int battery_read(void) /* {{{ */
 
   return 0;
 } /* }}} int battery_read */
-/* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
+  /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
 #elif KERNEL_LINUX
 /* Reads a file which contains only a number (and optionally a trailing

--- a/src/battery.c
+++ b/src/battery.c
@@ -404,16 +404,16 @@ static int read_sysfs_capacity(char const *dir, /* {{{ */
 } /* }}} int read_sysfs_capacity */
 
 static int read_sysfs_capacity_from_charge(char const *dir, /* {{{ */
-                               char const *power_supply,
-                               char const *plugin_instance) {
+                                           char const *power_supply,
+                                           char const *plugin_instance) {
   gauge_t capacity_charged = NAN;
   gauge_t capacity_full = NAN;
   gauge_t capacity_design = NAN;
   gauge_t voltage_min_design = NAN;
   int status;
 
-  status =
-      sysfs_file_to_gauge(dir, power_supply, "voltage_min_design", &voltage_min_design);
+  status = sysfs_file_to_gauge(dir, power_supply, "voltage_min_design",
+                               &voltage_min_design);
   if (status != 0)
     return status;
   voltage_min_design *= SYSFS_FACTOR;
@@ -440,7 +440,6 @@ static int read_sysfs_capacity_from_charge(char const *dir, /* {{{ */
                   capacity_full * SYSFS_FACTOR, capacity_design * SYSFS_FACTOR);
   return 0;
 } /* }}} int read_sysfs_capacity_from_charge */
-
 
 static int read_sysfs_callback(char const *dir, /* {{{ */
                                char const *power_supply, void *user_data) {

--- a/src/battery.c
+++ b/src/battery.c
@@ -403,6 +403,45 @@ static int read_sysfs_capacity(char const *dir, /* {{{ */
   return 0;
 } /* }}} int read_sysfs_capacity */
 
+static int read_sysfs_capacity_from_charge(char const *dir, /* {{{ */
+                               char const *power_supply,
+                               char const *plugin_instance) {
+  gauge_t capacity_charged = NAN;
+  gauge_t capacity_full = NAN;
+  gauge_t capacity_design = NAN;
+  gauge_t voltage_min_design = NAN;
+  int status;
+
+  status =
+      sysfs_file_to_gauge(dir, power_supply, "voltage_min_design", &voltage_min_design);
+  if (status != 0)
+    return status;
+  voltage_min_design *= SYSFS_FACTOR;
+
+  status =
+      sysfs_file_to_gauge(dir, power_supply, "charge_now", &capacity_charged);
+  if (status != 0)
+    return status;
+  capacity_charged *= voltage_min_design;
+
+  status =
+      sysfs_file_to_gauge(dir, power_supply, "charge_full", &capacity_full);
+  if (status != 0)
+    return status;
+  capacity_full *= voltage_min_design;
+
+  status = sysfs_file_to_gauge(dir, power_supply, "charge_full_design",
+                               &capacity_design);
+  if (status != 0)
+    return status;
+  capacity_design *= voltage_min_design;
+
+  submit_capacity(plugin_instance, capacity_charged * SYSFS_FACTOR,
+                  capacity_full * SYSFS_FACTOR, capacity_design * SYSFS_FACTOR);
+  return 0;
+} /* }}} int read_sysfs_capacity_from_charge */
+
+
 static int read_sysfs_callback(char const *dir, /* {{{ */
                                char const *power_supply, void *user_data) {
   int *battery_index = user_data;
@@ -434,7 +473,10 @@ static int read_sysfs_callback(char const *dir, /* {{{ */
   plugin_instance = (*battery_index == 0) ? "0" : power_supply;
   (*battery_index)++;
 
-  read_sysfs_capacity(dir, power_supply, plugin_instance);
+  if (sysfs_file_to_gauge(dir, power_supply, "energy_now", &v) == 0)
+    read_sysfs_capacity(dir, power_supply, plugin_instance);
+  else
+    read_sysfs_capacity_from_charge(dir, power_supply, plugin_instance);
 
   if (sysfs_file_to_gauge(dir, power_supply, "power_now", &v) == 0) {
     if (discharging)


### PR DESCRIPTION
This patch will enable the collectd battery module to read capacity off the sysfs power_supply charge_now, charge_full and charge_full_design files since some systems do not offer the "energy_now", "energy_full" and "energy_full_design" files that are currently used.

The module will still check for the energy files but fall back to the new method.

Since the charge files are provided in microamps/hour, the values are adjusted to be Wh and therefore the same as provided by the original approach. (The same conversion factor _voltage_min_design_ is used by xfce4 power manager so the values match)

ChangeLog: battery plugin: read linux sysfs charge files