### PR TITLE
Factor out read_text_file_contents to ensure that data read from text files is a valid C string.

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -349,11 +349,9 @@ static int sysfs_file_to_buffer(char const *dir, /* {{{ */
 
   snprintf(filename, sizeof(filename), "%s/%s/%s", dir, power_supply, basename);
 
-  status = (int)read_file_contents(filename, buffer, buffer_size - 1);
+  status = (int)read_text_file_contents(filename, buffer, buffer_size);
   if (status < 0)
     return status;
-
-  buffer[status] = '\0';
 
   strstripnewline(buffer);
   return 0;

--- a/src/processes.c
+++ b/src/processes.c
@@ -1316,11 +1316,10 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   snprintf(filename, sizeof(filename), "/proc/%li/stat", pid);
 
-  status = read_file_contents(filename, buffer, sizeof(buffer) - 1);
+  status = read_text_file_contents(filename, buffer, sizeof(buffer));
   if (status <= 0)
     return -1;
   buffer_len = (size_t)status;
-  buffer[buffer_len] = 0;
 
   /* The name of the process is enclosed in parens. Since the name can
    * contain parens itself, spaces, numbers and pretty much everything
@@ -1569,7 +1568,7 @@ static char *ps_get_cmdline(long pid,
 
   snprintf(path, sizeof(path), "/proc/%li/psinfo", pid);
 
-  status = read_file_contents(path, (void *)&info, sizeof(info));
+  status = read_file_contents(path, &info, sizeof(info));
   if ((status < 0) || (((size_t)status) != sizeof(info))) {
     ERROR("processes plugin: Unexpected return value "
           "while reading \"%s\": "

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -103,7 +103,7 @@ static int thermal_procfs_device_read(const char __attribute__((unused)) * dir,
   if ((len < 0) || ((size_t)len >= sizeof(filename)))
     return -1;
 
-  len = (ssize_t)read_file_contents(filename, data, sizeof(data));
+  len = (ssize_t)read_text_file_contents(filename, data, sizeof(data));
   if ((len > 0) && ((size_t)len > sizeof(str_temp)) && (data[--len] == '\n') &&
       (!strncmp(data, str_temp, sizeof(str_temp) - 1))) {
     char *endptr = NULL;

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -1263,7 +1263,7 @@ int walk_directory(const char *dir, dirwalk_callback_f callback,
   return 0;
 }
 
-ssize_t read_file_contents(const char *filename, char *buf, size_t bufsize) {
+ssize_t read_file_contents(const char *filename, void *buf, size_t bufsize) {
   FILE *fh;
   ssize_t ret;
 
@@ -1279,6 +1279,16 @@ ssize_t read_file_contents(const char *filename, char *buf, size_t bufsize) {
 
   fclose(fh);
   return ret;
+}
+
+ssize_t read_text_file_contents(const char *filename, char *buf,
+                                size_t bufsize) {
+  ssize_t ret = read_file_contents(filename, buf, bufsize - 1);
+  if (ret < 0)
+    return ret;
+
+  buf[ret] = '\0';
+  return ret + 1;
 }
 
 counter_t counter_diff(counter_t old_value, counter_t new_value) {

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -356,7 +356,11 @@ typedef int (*dirwalk_callback_f)(const char *dirname, const char *filename,
 int walk_directory(const char *dir, dirwalk_callback_f callback,
                    void *user_data, int hidden);
 /* Returns the number of bytes read or negative on error. */
-ssize_t read_file_contents(char const *filename, char *buf, size_t bufsize);
+ssize_t read_file_contents(char const *filename, void *buf, size_t bufsize);
+/* Writes the contents of the file into the buffer with a trailing NUL.
+ * Returns the number of bytes written to the buffer or negative on error. */
+ssize_t read_text_file_contents(char const *filename, char *buf,
+                                size_t bufsize);
 
 counter_t counter_diff(counter_t old_value, counter_t new_value);
 


### PR DESCRIPTION
Also fixes a potential unterminated string in `thermal_procfs_device_read`.

ChangeLog: collectd: Factored out read_text_file_contents for reading text files

 and used it to fix a potential unterminated string in the `thermal` plugin.

/cc @jkohen 

[edit @mrunge]: Broke the ChangeLog line, since CI fails on long changelog lines.