### PR TITLE
Support for Varnish 6 and remove Varnish 2, 3 and 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5908,23 +5908,13 @@ if test "x$with_libvarnish" = "xyes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
 
-  $PKG_CONFIG --atleast-version=5.2 'varnishapi' 2>/dev/null
+  $PKG_CONFIG --atleast-version=6 'varnishapi' 2>/dev/null
   if test $? -eq 0; then
-    AC_DEFINE([HAVE_VARNISH_V5], [1], [Varnish 5 API support])
+    AC_DEFINE([HAVE_VARNISH_V6], [1], [Varnish 6 API support])
   else
     AC_CHECK_HEADERS([vapi/vsc.h],
       [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
-      [
-        AC_CHECK_HEADERS([vsc.h],
-          [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
-          [
-            AC_CHECK_HEADERS([varnishapi.h],
-              [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
-              [with_libvarnish="no (found none of the varnish header files)"]
-            )
-          ]
-        )
-      ]
+      [with_libvarnish="no (found none of the varnish header files)"]
     )
   fi
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1691,6 +1691,7 @@
 #      CollectSMF false
 #      CollectVBE false
 #      CollectMSE false           # Varnish-Plus only
+#      CollectGOTO false           # Varnish-Plus 6 only
 #   </Instance>
 #</Plugin>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1668,32 +1668,29 @@
 #   so by using <Instance "myinstance">
 #   <Instance>
 #      CollectBackend true
-#      CollectBan false           # Varnish 3 and above
+#      CollectBan false
 #      CollectCache true
 #      CollectConnections true
-#      CollectDirectorDNS false   # Varnish 3 only
 #      CollectESI false
 #      CollectFetch false
 #      CollectHCB false
 #      CollectObjects false
-#      CollectPurge false         # Varnish 2 only
 #      CollectSession false
 #      CollectSHM true
-#      CollectSMA false           # Varnish 2 & 4 only
+#      CollectSMA false
 #      CollectSMS false
-#      CollectSM false            # Varnish 2 only
 #      CollectStruct false
 #      CollectTotals false
-#      CollectUptime false        # Varnish 3 and above
+#      CollectUptime false
 #      CollectVCL false
 #      CollectVSM false           # Varnish 4 only
 #      CollectWorkers false
-#      CollectLock false          # Varnish 4 only
-#      CollectMempool false       # Varnish 4 only
-#      CollectManagement false    # Varnish 4 only
-#      CollectSMF false           # Varnish 4 only
-#      CollectVBE false           # Varnish 4 only
-#      CollectMSE false           # Varnish-Plus 4 only
+#      CollectLock false
+#      CollectMempool false
+#      CollectManagement false
+#      CollectSMF false
+#      CollectVBE false
+#      CollectMSE false           # Varnish-Plus only
 #   </Instance>
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9390,6 +9390,10 @@ Varnish, replacing the traditional malloc and file storages. Only available
 with Varnish-Plus 4.x. Note: SMA, SMF and MSE share counters, enable only the
 one used by the Varnish instance. False by default.
 
+=item B<CollectGOTO> B<true>|B<false>
+
+vmod-goto counters. Only available with Varnish Plus 6.x. False by default.
+
 =back
 
 =head2 Plugin C<virt>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9227,7 +9227,6 @@ Synopsis:
      CollectBan         false
      CollectCache       true
      CollectConnections true
-     CollectDirectorDNS false
      CollectESI         false
      CollectFetch       false
      CollectHCB         false
@@ -9237,7 +9236,6 @@ Synopsis:
      CollectSHM         true
      CollectSMA         false
      CollectSMS         false
-     CollectSM          false
      CollectStruct      false
      CollectTotals      false
      CollectUptime      false
@@ -9280,11 +9278,6 @@ Cache hits and misses. True by default.
 =item B<CollectConnections> B<true>|B<false>
 
 Number of client connections received, accepted and dropped. True by default.
-
-=item B<CollectDirectorDNS> B<true>|B<false>
-
-DNS director lookup cache statistics. Only available with Varnish 3.x. False by
-default.
 
 =item B<CollectESI> B<true>|B<false>
 

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -765,22 +765,22 @@ static int varnish_monitor(void *priv,
 #if HAVE_VARNISH_V6
     else if (strcmp(name, "n_lru_nuked") == 0)
       return varnish_submit_derive(conf->instance, category, "total_objects",
-                                  "lru_nuked", val);
+                                   "lru_nuked", val);
     else if (strcmp(name, "n_lru_moved") == 0)
       return varnish_submit_derive(conf->instance, category, "total_objects",
-                                  "lru_moved", val);
+                                   "lru_moved", val);
     else if (strcmp(name, "n_vary") == 0)
       return varnish_submit_derive(conf->instance, category, "total_objects",
-                                  "vary_headers", val);
+                                   "vary_headers", val);
     else if (strcmp(name, "c_memcache_hit") == 0)
       return varnish_submit_derive(conf->instance, category, "total_operations",
-                                  "memcache_hit", val);
+                                   "memcache_hit", val);
     else if (strcmp(name, "c_memcache_miss") == 0)
       return varnish_submit_derive(conf->instance, category, "total_operations",
-                                  "memcache_miss", val);
+                                   "memcache_miss", val);
     else if (strcmp(name, "g_ykey_keys") == 0)
-      return varnish_submit_gauge(conf->instance, category, "objects",
-                                  "ykey", val);
+      return varnish_submit_gauge(conf->instance, category, "objects", "ykey",
+                                  val);
 #endif
   }
 

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -29,22 +29,9 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
 #include <vapi/vsc.h>
 #include <vapi/vsm.h>
 typedef struct VSC_C_main c_varnish_stats_t;
