### PR TITLE
Add error handling for PyType_Ready

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -1261,31 +1261,31 @@ static int cpy_init_python(void) {
   Py_Initialize();
   python_sigint_handler = PyOS_setsig(SIGINT, cur_sig);
 
-  if (PyType_Ready(&ConfigType) < 0) {
+  if (PyType_Ready(&ConfigType) == -1) {
     cpy_log_exception("python initialization: ConfigType");
     return 1;
   }
-  if (PyType_Ready(&PluginDataType) < 0) {
+  if (PyType_Ready(&PluginDataType) == -1) {
     cpy_log_exception("python initialization: PluginDataType");
     return 1;
   }
   ValuesType.tp_base = &PluginDataType;
-  if (PyType_Ready(&ValuesType) < 0) {
+  if (PyType_Ready(&ValuesType) == -1) {
     cpy_log_exception("python initialization: ValuesType");
     return 1;
   }
   NotificationType.tp_base = &PluginDataType;
-  if (PyType_Ready(&NotificationType) < 0) {
+  if (PyType_Ready(&NotificationType) == -1) {
     cpy_log_exception("python initialization: NotificationType");
     return 1;
   }
   SignedType.tp_base = &PyLong_Type;
-  if (PyType_Ready(&SignedType) < 0) {
+  if (PyType_Ready(&SignedType) == -1) {
     cpy_log_exception("python initialization: SignedType");
     return 1;
   }
   UnsignedType.tp_base = &PyLong_Type;
-  if (PyType_Ready(&UnsignedType) < 0) {
+  if (PyType_Ready(&UnsignedType) == -1) {
     cpy_log_exception("python initialization: UnsignedType");
     return 1;
   }

--- a/src/python.c
+++ b/src/python.c
@@ -1261,16 +1261,34 @@ static int cpy_init_python(void) {
   Py_Initialize();
   python_sigint_handler = PyOS_setsig(SIGINT, cur_sig);
 
-  PyType_Ready(&ConfigType);
-  PyType_Ready(&PluginDataType);
+  if (PyType_Ready(&ConfigType) < 0) {
+    cpy_log_exception("python initialization: ConfigType");
+    return 1;
+  }
+  if (PyType_Ready(&PluginDataType) < 0) {
+    cpy_log_exception("python initialization: PluginDataType");
+    return 1;
+  }
   ValuesType.tp_base = &PluginDataType;
-  PyType_Ready(&ValuesType);
+  if (PyType_Ready(&ValuesType) < 0) {
+    cpy_log_exception("python initialization: ValuesType");
+    return 1;
+  }
   NotificationType.tp_base = &PluginDataType;
-  PyType_Ready(&NotificationType);
+  if (PyType_Ready(&NotificationType) < 0) {
+    cpy_log_exception("python initialization: NotificationType");
+    return 1;
+  }
   SignedType.tp_base = &PyLong_Type;
-  PyType_Ready(&SignedType);
+  if (PyType_Ready(&SignedType) < 0) {
+    cpy_log_exception("python initialization: SignedType");
+    return 1;
+  }
   UnsignedType.tp_base = &PyLong_Type;
-  PyType_Ready(&UnsignedType);
+  if (PyType_Ready(&UnsignedType) < 0) {
+    cpy_log_exception("python initialization: UnsignedType");
+    return 1;
+  }
   errordict = PyDict_New();
   PyDict_SetItemString(
       errordict, "__doc__",


### PR DESCRIPTION
Add individual error messages required in #2700 

The API PyType_Ready may fail, when it happens, the program may crash.

ChangeLog: collectd: Error-handling code of PyType_Ready has been added.