### PR TITLE
dcpmm plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -157,6 +157,9 @@ Franck Lombardi
 Gergely Nagy <algernon at madhouse-project.org>
  - Write-Riemann plugin.
 
+Hari TG <hari.tg at intel.com>
+ - dcpmm plugin.
+
 Jason Pepas <cell at ices.utexas.edu>
  - nfs plugin.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -880,6 +880,14 @@ dbi_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBDBI_LDFLAGS)
 dbi_la_LIBADD = $(BUILD_WITH_LIBDBI_LIBS)
 endif
 
+if BUILD_PLUGIN_DCPMM
+pkglib_LTLIBRARIES += dcpmm.la
+dcpmm_la_SOURCES = src/dcpmm.c
+dcpmm_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBPMWAPI_CPPFLAGS)
+dcpmm_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBPMWAPI_LDFLAGS)
+dcpmm_la_LIBADD = -lpmwapi
+endif
+
 if BUILD_PLUGIN_DF
 pkglib_LTLIBRARIES += df.la
 df_la_SOURCES = src/df.c

--- a/README
+++ b/README
@@ -85,6 +85,9 @@ Features
       Executes SQL statements on various databases and interprets the returned
       data.
 
+    - dcpmm
+      Collects Intel Optane DC Presistent Memory (DCPMM) performance and health statistics.
+
     - df
       Mountpoint usage (Basically the values `df(1)' delivers)
 
@@ -908,6 +911,9 @@ Prerequisites
     Obviously used by the `perl' plugin. The library has to be compiled with
     ithread support (introduced in Perl 5.6.0).
     <http://www.perl.org/>
+
+  * libpmwapi (optional)
+    Used by the `dcpmm` plugin.
 
   * libpq (optional)
     The PostgreSQL C client library used by the `postgresql' plugin.

--- a/README
+++ b/README
@@ -914,6 +914,9 @@ Prerequisites
 
   * libpmwapi (optional)
     Used by the `dcpmm` plugin.
+    The library github: https://github.com/intel/intel-pmwatch
+    Follow the pmwatch build instructions mentioned for dcpmm plugin and
+    use the install path to resolve the dependency here.
 
   * libpq (optional)
     The PostgreSQL C client library used by the `postgresql' plugin.

--- a/configure.ac
+++ b/configure.ac
@@ -4388,6 +4388,74 @@ fi
 AC_SUBST([PERL_CFLAGS])
 AC_SUBST([PERL_LIBS])
 
+
+# }}}
+
+# --with-libpmwapi {{{
+AC_ARG_WITH([libpmwapi],
+  [AS_HELP_STRING([--with-libpmwapi@<:@=PREFIX@:>@], [Path to libpmwapi.])],
+  [
+    if test "x$withval" = "xyes" || test "x$withval" = "xno"; then
+      with_libpmwapi="$withval"
+    else
+      with_libpmwapi_cppflags="-I$withval/include"
+      with_libpmwapi_ldflags="-L$withval/lib64"
+      with_libpmwapi="yes"
+    fi
+  ],
+  [with_libpmwapi="yes"]
+)
+
+if test "x$with_libpmwapi" = "xyes"; then
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $with_libpmwapi_cppflags"
+
+  AC_CHECK_HEADERS([pmw_api.h],
+    [with_libpmwapi="yes"],
+    [with_libpmwapi="no (pmw_api.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
+if test "x$with_libpmwapi" = "xyes"; then
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $with_libpmwapi_ldflags"
+
+  AC_CHECK_LIB([pmwapi], [PMWAPIGetDIMMCount],
+    [with_libpmwapis="yes"],
+    [with_libpmwapi="no (symbol 'PMWAPIGetDIMMCount' not found)"],
+    [-lpmwcollect]
+  )
+
+  AC_CHECK_LIB([pmwapi], [PMWAPIStart],
+    [with_libpmwapi="yes"],
+    [with_libpmwapi="no (symbol 'PMWAPIStart' not found)"],
+    [-lpmwcollect]
+  )
+
+  AC_CHECK_LIB([pmwapi], [PMWAPIStop],
+    [with_libpmwapi="yes"],
+    [with_libpmwapi="no (symbol 'PMWAPIStop' not found)"],
+    [-lpmwcollect]
+  )
+
+  AC_CHECK_LIB([pmwapi], [PMWAPIRead],
+    [with_libpmwapi="yes"],
+    [with_libpmwapi="no (symbol 'PMWAPIRead' not found)"],
+    [-lpmwcollect]
+  )
+
+  LDFLAGS="$SAVE_LDFLAGS"
+fi
+
+if test "x$with_libpmwapi" = "xyes"; then
+  BUILD_WITH_LIBPMWAPI_CPPFLAGS="$with_libpmwapi_cppflags"
+  BUILD_WITH_LIBPMWAPI_LDFLAGS="$with_libpmwapi_ldflags"
+fi
+
+AC_SUBST([BUILD_WITH_LIBPMWAPI_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBPMWAPI_LDFLAGS])
 # }}}
 
 # --with-libpq {{{
@@ -6800,6 +6868,7 @@ AC_PLUGIN([curl],                [$with_libcurl],             [CURL generic web 
 AC_PLUGIN([curl_json],           [$plugin_curl_json],         [CouchDB statistics])
 AC_PLUGIN([curl_xml],            [$plugin_curl_xml],          [CURL generic xml statistics])
 AC_PLUGIN([dbi],                 [$with_libdbi],              [General database statistics])
+AC_PLUGIN([dcpmm],               [$with_libpmwapi],           [Intel(R) Optane(TM) DC Persistent Memory performance and health statistics])
 AC_PLUGIN([df],                  [$plugin_df],                [Filesystem usage statistics])
 AC_PLUGIN([disk],                [$plugin_disk],              [Disk usage statistics])
 AC_PLUGIN([dns],                 [$with_libpcap],             [DNS traffic analysis])
@@ -7171,6 +7240,7 @@ AC_MSG_RESULT([    libowcapi . . . . . . $with_libowcapi])
 AC_MSG_RESULT([    libpcap . . . . . . . $with_libpcap])
 AC_MSG_RESULT([    libperfstat . . . . . $with_perfstat])
 AC_MSG_RESULT([    libperl . . . . . . . $with_libperl])
+AC_MSG_RESULT([    libpmwapi . . . . . . $with_libpmwapi])
 AC_MSG_RESULT([    libpq . . . . . . . . $with_libpq])
 AC_MSG_RESULT([    libpqos . . . . . . . $with_libpqos])
 AC_MSG_RESULT([    libprotobuf . . . . . $with_libprotobuf])
@@ -7231,6 +7301,7 @@ AC_MSG_RESULT([    curl  . . . . . . . . $enable_curl])
 AC_MSG_RESULT([    curl_json . . . . . . $enable_curl_json])
 AC_MSG_RESULT([    curl_xml  . . . . . . $enable_curl_xml])
 AC_MSG_RESULT([    dbi . . . . . . . . . $enable_dbi])
+AC_MSG_RESULT([    dcpmm  . . . . . .  . $enable_dcpmm])
 AC_MSG_RESULT([    df  . . . . . . . . . $enable_df])
 AC_MSG_RESULT([    disk  . . . . . . . . $enable_disk])
 AC_MSG_RESULT([    dns . . . . . . . . . $enable_dns])

--- a/configure.ac
+++ b/configure.ac
@@ -4388,8 +4388,8 @@ fi
 AC_SUBST([PERL_CFLAGS])
 AC_SUBST([PERL_LIBS])
 
-
 # }}}
+
 
 # --with-libpmwapi {{{
 AC_ARG_WITH([libpmwapi],

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -547,9 +547,9 @@
 
 #<Plugin dcpmm>
 #    Interval 10.0
-#    CollectHealth 0
-#    CollectPerfMetrics 1
-#    EnableDispatchAll 0
+#    CollectHealth false
+#    CollectPerfMetrics true
+#    EnableDispatchAll false
 #</Plugin>
 
 #<Plugin df>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -112,6 +112,7 @@
 #@BUILD_PLUGIN_CURL_JSON_TRUE@LoadPlugin curl_json
 #@BUILD_PLUGIN_CURL_XML_TRUE@LoadPlugin curl_xml
 #@BUILD_PLUGIN_DBI_TRUE@LoadPlugin dbi
+#@BUILD_PLUGIN_DCPMM_TRUE@LoadPlugin dcpmm
 #@BUILD_PLUGIN_DF_TRUE@LoadPlugin df
 #@BUILD_PLUGIN_DISK_TRUE@LoadPlugin disk
 #@BUILD_PLUGIN_DNS_TRUE@LoadPlugin dns
@@ -542,6 +543,13 @@
 #		#Query "..."
 #		#Host "..."
 #	</Database>
+#</Plugin>
+
+#<Plugin dcpmm>
+#    Interval 10.0
+#    CollectHealth 0
+#    CollectPerfMetrics 1
+#    EnableDispatchAll 0
 #</Plugin>
 
 #<Plugin df>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2564,16 +2564,18 @@ This will override the I<global Interval> for I<dcpmm> plugin. None of the other
 Collects health information. I<CollectHealth and CollectPerfMetrics cannot be true at the same time>. Defaults to C<false>.
 
 The health information metrics are the following:
-  health_status        Overall health summary (0: normal | 1: non-critical | 2: critical | 3: fatal).
-  percentage_remaining The module’s remaining life as a percentage value of factory expected life span.
-  percentage_used      The module’s used life as a percentage value of factory expected life span.
-  power_on_time        The lifetime the DIMM has been powered on in seconds.
-  uptime               The current uptime of the DIMM for the current power cycle in seconds.
-  last_shutdown_time   The time the system was last shutdown. The time is represented in epoch (seconds).
-  media_temp           The media’s current temperature in degrees Celsius.
-  controller_temp      The controller’s current temperature in degrees Celsius.
-  max_media_temp       The media’s the highest temperature reported in degrees Celsius.
-  max_controller_temp  The controller’s highest temperature reported in degrees Celsius.
+  health_status              Overall health summary (0: normal | 1: non-critical | 2: critical | 3: fatal).
+  lifespan_remaining         The module’s remaining life as a percentage value of factory expected life span.
+  lifespan_used              The module’s used life as a percentage value of factory expected life span.
+  power_on_time              The lifetime the DIMM has been powered on in seconds.
+  uptime                     The current uptime of the DIMM for the current power cycle in seconds.
+  last_shutdown_time         The time the system was last shutdown. The time is represented in epoch (seconds).
+  media_temperature          The media’s current temperature in degree Celsius.
+  controller_temperature     The controller’s current temperature in degree Celsius.
+  max_media_temperature      The media’s the highest temperature reported in degree Celsius.
+  max_controller_temperature The controller’s highest temperature reported in degree Celsius.
+  tsc_cycles                 The number of tsc cycles during each interval.
+  epoch                      The timestamp in seconds at which the metrics are collected from DCPMM DIMMs.
 
 =item B<CollectPerfMetrics> I<true>|I<false>
 
@@ -2588,8 +2590,10 @@ The memory performance metrics are the following:
   media_write_ops     Number of write operations performed to the physical media.
   host_reads          Number of read operations received from the CPU (memory controller).
   host_writes         Number of write operations received from the CPU (memory controller).
-  read_hit_ratio      Measures the efficiency of the buffer in the read path. Range of 0.0 - 0.75.
+  read_hit_ratio      Measures the efficiency of the buffer in the read path. Range of 0.0 - 1.0.
   write_hit_ratio     Measures the efficiency of the buffer in the write path. Range of 0.0 - 1.0.
+  tsc_cycles          The number of tsc cycles during each interval.
+  epoch               The timestamp in seconds at which the metrics are collected from DCPMM DIMMs.
 
 =item B<EnableDispatchAll> I<false>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2541,14 +2541,15 @@ values. Defaults to the global hostname setting.
 =head2 Plugin C<dcpmm>
 
 The I<dcpmm plugin> will collect Intel(R) Optane(TM) DC Persistent Memory related performance statistics.
+The plugin requires root privileges to perform the statistics collection.
 
 B<Synopsis:>
 
  <Plugin "dcpmm">
    Interval 10.0
-   CollectHealth 0
-   CollectPerfMetrics 1
-   EnableDispatchAll 0
+   CollectHealth false
+   CollectPerfMetrics true
+   EnableDispatchAll false
  </Plugin>
 
 =over 4
@@ -2558,9 +2559,9 @@ B<Synopsis:>
 Sets the I<Interval (in seconds)> in which the values will be collected. Defaults to C<global Interval> value.
 This will override the I<global Interval> for I<dcpmm> plugin. None of the other plugins will be affected.
 
-=item B<CollectHealth> I<0>|I<1>
+=item B<CollectHealth> I<true>|I<false>
 
-Collects health information. I<CollectHealth and CollectPerfMetrics cannot be 1 at the same time>. Defaults to C<0>.
+Collects health information. I<CollectHealth and CollectPerfMetrics cannot be true at the same time>. Defaults to C<false>.
 
 The health information metrics are the following:
   health_status        Overall health summary (0: normal | 1: non-critical | 2: critical | 3: fatal).
@@ -2574,9 +2575,9 @@ The health information metrics are the following:
   max_media_temp       The media’s the highest temperature reported in degrees Celsius.
   max_controller_temp  The controller’s highest temperature reported in degrees Celsius.
 
-=item B<CollectPerfMetrics> I<0>|I<1>
+=item B<CollectPerfMetrics> I<true>|I<false>
 
-Collects memory performance metrics. I<CollectHealth and CollectPerfMetrics cannot be 1 at the same time>. Defaults to C<1>.
+Collects memory performance metrics. I<CollectHealth and CollectPerfMetrics cannot be true at the same time>. Defaults to C<true>.
 
 The memory performance metrics are the following:
   total_bytes_read    Number of bytes transacted by the read operations.
@@ -2590,10 +2591,10 @@ The memory performance metrics are the following:
   read_hit_ratio      Measures the efficiency of the buffer in the read path. Range of 0.0 - 0.75.
   write_hit_ratio     Measures the efficiency of the buffer in the write path. Range of 0.0 - 1.0.
 
-=item B<EnableDispatchAll> I<0>
+=item B<EnableDispatchAll> I<false>
 
 This parameter helps to seamlessly enable simultaneous health and memory perf metrics collection in future.
-This is unused at the moment and I<must> always be I<0>.
+This is unused at the moment and I<must> always be I<false>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2538,6 +2538,65 @@ values. Defaults to the global hostname setting.
 
 =back
 
+=head2 Plugin C<dcpmm>
+
+The I<dcpmm plugin> will collect Intel(R) Optane(TM) DC Persistent Memory related performance statistics.
+
+B<Synopsis:>
+
+ <Plugin "dcpmm">
+   Interval 10.0
+   CollectHealth 0
+   CollectPerfMetrics 1
+   EnableDispatchAll 0
+ </Plugin>
+
+=over 4
+
+=item B<Interval> I<time in seconds>
+
+Sets the I<Interval (in seconds)> in which the values will be collected. Defaults to C<global Interval> value.
+This will override the I<global Interval> for I<dcpmm> plugin. None of the other plugins will be affected.
+
+=item B<CollectHealth> I<0>|I<1>
+
+Collects health information. I<CollectHealth and CollectPerfMetrics cannot be 1 at the same time>. Defaults to C<0>.
+
+The health information metrics are the following:
+  health_status        Overall health summary (0: normal | 1: non-critical | 2: critical | 3: fatal).
+  percentage_remaining The module’s remaining life as a percentage value of factory expected life span.
+  percentage_used      The module’s used life as a percentage value of factory expected life span.
+  power_on_time        The lifetime the DIMM has been powered on in seconds.
+  uptime               The current uptime of the DIMM for the current power cycle in seconds.
+  last_shutdown_time   The time the system was last shutdown. The time is represented in epoch (seconds).
+  media_temp           The media’s current temperature in degrees Celsius.
+  controller_temp      The controller’s current temperature in degrees Celsius.
+  max_media_temp       The media’s the highest temperature reported in degrees Celsius.
+  max_controller_temp  The controller’s highest temperature reported in degrees Celsius.
+
+=item B<CollectPerfMetrics> I<0>|I<1>
+
+Collects memory performance metrics. I<CollectHealth and CollectPerfMetrics cannot be 1 at the same time>. Defaults to C<1>.
+
+The memory performance metrics are the following:
+  total_bytes_read    Number of bytes transacted by the read operations.
+  total_bytes_written Number of bytes transacted by the write operations.
+  read_64B_ops_rcvd   Number of read operations performed to the physical media in 64 bytes granularity.
+  write_64B_ops_rcvd  Number of write operations performed to the physical media in 64 bytes granularity.
+  media_read_ops      Number of read operations performed to the physical media.
+  media_write_ops     Number of write operations performed to the physical media.
+  host_reads          Number of read operations received from the CPU (memory controller).
+  host_writes         Number of write operations received from the CPU (memory controller).
+  read_hit_ratio      Measures the efficiency of the buffer in the read path. Range of 0.0 - 0.75.
+  write_hit_ratio     Measures the efficiency of the buffer in the write path. Range of 0.0 - 1.0.
+
+=item B<EnableDispatchAll> I<0>
+
+This parameter helps to seamlessly enable simultaneous health and memory perf metrics collection in future.
+This is unused at the moment and I<must> always be I<0>.
+
+=back
+
 =head2 Plugin C<df>
 
 =over 4

--- a/src/dcpmm.c
+++ b/src/dcpmm.c
@@ -69,8 +69,10 @@ static void add_metric(const char *plugin_inst, const char *type,
 
   if (strncmp(type_inst, "read_hit_ratio", strlen("read_hit_ratio")) == 0 ||
       strncmp(type_inst, "write_hit_ratio", strlen("write_hit_ratio")) == 0 ||
-      strncmp(type_inst, "media_temp", strlen("media_temp")) == 0 ||
-      strncmp(type_inst, "controller_temp", strlen("controller_temp")) == 0) {
+      strncmp(type_inst, "media_temperature", strlen("media_temperature")) ==
+          0 ||
+      strncmp(type_inst, "controller_temperature",
+              strlen("controller_temperature")) == 0) {
     snprintf(n.message, sizeof(n.message), "Value: %0.2f", value);
   } else {
     snprintf(n.message, sizeof(n.message), "Value: %0.0f", value);
@@ -106,7 +108,7 @@ static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
     if (pmwatch_config.collect_perf_metrics) {
       add_metric(dimm_num, "timestamp", "epoch",
                  PMWATCH_OP_BUF_EPOCH(&pmw_output_buf[i]));
-      add_metric(dimm_num, "timestamp", "timestamp",
+      add_metric(dimm_num, "timestamp", "tsc_cycles",
                  PMWATCH_OP_BUF_TIMESTAMP(&pmw_output_buf[i]));
       add_metric(dimm_num, "media", "total_bytes_read",
                  PMWATCH_OP_BUF_TOTAL_BYTES_READ(&pmw_output_buf[i]));
@@ -136,13 +138,13 @@ static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
       }
       add_metric(dimm_num, "timestamp", "epoch",
                  PMWATCH_OP_BUF_EPOCH(&pmw_output_buf[i]));
-      add_metric(dimm_num, "timestamp", "timestamp",
+      add_metric(dimm_num, "timestamp", "tsc_cycles",
                  PMWATCH_OP_BUF_TIMESTAMP(&pmw_output_buf[i]));
       add_metric(dimm_num, "health", "health_status",
                  PMWATCH_OP_BUF_HEALTH_STATUS(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "percentage_remaining",
+      add_metric(dimm_num, "health", "lifespan_remaining",
                  PMWATCH_OP_BUF_PERCENTAGE_REMAINING(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "percentage_used",
+      add_metric(dimm_num, "health", "lifespan_used",
                  PMWATCH_OP_BUF_PERCENTAGE_USED(&pmw_output_buf[i]));
       add_metric(dimm_num, "health", "power_on_time",
                  PMWATCH_OP_POWER_ON_TIME(&pmw_output_buf[i]));
@@ -150,13 +152,13 @@ static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
                  PMWATCH_OP_BUF_UPTIME(&pmw_output_buf[i]));
       add_metric(dimm_num, "health", "last_shutdown_time",
                  PMWATCH_OP_BUF_LAST_SHUTDOWN_TIME(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "media_temp",
+      add_metric(dimm_num, "health", "media_temperature",
                  PMWATCH_OP_BUF_MEDIA_TEMP(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "controller_temp",
+      add_metric(dimm_num, "health", "controller_temperature",
                  PMWATCH_OP_BUF_CONTROLLER_TEMP(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "max_media_temp",
+      add_metric(dimm_num, "health", "max_media_temperature",
                  PMWATCH_OP_BUF_MAX_MEDIA_TEMP(&pmw_output_buf[i]));
-      add_metric(dimm_num, "health", "max_controller_temp",
+      add_metric(dimm_num, "health", "max_controller_temperature",
                  PMWATCH_OP_BUF_MAX_CONTROLLER_TEMP(&pmw_output_buf[i]));
     }
   }

--- a/src/dcpmm.c
+++ b/src/dcpmm.c
@@ -1,0 +1,264 @@
+/*
+ * collectd - src/dcpmm.c
+ * MIT License
+ *
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Hari TG <hari.tg at intel.com>
+ */
+
+#include "collectd.h"
+#include "utils/common/common.h"
+
+#include "pmw_api.h"
+
+#define PLUGIN_NAME "dcpmm"
+
+int num_nvdimms;
+int enable_dispatch_all = 0;
+cdtime_t interval = 0;
+PMWATCH_OP_BUF pmw_output_buf;
+PMWATCH_CONFIG_NODE pmwatch_config;
+
+static void add_metric(const char *plugin_inst, const char *type,
+                       const char *type_inst, gauge_t value) {
+  value_list_t vl = VALUE_LIST_INIT;
+
+  vl.values = &(value_t){.gauge = value};
+  vl.values_len = 1;
+
+  sstrncpy(vl.plugin, PLUGIN_NAME, sizeof(vl.plugin));
+  sstrncpy(vl.host, hostname_g, sizeof(vl.host));
+  sstrncpy(vl.type, type, sizeof(vl.type));
+
+  if (plugin_inst != NULL) {
+    sstrncpy(vl.plugin_instance, plugin_inst, sizeof(vl.plugin_instance));
+  }
+
+  if (type_inst != NULL) {
+    sstrncpy(vl.type_instance, type_inst, sizeof(vl.type_instance));
+  }
+
+  plugin_dispatch_values(&vl);
+
+#if COLLECT_DEBUG
+
+  notification_t n = {
+      .severity = NOTIF_OKAY, .time = cdtime(), .plugin = PLUGIN_NAME};
+
+  if (strncmp(type_inst, "read_hit_ratio", strlen("read_hit_ratio")) == 0 ||
+      strncmp(type_inst, "write_hit_ratio", strlen("write_hit_ratio")) == 0 ||
+      strncmp(type_inst, "media_temp", strlen("media_temp")) == 0 ||
+      strncmp(type_inst, "controller_temp", strlen("controller_temp")) == 0) {
+    snprintf(n.message, sizeof(n.message), "Value: %0.2f", value);
+  } else {
+    snprintf(n.message, sizeof(n.message), "Value: %0.0f", value);
+  }
+  sstrncpy(n.host, hostname_g, sizeof(n.host));
+  sstrncpy(n.type, type, sizeof(n.type));
+  sstrncpy(n.type_instance, type_inst, sizeof(n.type_instance));
+  sstrncpy(n.plugin_instance, plugin_inst, sizeof(n.plugin_instance));
+
+  plugin_dispatch_notification(&n);
+
+#endif /* COLLECT_DEBUG */
+
+  return;
+} /* void add_metric  */
+
+static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
+  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+
+  int i, ret = 0;
+  char dimm_num[16];
+
+  ret = PMWAPIRead(&pmw_output_buf);
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Failed to read data from the collection.");
+    return ret;
+  }
+
+  for (i = 0; i < num_nvdimms; i++) {
+    snprintf(dimm_num, sizeof(dimm_num), "%d", i);
+
+    if (pmwatch_config.collect_perf_metrics) {
+      add_metric(dimm_num, "timestamp", "epoch",
+                 PMWATCH_OP_BUF_EPOCH(&pmw_output_buf[i]));
+      add_metric(dimm_num, "timestamp", "timestamp",
+                 PMWATCH_OP_BUF_TIMESTAMP(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "total_bytes_read",
+                 PMWATCH_OP_BUF_TOTAL_BYTES_READ(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "total_bytes_written",
+                 PMWATCH_OP_BUF_TOTAL_BYTES_WRITTEN(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "read_64B_ops_rcvd",
+                 PMWATCH_OP_BUF_BYTES_READ(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "write_64B_ops_rcvd",
+                 PMWATCH_OP_BUF_BYTES_WRITTEN(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "media_read_ops",
+                 PMWATCH_OP_BUF_MEDIA_READ(&pmw_output_buf[i]));
+      add_metric(dimm_num, "media", "media_write_ops",
+                 PMWATCH_OP_BUF_MEDIA_WRITE(&pmw_output_buf[i]));
+      add_metric(dimm_num, "controller", "host_reads",
+                 PMWATCH_OP_BUF_HOST_READS(&pmw_output_buf[i]));
+      add_metric(dimm_num, "controller", "host_writes",
+                 PMWATCH_OP_BUF_HOST_WRITES(&pmw_output_buf[i]));
+      add_metric(dimm_num, "buffer", "read_hit_ratio",
+                 PMWATCH_OP_BUF_READ_HIT_RATIO(&pmw_output_buf[i]));
+      add_metric(dimm_num, "buffer", "write_hit_ratio",
+                 PMWATCH_OP_BUF_WRITE_HIT_RATIO(&pmw_output_buf[i]));
+    }
+
+    if (pmwatch_config.collect_health) {
+      if (pmwatch_config.collect_perf_metrics && !enable_dispatch_all) {
+        continue;
+      }
+      add_metric(dimm_num, "timestamp", "epoch",
+                 PMWATCH_OP_BUF_EPOCH(&pmw_output_buf[i]));
+      add_metric(dimm_num, "timestamp", "timestamp",
+                 PMWATCH_OP_BUF_TIMESTAMP(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "health_status",
+                 PMWATCH_OP_BUF_HEALTH_STATUS(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "percentage_remaining",
+                 PMWATCH_OP_BUF_PERCENTAGE_REMAINING(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "percentage_used",
+                 PMWATCH_OP_BUF_PERCENTAGE_USED(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "power_on_time",
+                 PMWATCH_OP_POWER_ON_TIME(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "uptime",
+                 PMWATCH_OP_BUF_UPTIME(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "last_shutdown_time",
+                 PMWATCH_OP_BUF_LAST_SHUTDOWN_TIME(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "media_temp",
+                 PMWATCH_OP_BUF_MEDIA_TEMP(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "controller_temp",
+                 PMWATCH_OP_BUF_CONTROLLER_TEMP(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "max_media_temp",
+                 PMWATCH_OP_BUF_MAX_MEDIA_TEMP(&pmw_output_buf[i]));
+      add_metric(dimm_num, "health", "max_controller_temp",
+                 PMWATCH_OP_BUF_MAX_CONTROLLER_TEMP(&pmw_output_buf[i]));
+    }
+  }
+
+  return 0;
+} /* int dcpmm_read */
+
+static int dcpmm_stop(void) {
+  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+
+  int ret;
+
+  ret = PMWAPIStop();
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Failed to stop the collection.");
+  }
+
+  return ret;
+} /* int dcpmm_stop */
+
+static int dcpmm_shutdown(void) {
+  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+
+  int ret = 0;
+
+  free(pmw_output_buf);
+
+  ret = dcpmm_stop();
+
+  return ret;
+} /* int dcpmm_shutdown */
+
+static int dcpmm_init(void) {
+  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+
+  int ret = 0;
+
+  ret = PMWAPIGetDIMMCount(&num_nvdimms);
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Failed to obtain count of Intel(R) Optane DCPMM.");
+    return ret;
+  }
+
+  ret = PMWAPIStart(pmwatch_config);
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Failed to start the collection.");
+    return ret;
+  }
+
+  pmw_output_buf =
+      (PMWATCH_OP_BUF)calloc(num_nvdimms, sizeof(PMWATCH_OP_BUF_NODE));
+  if (pmw_output_buf == NULL) {
+    ERROR(PLUGIN_NAME ": Memory allocation for output buffer failed.");
+    dcpmm_stop();
+    ret = 1;
+  }
+
+  return ret;
+} /* int dcpmm_init */
+
+static int dcpmm_config(oconfig_item_t *ci) {
+  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+
+  int ret = 0;
+
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strncasecmp("Interval", child->key, strlen("Interval")) == 0) {
+      ret = cf_util_get_cdtime(child, &interval);
+      if (!ret) {
+        ret = cf_util_get_double(child, &pmwatch_config.interval);
+      }
+    } else if (strncasecmp("CollectHealth", child->key,
+                           strlen("CollectHealth")) == 0) {
+      ret = cf_util_get_int(child, &pmwatch_config.collect_health);
+    } else if (strncasecmp("CollectPerfMetrics", child->key,
+                           strlen("CollectPerfMetrics")) == 0) {
+      ret = cf_util_get_int(child, &pmwatch_config.collect_perf_metrics);
+    } else if (strncasecmp("EnableDispatchAll", child->key,
+                           strlen("EnableDispatchAll")) == 0) {
+      ret = cf_util_get_int(child, &enable_dispatch_all);
+    } else {
+      ERROR(PLUGIN_NAME ": Unkown configuration parameter %s.", child->key);
+      ret = 1;
+    }
+
+    if (ret != 0) {
+      ERROR(PLUGIN_NAME ": Failed to parse configuration parameters");
+      return ret;
+    }
+  }
+
+  DEBUG("%s Config: Interval %.2f ; CollectHealth %d ; CollectdPerfMetrics %d "
+        "; EnableDispatchAll %d",
+        PLUGIN_NAME, pmwatch_config.interval, pmwatch_config.collect_health,
+        pmwatch_config.collect_perf_metrics, enable_dispatch_all);
+
+  plugin_register_complex_read(NULL, PLUGIN_NAME, dcpmm_read, interval, NULL);
+
+  return 0;
+} /* int dcpmm_config */
+
+void module_register(void) {
+  plugin_register_init(PLUGIN_NAME, dcpmm_init);
+  plugin_register_complex_config(PLUGIN_NAME, dcpmm_config);
+  plugin_register_shutdown(PLUGIN_NAME, dcpmm_shutdown);
+} /* void module_register */

--- a/src/types.db
+++ b/src/types.db
@@ -10,6 +10,7 @@ backends                value:GAUGE:0:65535
 bitrate                 value:GAUGE:0:4294967295
 blocked_clients         value:GAUGE:0:U
 bucket                  value:GAUGE:0:U
+buffer                  value:GAUGE:0:18446744073709551615
 bytes                   value:GAUGE:0:U
 cache_eviction          value:DERIVE:0:U
 cache_operation         value:DERIVE:0:U
@@ -35,6 +36,7 @@ commands                value:DERIVE:0:U
 connections             value:DERIVE:0:U
 conntrack               value:GAUGE:0:4294967295
 contextswitch           value:DERIVE:0:U
+controller              value:GAUGE:0:18446744073709551615
 cookies                 value:DERIVE:0:U
 count                   value:GAUGE:0:U
 counter                 value:COUNTER:U:U
@@ -103,6 +105,7 @@ frequency_offset        value:GAUGE:-1000000:1000000
 fscache_stat            value:DERIVE:0:U
 gauge                   value:GAUGE:U:U
 hash_collisions         value:DERIVE:0:U
+health                  value:GAUGE:0:18446744073709551615
 http_request_methods    value:DERIVE:0:U
 http_requests           value:DERIVE:0:U
 http_response_codes     value:DERIVE:0:U
@@ -134,6 +137,7 @@ job_stats               value:DERIVE:0:U
 latency                 value:GAUGE:0:U
 links                   value:GAUGE:0:U
 load                    shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
+media                   value:GAUGE:0:18446744073709551615
 memory_bandwidth        value:DERIVE:0:U
 md_disks                value:GAUGE:0:U
 memcached_command       value:DERIVE:0:U
@@ -253,6 +257,7 @@ time_offset_ntp         value:GAUGE:-1000000:1000000
 time_offset_rms         value:GAUGE:-1000000:1000000
 time_ref                value:GAUGE:0:U
 timeleft                value:GAUGE:0:U
+timestamp               value:GAUGE:0:18446744073709551615
 total_bytes             value:DERIVE:0:U
 total_connections       value:DERIVE:0:U
 total_events            value:DERIVE:0:U


### PR DESCRIPTION
ChangeLog: dcpmm plugin: a new plugin for Intel Optane DC Presistent Memory (DCPMM).

dcpmm plugin collects performance and health statistics from Intel Optane DC Presistent Memory (DCPMM).

Signed-off-by: TG, Hari <hari.tg@intel.com>