### PR TITLE
Check for sysevent plugin init calloc failures

### DIFF
--- a/src/sysevent.c
+++ b/src/sysevent.c
@@ -924,15 +924,25 @@ static int sysevent_init(void) /* {{{ */
   ring.buffer = (char **)calloc(buffer_length, sizeof(char *));
 
   if (ring.buffer == NULL) {
-    ERROR("sysevent plugin: sysevent_init calloc failed");
+    ERROR("sysevent plugin: sysevent_init ring buffer calloc failed");
     return -1;
   }
 
   for (int i = 0; i < buffer_length; i++) {
     ring.buffer[i] = calloc(1, listen_buffer_size);
+
+    if (ring.buffer[i] == NULL) {
+      ERROR("sysevent plugin: sysevent_init ring buffer entry calloc failed");
+      return -1;
+    }
   }
 
   ring.timestamp = (cdtime_t *)calloc(buffer_length, sizeof(cdtime_t));
+
+  if (ring.timestamp == NULL) {
+    ERROR("sysevent plugin: sysevent_init ring buffer timestamp calloc failed");
+    return -1;
+  }
 
   if (sock == -1) {
     struct addrinfo hints = {


### PR DESCRIPTION
ChangeLog: sysevent: Add a few missing calloc result checks in the sysevent_init function