### PR TITLE
capabilities: conditionalize mhd callback return type

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -33,6 +33,11 @@
 #include "utils/dmi/dmi.h"
 
 #include <microhttpd.h>
+#if MHD_VERSION >= 0x00097002
+#define MHD_RESULT enum MHD_Result
+#else
+#define MHD_RESULT int
+#endif
 
 #include <jansson.h>
 #include <netdb.h>
@@ -187,7 +192,7 @@ static int cap_get_dmi_variables(json_t *parent, const dmi_type type,
 
 /* http_handler is the callback called by the microhttpd library. It essentially
  * handles all HTTP request aspects and creates an HTTP response. */
-static int cap_http_handler(void *cls, struct MHD_Connection *connection,
+static MHD_RESULT cap_http_handler(void *cls, struct MHD_Connection *connection,
                             const char *url, const char *method,
                             const char *version, const char *upload_data,
                             size_t *upload_data_size, void **connection_state) {

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -193,9 +193,10 @@ static int cap_get_dmi_variables(json_t *parent, const dmi_type type,
 /* http_handler is the callback called by the microhttpd library. It essentially
  * handles all HTTP request aspects and creates an HTTP response. */
 static MHD_RESULT cap_http_handler(void *cls, struct MHD_Connection *connection,
-                            const char *url, const char *method,
-                            const char *version, const char *upload_data,
-                            size_t *upload_data_size, void **connection_state) {
+                                   const char *url, const char *method,
+                                   const char *version, const char *upload_data,
+                                   size_t *upload_data_size,
+                                   void **connection_state) {
   if (strcmp(method, MHD_HTTP_METHOD_GET) != 0) {
     return MHD_NO;
   }

--- a/src/capabilities_test.c
+++ b/src/capabilities_test.c
@@ -93,14 +93,14 @@ struct MHD_Response *MHD_create_response_from_data(size_t size, void *data,
   return mhd_res;
 }
 
-int MHD_add_response_header(struct MHD_Response *response, const char *header,
-                            const char *content) {
+MHD_RESULT MHD_add_response_header(struct MHD_Response *response,
+                                   const char *header, const char *content) {
   return 0;
 }
 
-int MHD_queue_response(struct MHD_Connection *connection,
-                       unsigned int status_code,
-                       struct MHD_Response *response) {
+MHD_RESULT MHD_queue_response(struct MHD_Connection *connection,
+                              unsigned int status_code,
+                              struct MHD_Response *response) {
   return MHD_HTTP_OK;
 }
 


### PR DESCRIPTION
Fixes #3511

ChangeLog: Conditionalize return type for microhttpd callback functions
