### PR TITLE
Improve SIGCHLD handling

### DIFF
--- a/src/daemon/cmd.c
+++ b/src/daemon/cmd.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
   /*
    * fork off child
    */
-  struct sigaction sig_chld_action = {.sa_handler = SIG_IGN};
+  struct sigaction sig_chld_action = {.sa_handler = SIG_DFL};
 
   sigaction(SIGCHLD, &sig_chld_action, NULL);
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -97,8 +97,8 @@ static pthread_mutex_t pl_lock = PTHREAD_MUTEX_INITIALIZER;
 /*
  * Functions
  */
-static void sigchld_sigaction(int __attribute__((unused)) sig, siginfo_t *info, void __attribute__((unused)) *ctx)
-{
+static void sigchld_sigaction(int __attribute__((unused)) sig, siginfo_t *info,
+                              void __attribute__((unused)) * ctx) {
   program_list_t *pl;
 
   if (info->si_signo != SIGCHLD || info->si_code != CLD_EXITED)
@@ -802,7 +802,8 @@ static void *exec_notification_one(void *arg) /* {{{ */
 
 static int exec_init(void) /* {{{ */
 {
-  struct sigaction sa = {.sa_sigaction = sigchld_sigaction, .sa_flags = SA_SIGINFO | SA_NOCLDSTOP};
+  struct sigaction sa = {.sa_sigaction = sigchld_sigaction,
+                         .sa_flags = SA_SIGINFO | SA_NOCLDSTOP};
 
   sigaction(SIGCHLD, &sa, NULL);
 


### PR DESCRIPTION
ChangeLog: SIGCHLD handling has been improved, allowing Perl and Python plugins to gather child processes exit status.

Don't explicitly (`SIG_IGN`) ignore the `SIGCHLD` signal. Contrary to implicitly (`SIG_DFL`) ignoring it, explicitly igoring `SIGCHLD` causes `wait()` et. al. to always raise `ECHILD`.
This behaviour seems neither to be widely known nor prominently documented everywhere. On NetBSD, wait(2) documents it; in POSIX, it's hidden in the `_exit`/`_Exit` description.

In the exec plugin, install a sigaction rather than a traditional handler.
When signalled, inspect the `siginfo's` `si_pid` field and only act on the signal and reap the child's status if the pid is one of the program list's pids.

This allows other plugins that fork child processes (Perl and Python plugins) to get their children's status via `wait()` et. al.

I fail to track down where the `SIG_IGN` was introduced so I can't find a possible rationale for it.

Child process status handling still appears dodgy to me. In `exec_read_one()`, there's a `waitpid()` which seems to race with the `SIGCHLD` handler; I fail to see where the `pl->status` field set by the `SIGCHLD` handler gets examined or acted upon.

This change has only been lightly tested. The Perl plugin is now able to correctly retrieve a sub-processes status; some artificial programs called by the Exec plugin (exit successfully/unsuccessfully; loop) appear to behave as before. Someone really using the Python or Exec plugins should double-check this.