### PR TITLE
strbuf: Library that implements printing to a dynamically allocated buffer.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,7 +140,8 @@ noinst_LTLIBRARIES = \
 	liblookup.la \
 	libmetadata.la \
 	libmount.la \
-	liboconfig.la
+	liboconfig.la \
+	libstrbuf.la
 
 
 check_LTLIBRARIES = \
@@ -157,6 +158,7 @@ check_PROGRAMS = \
 	test_utils_latency \
 	test_utils_message_parser \
 	test_utils_mount \
+	test_utils_strbuf \
 	test_utils_subst \
 	test_utils_time \
 	test_utils_vl_lookup \
@@ -545,6 +547,14 @@ if BUILD_WITH_LIBKSTAT
 test_utils_mount_LDADD += -lkstat
 endif
 
+libstrbuf_la_SOURCES = \
+		       src/utils/strbuf/strbuf.c \
+		       src/utils/strbuf/strbuf.h
+
+test_utils_strbuf_SOURCES = \
+			    src/utils/strbuf/strbuf_test.c \
+			    src/testing.h
+test_utils_strbuf_LDADD = libstrbuf.la
 
 libcollectdclient_la_SOURCES = \
 	src/libcollectdclient/client.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -399,7 +399,7 @@ libavltree_la_SOURCES = \
 libcommon_la_SOURCES = \
 	src/utils/common/common.c \
 	src/utils/common/common.h
-libcommon_la_LIBADD = $(COMMON_LIBS)
+libcommon_la_LIBADD = libstrbuf.la $(COMMON_LIBS)
 
 libheap_la_SOURCES = \
 	src/utils/heap/heap.c \

--- a/src/testing.h
+++ b/src/testing.h
@@ -28,6 +28,10 @@
 #define TESTING_H 1
 
 #include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static int fail_count__;
 static int check_count__;

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -31,6 +31,7 @@
 
 #include "plugin.h"
 #include "utils/common/common.h"
+#include "utils/strbuf/strbuf.h"
 #include "utils_cache.h"
 
 /* for getaddrinfo */
@@ -205,7 +206,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
     pthread_mutex_unlock(&strerror_r_lock);
   }
-    /* #endif !HAVE_STRERROR_R */
+  /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -221,7 +222,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
                  buflen);
     }
   }
