### PR TITLE
ceph plugin: Initialize file descriptor to -1.

### DIFF
--- a/src/ceph.c
+++ b/src/ceph.c
@@ -1326,6 +1326,7 @@ static ssize_t cconn_main_loop(uint32_t request_type) {
         .d = g_daemons[i],
         .request_type = request_type,
         .state = CSTATE_UNCONNECTED,
+        .asok = -1,
     };
   }
 


### PR DESCRIPTION
`(struct cconn).asok` was implicitly initialized to zero. If connecting to a ceph daemon failed, the field would be left unmodified and `cconn_close()` would eventually close file descriptor 0.

ChangeLog: ceph plugin: An incorrect close on file descriptor 0 has been fixed.
See also: #3455