### PR TITLE
types.db: iwinfo: 'stations value:GAUGE:0:256'

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -240,6 +240,7 @@ snr                     value:GAUGE:0:U
 spam_check              value:GAUGE:0:U
 spam_score              value:GAUGE:U:U
 spl                     value:GAUGE:U:U
+stations                value:GAUGE:0:256
 swap                    value:GAUGE:0:1099511627776
 swap_io                 value:DERIVE:0:U
 sysevent                value:GAUGE:0:1


### PR DESCRIPTION
Add `stations value:GAUGE:0:256` to types.db

https://github.com/grafana/grafana/issues/7425 mentions that this is necessary for the `collectd-mod-iwinfo` that ships with OpenWRT.

