### PR TITLE
Remove duplicate switch case.

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -334,9 +334,9 @@ static void read_cmdline(int argc, char **argv, struct cmdline_config *config) {
 #endif /* COLLECT_DAEMON */
       break;
     case 'f':
+#if COLLECT_DAEMON
       config->daemonize = false;
-      break;
-    case 'f':
+#endif /* COLLECT_DAEMON */
       break;
     case 'h':
       exit_usage(EXIT_SUCCESS);


### PR DESCRIPTION
The empty 'f' case probably used to be wrapped in its own #if
COLLECT_DAEMON, but that apparently somehow got lost and gcc 9.3
complains about the duplicate case. Therefore, just wrap the
config->daemonize assignment into #if/#endif, like for the other cases.

ChangeLog: collectd: Build fix