### PR TITLE
configure.ac: fix typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3951,7 +3951,7 @@ if test "x$with_libnetsnmpagent" = "xyes"; then
 
   AC_CHECK_LIB([netsnmpagent], [init_agent],
     [
-      # libnetsnmp can be built without without mib loading support
+      # libnetsnmp can be built without mib loading support
       AC_CHECK_LIB([netsnmp], [get_tree],
         [with_libnetsnmpagent="yes"],
         [with_libnetsnmpagent="no (libnetsnmp doesn't support mib loading)"]


### PR DESCRIPTION
ChangeLog: Remove double "without" added by commit b7818712d46e9fbac7bd9dfe93dca936c101d680

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>