-#endif
-
-#if HAVE_VARNISH_V3
-#include <varnishapi.h>
-#include <vsc.h>
-typedef struct VSC_C_main c_varnish_stats_t;
-#endif
-
-#if HAVE_VARNISH_V2
-#include <varnishapi.h>
-typedef struct varnish_stats c_varnish_stats_t;
-#endif
 
 /* {{{ user_config_s */
 struct user_config_s {
@@ -54,34 +41,19 @@ struct user_config_s {
   bool collect_connections;
   bool collect_esi;
   bool collect_backend;
-#ifdef HAVE_VARNISH_V3
-  bool collect_dirdns;
-#endif
   bool collect_fetch;
   bool collect_hcb;
   bool collect_objects;
-#if HAVE_VARNISH_V2
-  bool collect_purge;
-#else
   bool collect_ban;
-#endif
   bool collect_session;
   bool collect_shm;
   bool collect_sms;
-#if HAVE_VARNISH_V2
-  bool collect_sm;
-#endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   bool collect_sma;
-#endif
   bool collect_struct;
   bool collect_totals;
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   bool collect_uptime;
-#endif
   bool collect_vcl;
   bool collect_workers;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   bool collect_vsm;
   bool collect_lck;
   bool collect_mempool;
@@ -89,7 +61,6 @@ struct user_config_s {
   bool collect_smf;
   bool collect_vbe;
   bool collect_mse;
-#endif
 };
 typedef struct user_config_s user_config_t; /* }}} */
 
@@ -138,7 +109,6 @@ static int varnish_submit_derive(const char *plugin_instance, /* {{{ */
                         });
 } /* }}} int varnish_submit_derive */
 
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
 static int varnish_monitor(void *priv,
                            const struct VSC_point *const pt) /* {{{ */
 {
@@ -151,7 +121,7 @@ static int varnish_monitor(void *priv,
 
   conf = priv;
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V6
   char namebuff[DATA_MAX_NAME_LEN];
 
   char const *c = strrchr(pt->name, '.');
@@ -166,11 +136,6 @@ static int varnish_monitor(void *priv,
     return 0;
 
   name = pt->desc->name;
-#elif HAVE_VARNISH_V3
-  if (strcmp(pt->class, "") != 0)
-    return 0;
-
-  name = pt->name;
 #endif
 
   val = *(const volatile uint64_t *)pt->ptr;
@@ -185,6 +150,14 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "cache_hitpass") == 0)
       return varnish_submit_derive(conf->instance, "cache", "cache_result",
                                    "hitpass", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "cache_hit_grace") == 0)
+      return varnish_submit_derive(conf->instance, "cache", "cache_result",
+                                   "hit_grace", val);
+    else if (strcmp(name, "cache_hitmiss") == 0)
+      return varnish_submit_derive(conf->instance, "cache", "cache_result",
+                                   "hitmiss", val);
+#endif
   }
 
   if (conf->collect_connections) {
@@ -197,32 +170,13 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "client_req") == 0)
       return varnish_submit_derive(conf->instance, "connections", "connections",
                                    "received", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "client_req_400") == 0)
       return varnish_submit_derive(conf->instance, "connections", "connections",
                                    "error_400", val);
     else if (strcmp(name, "client_req_417") == 0)
       return varnish_submit_derive(conf->instance, "connections", "connections",
                                    "error_417", val);
-#endif
   }
-
-#ifdef HAVE_VARNISH_V3
-  if (conf->collect_dirdns) {
-    if (strcmp(name, "dir_dns_lookups") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns", "cache_operation",
-                                   "lookups", val);
-    else if (strcmp(name, "dir_dns_failed") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns", "cache_result",
-                                   "failed", val);
-    else if (strcmp(name, "dir_dns_hit") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns", "cache_result",
-                                   "hits", val);
-    else if (strcmp(name, "dir_dns_cache_full") == 0)
-      return varnish_submit_derive(conf->instance, "dirdns", "cache_result",
-                                   "cache_full", val);
-  }
-#endif
 
   if (conf->collect_esi) {
     if (strcmp(name, "esi_errors") == 0)
@@ -312,7 +266,6 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "fetch_304") == 0)
       return varnish_submit_derive(conf->instance, "fetch", "http_requests",
                                    "no_body_304", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "fetch_no_thread") == 0)
       return varnish_submit_derive(conf->instance, "fetch", "http_requests",
                                    "no_thread", val);
@@ -325,7 +278,6 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "busy_wakeup") == 0)
       return varnish_submit_derive(conf->instance, "fetch", "http_requests",
                                    "busy_wakeup", val);
-#endif
   }
 
   if (conf->collect_hcb) {
@@ -353,6 +305,11 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_lru_moved") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "lru_moved", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "n_lru_limited") == 0)
+      return varnish_submit_derive(conf->instance, "objects", "total_objects",
+                                   "lru_limited", val);
+#endif
     else if (strcmp(name, "n_deathrow") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "deathrow", val);
@@ -371,39 +328,14 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_objoverflow") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "workspace_overflow", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "exp_mailed") == 0)
       return varnish_submit_gauge(conf->instance, "struct", "objects",
                                   "exp_mailed", val);
     else if (strcmp(name, "exp_received") == 0)
       return varnish_submit_gauge(conf->instance, "struct", "objects",
                                   "exp_received", val);
-#endif
   }
 
-#if HAVE_VARNISH_V3
-  if (conf->collect_ban) {
-    if (strcmp(name, "n_ban") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "total", val);
-    else if (strcmp(name, "n_ban_add") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "added", val);
-    else if (strcmp(name, "n_ban_retire") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "deleted", val);
-    else if (strcmp(name, "n_ban_obj_test") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "objects_tested", val);
-    else if (strcmp(name, "n_ban_re_test") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "regexps_tested", val);
-    else if (strcmp(name, "n_ban_dups") == 0)
-      return varnish_submit_derive(conf->instance, "ban", "total_operations",
-                                   "duplicate", val);
-  }
-#endif
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   if (conf->collect_ban) {
     if (strcmp(name, "bans") == 0)
       return varnish_submit_derive(conf->instance, "ban", "total_operations",
@@ -457,7 +389,6 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "ban", "total_operations",
                                    "tests_tested", val);
   }
