### PR TITLE
Upstream turbostat

### DIFF
--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -988,6 +988,7 @@ static int __attribute__((warn_unused_result)) probe_cpu(void) {
     case 0x3A: /* IVB */
     case 0x3E: /* IVB Xeon */
     case 0x55: /* SKX,CLX Xeon */
+    case 0x6A: /* ICX Xeon */
       do_smi = true;
       do_core_cstate = (1 << 3) | (1 << 6) | (1 << 7);
       do_pkg_cstate = (1 << 2) | (1 << 3) | (1 << 6) | (1 << 7);
@@ -1044,6 +1045,7 @@ static int __attribute__((warn_unused_result)) probe_cpu(void) {
     case 0x2D: /* SNB Xeon */
     case 0x3E: /* IVB Xeon */
     case 0x55: /* SKX,CLX Xeon */
+    case 0x6A: /* ICX Xeon */
       do_rapl = RAPL_PKG | RAPL_CORES | RAPL_DRAM;
       do_power_fields = TURBO_PLATFORM | PSTATES_PLATFORM;
       break;

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -987,6 +987,7 @@ static int __attribute__((warn_unused_result)) probe_cpu(void) {
     /* Ivy Bridge */
     case 0x3A: /* IVB */
     case 0x3E: /* IVB Xeon */
+    case 0x55: /* SKX,CLX Xeon */
       do_smi = true;
       do_core_cstate = (1 << 3) | (1 << 6) | (1 << 7);
       do_pkg_cstate = (1 << 2) | (1 << 3) | (1 << 6) | (1 << 7);
@@ -1042,6 +1043,7 @@ static int __attribute__((warn_unused_result)) probe_cpu(void) {
       break;
     case 0x2D: /* SNB Xeon */
     case 0x3E: /* IVB Xeon */
+    case 0x55: /* SKX,CLX Xeon */
       do_rapl = RAPL_PKG | RAPL_CORES | RAPL_DRAM;
       do_power_fields = TURBO_PLATFORM | PSTATES_PLATFORM;
       break;


### PR DESCRIPTION
ChangeLog: turbostat plugin: Power metrics update for recent server CPUs.

Adding Intel server Skylake, Cascade lake and Ice Lake CPU watts telemetry. Added CPU model numbers to allow the plugin to read this CPU package telemetry.