### PR TITLE
Issue #3289: Add execvpe() wrapper, call it instead of setenv/unsetenv.

### DIFF
--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -75,6 +75,7 @@ __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
 char *sstrdup(const char *s);
 void *smalloc(size_t size);
 char *sstrerror(int errnum, char *buf, size_t buflen);
+int sexecvpe(const char *file, char *const argv[], char *const envp[]);
 
 #ifndef ERRBUF_SIZE
 #define ERRBUF_SIZE 256


### PR DESCRIPTION
ChangeLog: Exec plugin: Fix race condition in fork_child, where environment variables got unset before calling the exec program. #3289

execvpe() is a GNU extention, and not widely supported across other platforms, so the implementation has been made internal for the benefit of the exec plugin.

Because fork_child is called from multiple threads concurrently, it is not safe to use setenv()/unsetenv() to manipulate global shared state.
 
The bug witnessed is code being executed in the following order:

- Thread 0: setenv("COLLECTD_HOSTNAME")
- Thread 0: fork()
- Thread 1: setenv("COLLECTD_HOSTNAME")
- Thread 0: unsetenv("COLLECTD_HOSTNAME")
- Thread 1: fork()
- Thread 1: execvp(file, argv)

Leaving the program executed in thread 1 without COLLECTD_HOSTNAME and COLLECTD_INTERVAL being set.

Fixes: #3289