### PR TITLE
Move Makefile rules for pid_test inside conditional for code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -376,11 +376,6 @@ test_utils_config_cores_SOURCES = \
 	src/testing.h
 test_utils_config_cores_LDADD = libplugin_mock.la
 
-test_utils_proc_pids_SOURCES = \
-	src/utils/proc_pids/proc_pids_test.c \
-	src/testing.h
-test_utils_proc_pids_LDADD = libplugin_mock.la
-
 libavltree_la_SOURCES = \
 	src/utils/avltree/avltree.c \
 	src/utils/avltree/avltree.h
@@ -1088,8 +1083,14 @@ test_plugin_intel_rdt_CPPFLAGS = $(AM_CPPFLAGS)
 test_plugin_intel_rdt_LDFLAGS = $(PLUGIN_LDFLAGS)
 test_plugin_intel_rdt_LDADD = liboconfig.la libplugin_mock.la
 check_PROGRAMS += test_plugin_intel_rdt
-TESTS += test_utils_proc_pids
 TESTS += test_plugin_intel_rdt
+
+test_utils_proc_pids_SOURCES = \
+	src/utils/proc_pids/proc_pids_test.c \
+	src/testing.h
+test_utils_proc_pids_LDADD = libplugin_mock.la
+check_PROGRAMS += test_utils_proc_pids
+TESTS += test_utils_proc_pids
 endif
 
 if BUILD_PLUGIN_INTERFACE


### PR DESCRIPTION
This is to avoid some warnings in Makefile.am which I was introduced in the movement of the pid test inside the conditional using the code in PR #3197 

ChangeLog: Build system: Avoid warning in Makefile.am to fix issues introduced in PR #3197