### PR TITLE
Add standard include early or _FILE_OFFSET_BITS will have definition …

### DIFF
--- a/src/daemon/globals.c
+++ b/src/daemon/globals.c
@@ -21,8 +21,8 @@
  * DEALINGS IN THE SOFTWARE.
  **/
 
-#include "globals.h"
 #include "utils/common/common.h"
+#include "globals.h"
 
 #if HAVE_KSTAT_H
 #include <kstat.h>

--- a/src/daemon/globals.c
+++ b/src/daemon/globals.c
@@ -21,8 +21,14 @@
  * DEALINGS IN THE SOFTWARE.
  **/
 
+// clang-format off
+/*
+ * Explicit order is required or _FILE_OFFSET_BITS will have definition mismatches on Solaris
+ * See Github Issue #3193 for details
+ */
 #include "utils/common/common.h"
 #include "globals.h"
+// clang-format on
 
 #if HAVE_KSTAT_H
 #include <kstat.h>

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -24,9 +24,15 @@
  *   Sebastian 'tokkee' Harl <sh at tokkee.org>
  **/
 
+// clang-format off
+/*
+ * Explicit order is required or _FILE_OFFSET_BITS will have definition mismatches on Solaris
+ * See Github Issue #3193 for details
+ */
 #include "utils/common/common.h"
 #include "testing.h"
 #include "utils/cmds/cmds.h"
