### PR TITLE
Add varnish 6 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6084,24 +6084,29 @@ if test "x$with_libvarnish" = "xyes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $with_libvarnish_cflags"
 
-  $PKG_CONFIG --atleast-version=5.2 'varnishapi' 2>/dev/null
+  $PKG_CONFIG --atleast-version=6 'varnishapi' 2>/dev/null
   if test $? -eq 0; then
-    AC_DEFINE([HAVE_VARNISH_V5], [1], [Varnish 5 API support])
+    AC_DEFINE([HAVE_VARNISH_V6], [1], [Varnish 6 API support])
   else
-    AC_CHECK_HEADERS([vapi/vsc.h],
-      [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
-      [
-        AC_CHECK_HEADERS([vsc.h],
-          [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
-          [
-            AC_CHECK_HEADERS([varnishapi.h],
-              [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
-              [with_libvarnish="no (found none of the varnish header files)"]
-            )
-          ]
-        )
-      ]
-    )
+    $PKG_CONFIG --atleast-version=5.2 'varnishapi' 2>/dev/null
+    if test $? -eq 0; then
+      AC_DEFINE([HAVE_VARNISH_V5], [1], [Varnish 5 API support])
+    else
+      AC_CHECK_HEADERS([vapi/vsc.h],
+        [AC_DEFINE([HAVE_VARNISH_V4], [1], [Varnish 4 API support])],
+        [
+          AC_CHECK_HEADERS([vsc.h],
+            [AC_DEFINE([HAVE_VARNISH_V3], [1], [Varnish 3 API support]) ],
+            [
+              AC_CHECK_HEADERS([varnishapi.h],
+                [AC_DEFINE([HAVE_VARNISH_V2], [1], [Varnish 2 API support])],
+                [with_libvarnish="no (found none of the varnish header files)"]
+              )
+            ]
+          )
+        ]
+      )
+    fi
   fi
 
   CPPFLAGS="$SAVE_CPPFLAGS"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1842,6 +1842,7 @@
 #      CollectSMF false           # Varnish 4 and above
 #      CollectVBE false           # Varnish 4 and above
 #      CollectMSE false           # Varnish-Plus only
+#      CollectGOTO false          # Varnish-Plus 6 only
 #   </Instance>
 #</Plugin>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1827,7 +1827,7 @@
 #      CollectPurge false         # Varnish 2 only
 #      CollectSession false
 #      CollectSHM true
-#      CollectSMA false           # Varnish 2 & 4 only
+#      CollectSMA false           # Varnish 2 & Varnish 4 and above
 #      CollectSMS false
 #      CollectSM false            # Varnish 2 only
 #      CollectStruct false
@@ -1836,12 +1836,12 @@
 #      CollectVCL false
 #      CollectVSM false           # Varnish 4 only
 #      CollectWorkers false
-#      CollectLock false          # Varnish 4 only
-#      CollectMempool false       # Varnish 4 only
-#      CollectManagement false    # Varnish 4 only
-#      CollectSMF false           # Varnish 4 only
-#      CollectVBE false           # Varnish 4 only
-#      CollectMSE false           # Varnish-Plus 4 only
+#      CollectLock false          # Varnish 4 and above
+#      CollectMempool false       # Varnish 4 and above
+#      CollectManagement false    # Varnish 4 and above
+#      CollectSMF false           # Varnish 4 and above
+#      CollectVBE false           # Varnish 4 and above
+#      CollectMSE false           # Varnish-Plus only
 #   </Instance>
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -10077,6 +10077,10 @@ Varnish, replacing the traditional malloc and file storages. Only available
 with Varnish-Plus 4.x and above. Note: SMA, SMF and MSE share counters, enable only the
 one used by the Varnish instance. False by default.
 
+=item B<CollectGOTO> B<true>|B<false>
+
+vmod-goto counters. Only available with Varnish Plus 6.x. False by default.
+
 =back
 
 =head2 Plugin C<virt>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -10005,7 +10005,8 @@ log messages which is flushed to disk when full. True by default.
 
 malloc or umem (umem_alloc(3MALLOC) based) storage statistics. The umem storage
 component is Solaris specific. Note: SMA, SMF and MSE share counters, enable
-only the one used by the Varnish instance. Only available with Varnish 2.x.
+only the one used by the Varnish instance. Available with Varnish 2.x,
+varnish 4.x and above (Not available in varnish 3.x).
 False by default.
 
 =item B<CollectSMS> B<true>|B<false>
@@ -10015,8 +10016,8 @@ component is used internally only. False by default.
 
 =item B<CollectSM> B<true>|B<false>
 
-file (memory mapped file) storage statistics. Only available with Varnish 2.x.,
-in varnish 4.x. use CollectSMF.
+file (memory mapped file) storage statistics. Only available with Varnish 2.x,
+in varnish 4.x and above use CollectSMF.
 False by default.
 
 =item B<CollectStruct> B<true>|B<false>
@@ -10049,31 +10050,31 @@ Collect statistics about worker threads. False by default.
 
 =item B<CollectVBE> B<true>|B<false>
 
-Backend counters. Only available with Varnish 4.x. False by default.
+Backend counters. Only available with Varnish 4.x and above. False by default.
 
 =item B<CollectSMF> B<true>|B<false>
 
-file (memory mapped file) storage statistics. Only available with Varnish 4.x.
+file (memory mapped file) storage statistics. Only available with Varnish 4.x and above.
 Note: SMA, SMF and MSE share counters, enable only the one used by the Varnish
 instance. Used to be called SM in Varnish 2.x. False by default.
 
 =item B<CollectManagement> B<true>|B<false>
 
-Management process counters. Only available with Varnish 4.x. False by default.
+Management process counters. Only available with Varnish 4.x and above. False by default.
 
 =item B<CollectLock> B<true>|B<false>
 
-Lock counters. Only available with Varnish 4.x. False by default.
+Lock counters. Only available with Varnish 4.x and above. False by default.
 
 =item B<CollectMempool> B<true>|B<false>
 
-Memory pool counters. Only available with Varnish 4.x. False by default.
+Memory pool counters. Only available with Varnish 4.x and above. False by default.
 
 =item B<CollectMSE> B<true>|B<false>
 
 Varnish Massive Storage Engine 2.0 (MSE2) is an improved storage backend for
 Varnish, replacing the traditional malloc and file storages. Only available
-with Varnish-Plus 4.x. Note: SMA, SMF and MSE share counters, enable only the
+with Varnish-Plus 4.x and above. Note: SMA, SMF and MSE share counters, enable only the
 one used by the Varnish instance. False by default.
 
 =back

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -81,8 +81,10 @@ struct user_config_s {
 #endif
   bool collect_vcl;
   bool collect_workers;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   bool collect_vsm;
+#endif
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   bool collect_lck;
   bool collect_mempool;
   bool collect_mgt;
@@ -747,7 +749,7 @@ static int varnish_monitor(void *priv,
 #endif
   }
 
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   if (conf->collect_vsm) {
     if (strcmp(name, "vsm_free") == 0)
       return varnish_submit_gauge(conf->instance, "vsm", "bytes", "free", val);
@@ -763,7 +765,9 @@ static int varnish_monitor(void *priv,
       return varnish_submit_derive(conf->instance, "vsm", "total_bytes",
                                    "overflowed", val);
   }
+#endif
 
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   if (conf->collect_vbe) {
     /* @TODO figure out the collectd type for bitmap
     if (strcmp(name, "happy") == 0)
@@ -1545,8 +1549,10 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
 #endif
   conf->collect_vcl = false;
   conf->collect_workers = false;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
   conf->collect_vsm = false;
+#endif
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   conf->collect_lck = false;
   conf->collect_mempool = false;
   conf->collect_mgt = false;
@@ -1694,11 +1700,11 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectWorkers", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_workers);
     else if (strcasecmp("CollectVSM", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
       cf_util_get_boolean(child, &conf->collect_vsm);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
-              child->key, "v4");
+              child->key, "v4 or v5");
 #endif
     else if (strcasecmp("CollectLock", child->key) == 0)
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
@@ -1781,8 +1787,11 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       && !conf->collect_uptime
 #endif
       && !conf->collect_vcl && !conf->collect_workers
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+      && !conf->collect_vsm 
+#endif
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
-      && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf &&
+      && !conf->collect_vbe && !conf->collect_smf &&
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse
 #endif

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -29,7 +29,7 @@
 #include "plugin.h"
 #include "utils/common/common.h"
 
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
 #include <vapi/vsc.h>
 #include <vapi/vsm.h>
 typedef struct VSC_C_main c_varnish_stats_t;
@@ -71,17 +71,17 @@ struct user_config_s {
 #if HAVE_VARNISH_V2
   bool collect_sm;
 #endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   bool collect_sma;
 #endif
   bool collect_struct;
   bool collect_totals;
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   bool collect_uptime;
 #endif
   bool collect_vcl;
   bool collect_workers;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   bool collect_vsm;
   bool collect_lck;
   bool collect_mempool;
@@ -138,7 +138,7 @@ static int varnish_submit_derive(const char *plugin_instance, /* {{{ */
                         });
 } /* }}} int varnish_submit_derive */
 
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
 static int varnish_monitor(void *priv,
                            const struct VSC_point *const pt) /* {{{ */
 {
@@ -151,7 +151,7 @@ static int varnish_monitor(void *priv,
 
   conf = priv;
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   char namebuff[DATA_MAX_NAME_LEN];
 
   char const *c = strrchr(pt->name, '.');
@@ -197,7 +197,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "client_req") == 0)
       return varnish_submit_derive(conf->instance, "connections", "connections",
                                    "received", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "client_req_400") == 0)
       return varnish_submit_derive(conf->instance, "connections", "connections",
                                    "error_400", val);
@@ -312,7 +312,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "fetch_304") == 0)
       return varnish_submit_derive(conf->instance, "fetch", "http_requests",
                                    "no_body_304", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "fetch_no_thread") == 0)
       return varnish_submit_derive(conf->instance, "fetch", "http_requests",
                                    "no_thread", val);
