### PR TITLE
types.db: fix ping_droprate range spec

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -194,7 +194,7 @@ pg_numbackends          value:GAUGE:0:U
 pg_scan                 value:DERIVE:0:U
 pg_xact                 value:DERIVE:0:U
 ping                    value:GAUGE:0:65535
-ping_droprate           value:GAUGE:0:100
+ping_droprate           value:GAUGE:0:1
 ping_stddev             value:GAUGE:0:65535
 players                 value:GAUGE:0:1000000
 pools                   value:GAUGE:0:U


### PR DESCRIPTION
Changelog: types.db: fix ping_droprate range spec

It's always in range 0-1 since the initial support for the data source
in commit 9cc8e54618fe3f8e7af879fcc9e04d71125456fd