### PR TITLE
CODEOWNERS: Add "core maintainers" owning daemon and important plugins.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,46 @@
 # Code ownership information.
-# See https://help.github.com/articles/about-code-owners/ for details.
+# See
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for details.
 
+# Order is important; the *last* matching pattern takes precedence.
+
+# Default
+#
 # These owners will be the default owners for everything in the repo. Unless a
-# later match takes precedence, # @trusted-contributors will be requested for
-# review when someone opens a pull request.
+# later match takes precedence, @collectd/trusted-contributors will be
+# requested for review when someone opens a pull request.
+*       @collectd/trusted-contributors
 
-/src/intel_pmu.c	@kwiatrox @sunkuranganath
-/src/intel_rdt.c	@kwiatrox @sunkuranganath
-/src/ipmi.c		@anaudx @rjablonx
-/src/mcelog.c		@kwiatrox @sunkuranganath
-/src/virt.c		@anaudx @rjablonx
+# Per-plugin owners
+#
+# These plugins are owned by subject matter experts and require their review.
+/src/intel_pmu.c	@collectd/intel
+/src/intel_rdt.c	@collectd/intel
+/src/ipmi.c		@collectd/intel
+/src/mcelog.c		@collectd/intel
+/src/virt.c		@collectd/intel
 # TODO(#2926): Add the following owners:
-#/src/redfish.c		@kkepka @mkobyli
+#/src/redfish.c		@collectd/intel
 
-# Order is important; the last matching pattern takes the most
-# precedence.
-*       @trusted-contributors
+# Core
+#
+# The daemon and some plugins with a huge "blast radius" are considered "core"
+# to the collectd project and require review form a "core owner".
+/CODEOWNERS		@collectd/core-maintainers
+/src/daemon/		@collectd/core-maintainers
+/src/liboconfig/	@collectd/core-maintainers
+/src/cpu.c		@collectd/core-maintainers
+/src/df.c		@collectd/core-maintainers
+/src/disk.c		@collectd/core-maintainers
+/src/exec.c		@collectd/core-maintainers
+/src/interface.c	@collectd/core-maintainers
+/src/memory.c		@collectd/core-maintainers
+/src/network.*		@collectd/core-maintainers
+/src/utils/avltree/	@collectd/core-maintainers
+/src/utils/common/	@collectd/core-maintainers
+/src/utils_fbhash.*	@collectd/core-maintainers
+/src/utils/heap/	@collectd/core-maintainers
+/src/utils/ignorelist/	@collectd/core-maintainers
+/src/utils/metadata/	@collectd/core-maintainers
+/src/utils/mount/	@collectd/core-maintainers


### PR DESCRIPTION
As discussed at the collectd meetup: add a new @collectd/core-maintainers group which owns the daemon and a few plugins that are hand-picked for having a large "blast radius". This is in preparation of adding a bunch of @collectd/trusted-contributors which can then approve PRs for the majority of files in the repository.