### PR TITLE
network plugin: Optimize metadata "network:ip_address" adding

### DIFF
--- a/src/network_test.c
+++ b/src/network_test.c
@@ -241,7 +241,8 @@ DEF_TEST(parse_packet) {
     size_t buffer_size = sizeof(buffer);
 
     EXPECT_EQ_INT(0, decode_string(raw_packet_data[i], buffer, &buffer_size));
-    EXPECT_EQ_INT(0, parse_packet(&se, buffer, buffer_size, 0, NULL, NULL));
+    EXPECT_EQ_INT(0,
+                  parse_packet(&se, buffer, buffer_size, 0, NULL, "127.0.0.1"));
   }
   EXPECT_EQ_INT(139, (int)stats_values_dispatched);
 


### PR DESCRIPTION
Changelog: network plugin: Optimize metadata "network:ip_address" adding
Changelog: network plugin: Optimize network_receive()
Changelog: network plugin: Add client address into error messages

There is no need in some `memcpy` and `memset` calls.

Issue: #3191