### PR TITLE
Move trusted-contributors down the list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,6 @@
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence, # @trusted-contributors will be requested for
 # review when someone opens a pull request.
-*       @trusted-contributors
 
 /src/intel_pmu.c	@kwiatrox @sunkuranganath
 /src/intel_rdt.c	@kwiatrox @sunkuranganath
@@ -13,3 +12,7 @@
 /src/virt.c		@anaudx @rjablonx
 # TODO(#2926): Add the following owners:
 #/src/redfish.c		@kkepka @mkobyli
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+*       @trusted-contributors


### PR DESCRIPTION
since the last matching pattern takes the most precedence.