### PR TITLE
Don't fail if syslog loglevel doesn't match

### DIFF
--- a/src/syslog.c
+++ b/src/syslog.c
@@ -51,8 +51,7 @@ static int sl_config(const char *key, const char *value) {
     log_level = parse_log_severity(value);
     if (log_level < 0) {
       log_level = LOG_INFO;
-      ERROR("syslog: invalid loglevel [%s] defaulting to 'info'", value);
-      return 1;
+      WARNING("syslog: invalid loglevel [%s] defaulting to 'info'", value);
     }
   } else if (strcasecmp(key, "NotifyLevel") == 0) {
     notif_severity = parse_notif_severity(value);


### PR DESCRIPTION
This makes the log message more consistent with the behaviour,
and also is consistent with pre-
3b9c7b21b4ddfcf59a0147bc9e91e8889ca78d56 behaviour

Change-Id: I0e8aa2f5c44cb5b4142001954f4544c4157125c9
Fixes: #3236
ChangeLog: Syslog plugin restore previous behaviour: fallback to info for unsupported level