-#endif
 
   if (conf->collect_session) {
     if (strcmp(name, "sess_closed") == 0)
@@ -478,6 +409,26 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "sess_fail") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "failed", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "sess_fail_econnaborted") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_econnaborted", val);
+    else if (strcmp(name, "sess_fail_eintr") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                  "total_operations", "failed_eintr", val);
+    else if (strcmp(name, "sess_fail_emfile") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                  "total_operations", "failed_emfile", val);
+    else if (strcmp(name, "sess_fail_ebadf") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                  "total_operations", "failedi_ebadf", val);
+    else if (strcmp(name, "sess_fail_enomem") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                  "total_operations", "failed_enomem", val);
+    else if (strcmp(name, "sess_fail_other") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_other", val);
+#endif
     else if (strcmp(name, "sess_pipe_overflow") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "overflow", val);
@@ -490,7 +441,6 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "sess_herd") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "herd", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "sess_closed_err") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "closed_err", val);
@@ -498,7 +448,6 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "dropped_for_thread",
                                    val);
-#endif
   }
 
   if (conf->collect_shm) {
@@ -703,17 +652,14 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_wrk_lqueue") == 0)
       return varnish_submit_derive(conf->instance, "workers", "total_requests",
                                    "queue_length", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "pools") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "pools", "pools",
                                   val);
     else if (strcmp(name, "busy_killed") == 0)
       return varnish_submit_derive(conf->instance, "workers", "http_requests",
                                    "busy_killed", val);
-#endif
   }
 
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   if (conf->collect_vsm) {
     if (strcmp(name, "vsm_free") == 0)
       return varnish_submit_gauge(conf->instance, "vsm", "bytes", "free", val);
@@ -982,358 +928,18 @@ static int varnish_monitor(void *priv,
                                    "total_operations", "sniped_objects", val);
   }
 
-#endif
 
   return 0;
 
 } /* }}} static int varnish_monitor */
