### PR TITLE
Allow cURL Statistics option in write-http plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2016,6 +2016,8 @@ if BUILD_PLUGIN_WRITE_HTTP
 pkglib_LTLIBRARIES += write_http.la
 write_http_la_SOURCES = \
 	src/write_http.c \
+	src/utils/curl_stats/curl_stats.c \
+	src/utils/curl_stats/curl_stats.h \
 	src/utils/format_kairosdb/format_kairosdb.c \
 	src/utils/format_kairosdb/format_kairosdb.h
 write_http_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBCURL_CFLAGS)

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -10132,17 +10132,18 @@ which means the connection never times out.
 
 Enables printing of HTTP error code to log. Turned off by default.
 
+=item E<lt>B<Statistics> I<Name>E<gt>
+
+One B<Statistics> block can be used to specify cURL statistics to be collected
+for each request to the remote URL. See the section "cURL Statistics" above
+for details.
+
 The C<write_http> plugin regularly submits the collected values to the HTTP
 server. How frequently this happens depends on how much data you are collecting
 and the size of B<BufferSize>. The optimal value to set B<Timeout> to is
 slightly below this interval, which you can estimate by monitoring the network
 traffic between collectd and the HTTP server.
 
-=item B<E<lt>StatisticsE<gt>>
-
-One B<Statistics> block can be used to specify cURL statistics to be collected
-for each request to the remote URL. See the section "cURL Statistics" above
-for details.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -10138,6 +10138,12 @@ and the size of B<BufferSize>. The optimal value to set B<Timeout> to is
 slightly below this interval, which you can estimate by monitoring the network
 traffic between collectd and the HTTP server.
 
+=item B<E<lt>StatisticsE<gt>>
+
+One B<Statistics> block can be used to specify cURL statistics to be collected
+for each request to the remote URL. See the section "cURL Statistics" above
+for details.
+
 =back
 
 =head2 Plugin C<write_kafka>

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -132,8 +132,15 @@ static int wh_post_nolock(wh_callback_t *cb, char const *data) /* {{{ */
 
   wh_log_http_error(cb);
 
-  if (cb->curl_stats != NULL)
-    curl_stats_dispatch(cb->curl_stats, cb->curl, NULL, "write_http", cb->name);
+  if (cb->curl_stats != NULL) {
+    int rc = curl_stats_dispatch(cb->curl_stats, cb->curl, NULL, "write_http",
+                                 cb->name);
+    if (rc != 0) {
+      ERROR("write_http plugin: curl_stats_dispatch failed with "
+            "status %i",
+            rc);
+    }
+  }
 
   if (status != CURLE_OK) {
     ERROR("write_http plugin: curl_easy_perform failed with "
@@ -323,6 +330,7 @@ static void wh_callback_free(void *data) /* {{{ */
   }
 
   curl_stats_destroy(cb->curl_stats);
+  cb->curl_stats = NULL;
 
   if (cb->headers != NULL) {
     curl_slist_free_all(cb->headers);

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -27,6 +27,7 @@
 
 #include "plugin.h"
 #include "utils/common/common.h"
+#include "utils/curl_stats/curl_stats.h"
 #include "utils/format_json/format_json.h"
 #include "utils/format_kairosdb/format_kairosdb.h"
 
@@ -72,6 +73,7 @@ struct wh_callback_s {
   bool send_notifications;
 
   CURL *curl;
+  curl_stats_t *curl_stats;
   struct curl_slist *headers;
   char curl_errbuf[CURL_ERROR_SIZE];
 
@@ -129,6 +131,9 @@ static int wh_post_nolock(wh_callback_t *cb, char const *data) /* {{{ */
   status = curl_easy_perform(cb->curl);
 
   wh_log_http_error(cb);
+
+  if (cb->curl_stats != NULL)
+    curl_stats_dispatch(cb->curl_stats, cb->curl, NULL, "write_http", cb->name);
 
   if (status != CURLE_OK) {
     ERROR("write_http plugin: curl_easy_perform failed with "
@@ -316,6 +321,8 @@ static void wh_callback_free(void *data) /* {{{ */
     curl_easy_cleanup(cb->curl);
     cb->curl = NULL;
   }
+
+  curl_stats_destroy(cb->curl_stats);
 
   if (cb->headers != NULL) {
     curl_slist_free_all(cb->headers);
@@ -636,6 +643,7 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
   cb->send_notifications = false;
   cb->data_ttl = 0;
   cb->metrics_prefix = strdup(WRITE_HTTP_DEFAULT_PREFIX);
+  cb->curl_stats = NULL;
 
   if (cb->metrics_prefix == NULL) {
     ERROR("write_http plugin: strdup failed.");
@@ -710,7 +718,11 @@ static int wh_config_node(oconfig_item_t *ci) /* {{{ */
       status = config_set_format(cb, child);
     else if (strcasecmp("Metrics", child->key) == 0)
       cf_util_get_boolean(child, &cb->send_metrics);
-    else if (strcasecmp("Notifications", child->key) == 0)
+    else if (strcasecmp("Statistics", child->key) == 0) {
+      cb->curl_stats = curl_stats_from_config(child);
+      if (cb->curl_stats == NULL)
+        status = -1;
+    } else if (strcasecmp("Notifications", child->key) == 0)
       cf_util_get_boolean(child, &cb->send_notifications);
     else if (strcasecmp("StoreRates", child->key) == 0)
       status = cf_util_get_boolean(child, &cb->store_rates);


### PR DESCRIPTION
write-http can optionally configure cURL Statistics as per other cURL based plugins

ChangeLog: write_http plugin: add ability to configure cURL Statistics
