### PR TITLE
Remove grpc from Mac builds for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,6 @@ addons:
     packages:
     - curl
     - glib
-    - grpc
     - hiredis
     - libdbi
     - libmemcached


### PR DESCRIPTION
This disables the grpc plugin on OSX in order to avoid CI issues shown in https://github.com/collectd/collectd/pull/3350