### PR TITLE
Integrate distribution metrics into collectd core

### DIFF
--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -205,7 +205,7 @@ int metric_reset(metric_t *m) {
   label_set_reset(&m->label);
   meta_data_destroy(m->meta);
 
-  if(m->family->type == METRIC_TYPE_DISTRIBUTION) {
+  if (m->family->type == METRIC_TYPE_DISTRIBUTION) {
     distribution_destroy(m->value.distribution);
   }
 
@@ -349,18 +349,18 @@ static int metric_list_clone(metric_list_t *dest, metric_list_t src,
 
   for (size_t i = 0; i < src.num; i++) {
 
-      ret.ptr[i] = (metric_t){
+    ret.ptr[i] = (metric_t){
         .family = fam,
         .time = src.ptr[i].time,
         .interval = src.ptr[i].interval,
-      };
+    };
 
-      if(src.ptr[i].family->type == METRIC_TYPE_DISTRIBUTION) {
-          ret.ptr[i].value.distribution = distribution_clone(src.ptr[i].value.distribution);    
-      }
-      else {
-          ret.ptr[i].value = src.ptr[i].value;
-      }
+    if (src.ptr[i].family->type == METRIC_TYPE_DISTRIBUTION) {
+      ret.ptr[i].value.distribution =
+          distribution_clone(src.ptr[i].value.distribution);
+    } else {
+      ret.ptr[i].value = src.ptr[i].value;
+    }
 
     int status = label_set_clone(&ret.ptr[i].label, src.ptr[i].label);
     if (status != 0) {
@@ -633,4 +633,3 @@ metric_t *metric_parse_identity(char const *buf) {
 
   return fam->metric.ptr;
 }
-

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -28,10 +28,10 @@
 #ifndef METRIC_H
 #define METRIC_H 1
 
+#include "distribution.h"
 #include "utils/metadata/meta_data.h"
 #include "utils/strbuf/strbuf.h"
 #include "utils_time.h"
-#include "distribution.h"
 
 #define VALUE_TYPE_GAUGE 1
 #define VALUE_TYPE_DERIVE 2
@@ -128,7 +128,8 @@ int metric_label_set(metric_t *m, char const *name, char const *value);
 char const *metric_label_get(metric_t const *m, char const *name);
 
 /* metric_reset frees all labels and meta data stored in the metric and resets
- * the metric to zero. If the metric is a distribution metric, the function frees the according distribution.*/
+ * the metric to zero. If the metric is a distribution metric, the function
+ * frees the according distribution.*/
 int metric_reset(metric_t *m);
 
 /* metric_list_t is an unordered list of metrics. */
@@ -178,10 +179,12 @@ void metric_family_free(metric_family_t *fam);
  * metric_family_free(). */
 metric_family_t *metric_family_clone(metric_family_t const *fam);
 
-/*The static function metric_list_clone creates a clone of the argument metric_list_t src. For each metric_t element
- *in the src list it checks if its value is a distribution metric and if yes, calls the distribution_clone function
- *for the value and saves the pointer to the returned distribution_t clone into the metric_list_t dest. If
- *the value is not a distribution_t, it simply sets the value of the element in the destination list to the value
- *of the element in the source list. */ 
+/*The static function metric_list_clone creates a clone of the argument
+ *metric_list_t src. For each metric_t element in the src list it checks if its
+ *value is a distribution metric and if yes, calls the distribution_clone
+ *function for the value and saves the pointer to the returned distribution_t
+ *clone into the metric_list_t dest. If the value is not a distribution_t, it
+ *simply sets the value of the element in the destination list to the value of
+ *the element in the source list. */
 
 #endif

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -31,6 +31,7 @@
 #include "utils/metadata/meta_data.h"
 #include "utils/strbuf/strbuf.h"
 #include "utils_time.h"
+#include "distribution.h"
 
 #define VALUE_TYPE_GAUGE 1
 #define VALUE_TYPE_DERIVE 2
@@ -39,6 +40,7 @@ typedef enum {
   METRIC_TYPE_COUNTER = 0,
   METRIC_TYPE_GAUGE = 1,
   METRIC_TYPE_UNTYPED = 2,
+  METRIC_TYPE_DISTRIBUTION = 3,
 } metric_type_t;
 
 typedef uint64_t counter_t;
@@ -49,6 +51,7 @@ union value_u {
   counter_t counter;
   gauge_t gauge;
   derive_t derive;
+  distribution_t *distribution;
 };
 typedef union value_u value_t;
 
@@ -125,7 +128,7 @@ int metric_label_set(metric_t *m, char const *name, char const *value);
 char const *metric_label_get(metric_t const *m, char const *name);
 
 /* metric_reset frees all labels and meta data stored in the metric and resets
- * the metric to zero. */
+ * the metric to zero. If the metric is a distribution metric, the function frees the according distribution.*/
 int metric_reset(metric_t *m);
 
 /* metric_list_t is an unordered list of metrics. */
@@ -174,5 +177,11 @@ void metric_family_free(metric_family_t *fam);
  * errno is set and NULL is returned. The returned pointer must be freed with
  * metric_family_free(). */
 metric_family_t *metric_family_clone(metric_family_t const *fam);
+
+/*The static function metric_list_clone creates a clone of the argument metric_list_t src. For each metric_t element
+ *in the src list it checks if its value is a distribution metric and if yes, calls the distribution_clone function
+ *for the value and saves the pointer to the returned distribution_t clone into the metric_list_t dest. If
+ *the value is not a distribution_t, it simply sets the value of the element in the destination list to the value
+ *of the element in the source list. */ 
 
 #endif


### PR DESCRIPTION
ChangeLog: Distribution Metrics: Integrated distribution metrics into collectd core.

Added new distribution_t value to metric_type_t enum, added distribution_t* to the value_t pointer, modified function metric_reset to call distribution_destroy when appropriate, added according documentation to metric.h. Modified metric_list_clone to call distribution_clone when appropriate.