### PR TITLE
Restrict use of sys/systl to BSD variants in alignment with gclib deprecation on Linux

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -58,7 +58,7 @@
 #include <sys/sysinfo.h>
 #endif /* HAVE_LIBKSTAT */
 
-#if defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)
+#if (defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
 /* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
@@ -79,13 +79,13 @@
 #endif /* HAVE_SYS_DKSTAT_H */
 
 #define CAN_USE_SYSCTL 0
-#if defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)
+#if (defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
 /* Implies BSD variant */
 #if defined(CTL_HW) && defined(HW_NCPU) && defined(CTL_KERN) &&                \
     defined(KERN_CPTIME) && defined(CPUSTATES)
 #define CAN_USE_SYSCTL 1
 #endif
-#endif /* HAVE_SYSCTL_H && HAVE_SYSCTLBYNAME */
+#endif /* HAVE_SYSCTL_H && HAVE_SYSCTLBYNAME || __OpenBSD__ */
 
 #define COLLECTD_CPU_STATE_USER 0
 #define COLLECTD_CPU_STATE_SYSTEM 1
@@ -143,7 +143,7 @@ static int numcpu;
 /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
-/* Only possible for BSD variant */
+/* Only possible for (Open) BSD variant */
 static int numcpu;
 /* #endif CAN_USE_SYSCTL */
 
