### PR TITLE
Implement metric_t and metric_family_t.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,6 +139,7 @@ noinst_LTLIBRARIES = \
 	libllist.la \
 	liblookup.la \
 	libmetadata.la \
+	libmetric.la \
 	libmount.la \
 	liboconfig.la \
 	libstrbuf.la
@@ -152,6 +153,7 @@ check_PROGRAMS = \
 	test_common \
 	test_format_graphite \
 	test_meta_data \
+	test_metric \
 	test_utils_avltree \
 	test_utils_cmds \
 	test_utils_heap \
@@ -268,6 +270,7 @@ collectd_LDADD = \
 	libcommon.la \
 	libheap.la \
 	libllist.la \
+	libmetric.la \
 	liboconfig.la \
 	-lm \
 	$(COMMON_LIBS) \
@@ -353,6 +356,11 @@ test_meta_data_SOURCES = \
 	src/testing.h
 test_meta_data_LDADD = libmetadata.la libplugin_mock.la
 
+test_metric_SOURCES = \
+	src/daemon/metric_test.c \
+	src/testing.h
+test_metric_LDADD = libmetric.la libplugin_mock.la
+
 test_utils_avltree_SOURCES = \
 	src/utils/avltree/avltree_test.c \
 	src/testing.h
@@ -416,6 +424,11 @@ libllist_la_SOURCES = \
 libmetadata_la_SOURCES = \
 	src/utils/metadata/meta_data.c \
 	src/utils/metadata/meta_data.h
+
+libmetric_la_SOURCES = \
+		       src/daemon/metric.c \
+		       src/daemon/metric.h
+libmetric_la_LIBADD = libmetadata.la $(COMMON_LIBS)
 
 libplugin_mock_la_SOURCES = \
 	src/daemon/plugin_mock.c \

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -50,7 +50,7 @@ int value_marshal_text(strbuf_t *buf, value_t v, metric_type_t type) {
   case METRIC_TYPE_COUNTER:
     return strbuf_printf(buf, "%" PRIu64, v.counter);
   default:
-    ERROR("Unknown metric value type: %d", type);
+    ERROR("Unknown metric value type: %d", (int)type);
     return EINVAL;
   }
 }

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -372,6 +372,39 @@ int metric_family_metric_append(metric_family_t *fam, metric_t m) {
   return metric_list_add(&fam->metric, m);
 }
 
