### PR TITLE
[Interns] Add a skeleton for benchmarking distribution_t.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_YFLAGS = -d
 
+SUBDIRS = distbench # Benchmark for distribution_t.
+
 if BUILD_WIN32
 cpkgdatadir=$(datadir)
 cpkglibdir=$(libdir)/plugins

--- a/configure.ac
+++ b/configure.ac
@@ -7333,6 +7333,7 @@ AC_SUBST([AM_CXXFLAGS])
 
 AC_CONFIG_FILES([ \
   Makefile \
+  distbench/Makefile \
   src/collectd.conf \
   src/libcollectdclient/libcollectdclient.pc \
 ])

--- a/distbench/Makefile.am
+++ b/distbench/Makefile.am
@@ -3,8 +3,8 @@ bin_PROGRAMS = bkjg margalit sshmidt
 # If you need special libraries, e.g. libm (math lib), declare them like so:
 # xxx_LIBS = -lm
 
-bkjg_SOURCES = main.c bkjg.c
+bkjg_SOURCES = main.c function.h bkjg.c
 
-margalit_SOURCES = main.c margalit.c
+margalit_SOURCES = main.c function.h margalit.c
 
-sshmidt_SOURCES = main.c sshmidt.c
+sshmidt_SOURCES = main.c function.h sshmidt.c

--- a/distbench/Makefile.am
+++ b/distbench/Makefile.am
@@ -1,0 +1,10 @@
+bin_PROGRAMS = bkjg margalit sshmidt
+
+# If you need special libraries, e.g. libm (math lib), declare them like so:
+# xxx_LIBS = -lm
+
+bkjg_SOURCES = main.c bkjg.c
+
+margalit_SOURCES = main.c margalit.c
+
+sshmidt_SOURCES = main.c sshmidt.c

--- a/distbench/bkjg.c
+++ b/distbench/bkjg.c
@@ -1,0 +1,3 @@
+int counter = 0; // Just an example
+
+int my_function() { return ++counter; }

--- a/distbench/function.h
+++ b/distbench/function.h
@@ -1,0 +1,3 @@
+/* Example function that returns something. */
+
+extern int my_function();

--- a/distbench/main.c
+++ b/distbench/main.c
@@ -1,0 +1,56 @@
+/* System headers */
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Local headers */
+#include "function.h"
+
+/* Macro to exit with an error. */
+#define error(fmt, args...)                                                    \
+  do {                                                                         \
+    fprintf(stderr, "ERROR: " fmt "\n", ##args);                               \
+    _exit(1);                                                                  \
+  } while (0)
+
+/* How many nanoseconds there are in a second. */
+#define NANOS_PER_SECOND 10000000
+
+/* How many iterations to run. */
+#define ITERATIONS 10000000
+
+/* Returns the monotonic clock in nanoseconds. */
+static uint64_t get_clock() {
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1)
+    error("Unable to retrieve monotonic clock: %s", strerror(errno));
+
+  return (ts.tv_sec * NANOS_PER_SECOND) + ts.tv_nsec;
+}
+
+int main(int argc, char **argv) {
+  uint64_t start = get_clock();
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    /* Store result in a volatile to prevent the compiler from ignoring the call
+     * because the result is unused. */
+    volatile int result = my_function();
+
+    /* Prevent "unused variable" warning/error. */
+    (void)result;
+  }
+
+  uint64_t end = get_clock();
+  uint64_t duration = end - start;
+
+  printf("%s: %d iterations took %f seconds (~ %d nanoseconds per call)\n",
+         argv[0],    /* Program name */
+         ITERATIONS, /* Number of iterations */
+         (duration * 1.0 /
+          NANOS_PER_SECOND), /* *1.0 to force floating-point arithmetic */
+         (int)(duration / ITERATIONS)); /* Only integer division here */
+}

--- a/distbench/margalit.c
+++ b/distbench/margalit.c
@@ -1,0 +1,3 @@
+int counter = ~0; // Just an example
+
+int my_function() { return --counter; }

--- a/distbench/run-all.sh
+++ b/distbench/run-all.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Change into distbench/ directory if not already.
+cd "$(dirname "$(readlink -f "$0")")"
+
+# (Re)build, just in case.
+make
+
+# Run all three benchmarks.
+for program in bkjg margalit sshmidt; do
+    echo "Running $program"
+    ./"$program"
+    echo
+done

--- a/distbench/sshmidt.c
+++ b/distbench/sshmidt.c
@@ -1,0 +1,3 @@
+unsigned int counter = 0; // Just an example
+
+int my_function() { return ++counter; }


### PR DESCRIPTION
This adds a “distbench” subdirectory for benchmarking different
implementations of distribution_t and three sample implementations.

ChangeLog: Added a benchmark for distribution metrics.