### PR TITLE
Fix truncated snprintf errors

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -172,7 +172,7 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
              sizeof(inst->ident.plugin_instance));
   else {
     char tmp_plugin[DATA_MAX_NAME_LEN];
-    char tmp_plugin_instance[DATA_MAX_NAME_LEN] = "";
+    char tmp_plugin_instance[DATA_MAX_NAME_LEN];
 
     if ((agg->regex_fields & LU_GROUP_BY_PLUGIN) &&
         (agg->group_by & LU_GROUP_BY_PLUGIN))
@@ -198,10 +198,10 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
       sstrncpy(inst->ident.plugin_instance, AGG_FUNC_PLACEHOLDER,
                sizeof(inst->ident.plugin_instance));
     else if (strcmp("", tmp_plugin) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance)  + sizeof(AGG_FUNC_PLACEHOLDER),
                "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
     else if (strcmp("", tmp_plugin_instance) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
+      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance) + sizeof(AGG_FUNC_PLACEHOLDER),
                "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
       snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),

--- a/src/collectdctl.c
+++ b/src/collectdctl.c
@@ -149,7 +149,7 @@ static int array_grow(void **array, size_t *array_len, size_t elem_size) {
 static int parse_identifier(lcc_connection_t *c, const char *value,
                             lcc_identifier_t *ident) {
   char hostname[1024];
-  char ident_str[1024] = "";
+  char ident_str[1025];
   int n_slashes;
 
   int status;

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -152,7 +152,7 @@ static int read_file(const char *path) {
 
     for (i = 0; i < key_fields_num; i++) {
       if (values_list != NULL) {
-        char match_name[2 * DATA_MAX_NAME_LEN];
+        char match_name[sizeof(key_buffer) +1];
 
         snprintf(match_name, sizeof(match_name), "%s:%s", key_buffer,
                  key_fields[i]);

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -689,7 +689,7 @@ static int ut_missing(const value_list_t *vl,
   FORMAT_VL(identifier, sizeof(identifier), vl);
 
   NOTIFICATION_INIT_VL(&n, vl);
-  snprintf(n.message, sizeof(n.message),
+  snprintf(n.message, sizeof(n.message) + sizeof(identifier),
            "%s has not been updated for %.3f seconds.", identifier,
            CDTIME_T_TO_DOUBLE(missing_time));
   n.time = now;


### PR DESCRIPTION
Fixes #3198 

These changes allow collectd to be built on RHEL 8.  Previously the compiler would issue a warning similar to below.  I'm not sure if these changes are the *correct* way to fix the problem however.

```
src/collectdctl.c:169:50: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
     snprintf(ident_str, sizeof(ident_str), "%s/%s", hostname, value);
```

ChangeLog: collectd: Fix compiler warnings when building with GCC 8.2.1
