### PR TITLE
processes: increase reading buffer for /proc/stat

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -757,7 +757,7 @@ static int ps_init(void) {
     pset_list_len = 0;
     return -1;
   }
-    /* #endif HAVE_THREAD_INFO */
+  /* #endif HAVE_THREAD_INFO */
 
 #elif KERNEL_LINUX
   pagesize_g = sysconf(_SC_PAGESIZE);
@@ -771,7 +771,7 @@ static int ps_init(void) {
     }
   }
 #endif
-    /* #endif KERNEL_LINUX */
+  /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKVM_GETPROCS &&                                                  \
     (HAVE_STRUCT_KINFO_PROC_FREEBSD || HAVE_STRUCT_KINFO_PROC_OPENBSD)
@@ -1429,7 +1429,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 } /* int ps_read_process (...) */
 
 static int procs_running(void) {
-  char buffer[4096] = {};
+  char buffer[65536] = {};
   char id[] = "procs_running "; /* white space terminated */
   char *running;
   char *endptr = NULL;


### PR DESCRIPTION
If machine has high number of CPUs or interrupts or both, the /proc/stat
can easily grow over current buffer size 4kB. On my current machine (64
cores, ~300 interrupts) the /proc/stat has 12kB of data. And since the
`procs_running` line is after the interrupts it is never read.

Increasing the size to 64KB so it will accommodate even heavier machines.

It would be nice if this would be more dynamic to don't allocate large buffer on smaller machines. I have no idea about the current smallest supported setup by the collectd. Optionally the part could be reprogrammed to read the whole file in 4kB chunks, something similar is already done in `read_fork_rate`.

ChangeLog: Process plugin: Increase reading buffer for /proc/stat