### PR TITLE
[interns] Add a bootstrapping script and a sample configuration

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eux
+
+readonly DO_CLEAN=true # Clean up previous build results (true/false)
+
+readonly MYDIR="$(dirname "$(readlink -f "$0")")" # Directory this script is in
+readonly PREFIX="$MYDIR/install"                  # Where to install collectd
+
+# Install dependencies
+sudo apt install liboping-dev libcurl4-openssl-dev libyajl-dev socat
+
+# Go to collectd root
+cd "$MYDIR"
+
+# Clean up previous build results
+if $DO_CLEAN; then
+    ./clean.sh
+    rm -rf "$PREFIX"
+fi
+
+# Rebuild
+./build.sh
+./configure --prefix="$PREFIX" \
+    --disable-all-plugins \
+    --enable-cpu \
+    --enable-memory \
+    --enable-ping \
+    --enable-write-http \
+    --enable-write-log
+make -j"$(grep -c '^processor' /proc/cpuinfo)"
+
+# Install to collectd/install/*
+make install
+
+# Make the ping plugin work without being root
+sudo setcap cap_net_raw+ep "$PREFIX"/sbin/collectd
+
+# Copy configuration
+readonly SRC_CONF="$MYDIR/collectd.conf"      # source config to copy
+readonly TGT_CONF="$PREFIX/etc/collectd.conf" # target where collectd expects it
+if [ ! -e "$TGT_CONF".orig ]; then
+    # Make a backup for reference
+    cp -v "$TGT_CONF" "$TGT_CONF".orig || true
+fi
+cp -v "$SRC_CONF" "$TGT_CONF"
+
+# Start collectd
+"$PREFIX"/sbin/collectd -f

--- a/collectd.conf
+++ b/collectd.conf
@@ -1,0 +1,67 @@
+LoadPlugin cpu
+LoadPlugin memory
+LoadPlugin ping
+LoadPlugin write_log
+
+# Start an HTTP server with:
+# socat -v TCP-LISTEN:8000,crlf,reuseaddr,fork SYSTEM:"echo HTTP/1.0 200; echo Content-Type\: text/plain; echo; cat"
+LoadPlugin write_http
+
+<Plugin cpu>
+  ReportByCpu true
+  ReportByState true
+#  ValuesPercentage false
+#  ReportNumCpu false
+#  ReportGuestState false
+#  SubtractGuestState true
+</Plugin>
+
+<Plugin memory>
+#	ValuesAbsolute true
+#	ValuesPercentage false
+</Plugin>
+
+<Plugin ping>
+	Host "google.com"
+	Host "bing.com"
+	Host "yahoo.com"
+#	Interval 1.0
+#	Timeout 0.9
+#	TTL 255
+#	SourceAddress "1.2.3.4"
+#	AddressFamily "any"
+#	Device "eth0"
+#	MaxMissed -1
+</Plugin>
+
+<Plugin write_http>
+	<Node "example">
+        # See top of this file for how to start a server
+		URL "http://127.0.0.1:8000/collectd-post"
+#		User "collectd"
+#		Password "hello"
+#		VerifyPeer true
+#		VerifyHost true
+#		CACert "/etc/ssl/ca.crt"
+#		CAPath "/etc/ssl/certs/"
+#		ClientKey "/etc/ssl/client.pem"
+#		ClientCert "/etc/ssl/client.crt"
+#		ClientKeyPass "secret"
+#		Header "X-Custom-Header: custom_value"
+#		SSLVersion "TLSv1"
+		Format "JSON"
+#		Prefix "collectd"  # metric prefix, only available for KAIROSDB format
+#		Attribute "key" "value"     # only available for KAIROSDB format
+#		TTL 0   # data ttl, only available for KAIROSDB format
+		Metrics true
+#		Notifications false
+#		StoreRates false
+#		BufferSize 4096
+#		LowSpeedLimit 0
+#		Timeout 0
+	</Node>
+</Plugin>
+
+<Plugin write_log>
+    Format JSON
+</Plugin>


### PR DESCRIPTION
This adds a script that installs necessary build dependencies to the
system, builds and installs collectd into an 'install/' subdirectory,
installs a sample config and starts collectd in foreground mode
afterwards.

Note that this script is entirely optional but it may help you to get
started (some plugins don't compile, so this script is only building a
few). Once installed this way, another 'make install' will re-install
collectd into install/sbin/collectd and it can be started normally.

NOTE: collectd segfaults in src/daemon/metric.c:208 (called from
src/cpu.c:545) when build this way from the current branch HEAD. It
works on tree 630b948, so it's likely caused by your code and you
already got something to fix. :-)

ChangeLog: collectd: added bootstrap helper script