### PR TITLE
Changelog: processes plugin: fix number of running processes

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -2119,7 +2119,14 @@ static int ps_read(void) {
 
   closedir(proc);
 
-  /* get procs_running from /proc/stat */
+  /* get procs_running from /proc/stat
+   * scanning /proc/stat AND computing other process stats takes too much time.
+   * Consequently, the number of running processes based on the occurences
+   * of 'R' as character indicating the running state is typically zero. Due
+   * to processes are actually changing state during the evaluation of it's
+   * stat(s).
+   * The 'procs_running' number in /proc/stat on the other hand is more
+   * accurate, and can be retrieved in a single 'read' call. */
   running = procs_running();
 
   ps_submit_state("running", running);

--- a/src/processes.c
+++ b/src/processes.c
@@ -1431,7 +1431,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
 static int procs_running(void) {
   char buffer[4096] = {};
-
+  char id[] = "procs_running "; /* white space terminated */
   char *running;
 
   ssize_t status;
@@ -1441,13 +1441,18 @@ static int procs_running(void) {
     return -1;
   }
 
-  running = strstr(buffer, "procs_running");
+  /* the data contains :
+   * the literal string 'procs_running',
+   * a whitespace
+   * the number of running processes.
+   * The parser does include the white-space character.
+   */
+  running = strstr(buffer, id);
   if (!running) {
     WARNING("procs_running not found, assuming 1");
     return 1;
   }
-
-  running += 14;
+  running += strlen(id);
 
   return atoi(running);
 }

--- a/src/processes.c
+++ b/src/processes.c
@@ -1433,6 +1433,8 @@ static int procs_running(void) {
   char buffer[4096] = {};
   char id[] = "procs_running "; /* white space terminated */
   char *running;
+  char *endptr = NULL;
+  long result = 0L;
 
   ssize_t status;
 
@@ -1449,12 +1451,17 @@ static int procs_running(void) {
    */
   running = strstr(buffer, id);
   if (!running) {
-    WARNING("procs_running not found, assuming 1");
-    return 1;
+    WARNING("procs_running not found");
+    return -1;
   }
   running += strlen(id);
 
-  return atoi(running);
+  result = strtol(running, &endptr, 10);
+  if ( (*running != '\0') && ((*endptr == '\0') || (*endptr == '\n')) ) {
+    return (int)result;
+  }
+
+  return -1;
 }
 
 static char *ps_get_cmdline(long pid, char *name, char *buf, size_t buf_len) {

--- a/src/processes.c
+++ b/src/processes.c
@@ -1457,7 +1457,7 @@ static int procs_running(void) {
   running += strlen(id);
 
   result = strtol(running, &endptr, 10);
-  if ( (*running != '\0') && ((*endptr == '\0') || (*endptr == '\n')) ) {
+  if ((*running != '\0') && ((*endptr == '\0') || (*endptr == '\n'))) {
     return (int)result;
   }
 

--- a/src/processes.c
+++ b/src/processes.c
@@ -2119,6 +2119,7 @@ static int ps_read(void) {
 
   closedir(proc);
 
+  /* get procs_running from /proc/stat */
   running = procs_running();
 
   ps_submit_state("running", running);


### PR DESCRIPTION
ChangeLog: processes plugin: fix number of running processes 

scanning /proc/*/stat AND computing other process stats takes too much
time. Consequently, the number of running processes based on the occurences
of 'R' as character indicating the running state is typically zero. Due
to processes are actually changing state during the evaluation of it's
stat(s).

The 'procs_running' number in /proc/stat on the other hand is more
accurate, and can be retrieved in one single 'read' call.

In the unlikely case that procs_running can not be retrieved from
/proc/stat, (read interrupted prior to reading up to 'procs_running'
the value '1' assumed, since this plugin is at least being executed.