@@ -371,7 +371,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_objoverflow") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "workspace_overflow", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "exp_mailed") == 0)
       return varnish_submit_gauge(conf->instance, "struct", "objects",
                                   "exp_mailed", val);
@@ -403,7 +403,7 @@ static int varnish_monitor(void *priv,
                                    "duplicate", val);
   }
 #endif
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   if (conf->collect_ban) {
     if (strcmp(name, "bans") == 0)
       return varnish_submit_derive(conf->instance, "ban", "total_operations",
@@ -490,7 +490,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "sess_herd") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "herd", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "sess_closed_err") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "closed_err", val);
@@ -703,7 +703,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_wrk_lqueue") == 0)
       return varnish_submit_derive(conf->instance, "workers", "total_requests",
                                    "queue_length", val);
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "pools") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "pools", "pools",
                                   val);
@@ -713,7 +713,7 @@ static int varnish_monitor(void *priv,
 #endif
   }
 
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   if (conf->collect_vsm) {
     if (strcmp(name, "vsm_free") == 0)
       return varnish_submit_gauge(conf->instance, "vsm", "bytes", "free", val);
@@ -1326,14 +1326,14 @@ static void varnish_monitor(const user_config_t *conf, /* {{{ */
 } /* }}} void varnish_monitor */
 #endif
 
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
 static int varnish_read(user_data_t *ud) /* {{{ */
 {
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   struct VSM_data *vd;
   bool ok;
   const c_varnish_stats_t *stats;
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   struct vsm *vd;
   struct vsc *vsc;
   int vsm_status;
@@ -1348,7 +1348,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 
   vd = VSM_New();
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   vsc = VSC_New();
 #endif
 
@@ -1361,14 +1361,14 @@ static int varnish_read(user_data_t *ud) /* {{{ */
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
     status = VSM_n_Arg(vd, conf->instance);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     status = VSM_Arg(vd, 'n', conf->instance);
 #endif
 
     if (status < 0) {
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
       VSM_Delete(vd);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       VSC_Destroy(&vsc, vd);
       VSM_Destroy(&vd);
 #endif
@@ -1405,7 +1405,7 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   }
 #endif
 
-#if HAVE_VARNISH_V5
+#if HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   if (VSM_Attach(vd, STDERR_FILENO)) {
     ERROR("varnish plugin: Cannot attach to varnish. %s", VSM_Error(vd));
     VSC_Destroy(&vsc, vd);
@@ -1426,13 +1426,13 @@ static int varnish_read(user_data_t *ud) /* {{{ */
   VSC_Iter(vd, varnish_monitor, conf);
 #elif HAVE_VARNISH_V4
   VSC_Iter(vd, NULL, varnish_monitor, conf);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   VSC_Iter(vsc, vd, varnish_monitor, conf);
 #endif
 
 #if HAVE_VARNISH_V3 || HAVE_VARNISH_V4
   VSM_Delete(vd);
-#elif HAVE_VARNISH_V5
+#elif HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   VSC_Destroy(&vsc, vd);
   VSM_Destroy(&vd);
 #endif
@@ -1500,18 +1500,18 @@ static int varnish_config_apply_default(user_config_t *conf) /* {{{ */
 #if HAVE_VARNISH_V2
   conf->collect_sm = false;
 #endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   conf->collect_sma = false;
 #endif
   conf->collect_sms = false;
   conf->collect_struct = false;
   conf->collect_totals = false;
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   conf->collect_uptime = false;
 #endif
   conf->collect_vcl = false;
   conf->collect_workers = false;
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
   conf->collect_vsm = false;
   conf->collect_lck = false;
   conf->collect_mempool = false;
@@ -1631,7 +1631,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectSMS", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_sms);
     else if (strcasecmp("CollectSMA", child->key) == 0)
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_sma);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
@@ -1649,7 +1649,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectTotals", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_totals);
     else if (strcasecmp("CollectUptime", child->key) == 0)
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_uptime);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
@@ -1660,56 +1660,56 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("CollectWorkers", child->key) == 0)
       cf_util_get_boolean(child, &conf->collect_workers);
     else if (strcasecmp("CollectVSM", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_vsm);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectLock", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_lck);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectMempool", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_mempool);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectManagement", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_mgt);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectSMF", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_smf);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectSMF", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_smf);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectVBE", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_vbe);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
               child->key, "v4");
 #endif
     else if (strcasecmp("CollectMSE", child->key) == 0)
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       cf_util_get_boolean(child, &conf->collect_mse);
 #else
       WARNING("Varnish plugin: \"%s\" is available for Varnish %s only.",
@@ -1739,15 +1739,15 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 #if HAVE_VARNISH_V2
       && !conf->collect_sm
 #endif
-#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V2 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       && !conf->collect_sma
 #endif
       && !conf->collect_struct && !conf->collect_totals
-#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       && !conf->collect_uptime
 #endif
       && !conf->collect_vcl && !conf->collect_workers
-#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
+#if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
       && !conf->collect_vsm && !conf->collect_vbe && !conf->collect_smf &&
       !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
       !conf->collect_mse

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -185,6 +185,14 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "cache_hitpass") == 0)
       return varnish_submit_derive(conf->instance, "cache", "cache_result",
                                    "hitpass", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "cache_hit_grace") == 0)