-#else /* if HAVE_VARNISH_V2 */
-static void varnish_monitor(const user_config_t *conf, /* {{{ */
-                            const c_varnish_stats_t *stats) {
-  if (conf->collect_cache) {
-    /* Cache hits */
-    varnish_submit_derive(conf->instance, "cache", "cache_result", "hit",
-                          stats->cache_hit);
-    /* Cache misses */
-    varnish_submit_derive(conf->instance, "cache", "cache_result", "miss",
-                          stats->cache_miss);
-    /* Cache hits for pass */
-    varnish_submit_derive(conf->instance, "cache", "cache_result", "hitpass",
-                          stats->cache_hitpass);
-  }
 
-  if (conf->collect_connections) {
-    /* Client connections accepted */
-    varnish_submit_derive(conf->instance, "connections", "connections",
-                          "accepted", stats->client_conn);
-    /* Connection dropped, no sess */
-    varnish_submit_derive(conf->instance, "connections", "connections",
-                          "dropped", stats->client_drop);
-    /* Client requests received    */
-    varnish_submit_derive(conf->instance, "connections", "connections",
-                          "received", stats->client_req);
-  }
-
-  if (conf->collect_esi) {
-    /* ESI parse errors (unlock)   */
-    varnish_submit_derive(conf->instance, "esi", "total_operations", "error",
-                          stats->esi_errors);
-    /* Objects ESI parsed (unlock) */
-    varnish_submit_derive(conf->instance, "esi", "total_operations", "parsed",
-                          stats->esi_parse);
-  }
-
-  if (conf->collect_backend) {
-    /* Backend conn. success       */
-    varnish_submit_derive(conf->instance, "backend", "connections", "success",
-                          stats->backend_conn);
-    /* Backend conn. not attempted */
-    varnish_submit_derive(conf->instance, "backend", "connections",
-                          "not-attempted", stats->backend_unhealthy);
-    /* Backend conn. too many      */
-    varnish_submit_derive(conf->instance, "backend", "connections", "too-many",
-                          stats->backend_busy);
-    /* Backend conn. failures      */
-    varnish_submit_derive(conf->instance, "backend", "connections", "failures",
-                          stats->backend_fail);
-    /* Backend conn. reuses        */
-    varnish_submit_derive(conf->instance, "backend", "connections", "reuses",
-                          stats->backend_reuse);
-    /* Backend conn. was closed    */
-    varnish_submit_derive(conf->instance, "backend", "connections",
-                          "was-closed", stats->backend_toolate);
-    /* Backend conn. recycles      */
-    varnish_submit_derive(conf->instance, "backend", "connections", "recycled",
-                          stats->backend_recycle);
-    /* Backend conn. unused        */
-    varnish_submit_derive(conf->instance, "backend", "connections", "unused",
-                          stats->backend_unused);
-    /* Backend requests mades      */
-    varnish_submit_derive(conf->instance, "backend", "http_requests",
-                          "requests", stats->backend_req);
-    /* N backends                  */
-    varnish_submit_gauge(conf->instance, "backend", "backends", "n_backends",
-                         stats->n_backend);
-  }
-
-  if (conf->collect_fetch) {
-    /* Fetch head                */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "head",
-                          stats->fetch_head);
-    /* Fetch with length         */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "length",
-                          stats->fetch_length);
-    /* Fetch chunked             */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "chunked",
-                          stats->fetch_chunked);
-    /* Fetch EOF                 */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "eof",
-                          stats->fetch_eof);
-    /* Fetch bad headers         */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests",
-                          "bad_headers", stats->fetch_bad);
-    /* Fetch wanted close        */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "close",
-                          stats->fetch_close);
-    /* Fetch pre HTTP/1.1 closed */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "oldhttp",
-                          stats->fetch_oldhttp);
-    /* Fetch zero len            */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "zero",
-                          stats->fetch_zero);
-    /* Fetch failed              */
-    varnish_submit_derive(conf->instance, "fetch", "http_requests", "failed",
-                          stats->fetch_failed);
-  }
-
-  if (conf->collect_hcb) {
-    /* HCB Lookups without lock */
-    varnish_submit_derive(conf->instance, "hcb", "cache_operation",
-                          "lookup_nolock", stats->hcb_nolock);
-    /* HCB Lookups with lock    */
-    varnish_submit_derive(conf->instance, "hcb", "cache_operation",
-                          "lookup_lock", stats->hcb_lock);
-    /* HCB Inserts              */
-    varnish_submit_derive(conf->instance, "hcb", "cache_operation", "insert",
-                          stats->hcb_insert);
-  }
-
-  if (conf->collect_objects) {
-    /* N expired objects             */
-    varnish_submit_derive(conf->instance, "objects", "total_objects", "expired",
-                          stats->n_expired);
-    /* N LRU nuked objects           */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "lru_nuked", stats->n_lru_nuked);
-    /* N LRU saved objects           */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "lru_saved", stats->n_lru_saved);
-    /* N LRU moved objects           */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "lru_moved", stats->n_lru_moved);
-    /* N objects on deathrow         */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "deathrow", stats->n_deathrow);
-    /* HTTP header overflows         */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "header_overflow", stats->losthdr);
-    /* Objects sent with sendfile    */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "sent_sendfile", stats->n_objsendfile);
-    /* Objects sent with write       */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "sent_write", stats->n_objwrite);
-    /* Objects overflowing workspace */
-    varnish_submit_derive(conf->instance, "objects", "total_objects",
-                          "workspace_overflow", stats->n_objoverflow);
-  }
-
-  if (conf->collect_purge) {
-    /* N total active purges      */
-    varnish_submit_derive(conf->instance, "purge", "total_operations", "total",
-                          stats->n_purge);
-    /* N new purges added         */
-    varnish_submit_derive(conf->instance, "purge", "total_operations", "added",
-                          stats->n_purge_add);
-    /* N old purges deleted       */
-    varnish_submit_derive(conf->instance, "purge", "total_operations",
-                          "deleted", stats->n_purge_retire);
-    /* N objects tested           */
-    varnish_submit_derive(conf->instance, "purge", "total_operations",
-                          "objects_tested", stats->n_purge_obj_test);
-    /* N regexps tested against   */
-    varnish_submit_derive(conf->instance, "purge", "total_operations",
-                          "regexps_tested", stats->n_purge_re_test);
-    /* N duplicate purges removed */
-    varnish_submit_derive(conf->instance, "purge", "total_operations",
-                          "duplicate", stats->n_purge_dups);
-  }
-
-  if (conf->collect_session) {
-    /* Session Closed     */
-    varnish_submit_derive(conf->instance, "session", "total_operations",
-                          "closed", stats->sess_closed);
-    /* Session Pipeline   */
-    varnish_submit_derive(conf->instance, "session", "total_operations",
-                          "pipeline", stats->sess_pipeline);
-    /* Session Read Ahead */
-    varnish_submit_derive(conf->instance, "session", "total_operations",
-                          "readahead", stats->sess_readahead);
-    /* Session Linger     */
-    varnish_submit_derive(conf->instance, "session", "total_operations",
-                          "linger", stats->sess_linger);
-    /* Session herd       */
-    varnish_submit_derive(conf->instance, "session", "total_operations", "herd",
-                          stats->sess_herd);
-  }
-
-  if (conf->collect_shm) {
-    /* SHM records                 */
-    varnish_submit_derive(conf->instance, "shm", "total_operations", "records",
-                          stats->shm_records);
-    /* SHM writes                  */
-    varnish_submit_derive(conf->instance, "shm", "total_operations", "writes",
-                          stats->shm_writes);
-    /* SHM flushes due to overflow */
-    varnish_submit_derive(conf->instance, "shm", "total_operations", "flushes",
-                          stats->shm_flushes);
-    /* SHM MTX contention          */
-    varnish_submit_derive(conf->instance, "shm", "total_operations",
-                          "contention", stats->shm_cont);
-    /* SHM cycles through buffer   */
-    varnish_submit_derive(conf->instance, "shm", "total_operations", "cycles",
-                          stats->shm_cycles);
-  }
-
-  if (conf->collect_sm) {
-    /* allocator requests */
-    varnish_submit_derive(conf->instance, "sm", "total_requests", "nreq",
-                          stats->sm_nreq);
-    /* outstanding allocations */
-    varnish_submit_gauge(conf->instance, "sm", "requests", "outstanding",
-                         stats->sm_nobj);
-    /* bytes allocated */
-    varnish_submit_derive(conf->instance, "sm", "total_bytes", "allocated",
-                          stats->sm_balloc);
-    /* bytes free */
-    varnish_submit_derive(conf->instance, "sm", "total_bytes", "free",
-                          stats->sm_bfree);
-  }
-
-  if (conf->collect_sma) {
-    /* SMA allocator requests */
-    varnish_submit_derive(conf->instance, "sma", "total_requests", "nreq",
-                          stats->sma_nreq);
-    /* SMA outstanding allocations */
-    varnish_submit_gauge(conf->instance, "sma", "requests", "outstanding",
-                         stats->sma_nobj);
-    /* SMA outstanding bytes */
-    varnish_submit_gauge(conf->instance, "sma", "bytes", "outstanding",
-                         stats->sma_nbytes);
-    /* SMA bytes allocated */
-    varnish_submit_derive(conf->instance, "sma", "total_bytes", "allocated",
-                          stats->sma_balloc);
-    /* SMA bytes free */
-    varnish_submit_derive(conf->instance, "sma", "total_bytes", "free",
-                          stats->sma_bfree);
-  }
-
-  if (conf->collect_sms) {
-    /* SMS allocator requests */
-    varnish_submit_derive(conf->instance, "sms", "total_requests", "allocator",
-                          stats->sms_nreq);
-    /* SMS outstanding allocations */
-    varnish_submit_gauge(conf->instance, "sms", "requests", "outstanding",
-                         stats->sms_nobj);
-    /* SMS outstanding bytes */
-    varnish_submit_gauge(conf->instance, "sms", "bytes", "outstanding",
-                         stats->sms_nbytes);
-    /* SMS bytes allocated */
-    varnish_submit_derive(conf->instance, "sms", "total_bytes", "allocated",
-                          stats->sms_balloc);
-    /* SMS bytes freed */
-    varnish_submit_derive(conf->instance, "sms", "total_bytes", "free",
-                          stats->sms_bfree);
-  }
-
-  if (conf->collect_struct) {
-    /* N struct sess_mem       */
-    varnish_submit_gauge(conf->instance, "struct", "current_sessions",
-                         "sess_mem", stats->n_sess_mem);
-    /* N struct sess           */
-    varnish_submit_gauge(conf->instance, "struct", "current_sessions", "sess",
-                         stats->n_sess);
-    /* N struct object         */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "object",
-                         stats->n_object);
-    /* N struct objecthead     */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "objecthead",
-                         stats->n_objecthead);
-    /* N struct smf            */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "smf",
-                         stats->n_smf);
-    /* N small free smf         */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "smf_frag",
-                         stats->n_smf_frag);
-    /* N large free smf         */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "smf_large",
-                         stats->n_smf_large);
-    /* N struct vbe_conn        */
-    varnish_submit_gauge(conf->instance, "struct", "objects", "vbe_conn",
-                         stats->n_vbe_conn);
-  }
-
-  if (conf->collect_totals) {
-    /* Total Sessions */
-    varnish_submit_derive(conf->instance, "totals", "total_sessions",
-                          "sessions", stats->s_sess);
-    /* Total Requests */
-    varnish_submit_derive(conf->instance, "totals", "total_requests",
-                          "requests", stats->s_req);
-    /* Total pipe */
-    varnish_submit_derive(conf->instance, "totals", "total_operations", "pipe",
-                          stats->s_pipe);
-    /* Total pass */
-    varnish_submit_derive(conf->instance, "totals", "total_operations", "pass",
-                          stats->s_pass);
-    /* Total fetch */
-    varnish_submit_derive(conf->instance, "totals", "total_operations",
-                          "fetches", stats->s_fetch);
-    /* Total header bytes */
-    varnish_submit_derive(conf->instance, "totals", "total_bytes",
-                          "header-bytes", stats->s_hdrbytes);
-    /* Total body byte */
-    varnish_submit_derive(conf->instance, "totals", "total_bytes", "body-bytes",
-                          stats->s_bodybytes);
-  }
-
-  if (conf->collect_vcl) {
-    /* N vcl total     */
-    varnish_submit_gauge(conf->instance, "vcl", "vcl", "total_vcl",
-                         stats->n_vcl);
-    /* N vcl available */
-    varnish_submit_gauge(conf->instance, "vcl", "vcl", "avail_vcl",
-                         stats->n_vcl_avail);
-    /* N vcl discarded */
-    varnish_submit_gauge(conf->instance, "vcl", "vcl", "discarded_vcl",
-                         stats->n_vcl_discard);
-  }
-
-  if (conf->collect_workers) {
-    /* worker threads */
-    varnish_submit_gauge(conf->instance, "workers", "threads", "worker",
-                         stats->n_wrk);
-    /* worker threads created */
-    varnish_submit_derive(conf->instance, "workers", "total_threads", "created",
-                          stats->n_wrk_create);
-    /* worker threads not created */
-    varnish_submit_derive(conf->instance, "workers", "total_threads", "failed",
-                          stats->n_wrk_failed);
-    /* worker threads limited */
-    varnish_submit_derive(conf->instance, "workers", "total_threads", "limited",
-                          stats->n_wrk_max);
-    /* dropped work requests */
-    varnish_submit_derive(conf->instance, "workers", "total_threads", "dropped",
-                          stats->n_wrk_drop);
-    /* queued work requests */
-    varnish_submit_derive(conf->instance, "workers", "total_requests", "queued",
-                          stats->n_wrk_queue);
-    /* overflowed work requests */
-    varnish_submit_derive(conf->instance, "workers", "total_requests",
-                          "overflowed", stats->n_wrk_overflow);
-  }
-
-} /* }}} void varnish_monitor */
-#endif
-
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
 static int varnish_read(user_data_t *ud) /* {{{ */
 {
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
   struct VSM_data *vd;
   bool ok;
   const c_varnish_stats_t *stats;
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V6
   struct vsm *vd;
   struct vsc *vsc;
   int vsm_status;
@@ -1348,27 +954,23 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 
   vd = VSM_New();
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V6
   vsc = VSC_New();
-#endif
-
-#if HAVE_VARNISH_V3
-  VSC_Setup(vd);
 #endif
 
   if (conf->instance != NULL) {
     int status;
 
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
     status = VSM_n_Arg(vd, conf->instance);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V6
     status = VSM_Arg(vd, 'n', conf->instance);
 #endif
 
     if (status < 0) {
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
       VSM_Delete(vd);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V6
       VSC_Destroy(&vsc, vd);
       VSM_Destroy(&vd);
 #endif
@@ -1379,12 +981,8 @@ static int varnish_read(user_data_t *ud) /* {{{ */
     }
   }
 
-#if HAVE_VARNISH_V3
-  ok = (VSC_Open(vd, /* diag = */ 1) == 0);
-#elif HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
   ok = (VSM_Open(vd) == 0);
-#endif
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   if (!ok) {
     VSM_Delete(vd);
     ERROR("varnish plugin: Unable to open connection.");
@@ -1392,12 +990,8 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   }
 #endif
 
-#if HAVE_VARNISH_V3
-  stats = VSC_Main(vd);
-#elif HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
   stats = VSC_Main(vd, NULL);
-#endif
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   if (!stats) {
     VSM_Delete(vd);
     ERROR("varnish plugin: Unable to get statistics.");
@@ -1405,7 +999,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   }
 #endif
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V6
   if (VSM_Attach(vd, STDERR_FILENO)) {
     ERROR("varnish plugin: Cannot attach to varnish. %s", VSM_Error(vd));
     VSC_Destroy(&vsc, vd);
@@ -1422,47 +1016,21 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   }
 #endif
 
-#if HAVE_VARNISH_V3
-  VSC_Iter(vd, varnish_monitor, conf);
-#elif HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
   VSC_Iter(vd, NULL, varnish_monitor, conf);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V6
   VSC_Iter(vsc, vd, varnish_monitor, conf);
 #endif
 
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
+#if HAVE_VARNISH_V4
   VSM_Delete(vd);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V6
   VSC_Destroy(&vsc, vd);
   VSM_Destroy(&vd);
 #endif
 
   return 0;
 } /* }}} */
