### PR TITLE
snmp plugin: add support for SNMP Bulk Transfer

### DIFF
--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -373,6 +373,13 @@ How long to wait for a response. The C<Net-SNMP> library default is 1 second.
 The number of times that a query should be retried after the Timeout expires.
 The C<Net-SNMP> library default is 5.
 
+=item B<Bulk_Size> I<Integer>
+
+This number activate and configure snmp bulk transfers. For B<Table> data it allow
+the host to send multiple values per query. Only available for SNMP v2 and greater, this
+usually allow for more efficient querying and faster data transfert.
+The default is 0/disabled.
+
 =back
 
 =head1 SEE ALSO

--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -375,10 +375,7 @@ The C<Net-SNMP> library default is 5.
 
 =item B<BulkSize> I<Integer>
 
-This option activate and configure snmp bulk transfers. For B<Table> data it allows
-the host to send multiple values per query. Only available for SNMP v2 and greater, this
-usually allow for more efficient querying and faster data transferts.
-The default is 0/disabled.
+Configures the size of SNMP bulk tranfers, The default is 0, which disables bulk transfers altogether.
 
 =back
 

--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -373,11 +373,11 @@ How long to wait for a response. The C<Net-SNMP> library default is 1 second.
 The number of times that a query should be retried after the Timeout expires.
 The C<Net-SNMP> library default is 5.
 
-=item B<Bulk_Size> I<Integer>
+=item B<BulkSize> I<Integer>
 
-This number activate and configure snmp bulk transfers. For B<Table> data it allow
+This option activate and configure snmp bulk transfers. For B<Table> data it allows
 the host to send multiple values per query. Only available for SNMP v2 and greater, this
-usually allow for more efficient querying and faster data transfert.
+usually allow for more efficient querying and faster data transferts.
 The default is 0/disabled.
 
 =back

--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -375,7 +375,7 @@ The C<Net-SNMP> library default is 5.
 
 =item B<BulkSize> I<Integer>
 
-Configures the size of SNMP bulk tranfers, The default is 0, which disables bulk transfers altogether.
+Configures the size of SNMP bulk transfers. The default is 0, which disables bulk transfers altogether.
 
 =back
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1402,7 +1402,7 @@
 #       Version 2
 #       Community "another_string"
 #       Collect "std_traffic" "hr_users"
-#       Bulk_Size 100
+#       BulkSize 0
 #   </Host>
 #   <Host "some.ups.mydomain.org">
 #       Address "192.168.0.3"
@@ -1412,6 +1412,15 @@
 #       Interval 300
 # 	Timeout 5
 #	Retries 5
+#   </Host>
+#   <Host "highend.switch.example.org">
+#       Address "192.168.0.3"
+#       Version 2
+#       Community "another_string"
+#       Collect "std_traffic"
+#       Interval 10
+#       Timeout 10
+#       BulkSize 100
 #   </Host>
 #</Plugin>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1402,6 +1402,7 @@
 #       Version 2
 #       Community "another_string"
 #       Collect "std_traffic" "hr_users"
+#       Bulk_Size 100
 #   </Host>
 #   <Host "some.ups.mydomain.org">
 #       Address "192.168.0.3"

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1593,8 +1593,8 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   csnmp_cell_value_t **value_cells_head;
   csnmp_cell_value_t **value_cells_tail;
 
