### PR TITLE
Fix linking with Python 3.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4711,7 +4711,7 @@ if test "$PYTHON_CONFIG" != ""; then
   if test $? -ne 0; then
     with_libpython="no"
   fi
-  LIBPYTHON_LDFLAGS="`${PYTHON_CONFIG} --ldflags`"
+  LIBPYTHON_LDFLAGS="`${PYTHON_CONFIG} --ldflags --embed`" || LIBPYTHON_LDFLAGS="`${PYTHON_CONFIG} --ldflags`"
   if test $? -ne 0; then
     with_libpython="no"
   fi


### PR DESCRIPTION
Since Python 3.8 --embed flag needs to be provided to python-config to embed python.
Reference: https://bugs.python.org/issue36721

This was partially addressed in #3170 but only fixed building and not linking with python.

ChangeLog: Fix linking with Python 3.8