### PR TITLE
Issue 3181

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,7 @@ AC_CHECK_HEADERS_ONCE([ \
   kstat.h \
   kvm.h \
   libgen.h \
+  locale.h \
   mntent.h \
   mnttab.h \
   netdb.h \
@@ -758,6 +759,7 @@ AC_CHECK_FUNCS_ONCE([ \
     select \
     setenv \
     setgroups \
+    setlocale \
     strcasecmp \
     strdup \
     strncasecmp \

--- a/configure.ac
+++ b/configure.ac
@@ -743,27 +743,12 @@ test_cxx_flags() {
 #
 AC_CHECK_FUNCS_ONCE([ \
     asprintf \
-    closelog \
-    getaddrinfo \
-    getgrnam_r \
-    getnameinfo \
     getpwnam \
     getpwnam_r \
-    gettimeofday \
     if_indextoname \
-    openlog \
-    regcomp \
-    regerror \
-    regexec \
-    regfree \
-    select \
     setenv \
     setgroups \
-    setlocale \
-    strcasecmp \
-    strdup \
-    strncasecmp \
-    sysconf
+    setlocale
   ]
 )
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -59,9 +59,6 @@
 #include <libgeom.h>
 #endif
 
-#if HAVE_LIMITS_H
-#include <limits.h>
-#endif
 #ifndef UINT_MAX
 #define UINT_MAX 4294967295U
 #endif


### PR DESCRIPTION
Changelog: Recover setlocale() call in src/daemon/collectd.c do_init() - issue #3181 
Changelog: configure.ac: Removed unused checks for functions

(Cause is #1865 changes, released in 5.8.0, so it might require backport)

![image](https://user-images.githubusercontent.com/13328211/61130371-b783ab80-a4e0-11e9-9637-e1f6f1bc0a98.png)