-  DEBUG("snmp plugin: csnmp_read_table (host = %s, data = %s (%ld))",
-        host->name, data->name, data->values_len);
+  DEBUG("snmp plugin: csnmp_read_table (host = %s, data = %s)", host->name,
+        data->name);
 
   if (host->sess_handle == NULL) {
     DEBUG("snmp plugin: csnmp_read_table: host->sess_handle == NULL");

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -99,7 +99,6 @@ struct host_definition_s {
   c_complain_t complaint;
   data_definition_t **data_list;
   int data_list_len;
-
   int bulk_size;
 };
 typedef struct host_definition_s host_definition_t;
@@ -822,7 +821,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
       break;
     }
     if (hd->bulk_size > 0 && hd->version < 2) {
-      WARNING("snmp plugin: Bulk transferts is only available for snmp v2 and "
+      WARNING("snmp plugin: Bulk transfers is only available for SNMP v2 and "
               "later, host '%s' is configured as version '%d'",
               hd->name, hd->version);
     }
@@ -1665,7 +1664,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
 
   status = 0;
   while (status == 0) {
-    /* If SNMP v2 and later and bulk transfert enabled, use GETBULK PDU */
+    /* If SNMP v2 and later and bulk transfers enabled, use GETBULK PDU */
     if (host->version > 1 && host->bulk_size > 0) {
       req = snmp_pdu_create(SNMP_MSG_GETBULK);
       req->non_repeaters = 0;
@@ -1780,11 +1779,10 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
 
     for (vb = res->variables, j = 0; (vb != NULL);
          vb = vb->next_variable, j++) {
+      i = j;
       /* If bulk request is active convert value index of the extra value */
       if (host->version > 1 && host->bulk_size > 0) {
-        i = j % oid_list_todo_num;
-      } else {
-        i = j;
+        i %= oid_list_todo_num;
       }
       /* Calculate value index from todo list */
       while ((i < oid_list_len) && !oid_list_todo[i]) {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -822,7 +822,9 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
       break;
     }
     if (hd->bulk_size > 0 && hd->version < 2) {
-      WARNING("snmp plugin: Bulk transferts is only available for snmp v2 and later, host '%s' is configured as version '%d'", hd->name, hd->version );
+      WARNING("snmp plugin: Bulk transferts is only available for snmp v2 and "
+              "later, host '%s' is configured as version '%d'",
+              hd->name, hd->version);
     }
     if (hd->version == 3) {
       if (hd->username == NULL) {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -764,7 +764,7 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
   /* These mean that we have not set a timeout or retry value */
   hd->timeout = 0;
   hd->retries = -1;
-  hd->build_size = 0;
+  hd->bulk_size = 0;
 
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *option = ci->children + i;

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1581,7 +1581,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   csnmp_oid_type_t oid_list_todo[oid_list_len];
 
   int status;
-  size_t i, j;
+  size_t i;
 
   /* `value_list_head' and `value_cells_tail' implement a linked list for each
    * value. `instance_cells_head' and `instance_cells_tail' implement a linked
@@ -1777,6 +1777,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
       continue;
     }
 
+    size_t j;
     for (vb = res->variables, j = 0; (vb != NULL);
          vb = vb->next_variable, j++) {
       i = j;

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -1577,7 +1577,7 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   csnmp_oid_type_t oid_list_todo[oid_list_len];
 
   int status;
-  size_t i,j;
+  size_t i, j;
 
   /* `value_list_head' and `value_cells_tail' implement a linked list for each
    * value. `instance_cells_head' and `instance_cells_tail' implement a linked
@@ -1593,8 +1593,8 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
   csnmp_cell_value_t **value_cells_head;
   csnmp_cell_value_t **value_cells_tail;
 
-  DEBUG("snmp plugin: csnmp_read_table (host = %s, data = %s (%ld))", host->name,
-        data->name, data->values_len);
+  DEBUG("snmp plugin: csnmp_read_table (host = %s, data = %s (%ld))",
+        host->name, data->name, data->values_len);
 
   if (host->sess_handle == NULL) {
     DEBUG("snmp plugin: csnmp_read_table: host->sess_handle == NULL");
@@ -1696,10 +1696,10 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
     }
 
     if (req->command == SNMP_MSG_GETBULK) {
-        /* In bulk mode the host will send 'max_repetitions' values per
-           requested variable, so we need to split it per number of variable
-           to stay 'in budget' */
-        req->max_repetitions = floor(host->bulk_size/oid_list_todo_num);
+      /* In bulk mode the host will send 'max_repetitions' values per
+         requested variable, so we need to split it per number of variable
+         to stay 'in budget' */
+      req->max_repetitions = floor(host->bulk_size / oid_list_todo_num);
     }
 
     res = NULL;
@@ -1783,7 +1783,8 @@ static int csnmp_read_table(host_definition_t *host, data_definition_t *data) {
       }
       /* Calculate value index from todo list */
       while ((i < oid_list_len) && !oid_list_todo[i]) {
-        i++; j++;
+        i++;
+        j++;
       }
       if (i >= oid_list_len) {
         break;

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -821,6 +821,9 @@ static int csnmp_config_add_host(oconfig_item_t *ci) {
       status = -1;
       break;
     }
+    if (hd->bulk_size > 0 && hd->version < 2) {
+      WARNING("snmp plugin: Bulk transferts is only available for snmp v2 and later, host '%s' is configured as version '%d'", hd->name, hd->version );
+    }
     if (hd->version == 3) {
       if (hd->username == NULL) {
         WARNING("snmp plugin: `Username' not given for host `%s'", hd->name);


### PR DESCRIPTION
ChangeLog: snmp plugin: support for bulk transfer.

As per issue #2495 we are experiencing so long collect time for switch with high number of port so i took a try at that.

This is the first attempt, it's working but i may not have seen every failure opportunities, i tried to be the less disruptive as possible.

This mostly modify the csnmp_read_table to switch over to 'GETBULK' PDUs if conditions are ok, and handle the extra return values with the same loop.

Comments are welcome