### PR TITLE
zfs_arc plugin: Fix skipping of leading lines

### DIFF
--- a/src/zfs_arc.c
+++ b/src/zfs_arc.c
@@ -231,23 +231,6 @@ static int za_read(void) {
     return -1;
   }
 
-  // Ignore the first two lines because they contain information about
-  // the rest of the file.
-  // See kstat_seq_show_headers module/spl/spl-kstat.c of the spl kernel
-  // module.
-  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
-    ERROR("zfs_arc plugin: \"%s\" does not contain a single line.",
-          ZOL_ARCSTATS_FILE);
-    fclose(fh);
-    return (-1);
-  }
-  if (fgets(buffer, sizeof(buffer), fh) == NULL) {
-    ERROR("zfs_arc plugin: \"%s\" does not contain at least two lines.",
-          ZOL_ARCSTATS_FILE);
-    fclose(fh);
-    return (-1);
-  }
-
   while (fgets(buffer, sizeof(buffer), fh) != NULL) {
     char *fields[3];
     value_t v;


### PR DESCRIPTION
Probably due to a merge gone wrong, the first two lines were skipped twice, skipping four lines in total and thus missing the "hits" and "misses" counts.

ChangeLog: zfs_arc plugin: A bug that caused the first to values to be skipped was fixed.