### PR TITLE
write_http: Remove curl default http response to stdout

### DIFF
--- a/src/write_http.c
+++ b/src/write_http.c
@@ -40,6 +40,11 @@
 #define WRITE_HTTP_DEFAULT_PREFIX "collectd"
 #endif
 
+#ifndef WRITE_HTTP_RESPONSE_BUFFER_SIZE
+#define WRITE_HTTP_RESPONSE_BUFFER_SIZE 4096
+#endif
+
+
 /*
  * Private variables
  */
@@ -83,6 +88,10 @@ struct wh_callback_s {
 
   pthread_mutex_t send_lock;
 
+  char *response_buffer;
+  size_t response_buffer_size;
+  size_t response_buffer_fill;
+
   int data_ttl;
   char *metrics_prefix;
 };
@@ -90,6 +99,10 @@ typedef struct wh_callback_s wh_callback_t;
 
 static char **http_attrs;
 static size_t http_attrs_num;
+
+static size_t wh_curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata) {
+  return nmemb;
+}
 
 static void wh_log_http_error(wh_callback_t *cb) {
   if (!cb->log_http_error)
@@ -117,6 +130,12 @@ static void wh_reset_buffer(wh_callback_t *cb) /* {{{ */
     format_json_initialize(cb->send_buffer, &cb->send_buffer_fill,
                            &cb->send_buffer_free);
   }
+
+  if(cb -> response_buffer == NULL)
+    return;
+  memset(cb->response_buffer, 0, cb->response_buffer_size);
+  cb->send_buffer_fill = 0;
+
 } /* }}} wh_reset_buffer */
 
 /* must hold cb->send_lock when calling */
@@ -126,6 +145,8 @@ static int wh_post_nolock(wh_callback_t *cb, char const *data) /* {{{ */
 
   curl_easy_setopt(cb->curl, CURLOPT_URL, cb->location);
   curl_easy_setopt(cb->curl, CURLOPT_POSTFIELDS, data);
+  curl_easy_setopt(cb->curl, CURLOPT_WRITEFUNCTION, &wh_curl_write_callback);
+  //curl_easy_setopt(cu->curl, CURLOPT_WRITEDATA, (void *)&chunk);
   status = curl_easy_perform(cb->curl);
 
   wh_log_http_error(cb);
@@ -807,6 +828,17 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
     wh_callback_free(cb);
     return -1;
   }
+
+  cb->response_buffer_size = WRITE_HTTP_RESPONSE_BUFFER_SIZE;
+  cb->response_buffer = malloc(cb->response_buffer_size);
+  if (cb->response_buffer == NULL) {
+    ERROR("write_http plugin: malloc(%" PRIsz ") failed.",
+          cb->send_buffer_size);
+    wh_callback_free(cb);
+    return -1;
+  }
+
+
   /* Nulls the buffer and sets ..._free and ..._fill. */
   wh_reset_buffer(cb);
 


### PR DESCRIPTION
ChangeLog:  write_http:  Remove curl default HTTP response to stdout

Should fix #3105.  Adds a callback to the calls to curl to write to a response buffer.  The response buffer is only dumped to the collectd logs in DEBUG or when there's an error.  Tested with output to Splunk.