+int metric_family_append(metric_family_t *fam, char const *lname,
+                         char const *lvalue, value_t v, metric_t const *templ) {
+  if ((fam == NULL) || ((lname == NULL) != (lvalue == NULL))) {
+    return EINVAL;
+  }
+
+  metric_t m = {
+      .family = fam,
+      .value = v,
+  };
+  if (templ != NULL) {
+    int status = label_set_clone(&m.label, templ->label);
+    if (status != 0) {
+      return status;
+    }
+
+    m.time = templ->time;
+    m.interval = templ->interval;
+    m.meta = meta_data_clone(templ->meta);
+  }
+
+  if (lname != NULL) {
+    int status = metric_label_set(&m, lname, lvalue);
+    if (status != 0) {
+      return status;
+    }
+  }
+
+  int status = metric_family_metric_append(fam, m);
+  metric_reset(&m);
+  return status;
+}
+
 int metric_family_metric_reset(metric_family_t *fam) {
   if (fam == NULL) {
     return EINVAL;

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -1,0 +1,325 @@
+/**
+ * collectd - src/daemon/metric.c
+ * Copyright (C) 2019-2020  Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ *   Manoj Srivastava <srivasta at google.com>
+ **/
+
+#include "collectd.h"
+
+#include "metric.h"
+#include "plugin.h"
+
+/* Label names must match the regex `[a-zA-Z_][a-zA-Z0-9_]*`. Label names
+ * beginning with __ are reserved for internal use.
+ *
+ * Source:
+ * https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels */
+#define VALID_LABEL_CHARS                                                      \
+  "abcdefghijklmnopqrstuvwxyz"                                                 \
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"                                                 \
+  "0123456789_"
+/* Metric names must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*` */
+#define VALID_NAME_CHARS VALID_LABEL_CHARS ":"
+
+int value_marshal_text(strbuf_t *buf, value_t v, metric_type_t type) {
+  switch (type) {
+  case METRIC_TYPE_GAUGE:
+  case METRIC_TYPE_UNTYPED:
+    return strbuf_printf(buf, GAUGE_FORMAT, v.gauge);
+  case METRIC_TYPE_COUNTER:
+    return strbuf_printf(buf, "%" PRIu64, v.counter);
+  default:
+    ERROR("Unknown metric value type: %d", type);
+    return EINVAL;
+  }
+}
+
+static int label_pair_compare(void const *a, void const *b) {
+  return strcmp(((label_pair_t const *)a)->name,
+                ((label_pair_t const *)b)->name);
+}
+
+label_pair_t *label_set_get(label_set_t labels, char const *name) {
+  if (name == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  label_t label = {
+      .name = name,
+  };
+
+  label_pair_t *ret = bsearch(&label, labels.ptr, labels.num,
+                              sizeof(*labels.ptr), label_pair_compare);
+  if (ret == NULL) {
+    errno = ENOENT;
+    return NULL;
+  }
+
+  return ret;
+}
+
+int label_set_add(label_set_t *labels, char const *name, char const *value) {
+  if ((labels == NULL) || (name == NULL) || (value == NULL)) {
+    return EINVAL;
+  }
+
+  size_t name_len = strlen(name);
+  if (name_len == 0) {
+    return EINVAL;
+  }
+
+  size_t valid_len = strspn(name, VALID_LABEL_CHARS);
+  if ((valid_len != name_len) || isdigit((int)name[0])) {
+    return EINVAL;
+  }
+
+  if (label_set_get(*labels, name) != NULL) {
+    return EEXIST;
+  }
+
+  if (strlen(value) == 0) {
+    return 0;
+  }
+
+  label_pair_t *tmp =
+      realloc(labels->ptr, sizeof(*labels->ptr) * (labels->num + 1));
+  if (tmp == NULL) {
+    return errno;
+  }
+  labels->ptr = tmp;
+
+  label_pair_t pair = {
+      .name = strdup(name),
+      .value = strdup(value),
+  };
+  if ((pair.name == NULL) || (pair.value == NULL)) {
+    free(pair.name);
+    free(pair.value);
+    return ENOMEM;
+  }
+
+  labels->ptr[labels->num] = pair;
+  labels->num++;
+
+  qsort(labels->ptr, labels->num, sizeof(*labels->ptr), label_pair_compare);
+  return 0;
+}
+
+static int label_set_clone(label_set_t *dest, label_set_t src) {
+  if (src.num == 0) {
+    return 0;
+  }
+
+  label_set_t ret = {
+      .ptr = calloc(src.num, sizeof(*ret.ptr)),
+      .num = src.num,
+  };
+  if (ret.ptr == NULL) {
+    return ENOMEM;
+  }
+
+  for (size_t i = 0; i < src.num; i++) {
+    ret.ptr[i].name = strdup(src.ptr[i].name);
+    ret.ptr[i].value = strdup(src.ptr[i].value);
+    if ((ret.ptr[i].name == NULL) || (ret.ptr[i].value == NULL)) {
+      label_set_reset(&ret);
+      return ENOMEM;
+    }
+  }
+
+  *dest = ret;
+  return 0;
+}
+
+void label_set_reset(label_set_t *labels) {
+  if (labels == NULL) {
+    return;
+  }
+  for (size_t i = 0; i < labels->num; i++) {
+    free(labels->ptr[i].name);
+    free(labels->ptr[i].value);
+  }
+  free(labels->ptr);
+
+  labels->ptr = NULL;
+  labels->num = 0;
+}
+
+int metric_identity(strbuf_t *buf, metric_t const *m) {
+  if ((buf == NULL) || (m == NULL) || (m->family == NULL)) {
+    return EINVAL;
+  }
+
+  int status = strbuf_print(buf, m->family->name);
+  if (m->label.num == 0) {
+    return status;
+  }
+
+  status = status || strbuf_print(buf, "{");
+  for (size_t i = 0; i < m->label.num; i++) {
+    if (i != 0) {
+      status = status || strbuf_print(buf, ",");
+    }
+
+    status = status || strbuf_print(buf, m->label.ptr[i].name);
+    status = status || strbuf_print(buf, "=\"");
+    status = status || strbuf_print_escaped(buf, m->label.ptr[i].value,
+                                            "\\\"\n\r\t", '\\');
+    status = status || strbuf_print(buf, "\"");
+  }
+
+  return status || strbuf_print(buf, "}");
+}
+
+int metric_list_add(metric_list_t *metrics, metric_t m) {
+  if (metrics == NULL) {
+    return EINVAL;
+  }
+
+  metric_t *tmp =
+      realloc(metrics->ptr, sizeof(*metrics->ptr) * (metrics->num + 1));
+  if (tmp == NULL) {
+    return errno;
+  }
+  metrics->ptr = tmp;
+
+  metrics->ptr[metrics->num] = m;
+  metrics->num++;
+
+  return 0;
+}
+
+static int metric_list_clone(metric_list_t *dest, metric_list_t src,
+                             metric_family_t *fam) {
+  if (src.num == 0) {
+    return 0;
+  }
+
+  metric_list_t ret = {
+      .ptr = calloc(src.num, sizeof(*ret.ptr)),
+      .num = src.num,
+  };
+  if (ret.ptr == NULL) {
+    return ENOMEM;
+  }
+
+  for (size_t i = 0; i < src.num; i++) {
+    ret.ptr[i] = (metric_t){
+        .family = fam,
+        .value = src.ptr[i].value,
+        .time = src.ptr[i].time,
+        .interval = src.ptr[i].interval,
+    };
+
+    int status = label_set_clone(&ret.ptr[i].label, src.ptr[i].label);
+    if (status != 0) {
+      metric_list_reset(&ret);
+      return status;
+    }
+  }
+
+  *dest = ret;
+  return 0;
+}
+
+void metric_list_reset(metric_list_t *metrics) {
+  if (metrics == NULL) {
+    return;
+  }
+
+  for (size_t i = 0; i < metrics->num; i++) {
+    label_set_reset(&metrics->ptr[i].label);
+  }
+  free(metrics->ptr);
+
+  metrics->ptr = NULL;
+  metrics->num = 0;
+}
+
+int metric_family_metrics_append(metric_family_t *fam, value_t v,
+                                 label_t const *label, size_t label_num) {
+  if ((fam == NULL) || ((label_num != 0) && (label == NULL))) {
+    return EINVAL;
+  }
+
+  metric_t m = {
+      .family = fam,
+      .value = v,
+  };
+
+  for (size_t i = 0; i < label_num; i++) {
+    int status = label_set_add(&m.label, label[i].name, label[i].value);
+    if (status != 0) {
+      label_set_reset(&m.label);
+      return status;
+    }
+  }
+
+  int status = metric_list_add(&fam->metric, m);
+  if (status != 0) {
+    label_set_reset(&m.label);
+    return status;
+  }
+
+  return 0;
+}
+
+void metric_family_free(metric_family_t *fam) {
+  if (fam == NULL) {
+    return;
+  }
+
+  free(fam->name);
+  free(fam->help);
+  metric_list_reset(&fam->metric);
+  free(fam);
+}
+
+metric_family_t *metric_family_clone(metric_family_t const *fam) {
+  if (fam == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  metric_family_t *ret = calloc(1, sizeof(*ret));
+  if (ret == NULL) {
+    return NULL;
+  }
+
+  ret->name = strdup(fam->name);
+  if (fam->help != NULL) {
+    ret->help = strdup(fam->help);
+  }
+  ret->type = fam->type;
+
+  int status = metric_list_clone(&ret->metric, fam->metric, ret);
+  if (status != 0) {
+    metric_family_free(ret);
+    errno = status;
+    return NULL;
+  }
+
+  return ret;
+}

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -323,3 +323,175 @@ metric_family_t *metric_family_clone(metric_family_t const *fam) {
 
   return ret;
 }
+
+/* parse_label_value reads a label value, unescapes it and prints it to buf. On
+ * success, inout is updated to point to the character just *after* the label
+ * value, i.e. the character *following* the ending quotes - either a comma or
+ * closing curlies. */
+static int parse_label_value(strbuf_t *buf, char const **inout) {
+  char const *ptr = *inout;
+
+  if (ptr[0] != '"') {
+    return EINVAL;
+  }
+  ptr++;
+
+  while (ptr[0] != '"') {
+    size_t valid_len = strcspn(ptr, "\\\"\n");
+    if (valid_len != 0) {
+      strbuf_printn(buf, ptr, valid_len);
+      ptr += valid_len;
+      continue;
+    }
+
+    if ((ptr[0] == 0) || (ptr[0] == '\n')) {
+      return EINVAL;
+    }
+
+    assert(ptr[0] == '\\');
+    if (ptr[1] == 0) {
+      return EINVAL;
+    }
+
+    char tmp[2] = {ptr[1], 0};
+    if (tmp[0] == 'n') {
+      tmp[0] = '\n';
+    } else if (tmp[0] == 'r') {
+      tmp[0] = '\r';
+    } else if (tmp[0] == 't') {
+      tmp[0] = '\t';
+    }
+
+    strbuf_print(buf, tmp);
+
+    ptr += 2;
+  }
+
+  assert(ptr[0] == '"');
+  ptr++;
+  *inout = ptr;
+  return 0;
+}
+
+/* metric_family_unmarshal_identity parses the metric identity and updates
+ * "inout" to point to the first character following the identity. With valid
+ * input, this means that "inout" will then point either to a '\0' (null byte)
+ * or a ' ' (space). */
+static int metric_family_unmarshal_identity(metric_family_t *fam,
+                                            char const **inout) {
+  if ((fam == NULL) || (inout == NULL) || (*inout == NULL)) {
+    return EINVAL;
+  }
+
+  char const *ptr = *inout;
+  size_t name_len = strspn(ptr, VALID_NAME_CHARS);
+  if (name_len == 0) {
+    return EINVAL;
+  }
+
+  char name[name_len + 1];
+  strncpy(name, ptr, name_len);
+  name[name_len] = 0;
+  ptr += name_len;
+
+  fam->name = strdup(name);
+  if (fam->name == NULL) {
+    return ENOMEM;
+  }
+
+  /* metric name without labels */
+  if ((ptr[0] == 0) || (ptr[0] == ' ')) {
+    *inout = ptr;
+    return 0;
+  }
+
+  if (ptr[0] != '{') {
+    return EINVAL;
+  }
+
+  metric_t *m = fam->metric.ptr;
+  int ret = 0;
+  while ((ptr[0] == '{') || (ptr[0] == ',')) {
+    ptr++;
+
+    size_t key_len = strspn(ptr, VALID_LABEL_CHARS);
+    if (key_len == 0) {
+      ret = EINVAL;
+      break;
+    }
+    char key[key_len + 1];
+    strncpy(key, ptr, key_len);
+    key[key_len] = 0;
+    ptr += key_len;
+
+    if (ptr[0] != '=') {
+      ret = EINVAL;
+      break;
+    }
+    ptr++;
+
+    strbuf_t value = STRBUF_CREATE;
+    int status = parse_label_value(&value, &ptr);
+    if (status != 0) {
+      ret = status;
+      STRBUF_DESTROY(value);
+      break;
+    }
+
+    /* one metric is added to the family by metric_family_unmarshal_text. */
+    assert(fam->metric.num >= 1);
+
+    status = label_set_add(&fam->metric.ptr[0].label, key, value.ptr);
+    STRBUF_DESTROY(value);
+    if (status != 0) {
+      ret = status;
+      break;
+    }
+  }
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  if ((ptr[0] != '}') || ((ptr[1] != 0) && (ptr[1] != ' '))) {
+    return EINVAL;
+  }
+
+  *inout = &ptr[1];
+  return 0;
+}
+
+metric_t *metric_parse_identity(char const *buf) {
+  if (buf == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  metric_family_t *fam = calloc(1, sizeof(*fam));
+  if (fam == NULL) {
+    return NULL;
+  }
+  fam->type = METRIC_TYPE_UNTYPED;
+
+  int status = metric_list_add(&fam->metric, (metric_t){.family = fam});
+  if (status != 0) {
+    metric_family_free(fam);
+    errno = status;
+    return NULL;
+  }
+
+  status = metric_family_unmarshal_identity(fam, &buf);
+  if (status != 0) {
+    metric_family_free(fam);
+    errno = status;
+    return NULL;
+  }
+
+  if (buf[0] != 0) {
+    metric_family_free(fam);
+    errno = EINVAL;
+    return NULL;
+  }
+
+  return fam->metric.ptr;
+}

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -120,6 +120,11 @@ typedef struct {
  */
 int metric_identity(strbuf_t *buf, metric_t const *m);
 
+/* metric_parse_identity parses "s" and returns a metric with only its identity
+ * set. On error, errno is set and NULL is returned. The returned memory must
+ * be freed by passing m->family to metric_family_free(). */
+metric_t *metric_parse_identity(char const *s);
+
 /* metric_list_t is an unordered list of metrics. */
 typedef struct {
   metric_t *ptr;

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -64,11 +64,11 @@ typedef struct {
   char *value;
 } label_pair_t;
 
-/* label_t represents a constant label, i.e. a key/value pair. It is similar to
- * label_pair_t, except that is has const fields. label_t is used in function
- * arguments to prevent the called function from modifying its argument.
- * Internally labels are stored as label_pair_t to allow modification, e.g. by
- * targets in the "filter chain". */
+/* label_t represents a key/value pair. It is similar to label_pair_t, except
+ * that is has const fields. label_t is used in function arguments to prevent
+ * the called function from modifying its argument. Internally labels are
+ * stored as label_pair_t to allow modification, e.g. by targets in the "filter
+ * chain". */
 typedef struct {
   char const *name;
   char const *value;
@@ -79,19 +79,6 @@ typedef struct {
   label_pair_t *ptr;
   size_t num;
 } label_set_t;
-
-/* label_set_get efficiently looks up and returns the "name" label. If a label
- * does not exist, NULL is returned and errno is set to ENOENT. */
-label_pair_t *label_set_get(label_set_t labels, char const *name);
-
-/* label_set_add adds a new label to the set of labels. If a label with "name"
- * already exists, EEXIST is returned. If "value" is the empty string, no label
- * is added and zero is returned. */
-int label_set_add(label_set_t *labels, char const *name, char const *value);
-
-/* label_set_reset frees all the labels in the label set. It does *not* free
- * the passed "label_set_t*" itself. */
-void label_set_reset(label_set_t *labels);
 
 /*
  * Metric
@@ -110,7 +97,7 @@ typedef struct {
   cdtime_t time; /* TODO(octo): use ms or µs instead? */
   cdtime_t interval;
   /* TODO(octo): target labels */
-  meta_data_t *meta; /* TODO(octo): free in metric_list_reset() */
+  meta_data_t *meta;
 } metric_t;
 
 /* metric_identity writes the identity of the metric "m" to "buf". An example
@@ -125,13 +112,29 @@ int metric_identity(strbuf_t *buf, metric_t const *m);
  * be freed by passing m->family to metric_family_free(). */
 metric_t *metric_parse_identity(char const *s);
 
+/* metric_label_set adds or updates a label to/in the label set.
+ * If "value" is NULL or the empty string, the label is removed. Removing a
+ * label that does not exist is *not* an error. */
+int metric_label_set(metric_t *m, char const *name, char const *value);
+
+/* metric_label_get efficiently looks up and returns the value of the "name"
+ * label. If a label does not exist, NULL is returned and errno is set to
+ * ENOENT. The returned pointer may not be valid after a subsequent call to
+ * "metric_label_set". */
+char const *metric_label_get(metric_t const *m, char const *name);
+
+/* metric_reset frees all labels and meta data stored in the metric and resets
+ * the metric to zero. */
+int metric_reset(metric_t *m);
+
 /* metric_list_t is an unordered list of metrics. */
 typedef struct {
   metric_t *ptr;
   size_t num;
 } metric_list_t;
 
-/* metric_list_add appends a metric to the metric list. */
+/* metric_list_add appends a metric to the metric list. The metric's labels and
+ * meta data are copied. */
 int metric_list_add(metric_list_t *metrics, metric_t m);
 
 /* metric_list_reset frees all the metrics in the metric list. It does *not*

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -1,0 +1,162 @@
+/**
+ * collectd - src/daemon/metric.h
+ * Copyright (C) 2019-2020  Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ *   Manoj Srivastava <srivasta at google.com>
+ **/
+
+#ifndef METRIC_H
+#define METRIC_H 1
+
+#include "utils/metadata/meta_data.h"
+#include "utils/strbuf/strbuf.h"
+#include "utils_time.h"
+
+#define VALUE_TYPE_GAUGE 1
+#define VALUE_TYPE_DERIVE 2
+
+typedef enum {
+  METRIC_TYPE_COUNTER = 0,
+  METRIC_TYPE_GAUGE = 1,
+  METRIC_TYPE_UNTYPED = 2,
+} metric_type_t;
+
+typedef uint64_t counter_t;
+typedef double gauge_t;
+typedef int64_t derive_t;
+
+union value_u {
+  counter_t counter;
+  gauge_t gauge;
+  derive_t derive;
+};
+typedef union value_u value_t;
+
+/* value_marshal_text prints a text representation of v to buf. */
+int value_marshal_text(strbuf_t *buf, value_t v, metric_type_t type);
+
+/*
+ * Labels
+ */
+/* label_pair_t represents a label, i.e. a key/value pair. */
+typedef struct {
+  char *name;
+  char *value;
+} label_pair_t;
+
+/* label_t represents a constant label, i.e. a key/value pair. It is similar to
+ * label_pair_t, except that is has const fields. label_t is used in function
+ * arguments to prevent the called function from modifying its argument.
+ * Internally labels are stored as label_pair_t to allow modification, e.g. by
+ * targets in the "filter chain". */
+typedef struct {
+  char const *name;
+  char const *value;
+} label_t;
+
+/* label_set_t is a sorted set of labels. */
+typedef struct {
+  label_pair_t *ptr;
+  size_t num;
+} label_set_t;
+
+/* label_set_get efficiently looks up and returns the "name" label. If a label
+ * does not exist, NULL is returned and errno is set to ENOENT. */
+label_pair_t *label_set_get(label_set_t labels, char const *name);
+
+/* label_set_add adds a new label to the set of labels. If a label with "name"
+ * already exists, EEXIST is returned. If "value" is the empty string, no label
+ * is added and zero is returned. */
+int label_set_add(label_set_t *labels, char const *name, char const *value);
+
+/* label_set_reset frees all the labels in the label set. It does *not* free
+ * the passed "label_set_t*" itself. */
+void label_set_reset(label_set_t *labels);
+
+/*
+ * Metric
+ */
+/* forward declaration since metric_family_t and metric_t refer to each other.
+ */
+struct metric_family_s;
+typedef struct metric_family_s metric_family_t;
+
+/* metric_t is a metric inside a metric family. */
+typedef struct {
+  metric_family_t *family; /* for family->name and family->type */
+
+  label_set_t label;
+  value_t value;
+  cdtime_t time; /* TODO(octo): use ms or µs instead? */
+  cdtime_t interval;
+  /* TODO(octo): target labels */
+  meta_data_t *meta; /* TODO(octo): free in metric_list_reset() */
+} metric_t;
+
+/* metric_identity writes the identity of the metric "m" to "buf". An example
+ * string is:
+ *
+ *   "http_requests_total{method=\"post\",code=\"200\"}"
+ */
+int metric_identity(strbuf_t *buf, metric_t const *m);
+
+/* metric_list_t is an unordered list of metrics. */
+typedef struct {
+  metric_t *ptr;
+  size_t num;
+} metric_list_t;
+
+/* metric_list_add appends a metric to the metric list. */
+int metric_list_add(metric_list_t *metrics, metric_t m);
+
+/* metric_list_reset frees all the metrics in the metric list. It does *not*
+ * free the passed "metric_list_t*" itself. */
+void metric_list_reset(metric_list_t *metrics);
+
+/*
+ * Metric Family
+ */
+/* metric_family_t is a group of metrics of the same type. */
+struct metric_family_s {
+  char *name;
+  char *help;
+  metric_type_t type;
+
+  metric_list_t metric;
+};
+
+/* metric_family_metrics_append appends a new metric to the metric family. This
+ * allocates memory which must be freed using metric_family_metrics_reset. */
+int metric_family_metrics_append(metric_family_t *fam, value_t v,
+                                 label_t const *label, size_t label_num);
+
+/* metric_family_free frees a "metric_family_t" that was allocated with
+ * metric_family_clone(). */
+void metric_family_free(metric_family_t *fam);
+
+/* metric_family_clone returns a copy of the provided metric family. On error,
+ * errno is set and NULL is returned. The returned pointer must be freed with
+ * metric_family_free(). */
+metric_family_t *metric_family_clone(metric_family_t const *fam);
+
+#endif

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -149,6 +149,18 @@ struct metric_family_s {
  * allocates memory which must be freed using metric_family_metric_reset. */
 int metric_family_metric_append(metric_family_t *fam, metric_t m);
 
+/* metric_family_append constructs a new metric_t and appends it to fam. It is
+ * a convenience function that is funcitonally approximately equivalent to the
+ * following code, but without modifying templ:
+ *
+ *   metric_t m = *templ;
+ *   m.value = v;
+ *   metric_label_set(&m, lname, lvalue);
+ *   metric_family_metric_append(fam, m);
+ */
+int metric_family_append(metric_family_t *fam, char const *lname,
+                         char const *lvalue, value_t v, metric_t const *templ);
+
 /* metric_family_metric_reset frees all metrics in the metric family and
  * resets the count to zero. */
 int metric_family_metric_reset(metric_family_t *fam);

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -90,7 +90,7 @@ typedef struct metric_family_s metric_family_t;
 
 /* metric_t is a metric inside a metric family. */
 typedef struct {
-  metric_family_t *family; /* for family->name and family->type */
+  metric_family_t *family; /* backreference for family->name and family->type */
 
   label_set_t label;
   value_t value;
@@ -100,9 +100,10 @@ typedef struct {
   meta_data_t *meta;
 } metric_t;
 
-/* metric_identity writes the identity of the metric "m" to "buf". An example
- * string is:
+/* metric_identity writes the identity of the metric "m" to "buf", using the
+ * OpenMetrics / Prometheus plain text exposition format.
  *
+ * Example:
  *   "http_requests_total{method=\"post\",code=\"200\"}"
  */
 int metric_identity(strbuf_t *buf, metric_t const *m);

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -133,14 +133,6 @@ typedef struct {
   size_t num;
 } metric_list_t;
 
-/* metric_list_add appends a metric to the metric list. The metric's labels and
- * meta data are copied. */
-int metric_list_add(metric_list_t *metrics, metric_t m);
-
-/* metric_list_reset frees all the metrics in the metric list. It does *not*
- * free the passed "metric_list_t*" itself. */
-void metric_list_reset(metric_list_t *metrics);
-
 /*
  * Metric Family
  */
@@ -153,10 +145,13 @@ struct metric_family_s {
   metric_list_t metric;
 };
 
-/* metric_family_metrics_append appends a new metric to the metric family. This
- * allocates memory which must be freed using metric_family_metrics_reset. */
-int metric_family_metrics_append(metric_family_t *fam, value_t v,
-                                 label_t const *label, size_t label_num);
+/* metric_family_metric_append appends a new metric to the metric family. This
+ * allocates memory which must be freed using metric_family_metric_reset. */
+int metric_family_metric_append(metric_family_t *fam, metric_t m);
+
+/* metric_family_metric_reset frees all metrics in the metric family and
+ * resets the count to zero. */
+int metric_family_metric_reset(metric_family_t *fam);
 
 /* metric_family_free frees a "metric_family_t" that was allocated with
  * metric_family_clone(). */

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -1,0 +1,100 @@
+/**
+ * collectd - src/daemon/metric_test.c
+ * Copyright (C) 2020       Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#include "collectd.h"
+
+#include "metric.h"
+#include "testing.h"
+
+DEF_TEST(metric_identity) {
+  struct {
+    char *name;
+    label_t *labels;
+    size_t labels_num;
+    char const *want;
+  } cases[] = {
+      {
+          .name = "metric_without_labels",
+          .want = "metric_without_labels",
+      },
+      {
+          .name = "metric_with_labels",
+          .labels =
+              (label_t[]){
+                  {"sorted", "yes"},
+                  {"alphabetically", "true"},
+              },
+          .labels_num = 2,
+          .want = "metric_with_labels{alphabetically=\"true\",sorted=\"yes\"}",
+      },
+      {
+          .name = "escape_sequences",
+          .labels =
+              (label_t[]){
+                  {"newline", "\n"},
+                  {"quote", "\""},
+                  {"tab", "\t"},
+                  {"cardridge_return", "\r"},
+              },
+          .labels_num = 4,
+          .want = "escape_sequences{cardridge_return=\"\\r\",newline=\"\\n\","
+                  "quote=\"\\\"\",tab=\"\\t\"}",
+      },
+  };
+
+  for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
+    printf("## Case %zu: %s\n", i, cases[i].name);
+
+    metric_family_t fam = {
+        .name = cases[i].name,
+        .type = METRIC_TYPE_UNTYPED,
+    };
+    metric_t m = {
+        .family = &fam,
+    };
+    for (size_t j = 0; j < cases[i].labels_num; j++) {
+      CHECK_ZERO(metric_label_set(&m, cases[i].labels[j].name,
+                                  cases[i].labels[j].value));
+    }
+
+    strbuf_t buf = STRBUF_CREATE;
+    CHECK_ZERO(metric_identity(&buf, &m));
+
+    EXPECT_EQ_STR(cases[i].want, buf.ptr);
+
+    STRBUF_DESTROY(buf);
+    metric_family_metric_reset(&fam);
+    metric_reset(&m);
+  }
+
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(metric_identity);
+
+  END_TEST;
+}

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -31,6 +31,7 @@
 #include "collectd.h"
 
 #include "configfile.h"
+#include "metric.h"
 #include "utils/metadata/meta_data.h"
 #include "utils_time.h"
 
@@ -82,17 +83,6 @@ struct identifier_s {
   char *type_instance;
 };
 typedef struct identifier_s identifier_t;
-
-typedef unsigned long long counter_t;
-typedef double gauge_t;
-typedef int64_t derive_t;
-
-union value_u {
-  counter_t counter;
-  gauge_t gauge;
-  derive_t derive;
-};
-typedef union value_u value_t;
 
 struct value_list_s {
   value_t *values;

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -48,11 +48,15 @@
 #define STATSD_DEFAULT_SERVICE "8125"
 #endif
 
-enum metric_type_e { STATSD_COUNTER, STATSD_TIMER, STATSD_GAUGE, STATSD_SET };
-typedef enum metric_type_e metric_type_t;
+typedef enum statsd_metric_type_e {
+  STATSD_COUNTER,
+  STATSD_TIMER,
+  STATSD_GAUGE,
+  STATSD_SET,
+} statsd_metric_type_t;
 
 struct statsd_metric_s {
-  metric_type_t type;
+  statsd_metric_type_t type;
   double value;
   derive_t counter;
   latency_counter_t *latency;
@@ -87,7 +91,7 @@ static bool conf_timer_count;
 
 /* Must hold metrics_lock when calling this function. */
 static statsd_metric_t *statsd_metric_lookup_unsafe(char const *name, /* {{{ */
-                                                    metric_type_t type) {
+                                                    statsd_metric_type_t type) {
   char key[DATA_MAX_NAME_LEN + 2];
   char *key_copy;
   statsd_metric_t *metric;
@@ -146,7 +150,7 @@ static statsd_metric_t *statsd_metric_lookup_unsafe(char const *name, /* {{{ */
 } /* }}} statsd_metric_lookup_unsafe */
 
 static int statsd_metric_set(char const *name, double value, /* {{{ */
-                             metric_type_t type) {
+                             statsd_metric_type_t type) {
   statsd_metric_t *metric;
 
   pthread_mutex_lock(&metrics_lock);
@@ -166,7 +170,7 @@ static int statsd_metric_set(char const *name, double value, /* {{{ */
 } /* }}} int statsd_metric_set */
 
 static int statsd_metric_add(char const *name, double delta, /* {{{ */
-                             metric_type_t type) {
+                             statsd_metric_type_t type) {
   statsd_metric_t *metric;
 
   pthread_mutex_lock(&metrics_lock);

--- a/src/testing.h
+++ b/src/testing.h
@@ -72,12 +72,18 @@ static int check_count__;
   do {                                                                         \
     /* Evaluate 'actual' only once. */                                         \
     const char *got__ = actual;                                                \
-    if (strcmp(expect, got__) != 0) {                                          \
+    if ((expect == NULL) != (got__ == NULL)) {                                 \
+      printf("not ok %i - %s = \"%s\", want \"%s\"\n", ++check_count__,        \
+             #actual, got__ ? got__ : "(null)", expect ? expect : "(null)");   \
+      return -1;                                                               \
+    }                                                                          \
+    if ((expect != NULL) && (strcmp(expect, got__) != 0)) {                    \
       printf("not ok %i - %s = \"%s\", want \"%s\"\n", ++check_count__,        \
              #actual, got__, expect);                                          \
       return -1;                                                               \
     }                                                                          \
-    printf("ok %i - %s = \"%s\"\n", ++check_count__, #actual, got__);          \
+    printf("ok %i - %s = \"%s\"\n", ++check_count__, #actual,                  \
+           got__ ? got__ : "(null)");                                          \
   } while (0)
 
 #define EXPECT_EQ_INT(expect, actual)                                          \

--- a/src/testing.h
+++ b/src/testing.h
@@ -136,7 +136,7 @@ static int check_count__;
 
 #define CHECK_NOT_NULL(expr)                                                   \
   do {                                                                         \
-    void *ptr_;                                                                \
+    void const *ptr_;                                                          \
     ptr_ = (expr);                                                             \
     OK1(ptr_ != NULL, #expr);                                                  \
   } while (0)

--- a/src/utils/format_graphite/format_graphite_test.c
+++ b/src/utils/format_graphite/format_graphite_test.c
@@ -159,8 +159,11 @@ DEF_TEST(metric_name) {
         .type = "single",
     };
 
-    char want[1024];
-    ssnprintf(want, sizeof(want), "%s 42 1480063672\r\n", cases[i].want_name);
+    strbuf_t want = STRBUF_CREATE;
+    if (cases[i].want_name != NULL) {
+      strbuf_print(&want, cases[i].want_name);
+      strbuf_print(&want, " 42 1480063672\r\n");
+    }
 
     if (cases[i].plugin_instance != NULL)
       sstrncpy(vl.plugin_instance, cases[i].plugin_instance,
@@ -173,7 +176,8 @@ DEF_TEST(metric_name) {
     EXPECT_EQ_INT(0, format_graphite(got, sizeof(got), &ds_single, &vl,
                                      cases[i].prefix, cases[i].suffix, '@',
                                      cases[i].flags));
-    EXPECT_EQ_STR(want, got);
+    EXPECT_EQ_STR(want.ptr, got);
+    STRBUF_DESTROY(want);
   }
 
   return 0;

--- a/src/utils/format_json/format_json_test.c
+++ b/src/utils/format_json/format_json_test.c
@@ -24,18 +24,6 @@
  *   Florian octo Forster <octo at collectd.org>
  */
 
-/* Workaround for Solaris 10 defining label_t
- * Issue #1301
- */
-
-#include "config.h"
-#if KERNEL_SOLARIS
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
-#undef __EXTENSIONS__
-#endif
-
 #include "collectd.h"
 
 #include "testing.h"
@@ -54,13 +42,13 @@
 typedef struct {
   char const *key;
   char const *value;
-} label_t;
+} keyval_t;
 
 typedef struct {
-  label_t *expected_labels;
+  keyval_t *expected_labels;
   size_t expected_labels_num;
 
-  label_t *current_label;
+  keyval_t *current_label;
 } test_case_t;
 
 #if HAVE_YAJL_V2
@@ -75,7 +63,7 @@ static int test_map_key(void *ctx, unsigned char const *key,
 
   c->current_label = NULL;
   for (i = 0; i < c->expected_labels_num; i++) {
-    label_t *l = c->expected_labels + i;
+    keyval_t *l = c->expected_labels + i;
     if ((strlen(l->key) == key_len) &&
         (strncmp(l->key, (char const *)key, key_len) == 0)) {
       c->current_label = l;
@@ -110,7 +98,7 @@ static int test_string(void *ctx, unsigned char const *value,
   test_case_t *c = ctx;
 
   if (c->current_label != NULL) {
-    label_t *l = c->current_label;
+    keyval_t *l = c->current_label;
     char *got;
     int status;
 
@@ -129,7 +117,7 @@ static int test_string(void *ctx, unsigned char const *value,
   return 1; /* continue */
 }
 
-static int expect_json_labels(char *json, label_t *labels, size_t labels_num) {
+static int expect_json_labels(char *json, keyval_t *labels, size_t labels_num) {
   yajl_callbacks funcs = {
       .yajl_string = test_string,
       .yajl_map_key = test_map_key,
@@ -151,7 +139,7 @@ static int expect_json_labels(char *json, label_t *labels, size_t labels_num) {
 }
 
 DEF_TEST(notification) {
-  label_t labels[] = {
+  keyval_t labels[] = {
       {"summary", "this is a message"},
       {"alertname", "collectd_unit_test"},
       {"instance", "example.com"},

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -150,7 +150,7 @@ static int format_typed_value(yajl_gen gen, int ds_type, value_t v,
   }
   case DS_TYPE_COUNTER: {
     counter_t diff = counter_diff((counter_t)start_value, v.counter);
-    ssnprintf(integer, sizeof(integer), "%llu", diff);
+    ssnprintf(integer, sizeof(integer), "%" PRIu64, diff);
     break;
   }
   default: {


### PR DESCRIPTION
*   `metric_family_t` holds the metric type, metric name, and a list of metrics.
*   `metric_t` holds the value, a label set, collection time, interval, and a pointer to the parent *metric family*.

This another break-out from #3506, trying to make the change easier to review.

ChangeLog: collectd: The new `metric_t` and `metric_family_t` data structures hold metrics that are identified by a label set.