-    /* #endif STRERROR_R_CHAR_P */
+  /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
@@ -793,8 +794,8 @@ unsigned long long htonll(unsigned long long n) {
 #endif /* HAVE_HTONLL */
 
 #if FP_LAYOUT_NEED_NOTHING
-  /* Well, we need nothing.. */
-  /* #endif FP_LAYOUT_NEED_NOTHING */
+/* Well, we need nothing.. */
+/* #endif FP_LAYOUT_NEED_NOTHING */
 
 #elif FP_LAYOUT_NEED_ENDIANFLIP || FP_LAYOUT_NEED_INTSWAP
 #if FP_LAYOUT_NEED_ENDIANFLIP
@@ -905,54 +906,37 @@ int format_name(char *ret, int ret_len, const char *hostname,
 int format_values(char *ret, size_t ret_len, /* {{{ */
                   const data_set_t *ds, const value_list_t *vl,
                   bool store_rates) {
-  size_t offset = 0;
-  int status;
-  gauge_t *rates = NULL;
-
   assert(0 == strcmp(ds->type, vl->type));
 
-  memset(ret, 0, ret_len);
+  ret[0] = 0;
+  strbuf_t buf = STRBUF_CREATE_FIXED(ret, ret_len);
 
-#define BUFFER_ADD(...)                                                        \
-  do {                                                                         \
-    status = snprintf(ret + offset, ret_len - offset, __VA_ARGS__);            \
-    if (status < 1) {                                                          \
-      sfree(rates);                                                            \
-      return -1;                                                               \
-    } else if (((size_t)status) >= (ret_len - offset)) {                       \
-      sfree(rates);                                                            \
-      return -1;                                                               \
-    } else                                                                     \
-      offset += ((size_t)status);                                              \
-  } while (0)
+  strbuf_printf(&buf, "%.3f", CDTIME_T_TO_DOUBLE(vl->time));
 
-  BUFFER_ADD("%.3f", CDTIME_T_TO_DOUBLE(vl->time));
-
+  gauge_t *rates = NULL;
   for (size_t i = 0; i < ds->ds_num; i++) {
-    if (ds->ds[i].type == DS_TYPE_GAUGE)
-      BUFFER_ADD(":" GAUGE_FORMAT, vl->values[i].gauge);
-    else if (store_rates) {
+    if (ds->ds[i].type == DS_TYPE_GAUGE) {
+      strbuf_printf(&buf, ":" GAUGE_FORMAT, vl->values[i].gauge);
+    } else if (store_rates) {
       if (rates == NULL)
         rates = uc_get_rate(ds, vl);
       if (rates == NULL) {
         WARNING("format_values: uc_get_rate failed.");
         return -1;
       }
-      BUFFER_ADD(":" GAUGE_FORMAT, rates[i]);
+      strbuf_printf(&buf, ":" GAUGE_FORMAT, rates[i]);
     } else if (ds->ds[i].type == DS_TYPE_COUNTER)
-      BUFFER_ADD(":%" PRIu64, (uint64_t)vl->values[i].counter);
+      strbuf_printf(&buf, ":%" PRIu64, (uint64_t)vl->values[i].counter);
     else if (ds->ds[i].type == DS_TYPE_DERIVE)
-      BUFFER_ADD(":%" PRIi64, vl->values[i].derive);
+      strbuf_printf(&buf, ":%" PRIi64, vl->values[i].derive);
     else if (ds->ds[i].type == DS_TYPE_ABSOLUTE)
-      BUFFER_ADD(":%" PRIu64, vl->values[i].absolute);
+      strbuf_printf(&buf, ":%" PRIu64, vl->values[i].absolute);
     else {
       ERROR("format_values: Unknown data source type: %i", ds->ds[i].type);
       sfree(rates);
       return -1;
     }
   } /* for ds->ds_num */
-
-#undef BUFFER_ADD
 
   sfree(rates);
   return 0;

--- a/src/utils/common/common_test.c
+++ b/src/utils/common/common_test.c
@@ -375,6 +375,44 @@ DEF_TEST(value_to_rate) {
   return 0;
 }
 
+DEF_TEST(format_values) {
+  struct {
+    int ds_type;
+    value_t value;
+    char const *want;
+  } cases[] = {
+      {DS_TYPE_GAUGE, (value_t){.gauge = 47.11}, "1592558427.435:47.11"},
+      {DS_TYPE_GAUGE, (value_t){.gauge = NAN}, "1592558427.435:nan"},
+      {DS_TYPE_DERIVE, (value_t){.derive = 42}, "1592558427.435:42"},
+      {DS_TYPE_COUNTER, (value_t){.counter = 18446744073709551615LLU},
+       "1592558427.435:18446744073709551615"},
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    char buf[1024];
+
+    data_set_t ds = {
+        .type = "testing",
+        .ds_num = 1,
+        .ds =
+            &(data_source_t){
+                .type = cases[i].ds_type,
+            },
+    };
+    value_list_t vl = {
+        .type = "testing",
+        .values = &cases[i].value,
+        .values_len = 1,
+        .time = 1709996590700628541,
+    };
+
+    EXPECT_EQ_INT(0, format_values(buf, sizeof(buf), &ds, &vl, false));
+    EXPECT_EQ_STR(cases[i].want, buf);
+  }
+
+  return 0;
+}
+
 int main(void) {
   RUN_TEST(sstrncpy);
   RUN_TEST(sstrdup);
@@ -385,6 +423,7 @@ int main(void) {
   RUN_TEST(strunescape);
   RUN_TEST(parse_values);
   RUN_TEST(value_to_rate);
+  RUN_TEST(format_values);
 
   END_TEST;
 }

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -135,10 +135,13 @@ void strbuf_reset(strbuf_t *buf) {
   /* Truncate the buffer to the page size. This is deemed a good compromise
    * between freeing memory (after a large buffer has been constructed) and
    * performance (avoid unnecessary allocations). */
-  if (buf->size > strbuf_pagesize()) {
-    char *new_ptr = realloc(buf->ptr, strbuf_pagesize());
-    if (new_ptr != NULL)
+  size_t new_size = strbuf_pagesize();
+  if (buf->size > new_size) {
+    char *new_ptr = realloc(buf->ptr, new_size);
+    if (new_ptr != NULL) {
       buf->ptr = new_ptr;
+      buf->size = new_size;
+    }
   }
 }
 

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -95,7 +95,7 @@ static int strbuf_resize(strbuf_t *buf, size_t need) {
 
 strbuf_t *strbuf_create(void) { return calloc(1, sizeof(strbuf_t)); }
 
-strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size) {
+strbuf_t *strbuf_create_fixed(void *buffer, size_t buffer_size) {
   strbuf_t *buf = calloc(1, sizeof(*buf));
   if (buf == NULL)
     return NULL;

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -1,0 +1,198 @@
+/**
+ * collectd - src/utils_strbuf.h
+ * Copyright (C) 2017       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#include "collectd.h"
+
+#include "utils/strbuf/strbuf.h"
+
+#include <stdarg.h>
+
+static size_t strbuf_avail(strbuf_t *buf) {
+  if ((buf == NULL) || (buf->size == 0)) {
+    return 0;
+  }
+
+  assert(buf->pos < buf->size);
+  return buf->size - (buf->pos + 1);
+}
+
+static size_t strbuf_pagesize() {
+  static size_t cached_pagesize;
+
+  if (!cached_pagesize) {
+    long tmp = sysconf(_SC_PAGESIZE);
+    if (tmp >= 1)
+      cached_pagesize = (size_t)tmp;
+    else
+      cached_pagesize = 1024;
+  }
+
+  return cached_pagesize;
+}
+
+/* strbuf_resize resizes an dynamic buffer to ensure that "need" bytes can be
+ * stored in it. When called with an empty buffer, i.e. buf->size == 0, it will
+ * allocate just enough memory to store need+1 bytes. Subsequent calls will
+ * only allocate memory when needed, doubling the allocated memory size each
+ * time until the page size is reached, then allocating. */
+static int strbuf_resize(strbuf_t *buf, size_t need) {
+  if (buf->fixed)
+    return 0;
+
+  if (strbuf_avail(buf) > need)
+    return 0;
+
+  size_t new_size;
+  if (buf->size == 0) {
+    /* New buffers: try to use a reasonable default. */
+    new_size = 512;
+  } else if (buf->size < strbuf_pagesize()) {
+    /* Small buffers: double the size. */
+    new_size = 2 * buf->size;
+  } else {
+    /* Large buffers: allocate an additional page. */
+    size_t pages = (buf->size + strbuf_pagesize() - 1) / strbuf_pagesize();
+    new_size = (pages + 1) * strbuf_pagesize();
+  }
+
+  /* Check that the new size is large enough. If not, calculate the exact number
+   * of bytes needed. */
+  if (new_size < (buf->pos + need + 1))
+    new_size = buf->pos + need + 1;
+
+  char *new_ptr = realloc(buf->ptr, new_size);
+  if (new_ptr == NULL)
+    return ENOMEM;
+
+  buf->ptr = new_ptr;
+  buf->size = new_size;
+
+  return 0;
+}
+
+strbuf_t *strbuf_create(void) { return calloc(1, sizeof(strbuf_t)); }
+
+strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size) {
+  strbuf_t *buf = calloc(1, sizeof(*buf));
+  if (buf == NULL)
+    return NULL;
+
+  *buf = (strbuf_t){
+      .ptr = buffer,
+      .size = buffer_size,
+      .fixed = 1,
+  };
+  return buf;
+}
+
+void strbuf_destroy(strbuf_t *buf) {
+  if (buf == NULL) {
+    return;
+  }
+
+  if (!buf->fixed) {
+    free(buf->ptr);
+  }
+  free(buf);
+}
+
+void strbuf_reset(strbuf_t *buf) {
+  if (buf == NULL) {
+    return;
+  }
+
+  buf->pos = 0;
+  if (buf->ptr != NULL)
+    buf->ptr[buf->pos] = 0;
+
+  if (buf->fixed) {
+    return;
+  }
+
+  /* Truncate the buffer to the page size. This is deemed a good compromise
+   * between freeing memory (after a large buffer has been constructed) and
+   * performance (avoid unnecessary allocations). */
+  if (buf->size > strbuf_pagesize()) {
+    char *new_ptr = realloc(buf->ptr, strbuf_pagesize());
+    if (new_ptr != NULL)
+      buf->ptr = new_ptr;
+  }
+}
+
+int strbuf_print(strbuf_t *buf, char const *s) {
+  if ((buf == NULL) || (s == NULL))
+    return EINVAL;
+
+  size_t s_len = strlen(s);
+  int status = strbuf_resize(buf, s_len);
+  if (status != 0)
+    return status;
+
+  size_t bytes = strbuf_avail(buf);
+  if (bytes == 0)
+    return ENOSPC;
+
+  if (bytes > s_len)
+    bytes = s_len;
+
+  memmove(buf->ptr + buf->pos, s, bytes);
+  buf->pos += bytes;
+  buf->ptr[buf->pos] = 0;
+
+  return 0;
+}
+
+int strbuf_printf(strbuf_t *buf, char const *format, ...) {
+  va_list ap;
+
+  va_start(ap, format);
+  int status = vsnprintf(NULL, 0, format, ap);
+  va_end(ap);
+  if (status <= 0)
+    return status;
+
+  size_t s_len = (size_t)status;
+
+  status = strbuf_resize(buf, s_len);
+  if (status != 0)
+    return status;
+
+  size_t bytes = strbuf_avail(buf);
+  if (bytes == 0)
+    return ENOSPC;
+
+  if (bytes > s_len)
+    bytes = s_len;
+
+  va_start(ap, format);
+  (void)vsnprintf(buf->ptr + buf->pos, bytes + 1, format, ap);
+  va_end(ap);
+
+  buf->pos += bytes;
+  buf->ptr[buf->pos] = 0;
+
+  return 0;
+}

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -1,0 +1,66 @@
+/**
+ * collectd - src/utils/strbuf/strbuf.h
+ * Copyright (C) 2017       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#ifndef UTILS_STRBUF_H
+#define UTILS_STRBUF_H 1
+
+typedef struct {
+  char *ptr;
+  size_t pos;
+  size_t size;
+  _Bool fixed;
+} strbuf_t;
+
+#define STRBUF_NEW                                                             \
+  &(strbuf_t) { .ptr = NULL }
+#define STRBUF_NEW_STATIC(b)                                                   \
+  &(strbuf_t) { .ptr = b, .size = sizeof(b), .fixed = 1 }
+#define STRBUF_DELETE(buf)                                                     \
+  do {                                                                         \
+    if (!buf->fixed) {                                                         \
+      free(buf->ptr);                                                          \
+    }                                                                          \
+    *buf = (strbuf_t){.ptr = NULL};                                            \
+  }
+
+strbuf_t *strbuf_create(void);
+strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size);
+void strbuf_destroy(strbuf_t *buf);
+
+/* strbuf_reset empties the buffer. If the buffer is dynamically allocated, it
+ * will *not* release (all) the allocated memory. */
+void strbuf_reset(strbuf_t *buf);
+
+/* strbuf_print adds "s" to the buffer. If the size of the buffer is static and
+ * there is no space available in the buffer, ENOSPC is returned. */
+int strbuf_print(strbuf_t *buf, char const *s);
+
+/* strbuf_printf adds a string to the buffer using formatting. If the size of
+ * the buffer is static and there is no space available in the buffer, ENOSPC
+ * is returned. */
+int strbuf_printf(strbuf_t *buf, char const *format, ...);
+
+#endif

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -38,32 +38,41 @@ typedef struct {
  * using STRBUF_DESTROY before returning from the function. Failure to call
  * STRBUF_DESTROY will leak the memory allocated to (strbuf_t).ptr. */
 #define STRBUF_CREATE                                                          \
-  &(strbuf_t) { .ptr = NULL }
+  (strbuf_t) { .ptr = NULL }
 
-/* STRBUF_CREATE_STATIC allocates a new strbuf_t on the stack, using the fixed
- * sized buffer "b". You may optionally call STRBUF_DESTROY with a fixed-sized
- * buffer. */
+/* STRBUF_CREATE_FIXED allocates a new strbuf_t on the stack, using the buffer
+ * "b" of fixed size "sz". The buffer is freed automatically when it goes out
+ * of scope. */
+#define STRBUF_CREATE_FIXED(b, sz)                                             \
+  (strbuf_t) { .ptr = b, .size = sz, .fixed = 1 }
+
+/* STRBUF_CREATE_STATIC allocates a new strbuf_t on the stack, using the static
+ * buffer "b". This macro assumes that is can use `sizeof(b)` to determine the
+ * size of "b". If that is not the case, use STRBUF_CREATE_FIXED instead. */
 #define STRBUF_CREATE_STATIC(b)                                                \
-  &(strbuf_t) { .ptr = b, .size = sizeof(b), .fixed = 1 }
+  (strbuf_t) { .ptr = b, .size = sizeof(b), .fixed = 1 }
 
 /* STRBUF_DESTROY frees the memory allocated inside the buffer. The buffer
- * itself is assumed to be allocated on the stack and is not freed. */
+ * itself is assumed to be allocated on the stack and is not freed. Calling
+ * STRBUF_DESTROY with a buffer that was allocated with STRBUF_CREATE_FIXED or
+ * STRBUF_CREATE_STATIC is a no-op. */
 #define STRBUF_DESTROY(buf)                                                    \
   do {                                                                         \
-    if (!buf->fixed) {                                                         \
-      free(buf->ptr);                                                          \
+    if (buf.fixed) {                                                           \
+      break;                                                                   \
     }                                                                          \
-    *buf = (strbuf_t){.ptr = NULL};                                            \
+    free(buf.ptr);                                                             \
+    buf.ptr = NULL;                                                            \
   } while (0)
 
 /* strbuf_create allocates a new strbuf_t on the heap, which must be freed
  * using strbuf_destroy. */
 strbuf_t *strbuf_create(void);
 
-/* strbuf_create_static allocates a new strbuf_t on the stack, using the fixed
+/* strbuf_create_fixed allocates a new strbuf_t on the stack, using the fixed
  * sized buffer "buffer". The returned strbuf_t* must be freed using
  * strbuf_destroy. */
-strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size);
+strbuf_t *strbuf_create_fixed(void *buffer, size_t buffer_size);
 
 /* strbuf_destroy frees a strbuf_t* allocated on the heap. */
 void strbuf_destroy(strbuf_t *buf);

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -34,10 +34,20 @@ typedef struct {
   _Bool fixed;
 } strbuf_t;
 
+/* STRBUF_CREATE allocates a new strbuf_t on the stack, which must be freed
+ * using STRBUF_DESTROY before returning from the function. Failure to call
+ * STRBUF_DESTROY will leak the memory allocated to (strbuf_t).ptr. */
 #define STRBUF_CREATE                                                          \
   &(strbuf_t) { .ptr = NULL }
+
+/* STRBUF_CREATE_STATIC allocates a new strbuf_t on the stack, using the fixed
+ * sized buffer "b". You may optionally call STRBUF_DESTROY with a fixed-sized
+ * buffer. */
 #define STRBUF_CREATE_STATIC(b)                                                \
   &(strbuf_t) { .ptr = b, .size = sizeof(b), .fixed = 1 }
+
+/* STRBUF_DESTROY frees the memory allocated inside the buffer. The buffer
+ * itself is assumed to be allocated on the stack and is not freed. */
 #define STRBUF_DESTROY(buf)                                                    \
   do {                                                                         \
     if (!buf->fixed) {                                                         \
@@ -46,8 +56,16 @@ typedef struct {
     *buf = (strbuf_t){.ptr = NULL};                                            \
   } while (0)
 
+/* strbuf_create allocates a new strbuf_t on the heap, which must be freed
+ * using strbuf_destroy. */
 strbuf_t *strbuf_create(void);
+
+/* strbuf_create_static allocates a new strbuf_t on the stack, using the fixed
+ * sized buffer "buffer". The returned strbuf_t* must be freed using
+ * strbuf_destroy. */
 strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size);
+
+/* strbuf_destroy frees a strbuf_t* allocated on the heap. */
 void strbuf_destroy(strbuf_t *buf);
 
 /* strbuf_reset empties the buffer. If the buffer is dynamically allocated, it

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -34,17 +34,17 @@ typedef struct {
   _Bool fixed;
 } strbuf_t;
 
-#define STRBUF_NEW                                                             \
+#define STRBUF_CREATE                                                          \
   &(strbuf_t) { .ptr = NULL }
-#define STRBUF_NEW_STATIC(b)                                                   \
+#define STRBUF_CREATE_STATIC(b)                                                \
   &(strbuf_t) { .ptr = b, .size = sizeof(b), .fixed = 1 }
-#define STRBUF_DELETE(buf)                                                     \
+#define STRBUF_DESTROY(buf)                                                    \
   do {                                                                         \
     if (!buf->fixed) {                                                         \
       free(buf->ptr);                                                          \
     }                                                                          \
     *buf = (strbuf_t){.ptr = NULL};                                            \
-  }
+  } while (0)
 
 strbuf_t *strbuf_create(void);
 strbuf_t *strbuf_create_static(void *buffer, size_t buffer_size);

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -90,4 +90,16 @@ int strbuf_print(strbuf_t *buf, char const *s);
  * is returned. */
 int strbuf_printf(strbuf_t *buf, char const *format, ...);
 
+/* strbuf_printn adds at most n bytes from "s" to the buffer.  If the size of
+ * the buffer is static and there is no space available in the buffer, ENOSPC
+ * is returned. */
+int strbuf_printn(strbuf_t *buf, char const *s, size_t n);
+
+/* strbuf_print_escaped adds an escaped copy of "s" to the buffer. Each
+ * character in "need_escape" is prefixed by "escape_char". If "escape_char" is
+ * '\' (backslash), newline (\n), cartridge return (\r) and tab (\t) are
+ * handled correctly. */
+int strbuf_print_escaped(strbuf_t *buf, char const *s, char const *need_escape,
+                         char escape_char);
+
 #endif

--- a/src/utils/strbuf/strbuf_test.c
+++ b/src/utils/strbuf/strbuf_test.c
@@ -1,0 +1,88 @@
+/**
+ * collectd - src/utils/strbuf/strbuf_test.c
+ * Copyright (C) 2020       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#include "testing.h"
+#include "utils/strbuf/strbuf.h"
+
+#include <errno.h>
+
+DEF_TEST(dynamic) {
+  strbuf_t *buf;
+  CHECK_NOT_NULL(buf = strbuf_create());
+
+  CHECK_ZERO(strbuf_print(buf, "foo"));
+  EXPECT_EQ_STR("foo", buf->ptr);
+
+  CHECK_ZERO(strbuf_print(buf, "bar"));
+  EXPECT_EQ_STR("foobar", buf->ptr);
+
+  CHECK_ZERO(strbuf_printf(buf, "%d\n", 9000));
+  EXPECT_EQ_STR("foobar9000\n", buf->ptr);
+
+  strbuf_reset(buf);
+  CHECK_ZERO(strlen(buf->ptr));
+
+  CHECK_ZERO(strbuf_print(buf, "new content"));
+  EXPECT_EQ_STR("new content", buf->ptr);
+
+  strbuf_destroy(buf);
+  return 0;
+}
+
+DEF_TEST(static) {
+  char mem[8];
+  strbuf_t *buf;
+  CHECK_NOT_NULL(buf = strbuf_create_static(mem, sizeof(mem)));
+
+  CHECK_ZERO(strbuf_print(buf, "foo"));
+  EXPECT_EQ_STR("foo", buf->ptr);
+
+  CHECK_ZERO(strbuf_print(buf, "bar"));
+  EXPECT_EQ_STR("foobar", buf->ptr);
+
+  CHECK_ZERO(strbuf_printf(buf, "%d\n", 9000));
+  EXPECT_EQ_STR("foobar9", buf->ptr);
+
+  EXPECT_EQ_INT(ENOSPC, strbuf_print(buf, "buffer already filled"));
+  EXPECT_EQ_STR("foobar9", buf->ptr);
+
+  strbuf_reset(buf);
+  CHECK_ZERO(strlen(buf->ptr));
+
+  CHECK_ZERO(strbuf_print(buf, "new content"));
+  EXPECT_EQ_STR("new con", buf->ptr);
+
+  strbuf_destroy(buf);
+  return 0;
+}
+
+int main(int argc, char **argv) /* {{{ */
+{
+  RUN_TEST(dynamic);
+  RUN_TEST(static);
+
+  END_TEST;
+} /* }}} int main */


### PR DESCRIPTION
I'm planning on using this code to build the string representation of a label based metric. This certainly will have uses all throughout the daemon though. Looking for "ADD" or "ADDF" macros should uncover places that might benefit from this code.

ChangeLog: collectd: The `strbuf` utility library has been added. It simplifies building strings iteratively.