-#else /* if HAVE_VARNISH_V2 */
-static int varnish_read(user_data_t *ud) /* {{{ */
-{
-  const c_varnish_stats_t *stats;
-
-  user_config_t *conf;
-
-  if ((ud == NULL) || (ud->data == NULL))
-    return EINVAL;
-
-  conf = ud->data;
-
-  stats = VSL_OpenStats(conf->instance);
-  if (stats == NULL) {
-    ERROR("Varnish plugin : unable to load statistics");
-
-    return -1;
-  }
-
-  varnish_monitor(conf, stats);
-
-  return 0;
-} /* }}} */
-#endif
 
 static void varnish_config_free(void *ptr) /* {{{ */
 {
@@ -1483,35 +1051,20 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
   conf->collect_backend = true;
   conf->collect_cache = true;
   conf->collect_connections = true;
-#ifdef HAVE_VARNISH_V3
-  conf->collect_dirdns = false;
-#endif
   conf->collect_esi = false;
   conf->collect_fetch = false;
   conf->collect_hcb = false;
   conf->collect_objects = false;
-#if HAVE_VARNISH_V2
-  conf->collect_purge = false;
-#else
   conf->collect_ban = false;
-#endif
   conf->collect_session = false;
   conf->collect_shm = true;
-#if HAVE_VARNISH_V2
-  conf->collect_sm = false;
-#endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   conf->collect_sma = false;
-#endif
   conf->collect_sms = false;
   conf->collect_struct = false;
   conf->collect_totals = false;
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   conf->collect_uptime = false;
-#endif
   conf->collect_vcl = false;
   conf->collect_workers = false;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   conf->collect_vsm = false;
   conf->collect_lck = false;
   conf->collect_mempool = false;
@@ -1519,7 +1072,6 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
   conf->collect_smf = false;
   conf->collect_vbe = false;
   conf->collect_mse = false;
-#endif
 
   return 0;
 } /* }}} int varnish_config_apply_default */
