### PR TITLE
collection3: Show instance for Current/Voltage

### DIFF
--- a/contrib/collection3/etc/collection.conf
+++ b/contrib/collection3/etc/collection.conf
@@ -134,7 +134,7 @@ GraphWidth 400
 <Type current>
   DataSources value
   DSName value Current
-  RRDTitle "Current ({type_instance})"
+  RRDTitle "Current ({instance})"
   RRDVerticalLabel "Ampere"
   RRDFormat "%4.1lfA"
   Color value ffb000
@@ -717,7 +717,7 @@ GraphWidth 400
 <Type voltage>
   DataSources value
   DSName value Volts
-  RRDTitle "Voltage ({type_instance})"
+  RRDTitle "Voltage ({instance})"
   RRDVerticalLabel "Volts"
   RRDFormat "%4.1lfV"
   Color value f00000


### PR DESCRIPTION
Instead of just `{type_instance}` (which is sometimes empty for some data), show `{instance}`. This one contains the former and is more informative.

IMHO this is a minor change and doesn't warrant a `ChangeLog:` entry.

But anyway, to please the CI:

ChangeLog: collection3: Improve some small titles