### PR TITLE
Fix bug in postgresql plugin (conninfo)

### DIFF
--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
+    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);            \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -58,7 +58,7 @@
  * is ignored. */
 #define C_PSQL_PAR_APPEND(buf, buf_len, parameter, value)                      \
   if ((0 < (buf_len)) && (NULL != (value)) && ('\0' != *(value))) {            \
-    int s = ssnprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
+    int s = snprintf(buf, buf_len, " %s = '%s'", parameter, value);           \
     if (0 < s) {                                                               \
       buf += s;                                                                \
       buf_len -= s;                                                            \
@@ -323,7 +323,7 @@ static int c_psql_connect(c_psql_database_t *db) {
   if ((!db) || (!db->database))
     return -1;
 
-  status = ssnprintf(buf, buf_len, "dbname = '%s'", db->database);
+  status = snprintf(buf, buf_len, "dbname = '%s'", db->database);
   if (0 < status) {
     buf += status;
     buf_len -= status;


### PR DESCRIPTION
Error processing connection parameters.
The connection parameters specified in the config were not processed correctly, and therefore were not taken into account.
The snprintf function returns the number of bytes of a string, unlike
ssnprintf which returns bool.Bug in processing connection parameters.
Connection parameters specified in the config were not taken into account

ChangeLog: Postgresql plugin: Connection parameters not taken.