@@ -1595,13 +1147,6 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       cf_util_get_boolean(child, &conf->collect_connections);
     else if (strcasecmp("CollectESI", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_esi);
-    else if (strcasecmp("CollectDirectorDNS", child->key) == 0)
-#ifdef HAVE_VARNISH_V3
-      cf_util_get_boolean(child, &conf->collect_dirdns);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v3");
-#endif
     else if (strcasecmp("CollectBackend", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_backend);
     else if (strcasecmp("CollectFetch", child->key) == 0)
@@ -1610,20 +1155,8 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       cf_util_get_boolean(child, &conf->collect_hcb);
     else if (strcasecmp("CollectObjects", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_objects);
-    else if (strcasecmp("CollectPurge", child->key) == 0)
-#if HAVE_VARNISH_V2
-      cf_util_get_boolean(child, &conf->collect_purge);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v2");
-#endif
     else if (strcasecmp("CollectBan", child->key) == 0)
-#if HAVE_VARNISH_V2
-      WARNING("Varnish plugin: \"%s\" is not available for Varnish %s.",
-              child->key, "v2");
-#else
       cf_util_get_boolean(child, &conf->collect_ban);
-#endif
     else if (strcasecmp("CollectSession", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_session);
     else if (strcasecmp("CollectSHM", child->key) == 0)
@@ -1631,90 +1164,33 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectSMS", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_sms);
     else if (strcasecmp("CollectSMA", child->key) == 0)
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_sma);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v2 and v4");
-#endif
-    else if (strcasecmp("CollectSM", child->key) == 0)
-#if HAVE_VARNISH_V2
-      cf_util_get_boolean(child, &conf->collect_sm);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v2");
-#endif
     else if (strcasecmp("CollectStruct", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_struct);
     else if (strcasecmp("CollectTotals", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_totals);
     else if (strcasecmp("CollectUptime", child->key) == 0)
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_uptime);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v3 and v4");
-#endif
     else if (strcasecmp("CollectVCL", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_vcl);
     else if (strcasecmp("CollectWorkers", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_workers);
     else if (strcasecmp("CollectVSM", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_vsm);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectLock", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_lck);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectMempool", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_mempool);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectManagement", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_mgt);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectSMF", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_smf);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectSMF", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_smf);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectVBE", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_vbe);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
-#endif
     else if (strcasecmp("CollectMSE", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_mse);
-#else
-      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "Plus v4");
-#endif
     else {
       WARNING("Varnish plugin: Ignoring unknown "
               "configuration option: \"%s\". Did "
@@ -1726,32 +1202,16 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 
   if (!conf->collect_cache && !conf->collect_connections &&
       !conf->collect_esi && !conf->collect_backend
-#ifdef HAVE_VARNISH_V3
-      && !conf->collect_dirdns
-#endif
       && !conf->collect_fetch && !conf->collect_hcb && !conf->collect_objects
-#if HAVE_VARNISH_V2
-      && !conf->collect_purge
-#else
       && !conf->collect_ban
-#endif
       && !conf->collect_session && !conf->collect_shm && !conf->collect_sms
-#if HAVE_VARNISH_V2
-      && !conf->collect_sm
-#endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       && !conf->collect_sma
-#endif
       && !conf->collect_struct && !conf->collect_totals
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       && !conf->collect_uptime
-#endif
       && !conf->collect_vcl && !conf->collect_workers
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf &&
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
-#endif
   ) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -63,6 +63,9 @@ struct user_config_s {
   bool collect_smf;
   bool collect_vbe;
   bool collect_mse;
+#if HAVE_VARNISH_V6
+  bool collect_goto;
+#endif
 };
 typedef struct user_config_s user_config_t; /* }}} */
 
@@ -933,6 +936,20 @@ static int varnish_monitor(void *priv,
                                    "total_operations", "sniped_objects", val);
   }
 
+#if HAVE_VARNISH_V6
+  if (conf->collect_goto) {
+    if (strcmp(name, "goto_dns_cache_hits") == 0)
+      return varnish_submit_derive(conf->instance, "goto", "total_operations",
+                                   "dns_cache_hits", val);
+    else if (strcmp(name, "goto_dns_lookups") == 0)
+      return varnish_submit_derive(conf->instance, "goto", "total_operations",
+                                   "dns_lookups", val);
+    else if (strcmp(name, "goto_dns_lookup_fails") == 0)
+      return varnish_submit_derive(conf->instance, "goto", "total_operations",
+                                   "dns_lookup_fails", val);
+  }
+#endif
+
   return 0;
 
 } /* }}} static int varnish_monitor */
@@ -1078,6 +1095,9 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
   conf->collect_smf = false;
   conf->collect_vbe = false;
   conf->collect_mse = false;
+#if HAVE_VARNISH_V6
+  conf->collect_goto = false;
+#endif
 
   return 0;
 } /* }}} int varnish_config_apply_default */
@@ -1202,6 +1222,13 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       cf_util_get_boolean(child, &conf->collect_vbe);
     else if (strcasecmp("CollectMSE", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_mse);
+    else if (strcasecmp("CollectGOTO", child->key) == 0)
+#if HAVE_VARNISH_V6
+      cf_util_get_boolean(child, &conf->collect_goto);
+#else
+      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
+              child->key, "v6");
+#endif
     else {
       WARNING("Varnish plugin: Ignoring unknown "
               "configuration option: \"%s\". Did "
@@ -1221,7 +1248,11 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       && !conf->collect_vsm
 #endif
       && !conf->collect_vbe && !conf->collect_smf && !conf->collect_mgt &&
-      !conf->collect_lck && !conf->collect_mempool && !conf->collect_mse) {
+      !conf->collect_lck && !conf->collect_mempool && !conf->collect_mse
+#if HAVE_VARNISH_V6
+      && !conf->collect_goto
+#endif
+  ) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -414,19 +414,20 @@ static int varnish_monitor(void *priv,
 #if HAVE_VARNISH_V6
     else if (strcmp(name, "sess_fail_econnaborted") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                   "total_operations", "failed_econnaborted", val);
+                                   "total_operations", "failed_econnaborted",
+                                   val);
     else if (strcmp(name, "sess_fail_eintr") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                  "total_operations", "failed_eintr", val);
+                                   "total_operations", "failed_eintr", val);
     else if (strcmp(name, "sess_fail_emfile") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                  "total_operations", "failed_emfile", val);
+                                   "total_operations", "failed_emfile", val);
     else if (strcmp(name, "sess_fail_ebadf") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                  "total_operations", "failedi_ebadf", val);
+                                   "total_operations", "failedi_ebadf", val);
     else if (strcmp(name, "sess_fail_enomem") == 0)
       return varnish_submit_derive(conf->instance, "session",
-                                  "total_operations", "failed_enomem", val);
+                                   "total_operations", "failed_enomem", val);
     else if (strcmp(name, "sess_fail_other") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "failed_other", val);
