### PR TITLE
Zookeeper missing mntr fields

### DIFF
--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -213,10 +213,10 @@ static int zookeeper_read(void) {
       zookeeper_submit_gauge("gauge", "watch", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_ephemerals_count")) {
       zookeeper_submit_gauge("gauge", "ephemerals", atol(fields[1]));
-    } else if (FIELD_CHECK(fields[0], "zk_ephemerals_count")) {
-      zookeeper_submit_gauge("gauge", "ephemerals", atol(fields[1]));
-    } else if (FIELD_CHECK(fields[0], "zk_ephemerals_count")) {
-      zookeeper_submit_gauge("gauge", "ephemerals", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_open_file_descriptor_count")) {
+      zookeeper_submit_gauge("file_handles", "open", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_max_file_descriptor_count")) {
+      zookeeper_submit_gauge("file_handles", "max", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_approximate_data_size")) {
       zookeeper_submit_gauge("bytes", "approximate_data_size", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_followers")) {

--- a/src/zookeeper.c
+++ b/src/zookeeper.c
@@ -226,6 +226,12 @@ static int zookeeper_read(void) {
       zookeeper_submit_gauge("count", "synced_followers", atol(fields[1]));
     } else if (FIELD_CHECK(fields[0], "zk_pending_syncs")) {
       zookeeper_submit_gauge("count", "pending_syncs", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_last_proposal_size")) {
+      zookeeper_submit_gauge("bytes", "last_proposal", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_min_proposal_size")) {
+      zookeeper_submit_gauge("bytes", "min_proposal", atol(fields[1]));
+    } else if (FIELD_CHECK(fields[0], "zk_max_proposal_size")) {
+      zookeeper_submit_gauge("bytes", "max_proposal", atol(fields[1]));
     } else {
       DEBUG("Uncollected zookeeper MNTR field %s", fields[0]);
     }


### PR DESCRIPTION
Add missing `zk_open_file_descriptor_count` and `zk_max_file_descriptor_count` mntr fields to handled fields for 3.4 version.
There was, I think, a typo resulting in checking 3 times the `zk_ephemerals_count` field instead of these two missing fields.

Also add missing fields for the 3.5 zookeeper version : `zk_last_proposal_size`, `zk_min_proposal_size` and `zk_max_proposal_size`
Note : list of fields in the mntr 4LW can be found here [http://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_4lw](http://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_4lw). The current documentation (for the 3.6.0) is not up-to-date

ChangeLog: zookeeper plugin: add missing mntr fields