### PR TITLE
Expose meta_data_toc function in utils_cache.

### DIFF
--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -998,15 +998,16 @@ static meta_data_t *uc_get_meta(const value_list_t *vl) /* {{{ */
     pthread_mutex_unlock(&cache_lock);                                         \
     return status;                                                             \
   }
-int uc_meta_data_exists(const value_list_t *vl,
-                        const char *key) UC_WRAP(meta_data_exists)
+int uc_meta_data_exists(const value_list_t *vl, const char *key)
+    UC_WRAP(meta_data_exists)
 
-    int uc_meta_data_delete(const value_list_t *vl,
-                            const char *key) UC_WRAP(meta_data_delete)
+        int uc_meta_data_delete(const value_list_t *vl, const char *key)
+            UC_WRAP(meta_data_delete)
 
-/* The second argument is called `toc` in the API, but the macro expects
- * `key`. */
-int uc_meta_data_toc(const value_list_t *vl, char ***key) UC_WRAP(meta_data_toc)
+    /* The second argument is called `toc` in the API, but the macro expects
+     * `key`. */
+    int uc_meta_data_toc(const value_list_t *vl,
+                         char ***key) UC_WRAP(meta_data_toc)
 
 #undef UC_WRAP
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -1003,6 +1003,11 @@ int uc_meta_data_exists(const value_list_t *vl,
 
     int uc_meta_data_delete(const value_list_t *vl,
                             const char *key) UC_WRAP(meta_data_delete)
+
+/* The second argument is called `toc` in the API, but the macro expects
+ * `key`. */
+int uc_meta_data_toc(const value_list_t *vl, char ***key) UC_WRAP(meta_data_toc)
+
 #undef UC_WRAP
 
 /* We need a new version of this macro because the following functions take

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -118,6 +118,8 @@ int uc_iterator_get_meta(uc_iter_t *iter, meta_data_t **ret_meta);
  */
 int uc_meta_data_exists(const value_list_t *vl, const char *key);
 int uc_meta_data_delete(const value_list_t *vl, const char *key);
+/* Same API as meta_data_toc. */
+int uc_meta_data_toc(const value_list_t *vl, char ***toc);
 
 int uc_meta_data_add_string(const value_list_t *vl, const char *key,
                             const char *value);


### PR DESCRIPTION
This is useful for traversing all the meta data elements in a value list, since there is no element to look up the metadata object.

For sample usage, see Stackdriver#166

ChangeLog: internal API change.