@@ -932,7 +933,6 @@ static int varnish_monitor(void *priv,
                                    "total_operations", "sniped_objects", val);
   }
 
-
   return 0;
 
 } /* }}} static int varnish_monitor */
@@ -1212,21 +1212,16 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
   }
 
   if (!conf->collect_cache && !conf->collect_connections &&
-      !conf->collect_esi && !conf->collect_backend
-      && !conf->collect_fetch && !conf->collect_hcb && !conf->collect_objects
-      && !conf->collect_ban
-      && !conf->collect_session && !conf->collect_shm && !conf->collect_sms
-      && !conf->collect_sma
-      && !conf->collect_struct && !conf->collect_totals
-      && !conf->collect_uptime
-      && !conf->collect_vcl && !conf->collect_workers
+      !conf->collect_esi && !conf->collect_backend && !conf->collect_fetch &&
+      !conf->collect_hcb && !conf->collect_objects && !conf->collect_ban &&
+      !conf->collect_session && !conf->collect_shm && !conf->collect_sms &&
+      !conf->collect_sma && !conf->collect_struct && !conf->collect_totals &&
+      !conf->collect_uptime && !conf->collect_vcl && !conf->collect_workers
 #if HAVE_VARNISH_V4
-      && !conf->collect_vsm 
+      && !conf->collect_vsm
 #endif
-      && !conf->collect_vbe && !conf->collect_smf &&
-      !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
-      !conf->collect_mse
-  ) {
+      && !conf->collect_vbe && !conf->collect_smf && !conf->collect_mgt &&
+      !conf->collect_lck && !conf->collect_mempool && !conf->collect_mse) {
     WARNING("Varnish plugin: No metric has been configured for "
             "instance \"%s\". Disabling this instance.",
             (conf->instance == NULL) ? "localhost" : conf->instance);

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -742,6 +742,11 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "c_fail") == 0)
       return varnish_submit_derive(conf->instance, category, "total_operations",
                                    "alloc_fail", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "c_fail_malloc") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                   "alloc_fail_malloc", val);