+// clang-format on
 
 static void error_cb(void *ud, cmd_status_t status, const char *format,
                      va_list ap) {
@@ -51,114 +57,201 @@ static struct {
 } parse_data[] = {
     /* Valid FLUSH commands. */
     {
-        "FLUSH", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=myhost/magic/MAGIC", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH identifier=magic/MAGIC", &default_host_opts, CMD_OK, CMD_FLUSH,
+        "FLUSH identifier=magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_FLUSH,
     },
     {
-        "FLUSH timeout=123 plugin=\"A\"", NULL, CMD_OK, CMD_FLUSH,
+        "FLUSH timeout=123 plugin=\"A\"",
+        NULL,
+        CMD_OK,
+        CMD_FLUSH,
     },
     /* Invalid FLUSH commands. */
     {
         /* Missing hostname; no default. */
-        "FLUSH identifier=magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Missing 'identifier' key. */
-        "FLUSH myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid timeout. */
-        "FLUSH timeout=A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH timeout=A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid identifier. */
-        "FLUSH identifier=invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH identifier=invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
         /* Invalid option. */
-        "FLUSH invalid=option", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "FLUSH invalid=option",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid GETVAL commands. */
     {
-        "GETVAL myhost/magic/MAGIC", NULL, CMD_OK, CMD_GETVAL,
+        "GETVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_OK,
+        CMD_GETVAL,
     },
     {
-        "GETVAL magic/MAGIC", &default_host_opts, CMD_OK, CMD_GETVAL,
+        "GETVAL magic/MAGIC",
+        &default_host_opts,
+        CMD_OK,
+        CMD_GETVAL,
     },
 
     /* Invalid GETVAL commands. */
     {
-        "GETVAL magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "GETVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "GETVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid LISTVAL commands. */
     {
-        "LISTVAL", NULL, CMD_OK, CMD_LISTVAL,
+        "LISTVAL",
+        NULL,
+        CMD_OK,
+        CMD_LISTVAL,
     },
 
     /* Invalid LISTVAL commands. */
     {
-        "LISTVAL invalid", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "LISTVAL invalid",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
 
     /* Valid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", &default_host_opts, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC N:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23", NULL, CMD_OK, CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42", NULL, CMD_OK,
+        "PUTVAL magic/MAGIC N:42",
+        &default_host_opts,
+        CMD_OK,
         CMD_PUTVAL,
     },
     {
-        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23", NULL,
-        CMD_OK, CMD_PUTVAL,
+        "PUTVAL myhost/magic/MAGIC N:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC 1234:42 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
+    },
+    {
+        "PUTVAL myhost/magic/MAGIC interval=2 1234:42 interval=5 2345:23",
+        NULL,
+        CMD_OK,
+        CMD_PUTVAL,
     },
 
     /* Invalid PUTVAL commands. */
     {
-        "PUTVAL magic/MAGIC N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL magic/MAGIC N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL invalid N:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL invalid N:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC A:42", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC A:42",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/MAGIC", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL myhost/magic/MAGIC",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL 1234:A", NULL, CMD_PARSE_ERROR, CMD_UNKNOWN,
+        "PUTVAL 1234:A",
+        NULL,
+        CMD_PARSE_ERROR,
+        CMD_UNKNOWN,
     },
     {
-        "PUTVAL myhost/magic/UNKNOWN 1234:42", NULL, CMD_PARSE_ERROR,
+        "PUTVAL myhost/magic/UNKNOWN 1234:42",
+        NULL,
+        CMD_PARSE_ERROR,
         CMD_UNKNOWN,
     },
     /*
@@ -173,10 +266,16 @@ static struct {
 
     /* Invalid commands. */
     {
-        "INVALID", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
     {
-        "INVALID interval=2", NULL, CMD_UNKNOWN_COMMAND, CMD_UNKNOWN,
+        "INVALID interval=2",
+        NULL,
+        CMD_UNKNOWN_COMMAND,
+        CMD_UNKNOWN,
     },
 };
 
@@ -196,9 +295,10 @@ DEF_TEST(parse) {
     memset(&cmd, 0, sizeof(cmd));
 
     status = cmd_parse(input, &cmd, parse_data[i].opts, &err);
-    snprintf(description, sizeof(description), "cmd_parse (\"%s\", opts=%p) = "
-                                               "%d (type=%d [%s]); want %d "
-                                               "(type=%d [%s])",
+    snprintf(description, sizeof(description),
+             "cmd_parse (\"%s\", opts=%p) = "
+             "%d (type=%d [%s]); want %d "
+             "(type=%d [%s])",
              parse_data[i].input, parse_data[i].opts, status, cmd.type,
              CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
              parse_data[i].expected_type,

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -24,9 +24,9 @@
  *   Sebastian 'tokkee' Harl <sh at tokkee.org>
  **/
 
+#include "utils/common/common.h"
 #include "testing.h"
 #include "utils/cmds/cmds.h"
-#include "utils/common/common.h"
 
 static void error_cb(void *ud, cmd_status_t status, const char *format,
                      va_list ap) {

--- a/src/utils/common/common_test.c
+++ b/src/utils/common/common_test.c
@@ -24,8 +24,14 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
+// clang-format off
+/*
+ * Explicit order is required or _FILE_OFFSET_BITS will have definition mismatches on Solaris
+ * See Github Issue #3193 for details
+ */
 #include "utils/common/common.h"
 #include "testing.h"
+// clang-format on
 
 #if HAVE_KSTAT_H
 #include <kstat.h>
@@ -280,10 +286,15 @@ DEF_TEST(parse_values) {
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
     data_source_t dsrc = {
-        .name = "value", .type = DS_TYPE_GAUGE, .min = 0.0, .max = NAN,
+        .name = "value",
+        .type = DS_TYPE_GAUGE,
+        .min = 0.0,
+        .max = NAN,
     };
     data_set_t ds = {
-        .type = "example", .ds_num = 1, .ds = &dsrc,
+        .type = "example",
+        .ds_num = 1,
+        .ds = &dsrc,
     };
 
     value_t v = {
@@ -344,7 +355,8 @@ DEF_TEST(value_to_rate) {
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
     cdtime_t t0 = TIME_T_TO_CDTIME_T(cases[i].t0);
     value_to_rate_state_t state = {
-        .last_value = cases[i].v0, .last_time = t0,
+        .last_value = cases[i].v0,
+        .last_time = t0,
     };
     gauge_t got;
 

--- a/src/utils/common/common_test.c
+++ b/src/utils/common/common_test.c
@@ -24,8 +24,8 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-#include "testing.h"
 #include "utils/common/common.h"
+#include "testing.h"
 
 #if HAVE_KSTAT_H
 #include <kstat.h>

--- a/src/utils/proc_pids/proc_pids_test.c
+++ b/src/utils/proc_pids/proc_pids_test.c
@@ -1,5 +1,11 @@
+// clang-format off
+/*
+ * Explicit order is required or _FILE_OFFSET_BITS will have definition mismatches on Solaris
+ * See Github Issue #3193 for details
+ */
 #include "utils/proc_pids/proc_pids.c" /* sic */
 #include "testing.h"
+// clang-format on
 #include <sys/stat.h>
 
 /***************************************************************************

--- a/src/utils/proc_pids/proc_pids_test.c
+++ b/src/utils/proc_pids/proc_pids_test.c
@@ -1,5 +1,5 @@
-#include "testing.h"
 #include "utils/proc_pids/proc_pids.c" /* sic */
+#include "testing.h"
 #include <sys/stat.h>
 
 /***************************************************************************


### PR DESCRIPTION
…mismatches on Solaris.
This basically is a reappearance of issue #1301.

Changelog: Add standard include early or _FILE_OFFSET_BITS will have definition mismatches on Solaris.