### PR TITLE
Add missing definitions for libnetsnmpagent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3972,6 +3972,8 @@ if test "x$with_libnetsnmpagent" = "xyes"; then
 fi
 
 if test "x$with_libnetsnmpagent" = "xyes"; then
+  BUILD_WITH_LIBNETSNMPAGENT_CPPFLAGS="$with_libnetsnmpagent_cppflags"
+  BUILD_WITH_LIBNETSNMPAGENT_LDFLAGS="$with_libnetsnmpagent_ldflags"
   BUILD_WITH_LIBNETSNMPAGENT_LIBS="-lnetsnmpagent $libnetsnmphelpers"
 fi
 


### PR DESCRIPTION
Without these lines `--with-libnetsnmpagent=<dir>` will not set `CPPFLAGS` and `LDFLAGS` properly. The structure is now the same as it is already the case for the corresponding libnetsnmp library.

ChangeLog: Build system: Add missing definitions for libnetsnmpagent in configure.ac