### PR TITLE
Use test_utils_proc_pids only when compiling the plugin that uses it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -159,8 +159,7 @@ check_PROGRAMS = \
 	test_utils_time \
 	test_utils_vl_lookup \
 	test_libcollectd_network_parse \
-	test_utils_config_cores \
-	test_utils_proc_pids
+	test_utils_config_cores
 
 
 TESTS = $(check_PROGRAMS)
@@ -1089,6 +1088,7 @@ test_plugin_intel_rdt_CPPFLAGS = $(AM_CPPFLAGS)
 test_plugin_intel_rdt_LDFLAGS = $(PLUGIN_LDFLAGS)
 test_plugin_intel_rdt_LDADD = liboconfig.la libplugin_mock.la
 check_PROGRAMS += test_plugin_intel_rdt
+TESTS += test_utils_proc_pids
 TESTS += test_plugin_intel_rdt
 endif
 


### PR DESCRIPTION
This is a possible fix for #3194.

ChangeLog: Build system: Use test_utils_proc_pids only when compiling the plugin that uses it