### PR TITLE
Revert "Remove grpc from Mac builds for now"

### DIFF
--- a/docs/maintainer_guide.md
+++ b/docs/maintainer_guide.md
@@ -24,14 +24,3 @@ using your commit rights to merge the pull request.
 
 You have write access to the *collectd/collectd* repository. Please use it
 responsibly.
-
-#### Own work
-
-Open *pull requests* for your own changes, too:
-
-*   For simple changes it's okay to self-approve and merge after a
-    successful build on the CI systems.
-*   Trivial changes, cherry-picks from *master* and roll-up merges are
-    excempt and may be pushed to the version branches and *master* directly.
-*   "Simple" and "trivial" are not further defined; use your best judgement.
-    We'll revisit this if and when it becomes necessary.


### PR DESCRIPTION
This reverts commit e95e850a1688e6bee4ee87b27f92f2a4ffaf7a91.

This reverts https://github.com/collectd/collectd/pull/3353 which was done in attempt to fix https://travis-ci.org/collectd/collectd/jobs/625893485 seen in https://github.com/collectd/collectd/pull/3350