### PR TITLE
Fix libtokyotyrant handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5399,7 +5399,7 @@ AC_ARG_WITH([libtokyotyrant],
       with_libtokyotyrant="$withval"
     else
       with_libtokyotyrant_cppflags="-I$withval/include"
-      with_libtokyotyrant_ldflags="-L$withval/include"
+      with_libtokyotyrant_ldflags="-L$withval/lib"
       with_libtokyotyrant_libs="-ltokyotyrant"
       with_libtokyotyrant="yes"
     fi


### PR DESCRIPTION
In libtokyotyrant handling, set `with_libtokyotyrant_ldflags` to `"-L$withval/lib"`, not `"-L$withval/include"`.