+#endif
     else if (strcmp(name, "c_bytes") == 0)
       return varnish_submit_derive(conf->instance, category, "total_bytes",
                                    "bytes_allocated", val);
@@ -757,6 +762,26 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "g_space") == 0)
       return varnish_submit_gauge(conf->instance, category, "bytes",
                                   "bytes_available", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "n_lru_nuked") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_objects",
+                                  "lru_nuked", val);
+    else if (strcmp(name, "n_lru_moved") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_objects",
+                                  "lru_moved", val);
+    else if (strcmp(name, "n_vary") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_objects",
+                                  "vary_headers", val);
+    else if (strcmp(name, "c_memcache_hit") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                  "memcache_hit", val);
+    else if (strcmp(name, "c_memcache_miss") == 0)
+      return varnish_submit_derive(conf->instance, category, "total_operations",
+                                  "memcache_miss", val);
+    else if (strcmp(name, "g_ykey_keys") == 0)
+      return varnish_submit_gauge(conf->instance, category, "objects",
+                                  "ykey", val);
+#endif
   }
 
   /* No SMA specific counters */

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -54,7 +54,9 @@ struct user_config_s {
   bool collect_uptime;
   bool collect_vcl;
   bool collect_workers;
+#if HAVE_VARNISH_V4
   bool collect_vsm;
+#endif
   bool collect_lck;
   bool collect_mempool;
   bool collect_mgt;
@@ -660,6 +662,7 @@ static int varnish_monitor(void *priv,
                                    "busy_killed", val);
   }
 
+#if HAVE_VARNISH_V4
   if (conf->collect_vsm) {
     if (strcmp(name, "vsm_free") == 0)
       return varnish_submit_gauge(conf->instance, "vsm", "bytes", "free", val);
@@ -675,6 +678,7 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "vsm", "total_bytes",
                                    "overflowed", val);
   }
+#endif
 
   if (conf->collect_vbe) {
     /* @TODO figure out the collectd type for bitmap
@@ -1065,7 +1069,9 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
   conf->collect_uptime = false;
   conf->collect_vcl = false;
   conf->collect_workers = false;
+#if HAVE_VARNISH_V4
   conf->collect_vsm = false;
+#endif
   conf->collect_lck = false;
   conf->collect_mempool = false;
   conf->collect_mgt = false;
@@ -1176,7 +1182,12 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectWorkers", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_workers);
     else if (strcasecmp("CollectVSM", child->key) == 0)
+#if HAVE_VARNISH_V4
       cf_util_get_boolean(child, &conf->collect_vsm);
+#else
+      WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
+              child->key, "v4");
+#endif
     else if (strcasecmp("CollectLock", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_lck);
     else if (strcasecmp("CollectMempool", child->key) == 0)
@@ -1209,7 +1220,10 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       && !conf->collect_struct && !conf->collect_totals
       && !conf->collect_uptime
       && !conf->collect_vcl && !conf->collect_workers
-      && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf &&
+#if HAVE_VARNISH_V4
+      && !conf->collect_vsm 
+#endif
+      && !conf->collect_vbe && !conf->collect_smf &&
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
   ) {

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -631,33 +631,6 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "thread_queue_len") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "queue_length",
                                   "threads", val);
-    else if (strcmp(name, "n_wrk") == 0)
-      return varnish_submit_gauge(conf->instance, "workers", "threads",
-                                  "worker", val);
-    else if (strcmp(name, "n_wrk_create") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_threads",
-                                   "created", val);
-    else if (strcmp(name, "n_wrk_failed") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_threads",
-                                   "failed", val);
-    else if (strcmp(name, "n_wrk_max") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_threads",
-                                   "limited", val);
-    else if (strcmp(name, "n_wrk_drop") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_threads",
-                                   "dropped", val);
-    else if (strcmp(name, "n_wrk_queue") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queued", val);
-    else if (strcmp(name, "n_wrk_overflow") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "overflowed", val);
-    else if (strcmp(name, "n_wrk_queued") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queued", val);
-    else if (strcmp(name, "n_wrk_lqueue") == 0)
-      return varnish_submit_derive(conf->instance, "workers", "total_requests",
-                                   "queue_length", val);
     else if (strcmp(name, "pools") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "pools", "pools",
                                   val);


### PR DESCRIPTION
ChangeLog: varnish plugin: Support for Varnish 6, deprecated 2, 3 and 5.
ChangeLog: varnish plugin: Added counters for vmod-goto.

I keep Varnish 4 because Varnish Software keep support for Varnish Plus 4. Deleted Varnish 2, 3 and 5 because does't maintened: https://varnish-cache.org/releases/
