### PR TITLE
intel_pmu: fix crash after specifying incorrect HardwareEvents

### DIFF
--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -611,7 +611,7 @@ static int pmu_add_hw_events(struct eventlist *el, char **e, size_t count) {
     }
 
     /* Multiple events parsed in one entry */
-    if (group) {
+    if (group && group_events_count > 0) {
       /* Mark last added event as group end */
       el->eventlist_last->end_group = 1;
     }


### PR DESCRIPTION
ChangeLog: intel_pmu plugin: fix the possible crash on plugin init

If HardwareEvents group in configuration consisted only of events that can't be resolved collectd was crashing during init. Added a check to end the group only if some events were actually added to the group.