@@ -269,7 +269,7 @@ static int init(void) {
       /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
-  /* Only on BSD variant */
+  /* Only on (Open) BSD variant */
   size_t numcpu_size;
   int mib[2] = {CTL_HW, HW_NCPU};
   int status;
@@ -733,7 +733,7 @@ static int cpu_read(void) {
     /* }}} #endif defined(HAVE_LIBKSTAT) */
 
 #elif CAN_USE_SYSCTL /* {{{ */
-  /* Only on BSD variant */
+  /* Only on (Open) BSD variant */
   uint64_t cpuinfo[numcpu][CPUSTATES];
   size_t cpuinfo_size;
   int status;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -58,15 +58,14 @@
 #include <sys/sysinfo.h>
 #endif /* HAVE_LIBKSTAT */
 
-#if (defined(HAVE_SYSCTL) && HAVE_SYSCTL) ||                                   \
-    (defined(HAVE_SYSCTLBYNAME) && HAVE_SYSCTLBYNAME)
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 
 #ifdef HAVE_SYS_DKSTAT_H
+/* implies BSD variant */
 #include <sys/dkstat.h>
-#endif
 
 #if !defined(CP_USER) || !defined(CP_NICE) || !defined(CP_SYS) ||              \
     !defined(CP_INTR) || !defined(CP_IDLE) || !defined(CPUSTATES)
@@ -77,18 +76,16 @@
 #define CP_IDLE 4
 #define CPUSTATES 5
 #endif
-#endif /* HAVE_SYSCTL || HAVE_SYSCTLBYNAME */
+#endif /* HAVE_SYS_DKSTAT_H */
 
-#if HAVE_SYSCTL
+#define CAN_USE_SYSCTL 0
+#if defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)
+/* Implies BSD variant */
 #if defined(CTL_HW) && defined(HW_NCPU) && defined(CTL_KERN) &&                \
     defined(KERN_CPTIME) && defined(CPUSTATES)
 #define CAN_USE_SYSCTL 1
-#else
-#define CAN_USE_SYSCTL 0
 #endif
-#else
-#define CAN_USE_SYSCTL 0
-#endif
+#endif /* HAVE_SYSCTL_H && HAVE_SYSCTLBYNAME */
 
 #define COLLECTD_CPU_STATE_USER 0
 #define COLLECTD_CPU_STATE_SYSTEM 1
@@ -146,10 +143,12 @@ static int numcpu;
 /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
+/* Only possible for BSD variant */
 static int numcpu;
 /* #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME)
+/* Implies BSD variant */
 static int numcpu;
 #ifdef HAVE_SYSCTL_KERN_CP_TIMES
 static int maxcpu;
@@ -270,6 +269,7 @@ static int init(void) {
       /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
+  /* Only on BSD variant */
   size_t numcpu_size;
   int mib[2] = {CTL_HW, HW_NCPU};
   int status;
@@ -285,6 +285,7 @@ static int init(void) {
     /* #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME)
+  /* Only on BSD varient */
   size_t numcpu_size;
 
   numcpu_size = sizeof(numcpu);
@@ -732,6 +733,7 @@ static int cpu_read(void) {
     /* }}} #endif defined(HAVE_LIBKSTAT) */
 
 #elif CAN_USE_SYSCTL /* {{{ */
+  /* Only on BSD variant */
   uint64_t cpuinfo[numcpu][CPUSTATES];
   size_t cpuinfo_size;
   int status;
@@ -790,6 +792,7 @@ static int cpu_read(void) {
 
 #elif defined(HAVE_SYSCTLBYNAME) && defined(HAVE_SYSCTL_KERN_CP_TIMES) /* {{{  \
                                                                         */
+  /* Only on BSD variant */
   long cpuinfo[maxcpu][CPUSTATES];
   size_t cpuinfo_size;
 
@@ -812,6 +815,7 @@ static int cpu_read(void) {
     /* }}} #endif HAVE_SYSCTL_KERN_CP_TIMES */
 
 #elif defined(HAVE_SYSCTLBYNAME) /* {{{ */
+  /* Only on BSD variant */
   long cpuinfo[CPUSTATES];
   size_t cpuinfo_size;
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,7 +28,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
 /* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
@@ -81,10 +81,10 @@ static kstat_t *ksp;
 static kstat_t *ksz;
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
-/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
+#elif HAVE_SYSCTL && __OpenBSD__
+/* OpenBSD variant does not have sysctlbyname */ 
 static int pagesize;
-/* #endif HAVE_SYSCTL && HAVE_SYSCTLBYNAME */
+/* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
 /* no global variables */
@@ -144,14 +144,14 @@ static int memory_init(void) {
 
     /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
-/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
+#elif HAVE_SYSCTL && __OpenBSD__
+/* OpenBSD variant does not have sysctlbyname */ 
   pagesize = getpagesize();
   if (pagesize <= 0) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
     return -1;
   }
-    /* #endif HAVE_SYSCTL */
+    /* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
 /* no init stuff */
@@ -411,8 +411,8 @@ static int memory_read_internal(value_list_t *vl) {
                 (gauge_t)arcsize, "unusable", (gauge_t)mem_unus);
   /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
-/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
+#elif HAVE_SYSCTL && __OpenBSD__
+/* OpenBSD variant does not have HAVE_SYSCTLBYNAME */ 
   int mib[] = {CTL_VM, VM_METER};
   struct vmtotal vmtotal = {0};
   gauge_t mem_active;
@@ -434,7 +434,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   MEMORY_SUBMIT("active", mem_active, "inactive", mem_inactive, "free",
                 mem_free);
-  /* #endif HAVE_SYSCTL */
+  /* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
   sg_mem_stats *ios;

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,7 +28,8 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) ||              \
+    defined(__OpenBSD__)
 /* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
@@ -82,7 +83,7 @@ static kstat_t *ksz;
 /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYSCTL && __OpenBSD__
-/* OpenBSD variant does not have sysctlbyname */ 
+/* OpenBSD variant does not have sysctlbyname */
 static int pagesize;
 /* #endif HAVE_SYSCTL && __OpenBSD__ */
 
@@ -145,7 +146,7 @@ static int memory_init(void) {
     /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYSCTL && __OpenBSD__
-/* OpenBSD variant does not have sysctlbyname */ 
+  /* OpenBSD variant does not have sysctlbyname */
   pagesize = getpagesize();
   if (pagesize <= 0) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
@@ -412,7 +413,7 @@ static int memory_read_internal(value_list_t *vl) {
   /* #endif HAVE_LIBKSTAT */
 
 #elif HAVE_SYSCTL && __OpenBSD__
-/* OpenBSD variant does not have HAVE_SYSCTLBYNAME */ 
+  /* OpenBSD variant does not have HAVE_SYSCTLBYNAME */
   int mib[] = {CTL_VM, VM_METER};
   struct vmtotal vmtotal = {0};
   gauge_t mem_active;

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,7 +28,8 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 #ifdef HAVE_SYS_VMMETER_H
@@ -80,9 +81,10 @@ static kstat_t *ksp;
 static kstat_t *ksz;
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
+/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
 static int pagesize;
-/* #endif HAVE_SYSCTL */
+/* #endif HAVE_SYSCTL && HAVE_SYSCTLBYNAME */
 
 #elif HAVE_LIBSTATGRAB
 /* no global variables */
@@ -142,7 +144,8 @@ static int memory_init(void) {
 
     /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
+/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
   pagesize = getpagesize();
   if (pagesize <= 0) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
@@ -408,7 +411,8 @@ static int memory_read_internal(value_list_t *vl) {
                 (gauge_t)arcsize, "unusable", (gauge_t)mem_unus);
   /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && HAVE_SYSCTLBYNAME
+/* force BSD variant take HAVE_SYSCTLBYNAME conditional path above */ 
   int mib[] = {CTL_VM, VM_METER};
   struct vmtotal vmtotal = {0};
   gauge_t mem_active;

--- a/src/swap.c
+++ b/src/swap.c
@@ -49,7 +49,8 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) ||              \
+    defined(__OpenBSD__)
 /* implies BSD variant */
 #include <sys/sysctl.h>
 #endif

--- a/src/swap.c
+++ b/src/swap.c
@@ -49,7 +49,8 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+/* implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 #if HAVE_SYS_DKSTAT_H

--- a/src/swap.c
+++ b/src/swap.c
@@ -49,7 +49,7 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
 /* implies BSD variant */
 #include <sys/sysctl.h>
 #endif

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -29,7 +29,8 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME) || defined(__OpenBSD__)
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME) ||                \
+    defined(__OpenBSD__)
 /* Implies have BSD variant */
 #include <sys/sysctl.h>
 #endif

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -29,7 +29,8 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+/* Implies have BSD variant */
 #include <sys/sysctl.h>
 #endif
 

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -29,7 +29,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME) || defined(__OpenBSD__)
 /* Implies have BSD variant */
 #include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
Changelog: Contain use of sysctl / sysctrlbyname to BSD variants, as deprecated on Linux

With pending deprecation warning of gclib sys/sysctl.h and associated functions, refactor code that used sysctl so it constrains use to BSD variants.

As per analysis in of @kraj PR: https://github.com/collectd/collectd/pull/3234

The sysctl & sysctlbyname (declared in sys/sysctl.h) are BSD based functions, available in: FreeBSD, NetBSD and macOS. OpenBSD appears to be exception as it only has sysctl and no sysctlbyname declared.

Refactored code: cpu.c, memory.c, swap.c & uuid.

Changes have maintained existing precedence of use between sysctl / sysctrlbyname

Logic is based on:

HAVE_SYSCTL && HAVE_SYSCTLBYNAME == most BSDs or
__OpenBSD__ == OpenBSD which does not have sysctlbyname

TESTING:

Operationally tested on Linux (Ubuntu 19.10)

Build tested on FreeBSD 11.3

OUTSTANDING:

Need to look at detail of metrics collected to see if there are being returned ok

EDIT - Validated cpu, memory, swap on Linux (Ubuntu), metrics being collected and reported.

Looking to close issue: https://github.com/collectd/collectd/issues/3338
Follows up on this PR, without changing configure system: https://github.com/collectd/collectd/pull/3234