### PR TITLE
mysql: report slave_io_running and slave_sql_running

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -472,20 +472,13 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     unsigned long long counter;
     double gauge;
 
-    if (row[SLAVE_SQL_RUNNING_IDX] == NULL) {
-      gauge_submit("slave_running", "sql", 1, db);
-    } else if (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") != 0) {
-      gauge_submit("slave_running", "sql", 1, db);
-    } else {
-      gauge_submit("slave_running", "sql", 0, db);
-    }
-    if (row[SLAVE_IO_RUNNING_IDX] == NULL) {
-      gauge_submit("slave_running", "io", 1, db);
-    } else if (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") != 0) {
-      gauge_submit("slave_running", "io", 1, db);
-    } else {
-      gauge_submit("slave_running", "io", 0, db);
-    }
+    gauge_submit("bool", "slave-sql-running",
+      (row[SLAVE_SQL_RUNNING_IDX] != NULL) && (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") == 0),
+       db);
+
+    gauge_submit("bool", "slave-io-running",
+      (row[SLAVE_IO_RUNNING_IDX] != NULL) && (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") == 0),
+       db);
 
     counter = atoll(row[READ_MASTER_LOG_POS_IDX]);
     derive_submit("mysql_log_position", "slave-read", counter, db);

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -472,6 +472,21 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     unsigned long long counter;
     double gauge;
 
+    if (row[SLAVE_SQL_RUNNING_IDX] == NULL) {
+      gauge_submit("slave_running", "sql", 1, db);
+    } else if (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") != 0) {
+      gauge_submit("slave_running", "sql", 1, db);
+    } else {
+      gauge_submit("slave_running", "sql", 0, db);
+    }
+    if (row[SLAVE_IO_RUNNING_IDX] == NULL) {
+      gauge_submit("slave_running", "io", 1, db);
+    } else if (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") != 0) {
+      gauge_submit("slave_running", "io", 1, db);
+    } else {
+      gauge_submit("slave_running", "io", 0, db);
+    }
+
     counter = atoll(row[READ_MASTER_LOG_POS_IDX]);
     derive_submit("mysql_log_position", "slave-read", counter, db);
 

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -473,12 +473,14 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     double gauge;
 
     gauge_submit("bool", "slave-sql-running",
-      (row[SLAVE_SQL_RUNNING_IDX] != NULL) && (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") == 0),
-       db);
+                 (row[SLAVE_SQL_RUNNING_IDX] != NULL) &&
+                     (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") == 0),
+                 db);
 
     gauge_submit("bool", "slave-io-running",
-      (row[SLAVE_IO_RUNNING_IDX] != NULL) && (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") == 0),
-       db);
+                 (row[SLAVE_IO_RUNNING_IDX] != NULL) &&
+                     (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") == 0),
+                 db);
 
     counter = atoll(row[READ_MASTER_LOG_POS_IDX]);
     derive_submit("mysql_log_position", "slave-read", counter, db);

--- a/src/types.db
+++ b/src/types.db
@@ -249,6 +249,7 @@ slurm_last_cycle_depth  value:GAUGE:0:U
 slurm_cycle_depth       value:DERIVE:0:U
 slurm_job_stats         value:DERIVE:0:U
 slurm_queue_length      value:DERIVE:0:U
+slave_running           value:GAUGE:0:U
 smart_attribute         current:GAUGE:0:255, worst:GAUGE:0:255, threshold:GAUGE:0:255, pretty:GAUGE:0:U
 smart_badsectors        value:GAUGE:0:U
 smart_powercycles       value:GAUGE:0:U

--- a/src/types.db
+++ b/src/types.db
@@ -10,6 +10,7 @@ backends                value:GAUGE:0:65535
 bad_peb_count           value:COUNTER:0:U
 bitrate                 value:GAUGE:0:4294967295
 blocked_clients         value:GAUGE:0:U
+bool                    value:GAUGE:0:1
 bucket                  value:GAUGE:0:U
 buffer                  value:GAUGE:0:18446744073709551615
 bytes                   value:GAUGE:0:U
@@ -249,7 +250,6 @@ slurm_last_cycle_depth  value:GAUGE:0:U
 slurm_cycle_depth       value:DERIVE:0:U
 slurm_job_stats         value:DERIVE:0:U
 slurm_queue_length      value:DERIVE:0:U
-slave_running           value:GAUGE:0:U
 smart_attribute         current:GAUGE:0:255, worst:GAUGE:0:255, threshold:GAUGE:0:255, pretty:GAUGE:0:U
 smart_badsectors        value:GAUGE:0:U
 smart_powercycles       value:GAUGE:0:U


### PR DESCRIPTION
ChangeLog: mysql plugin: report slave_io_running and slave_sql_running

added reporting of the fields Slave_IO_Running and Slave_SQL_Running as 0 and 1. Needed to catch more cases when replications broke.

I have added an entry to types.db, please advise me which existing type should be used.