### PR TITLE
New setting to specify the start time of read plugins

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -50,6 +50,17 @@
 #WriteQueueLimitHigh 1000000
 #WriteQueueLimitLow   800000
 
+#----------------------------------------------------------------------------#
+# StartRead specifies when the first read for each read plugin is performed. #
+# The float value is in seconds and specifies the minutes, seconds and       #
+# milliseconds per hour. This may be overwritten on a per-plugin base by     #
+# using the 'StartAt' option of the LoadPlugin block:                       #
+#   <LoadPlugin foo>                                                         #
+#       StartRead 301.42 # minute 5, second 1, millisecond 420               #
+#   </LoadPlugin>                                                            #
+#----------------------------------------------------------------------------#
+#StartRead -1.0
+
 ##############################################################################
 # Logging                                                                    #
 #----------------------------------------------------------------------------#

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9,6 +9,7 @@ collectd.conf - Configuration for the system statistics collection daemon B<coll
   BaseDir "/var/lib/collectd"
   PIDFile "/run/collectd.pid"
   Interval 10.0
+  StartRead -1.0
 
   LoadPlugin cpu
   LoadPlugin load
@@ -138,6 +139,13 @@ defined in this plugin. By default, this is disabled.
 =item B<FlushTimeout> I<Seconds>
 
 Specifies the value of the timeout argument of the flush callback.
+
+=item B<StartRead> I<Seconds>
+
+Sets a start time for the specific read plugin. The value is interpreted as 
+minutes, seconds and milliseconds of an hour. This plugin setting overrides the
+global B<StartRead> setting. If a plugin provides its own support for specifying
+a start time, that setting will take precedence.
 
 =back
 
@@ -320,6 +328,13 @@ to the same value.
 
 Enabling the B<CollectInternalStats> option is of great help to figure out the
 values to set B<WriteQueueLimitHigh> and B<WriteQueueLimitLow> to.
+
+=item B<StartRead> I<Seconds>
+
+Configures when read plugins start execution. This allows the acquisition of 
+metrics at specific times, e.g. at round points in time. It also allows 
+staggered reading (even within a second) to prevent measurements from affecting 
+each other.
 
 =item B<Hostname> I<Name>
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -106,7 +106,7 @@ static cf_global_option_t cf_global_options[] = {
     {"Hostname", NULL, 0, NULL},
     {"FQDNLookup", NULL, 0, "true"},
     {"Interval", NULL, 0, NULL},
-    {"StartAt", NULL, 0, NULL},
+    {"StartRead", NULL, 0, NULL},
     {"ReadThreads", NULL, 0, "5"},
     {"WriteThreads", NULL, 0, "5"},
     {"WriteQueueLimitHigh", NULL, 0, NULL},
@@ -286,8 +286,8 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
   /* default to the global interval set before loading this plugin */
   plugin_ctx_t ctx = {
-      .start_time = cf_get_default_start_time(), 
-      .interval = cf_get_default_interval(), 
+      .start_time = cf_get_default_start_read(),
+      .interval = cf_get_default_interval(),
       .name = strdup(name),
   };
   if (ctx.name == NULL)
@@ -298,7 +298,7 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
     if (strcasecmp("Globals", child->key) == 0)
       cf_util_get_boolean(child, &global);
-    else if (strcasecmp("StartAt", child->key) == 0)
+    else if (strcasecmp("StartRead", child->key) == 0)
       cf_util_get_double(child, &ctx.start_time);
     else if (strcasecmp("Interval", child->key) == 0)
       cf_util_get_cdtime(child, &ctx.interval);
@@ -955,8 +955,8 @@ cdtime_t cf_get_default_interval(void) {
                                 DOUBLE_TO_CDTIME_T(COLLECTD_DEFAULT_INTERVAL));
 }
 
-double cf_get_default_start_time(void) {
-  return global_option_get_double("StartAt", -1.0);
+double cf_get_default_start_read(void) {
+  return global_option_get_double("StartRead", -1.0);
 }
 
 void cf_unregister(const char *type) {

--- a/src/daemon/configfile.h
+++ b/src/daemon/configfile.h
@@ -97,7 +97,7 @@ cdtime_t global_option_get_time(char const *option, cdtime_t default_value);
 
 cdtime_t cf_get_default_interval(void);
 
-double cf_get_default_start_time(void);
+double cf_get_default_start_read(void);
 
 /* Assures the config option is a string, duplicates it and returns the copy in
  * "ret_string". If necessary "*ret_string" is freed first. Returns zero upon

--- a/src/daemon/configfile.h
+++ b/src/daemon/configfile.h
@@ -97,6 +97,8 @@ cdtime_t global_option_get_time(char const *option, cdtime_t default_value);
 
 cdtime_t cf_get_default_interval(void);
 
+double cf_get_default_start_time(void);
+
 /* Assures the config option is a string, duplicates it and returns the copy in
  * "ret_string". If necessary "*ret_string" is freed first. Returns zero upon
  * success. */

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -173,6 +173,7 @@ typedef struct user_data_s user_data_t;
 
 struct plugin_ctx_s {
   char *name;
+  double start_time;
   cdtime_t interval;
   cdtime_t flush_interval;
   cdtime_t flush_timeout;
@@ -447,6 +448,17 @@ plugin_ctx_t plugin_set_ctx(plugin_ctx_t ctx);
  *  everything else fails, it will fall back to 10 seconds.
  */
 cdtime_t plugin_get_interval(void);
+
+/*
+ * NAME
+ *  plugin_get_start_time
+ *
+ * DESCRIPTION
+ *  This function returns the current value of the plugin's start time. The
+ *  return value will be a positive value in all cases. If
+ *  everything else fails, it will fall back to 0.
+ */
+double plugin_get_start_time(void);
 
 /*
  * Context-aware thread management.


### PR DESCRIPTION
Added the new setting _StartRead_, which specifies when the first read of each read plugin is performed. This allows the acquisition of metrics at specific times, e.g. at round points in time. It also allows staggered reading (even within a second) to prevent measurements from affecting each other.

The value is a float in seconds and interpreted as minutes, seconds and milliseconds of an hour, e.g. _StartRead 301.42_ performs the first read in minute 5, second 1 and millisecond 420 within the current hour. If the time has already passed, an initial read time in the future is determined by adding as many times _Interval_ as necessary.

The global value can be overwritten on a per-plugin base.

ChangeLog: New setting to specify the time of the first read for read plugins