### PR TITLE
Leak fixes

### DIFF
--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -572,8 +572,10 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("Format", child->key) == 0) {
       char *key = NULL;
       status = cf_util_get_string(child, &key);
-      if (status != 0)
+      if (status != 0) {
+        amqp1_config_instance_free(instance);
         return status;
+      }
       assert(key != NULL);
       if (strcasecmp(key, "Command") == 0) {
         instance->format = AMQP1_FORMAT_COMMAND;
@@ -627,12 +629,14 @@ static int amqp1_config_instance(oconfig_item_t *ci) /* {{{ */
     status = ssnprintf(tpname, sizeof(tpname), "amqp1/%s", instance->name);
     if ((status < 0) || (size_t)status >= sizeof(tpname)) {
       ERROR("amqp1 plugin: Instance name would have been truncated.");
+      amqp1_config_instance_free(instance);
       return -1;
     }
     status = ssnprintf(instance->send_to, sizeof(instance->send_to), "/%s/%s",
                        transport->address, instance->name);
     if ((status < 0) || (size_t)status >= sizeof(instance->send_to)) {
       ERROR("amqp1 plugin: send_to address would have been truncated.");
+      amqp1_config_instance_free(instance);
       return -1;
     }
     if (instance->notify) {

--- a/src/network.c
+++ b/src/network.c
@@ -2762,6 +2762,7 @@ network_config_set_bind_address(const oconfig_item_t *ci,
   *bind_address = malloc(sizeof(**bind_address));
   if (*bind_address == NULL) {
     ERROR("network plugin: network_config_set_bind_address: malloc failed.");
+    freeaddrinfo(res);
     return -1;
   }
   (*bind_address)->ss_family = res->ai_family;


### PR DESCRIPTION
Fix a few memory leaks on error paths in the amqp1 plugin and one in the network code.


ChangeLog: network: Fix memory leak.
ChangeLog: amqp1 plugin: Fix leaks on error paths.

