### PR TITLE
I think in this case we need sfree(cb);

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1306,7 +1306,7 @@ EXPORT int plugin_register_flush(const char *name, plugin_flush_cb callback,
             .data = cb,
             .free_func = plugin_flush_timeout_callback_free,
         });
-
+    sfree(cb);
     sfree(flush_name);
     return status;
   }


### PR DESCRIPTION
Hi guys,

I believe that in this case we need to call the sfree() function.

Regards.