### PR TITLE
Revert "Forward-port and rebase to master of "text protocol: Add support for meta_data in PUTVAL #2726""

### DIFF
--- a/src/collectd-exec.pod
+++ b/src/collectd-exec.pod
@@ -110,10 +110,6 @@ The currently defined B<Options> are:
 Gives the interval in which the data identified by I<Identifier> is being
 collected.
 
-=item meta:B<key>=I<value>
-
-Add meta data with the key B<key> and the value I<value>.
-
 =back
 
 Please note that this is the same format as used in the B<unixsock plugin>, see

--- a/src/collectd-unixsock.pod
+++ b/src/collectd-unixsock.pod
@@ -120,10 +120,6 @@ The currently defined B<Options> are:
 Gives the interval in which the data identified by I<Identifier> is being
 collected.
 
-=item meta:B<key>=I<value>
-
-Add meta data with the key B<key> and the value I<value>.
-
 =back
 
 Please note that this is the same format as used in the B<exec plugin>, see

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -204,18 +204,6 @@ static struct {
         CMD_OK,
         CMD_PUTVAL,
     },
-    {
-        "PUTVAL myhost/magic/MAGIC meta:KEY=\"string_value\" 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
-    {
-        "PUTVAL myhost/magic/MAGIC meta:KEY='string_value' 1234:42",
-        NULL,
-        CMD_OK,
-        CMD_PUTVAL,
-    },
 
     /* Invalid PUTVAL commands. */
     {

--- a/src/utils/cmds/putval.c
+++ b/src/utils/cmds/putval.c
@@ -35,16 +35,7 @@
  * private helper functions
  */
 
-static int is_quoted(const char *str, size_t len) {
-  if (len < 2) {
-    return 0;
-  }
-
-  return (str[0] == '"' && str[len - 1] == '"');
-}
-
-static int set_option(value_list_t *vl, const char *key, const char *value,
-                      cmd_error_handler_t *err) {
+static int set_option(value_list_t *vl, const char *key, const char *value) {
   if ((vl == NULL) || (key == NULL) || (value == NULL))
     return -1;
 
@@ -58,37 +49,10 @@ static int set_option(value_list_t *vl, const char *key, const char *value,
 
     if ((errno == 0) && (endptr != NULL) && (endptr != value) && (tmp > 0.0))
       vl->interval = DOUBLE_TO_CDTIME_T(tmp);
-  } else if (strncasecmp("meta:", key, 5) == 0) {
-    const char *meta_key = key + 5;
-    size_t value_len = strlen(value);
+  } else
+    return 1;
 
-    if (vl->meta == NULL) {
-      vl->meta = meta_data_create();
-      if (vl->meta == NULL) {
-        return CMD_ERROR;
-      }
-    }
-
-    if (is_quoted(value, value_len)) {
-      int metadata_err;
-      const char *value_str = sstrndup(value + 1, value_len - 2);
-      if (value_str == NULL) {
-        return CMD_ERROR;
-      }
-      metadata_err = meta_data_add_string(vl->meta, meta_key, value_str);
-      free((void *)value_str);
-      if (metadata_err != 0) {
-        return CMD_ERROR;
-      }
-      return CMD_OK;
-    }
-
-    cmd_error(CMD_NO_OPTION, err, "Non-string metadata not supported yet");
-    return CMD_NO_OPTION;
-  } else {
-    return CMD_ERROR;
-  }
-  return CMD_OK;
+  return 0;
 } /* int set_option */
 
 /*
@@ -192,15 +156,9 @@ cmd_status_t cmd_parse_putval(size_t argc, char **argv,
 
     status = cmd_parse_option(argv[i], &key, &value, err);
     if (status == CMD_OK) {
-      int option_err;
-
       assert(key != NULL);
       assert(value != NULL);
-      option_err = set_option(&vl, key, value, err);
-      if (option_err != CMD_OK && option_err != CMD_NO_OPTION) {
-        result = option_err;
-        break;
-      }
+      set_option(&vl, key, value);
       continue;
     } else if (status != CMD_NO_OPTION) {
       /* parse_option failed, buffer has been modified.

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -160,34 +160,6 @@ char *sstrdup(const char *s) {
   return r;
 } /* char *sstrdup */
 
-size_t sstrnlen(const char *s, size_t n) {
-  const char *p = s;
-
-  while (n-- > 0 && *p)
-    p++;
-
-  return p - s;
-} /* size_t sstrnlen */
-
-char *sstrndup(const char *s, size_t n) {
-  char *r;
-  size_t sz;
-
-  if (s == NULL)
-    return NULL;
-
-  sz = sstrnlen(s, n);
-  r = malloc(sz + 1);
-  if (r == NULL) {
-    ERROR("sstrndup: Out of memory.");
-    exit(3);
-  }
-  memcpy(r, s, sz);
-  r[sz] = '\0';
-
-  return r;
-} /* char *sstrndup */
-
 /* Even though Posix requires "strerror_r" to return an "int",
  * some systems (e.g. the GNU libc) return a "char *" _and_
  * ignore the second argument ... -tokkee */

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -73,8 +73,6 @@ __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
                                                             ...);
 
 char *sstrdup(const char *s);
-size_t sstrnlen(const char *s, size_t n);
-char *sstrndup(const char *s, size_t n);
 void *smalloc(size_t size);
 char *sstrerror(int errnum, char *buf, size_t buflen);
 


### PR DESCRIPTION
Changelog: Reverts collectd/collectd#3381

Feature, added in #3381, is not working.
Implementation broken. Tests are wrong.

`sstrndup()` implementation is wrong (it should never call `exit()`)