### PR TITLE
collectd.conf(5): Document the format expected by "sensors"' ignore list.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8550,6 +8550,9 @@ on the B<IgnoreSelected> below. For example, the option "B<Sensor>
 I<it8712-isa-0290/voltage-in1>" will cause collectd to gather data for the
 voltage sensor I<in1> of the I<it8712> on the isa bus at the address 0290.
 
+The value passed to this option has the format
+"I<plugin_instance>/I<type>-I<type_instance>".
+
 See F</"IGNORELISTS"> for details.
 
 =item B<IgnoreSelected> I<true>|I<false>


### PR DESCRIPTION
This question recently came up on the mailing list.

ChangeLog: sensors plugin: The documentation has been improved.