### PR TITLE
Network Plugin: allow to set the number of dispatch threads

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1139,6 +1139,9 @@
 #
 #	# "garbage collection"
 #	CacheFlush 1800
+#
+#	# Number of dispatch threads
+#	DispatchThreads 1
 @LOAD_PLUGIN_NETWORK@</Plugin>
 
 #<Plugin nfs>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6110,6 +6110,12 @@ signature):
 
 =over 4
 
+=item B<DispatchThreads> I<1->
+
+Number of threads to start for dispatch the incoming packets. The default value
+is B<1>. You may want to increase this if you cannot process all the incoming
+traffic in one thread.
+
 =item B<E<lt>Server> I<Host> [I<Port>]B<E<gt>>
 
 The B<Server> statement/block sets the server to send datagrams to. The


### PR DESCRIPTION
ChangeLog: Network Plugin: allow to set the number of dispatch threads

If you have a high number of incoming packets in the network plugin and a slow processor or a slow virtual machine, maybe  you cannot handle all the processing of the incoming packets in a single thread.

For example, in an old X5660 with a single dispatch thread I cannot process more than 6k packets/s (150k metrics/s).

Increasing the number of dispatch threads I can handle the traffic.
