### PR TITLE
MQTT: Resubscribe after a reconnect

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -458,20 +458,19 @@ static int publish(mqtt_client_conf_t *conf, char const *topic,
     return -1;
   }
 
-  #if LIBMOSQUITTO_MAJOR == 0
-    status = mosquitto_loop(conf->mosq, /* timeout = */ 1000 /* ms */);
-  #else
-    status = mosquitto_loop(conf->mosq,
-                            /* timeout[ms] = */ 1000,
-                            /* max_packets = */ 1);
-  #endif
+#if LIBMOSQUITTO_MAJOR == 0
+  status = mosquitto_loop(conf->mosq, /* timeout = */ 1000 /* ms */);
+#else
+  status = mosquitto_loop(conf->mosq,
+                          /* timeout[ms] = */ 1000,
+                          /* max_packets = */ 1);
+#endif
 
   if (status != MOSQ_ERR_SUCCESS) {
     c_complain(LOG_ERR, &conf->complaint_cantpublish,
                "mqtt plugin: mosquitto_loop failed: %s",
-               (status == MOSQ_ERR_ERRNO)
-                   ? STRERRNO
-                   : mosquitto_strerror(status));
+               (status == MOSQ_ERR_ERRNO) ? STRERRNO
+                                          : mosquitto_strerror(status));
     /* Mark our connection "down" regardless of the error as a safety
      * measure; we will try to reconnect the next time we have to publish a
      * message */

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -238,6 +238,19 @@ static void on_message(
   sfree(vl.values);
 } /* void on_message */
 
+static int mqtt_subscribe(mqtt_client_conf_t *conf) {
+  int status = mosquitto_subscribe(conf->mosq, /* message_id = */ NULL,
+                                   conf->topic, conf->qos);
+  if (status != MOSQ_ERR_SUCCESS) {
+    ERROR("mqtt plugin: Subscribing to \"%s\" failed: %s", conf->topic,
+          mosquitto_strerror(status));
+    mosquitto_disconnect(conf->mosq);
+    return -1;
+  }
+
+  return 0;
+}
+
 /* must hold conf->lock when calling. */
 static int mqtt_reconnect(mqtt_client_conf_t *conf) {
   int status;
@@ -250,6 +263,12 @@ static int mqtt_reconnect(mqtt_client_conf_t *conf) {
     ERROR("mqtt_connect_broker: mosquitto_connect failed: %s",
           (status == MOSQ_ERR_ERRNO) ? STRERRNO : mosquitto_strerror(status));
     return -1;
+  }
+
+  if (!conf->publish) {
+    status = mqtt_subscribe(conf);
+    if (status != 0)
+      return status;
   }
 
   conf->connected = true;
@@ -352,17 +371,11 @@ static int mqtt_connect(mqtt_client_conf_t *conf) {
   if (!conf->publish) {
     mosquitto_message_callback_set(conf->mosq, on_message);
 
-    status =
-        mosquitto_subscribe(conf->mosq,
-                            /* message_id = */ NULL, conf->topic, conf->qos);
-    if (status != MOSQ_ERR_SUCCESS) {
-      ERROR("mqtt plugin: Subscribing to \"%s\" failed: %s", conf->topic,
-            mosquitto_strerror(status));
-
-      mosquitto_disconnect(conf->mosq);
+    status = mqtt_subscribe(conf);
+    if (status != 0) {
       mosquitto_destroy(conf->mosq);
       conf->mosq = NULL;
-      return -1;
+      return status;
     }
   }
 


### PR DESCRIPTION
After losing our connection to a MQTT broker our subscription will be gone, too, so we need to subscribe to our topic once again after reconnecting, otherwise collectd will not receive any MQTT messages any more.

ChangeLog: MQTT plugin: Resubscribe after a reconnect
Fixes: #3442
