### PR TITLE
Remove including sys/sysctl.h on glibc systems

### DIFF
--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -26,7 +26,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -60,7 +60,7 @@
 
 #if (defined(HAVE_SYSCTL) && HAVE_SYSCTL) ||                                   \
     (defined(HAVE_SYSCTLBYNAME) && HAVE_SYSCTLBYNAME)
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,7 +28,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 #ifdef HAVE_SYS_VMMETER_H

--- a/src/processes.c
+++ b/src/processes.c
@@ -87,7 +87,7 @@
 #if HAVE_MACH_VM_PROT_H
 #include <mach/vm_prot.h>
 #endif
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 /* #endif HAVE_THREAD_INFO */

--- a/src/swap.c
+++ b/src/swap.c
@@ -49,7 +49,7 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 #if HAVE_SYS_DKSTAT_H

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -33,7 +33,7 @@
  */
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYS_SYSCTL_H
+#elif defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 /* Using sysctl interface to retrieve the boot time on *BSD / Darwin / OS X
  * systems */

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -29,7 +29,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
Changelog: Remove sys/sysctl.h which is removed in Glibc 2.30