+      return varnish_submit_derive(conf->instance, "cache", "cache_result",
+                                   "hit_grace", val);
+    else if (strcmp(name, "cache_hitmiss") == 0)
+      return varnish_submit_derive(conf->instance, "cache", "cache_result",
+                                   "hitmiss", val);
+#endif
   }
 
   if (conf->collect_connections) {
@@ -353,6 +361,11 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_lru_moved") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "lru_moved", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "n_lru_limited") == 0)
+      return varnish_submit_derive(conf->instance, "objects", "total_objects",
+                                   "lru_limited", val);
+#endif
     else if (strcmp(name, "n_deathrow") == 0)
       return varnish_submit_derive(conf->instance, "objects", "total_objects",
                                    "deathrow", val);
@@ -478,6 +491,27 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "sess_fail") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "failed", val);
+#if HAVE_VARNISH_V6
+    else if (strcmp(name, "sess_fail_econnaborted") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_econnaborted",
+                                   val);
+    else if (strcmp(name, "sess_fail_eintr") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_eintr", val);
+    else if (strcmp(name, "sess_fail_emfile") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_emfile", val);
+    else if (strcmp(name, "sess_fail_ebadf") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_ebadf", val);
+    else if (strcmp(name, "sess_fail_enomem") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_enomem", val);
+    else if (strcmp(name, "sess_fail_other") == 0)
+      return varnish_submit_derive(conf->instance, "session",
+                                   "total_operations", "failed_other", val);
+#endif
     else if (strcmp(name, "sess_pipe_overflow") == 0)
       return varnish_submit_derive(conf->instance, "session",
                                    "total_operations", "overflow", val);

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -846,8 +846,34 @@ static int varnish_monitor(void *priv,
                                   "bytes_available", val);
   }
 
+#if HAVE_VARNISH_V6
   /* No SMA specific counters */
+  if (conf->collect_mse) {
+    if (strcmp(name, "c_fail_malloc") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "alloc_fail_malloc", val);
+    else if (strcmp(name, "n_lru_nuked") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_objects",
+                                   "lru_nuked", val);
+    else if (strcmp(name, "n_lru_moved") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_objects",
+                                   "lru_moved", val);
+    else if (strcmp(name, "n_vary") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_objects",
+                                   "vary_headers", val);
+    else if (strcmp(name, "c_memcache_hit") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "memcache_hit", val);
+    else if (strcmp(name, "c_memcache_miss") == 0)
+      return varnish_submit_derive(conf->instance, "mse", "total_operations",
+                                   "memcache_miss", val);
+    else if (strcmp(name, "g_ykey_keys") == 0)
+      return varnish_submit_gauge(conf->instance, "mse", "objects", "ykey",
+                                  val);
+  }
+#endif
 
+  /* No SMA specific counters */
   if (conf->collect_smf) {
     if (strcmp(name, "g_smf") == 0)
       return varnish_submit_gauge(conf->instance, "smf", "objects",
@@ -1815,12 +1841,11 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
 #endif
       && !conf->collect_vcl && !conf->collect_workers
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5
-      && !conf->collect_vsm 
+      && !conf->collect_vsm
 #endif
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
-      && !conf->collect_vbe && !conf->collect_smf &&
-      !conf->collect_mgt && !conf->collect_lck && !conf->collect_mempool &&
-      !conf->collect_mse
+      && !conf->collect_vbe && !conf->collect_smf && !conf->collect_mgt &&
+      !conf->collect_lck && !conf->collect_mempool && !conf->collect_mse
 #endif
 #if HAVE_VARNISH_V6
       && !conf->collect_goto

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -715,6 +715,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "thread_queue_len") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "queue_length",
                                   "threads", val);
+#if HAVE_VARNISH_V2 || HAVE_VARNISH_V3 || HAVE_VARNISH_V4 || HAVE_VARNISH_V5
     else if (strcmp(name, "n_wrk") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "threads",
                                   "worker", val);
@@ -742,6 +743,7 @@ static int varnish_monitor(void *priv,
     else if (strcmp(name, "n_wrk_lqueue") == 0)
       return varnish_submit_derive(conf->instance, "workers", "total_requests",
                                    "queue_length", val);
+#endif
 #if HAVE_VARNISH_V4 || HAVE_VARNISH_V5 || HAVE_VARNISH_V6
     else if (strcmp(name, "pools") == 0)
       return varnish_submit_gauge(conf->instance, "workers", "pools", "pools",


### PR DESCRIPTION
This is mainly code taken from https://github.com/collectd/collectd/pull/3360, but without losing previous varnish versions.

ChangeLog: varnish plugin: Add varnish 6 support.
ChangeLog: varnish plugin: Add counters for vmod-goto.