### PR TITLE
configure.ac: fix activation of snmp_agent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3950,7 +3950,13 @@ if test "x$with_libnetsnmpagent" = "xyes"; then
   )
 
   AC_CHECK_LIB([netsnmpagent], [init_agent],
-    [with_libnetsnmpagent="yes"],
+    [
+      # libnetsnmp can be built without without mib loading support
+      AC_CHECK_LIB([netsnmp], [get_tree],
+        [with_libnetsnmpagent="yes"],
+        [with_libnetsnmpagent="no (libnetsnmp doesn't support mib loading)"]
+      )
+    ],
     [with_libnetsnmpagent="no (libnetsnmpagent not found)"],
     [$libnetsnmphelpers]
   )


### PR DESCRIPTION
ChangeLog: Build System: Fix activation of snmp_agent

If netsnmp library has been built without mib loading support (through
--disable-mib-loading), build of snmp_agent fails on:

```
src/snmp_agent.c: In function 'snmp_agent_get_asn_type':
src/snmp_agent.c:160:47: error: dereferencing pointer to incomplete type 'struct tree'
   return (node != NULL) ? mib_to_asn_type(node->type) : 0;
```

struct tree is defined in net-snmp/libray/parse.h which is included by
net-snmp/mib_api.h only if NETSNMP_DISABLE_MIB_LOADING is not set.

To fix this error, check for get_tree function in netsnmp library in
addition to init_agent in netsnmpagent library

Fixes:
 - http://autobuild.buildroot.org/results/6d7ac28f154f83208f949c62d28411855f1817f8

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>