### PR TITLE
Plugin msg error/warning message enhancement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+2019-07-17
+	* df plugin: Add ReportAvailUsed boolean. #2248
 2018-10-23, Version 5.8.1
 	* collectd: Fix "BaseDir" option. Thanks to Mariusz Białończyk and
 	  Pavel Rochnyak. #2857

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,3 @@
-2019-07-17
-	* df plugin: Add ReportAvailUsed boolean. #2248
 2018-10-23, Version 5.8.1
 	* collectd: Fix "BaseDir" option. Thanks to Mariusz Białończyk and
 	  Pavel Rochnyak. #2857

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -548,6 +548,7 @@
 #	MountPoint "/home"
 #	FSType "ext3"
 #	IgnoreSelected false
+#	ReportAvailUsed false
 #	ReportByDevice false
 #	ReportInodes false
 #	ValuesAbsolute true

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2567,6 +2567,14 @@ match any one of the criteria are collected. By default only selected
 partitions are collected if a selection is made. If no selection is configured
 at all, B<all> partitions are selected.
 
+=item B<ReportAvailUsed> B<true>|B<false>
+
+When set to B<true>, this option results in an extra metric for each filesystem
+to be reported: the amount of available space to non-root users that has been
+consued. In situations where all of the disk space available to non-root users
+has been consumed, the value reported here may exceed 100%. This option requires
+that B<ValuesPercentage> be set to true. The default for this option is I<false>.
+
 =item B<ReportByDevice> B<true>|B<false>
 
 Report using the device name rather than the mountpoint. i.e. with this I<false>,

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2122,7 +2122,8 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
   assert(0 == strcmp(ds->type, vl->type));
 #else
   if (0 != strcmp(ds->type, vl->type))
-    WARNING("plugin_dispatch_values: (ds->type = %s) != (vl->type = %s)",
+    WARNING("plugin_dispatch_values: <%s/%s-%s> (ds->type = %s) != (vl->type = %s)",
+            vl->host, vl->plugin, vl->plugin_instance,
             ds->type, vl->type);
 #endif
 
@@ -2130,9 +2131,11 @@ static int plugin_dispatch_values_internal(value_list_t *vl) {
   assert(ds->ds_num == vl->values_len);
 #else
   if (ds->ds_num != vl->values_len) {
-    ERROR("plugin_dispatch_values: ds->type = %s: "
+    ERROR("plugin_dispatch_values: <%s/%s-%s/%s-%s> ds->type = %s: "
           "(ds->ds_num = %" PRIsz ") != "
           "(vl->values_len = %" PRIsz ")",
+          vl->host, vl->plugin, vl->plugin_instance,
+          vl->type, vl->type_instance,
           ds->type, ds->ds_num, vl->values_len);
     return -1;
   }

--- a/src/df.c
+++ b/src/df.c
@@ -47,9 +47,9 @@
 #endif
 
 static const char *config_keys[] = {
-    "Device",         "MountPoint",   "FSType",         "IgnoreSelected",
-    "ReportAvailUsed",
-    "ReportByDevice", "ReportInodes", "ValuesAbsolute", "ValuesPercentage"};
+    "Device",         "MountPoint",      "FSType",
+    "IgnoreSelected", "ReportAvailUsed", "ReportByDevice",
+    "ReportInodes",   "ValuesAbsolute",  "ValuesPercentage"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static ignorelist_t *il_device;
@@ -99,7 +99,7 @@ static int df_config(const char *key, const char *value) {
       ignorelist_set_invert(il_fstype, 1);
     }
     return 0;
-  } else if (strcasecmp (key, "ReportAvailUsed") == 0) {
+  } else if (strcasecmp(key, "ReportAvailUsed") == 0) {
     if (IS_TRUE(value))
       report_availused = 1;
     else
@@ -293,7 +293,7 @@ static int df_read(void) {
           uint64_t available = blk_free + blk_used;
 
           df_submit_one(disk_name, "percent_bytes", "availused",
-                        (gauge_t) ((float_t)(blk_used) / available * 100));
+                        (gauge_t)((float_t)(blk_used) / available * 100));
         }
       } else {
         retval = -1;

--- a/src/df.c
+++ b/src/df.c
@@ -292,7 +292,7 @@ static int df_read(void) {
         if (report_availused) {
           uint64_t available = blk_free + blk_used;
 
-          df_submit_one(disk_name, "percent_bytes", "availused",
+          df_submit_one(disk_name, "percent_avail", "availused",
                         (gauge_t)((float_t)(blk_used) / available * 100));
         }
       } else {

--- a/src/df.c
+++ b/src/df.c
@@ -48,6 +48,7 @@
 
 static const char *config_keys[] = {
     "Device",         "MountPoint",   "FSType",         "IgnoreSelected",
+    "ReportAvailUsed",
     "ReportByDevice", "ReportInodes", "ValuesAbsolute", "ValuesPercentage"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
@@ -56,6 +57,7 @@ static ignorelist_t *il_mountpoint;
 static ignorelist_t *il_fstype;
 
 static bool by_device;
+static bool report_availused = false;
 static bool report_inodes;
 static bool values_absolute = true;
 static bool values_percentage;
@@ -97,6 +99,12 @@ static int df_config(const char *key, const char *value) {
       ignorelist_set_invert(il_fstype, 1);
     }
     return 0;
+  } else if (strcasecmp (key, "ReportAvailUsed") == 0) {
+    if (IS_TRUE(value))
+      report_availused = 1;
+    else
+      report_availused = 0;
+    return (0);
   } else if (strcasecmp(key, "ReportByDevice") == 0) {
     if (IS_TRUE(value))
       by_device = true;
@@ -281,6 +289,12 @@ static int df_read(void) {
             (gauge_t)((float_t)(blk_reserved) / statbuf.f_blocks * 100));
         df_submit_one(disk_name, "percent_bytes", "used",
                       (gauge_t)((float_t)(blk_used) / statbuf.f_blocks * 100));
+        if (report_availused) {
+          uint64_t available = blk_free + blk_used;
+
+          df_submit_one(disk_name, "percent_bytes", "availused",
+                        (gauge_t) ((float_t)(blk_used) / available * 100));
+        }
       } else {
         retval = -1;
         break;

--- a/src/types.db
+++ b/src/types.db
@@ -180,6 +180,7 @@ pending_operations      value:GAUGE:0:U
 percent                 value:GAUGE:0:100.1
 percent_bytes           value:GAUGE:0:100.1
 percent_inodes          value:GAUGE:0:100.1
+percent_avail           value:GAUGE:0:110.1
 perf                    value:DERIVE:0:U
 pf_counters             value:DERIVE:0:U
 pf_limits               value:DERIVE:0:U


### PR DESCRIPTION
The error/warning messages have very little detail in them about the actual origin, requiring debug mode to discover the problem.

This change adds more information about the origin of the message, making it easier for systems administrators to find out who/what sent the offending message in a more timely fashion.