### PR TITLE
src/dpdk_telemetry.c: fix build on musl

### DIFF
--- a/src/dpdk_telemetry.c
+++ b/src/dpdk_telemetry.c
@@ -40,7 +40,7 @@
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #define BUF_SIZE 100000
 #define PLUGIN_NAME "dpdk_telemetry"


### PR DESCRIPTION
ChangeLog: Fix build for dpdk-telemetry plugin

Include unistd.h instead of sys/unistd.h to fix the following build
failure on musl:

```
src/dpdk_telemetry.c:43:10: fatal error: sys/unistd.h: No such file or directory
 #include <sys/unistd.h>
          ^~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/aafb8c72f147fefc7a988c45e4dc17de48b07a95

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>