### PR TITLE
Fix network test

### DIFF
--- a/src/network_test.c
+++ b/src/network_test.c
@@ -224,17 +224,7 @@ static int decode_string(char const *in, uint8_t *out, size_t *out_size) {
 }
 
 DEF_TEST(parse_packet) {
-  sockent_t se
-#if HAVE_GCRYPT_H
-      = {.data.server =
-             (struct sockent_server){
-                 .cypher = NULL,
-                 .userdb = NULL,
-                 .security_level = SECURITY_LEVEL_NONE,
-             },
-        }
-#endif
-  ;
+  sockent_t se = {0};
 
   for (size_t i = 0; i < sizeof(raw_packet_data) / sizeof(raw_packet_data[0]);
        i++) {

--- a/src/network_test.c
+++ b/src/network_test.c
@@ -224,16 +224,17 @@ static int decode_string(char const *in, uint8_t *out, size_t *out_size) {
 }
 
 DEF_TEST(parse_packet) {
-  sockent_t se = {
-      .data.server =
-          (struct sockent_server){
+  sockent_t se
 #if HAVE_GCRYPT_H
-              .cypher = NULL,
-              .userdb = NULL,
-              .security_level = SECURITY_LEVEL_NONE,
+      = {.data.server =
+             (struct sockent_server){
+                 .cypher = NULL,
+                 .userdb = NULL,
+                 .security_level = SECURITY_LEVEL_NONE,
+             },
+        }
 #endif
-          },
-  };
+  ;
 
   for (size_t i = 0; i < sizeof(raw_packet_data) / sizeof(raw_packet_data[0]);
        i++) {


### PR DESCRIPTION
ChangeLog: Avoid empty initialization when gcrypt is absent as it leads to compile error on Sun Studio