### PR TITLE
Fix memory leak in curl plugin

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -467,6 +467,7 @@ static int cc_config_add_page(oconfig_item_t *ci) /* {{{ */
                 child->key, page->instance);
         status = -1;
       }
+      free(af);
     } else if (strcasecmp("User", child->key) == 0)
       status = cf_util_get_string(child, &page->user);
     else if (strcasecmp("Password", child->key) == 0)


### PR DESCRIPTION
When AddressFamily field was set in config file in configuration for curl plugin, memory was allocated and pointer was stored in af variable. At the end of block of code, this memory wasn't freed. 

ChangeLog: curl plugin: Fix memory leak