### PR TITLE
Use sstrncpy instead of strncpy in sysevent plugin

### DIFF
--- a/src/sysevent.c
+++ b/src/sysevent.c
@@ -472,7 +472,7 @@ static int read_socket() {
     } else {
       DEBUG("sysevent plugin: writing %s", buffer);
 
-      strncpy(ring.buffer[ring.head], buffer, sizeof(buffer));
+      sstrncpy(ring.buffer[ring.head], buffer, sizeof(buffer));
       ring.timestamp[ring.head] = cdtime();
       ring.head = next;
     }


### PR DESCRIPTION
ChangeLog: sysevent plugin: use sstrncpy instead of strncpy