### PR TITLE
match_regex: Accept all data types of meta data

### DIFF
--- a/src/match_regex.c
+++ b/src/match_regex.c
@@ -342,7 +342,7 @@ static int mr_match(const data_set_t __attribute__((unused)) * ds, /* {{{ */
     int status;
     if (vl->meta == NULL)
       return nomatch_value;
-    status = meta_data_get_string(vl->meta, e->key, &value);
+    status = meta_data_as_string(vl->meta, e->key, &value);
     if (status == (-ENOENT)) /* key is not present */
       return nomatch_value;
     if (status != 0) /* some other problem */


### PR DESCRIPTION
ChangeLog: match_regex: Accept all data types of meta data

match_regex currently accepts only string type of meta data, but
there is no reason to reject other data types since they can be
easily stringified by meta_data_as_string().
Accepting all data type will provide more benefit, for example
the following config can distinguish that data is local or remote,
the previous match_regex outputs many error logs for this config
though:

```xml
  <Match "regex">
    MetaData "network:received" "true"
  </Match>
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>