### PR TITLE
amqp1: Add options to limit send queue length

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -860,6 +860,18 @@ When the AMQP1 connection is lost, defines the time in seconds to wait
 before attempting to reconnect. Defaults to 1, which implies attempt
 to reconnect at 1 second intervals.
 
+=item B<SendQueueLimit> I<SendQueueLimit>
+If there is no AMQP1 connection, the plugin will continue to queue
+messages to send, which could result in unbounded memory consumption. This
+parameter is used to limit the number of messages in the outbound queue to
+the specified value. The default value is 0, which disables this feature.
+
+=item B<SendQueueDropNew> I<SendQueueDropNew>
+If the I<SendQueueLimit> parameter is set to a positive integer value and
+this parameter is set to true, new messages will be discarded if the queue is
+full. The default value is false, which results in the oldest message in the
+queue being dropped if the queue is full and a new message is enqueued.
+
 =back
 
 The following options are accepted within each I<Instance> block:


### PR DESCRIPTION
ChangeLog: amqp1 plugin: Add options to limit send queue length.

Add two options to control send queue length and behavior: SendQueueLimit and SendQueueDropNew

If SendQueueLimit is set to an integer greater than 0, the send queue in the
amqp1 plugin will be constrained to that number of entries to avoid unbounded
memory use in the case that there is no amqp1 connection. If the
SendQueueDropNew parameter is set to true, new messages will be dropped when
the queue is full and a new message is enqueued, otherwise the oldest message
in the queue will be dropped. The default is for the oldest message to be
dropped.

Signed-off-by: Ryan McCabe <rmccabe@redhat.com>