### PR TITLE
Daemon: Add the "collectd_version" symbol.

### DIFF
--- a/src/daemon/globals.c
+++ b/src/daemon/globals.c
@@ -52,3 +52,37 @@ void hostname_set(char const *hostname) {
   sfree(hostname_g);
   hostname_g = h;
 }
+
+/* sanitize_version copies v into buf and drops the third period and everything
+ * following it, so that "5.11.0.32.g86275a6+" becomes "5.11.0". */
+static void sanitize_version(char *buf, size_t buf_size, char const *v) {
+  sstrncpy(buf, v, buf_size);
+
+  // find the third period.
+  char *ptr = buf;
+  for (int i = 0; i < 3; i++) {
+    if (i != 0) {
+      // point to the character *following* the period.
+      ptr++;
+    }
+    char *chr = strchr(ptr, '.');
+    if (chr == NULL) {
+      return;
+    }
+    ptr = chr;
+  }
+
+  // If we get here, there are at least three period in the version
+  // string. Such a version string may look like this:
+  // "5.11.0.32.g86275a6+". `ptr` is pointing here:
+  //        ^-- ptr
+  *ptr = 0;
+}
+
+static char clean_version[32] = "";
+char const *collectd_version(void) {
+  if (strlen(clean_version) == 0) {
+    sanitize_version(clean_version, sizeof(clean_version), PACKAGE_VERSION);
+  }
+  return clean_version;
+}

--- a/src/daemon/globals.h
+++ b/src/daemon/globals.h
@@ -44,6 +44,12 @@ typedef uint64_t cdtime_t;
 /* hostname_set updates hostname_g */
 void hostname_set(char const *hostname);
 
+/* collectd_version returns the sanitized version of the collectd binary.
+ * "sanitized" means that everything following the patch version is dropped.
+ * E.g. if collectd is built from the Git repository, PACKAGE_VERSION may
+ * contain "5.11.0.32.g86275a6+". If so, this function returns "5.11.0". */
+char const *collectd_version(void);
+
 extern char *hostname_g;
 extern cdtime_t interval_g;
 extern int pidfile_from_cli;


### PR DESCRIPTION
Go and Rust both allow contributors to write plugins in those languages and compile them to a shared object to be loaded and executed by collectd. Since these plugins are developed and built out of tree, it would be very useful to be able to determine the *application binary interface* (ABI) of the daemon at runtime.

The new `collectd_version()` allows to implement that: it returns the version of the daemon, allowing plugin code to infer which functions are available and what their semantic is.