### PR TITLE
mysql: Compatibility with MariaDB >= 10.5

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -69,6 +69,7 @@ struct mysql_database_s /* {{{ */
 
   MYSQL *con;
   bool is_connected;
+  unsigned long mysql_version;
 };
 typedef struct mysql_database_s mysql_database_t; /* }}} */
 
@@ -299,6 +300,7 @@ static MYSQL *getconnection(mysql_database_t *db) {
 
   cipher = mysql_get_ssl_cipher(db->con);
 
+  db->mysql_version = mysql_get_server_version(db->con);
   INFO("mysql plugin: Successfully connected to database %s "
        "at server %s with cipher %s "
        "(server version: %s, protocol version: %d) ",
@@ -592,8 +594,12 @@ static int mysql_read_innodb_stats(mysql_database_t *db, MYSQL *con) {
 
       {NULL, NULL, 0}};
 
-  query = "SELECT name, count, type FROM information_schema.innodb_metrics "
-          "WHERE status = 'enabled'";
+  if (db->mysql_version >= 100500)
+    query = "SELECT name, count, type FROM information_schema.innodb_metrics "
+            "WHERE enabled";
+  else
+    query = "SELECT name, count, type FROM information_schema.innodb_metrics "
+            "WHERE status = 'enabled'";
 
   res = exec_query(con, query);
   if (res == NULL)
@@ -735,7 +741,6 @@ static int mysql_read(user_data_t *ud) {
 
   unsigned long long traffic_incoming = 0ULL;
   unsigned long long traffic_outgoing = 0ULL;
-  unsigned long mysql_version = 0ULL;
 
   if ((ud == NULL) || (ud->data == NULL)) {
     ERROR("mysql plugin: mysql_database_read: Invalid user data.");
@@ -748,10 +753,8 @@ static int mysql_read(user_data_t *ud) {
   if ((con = getconnection(db)) == NULL)
     return -1;
 
-  mysql_version = mysql_get_server_version(con);
-
   query = "SHOW STATUS";
-  if (mysql_version >= 50002)
+  if (db->mysql_version >= 50002)
     query = "SHOW GLOBAL STATUS";
 
   res = exec_query(con, query);
@@ -934,7 +937,7 @@ static int mysql_read(user_data_t *ud) {
 
   traffic_submit(traffic_incoming, traffic_outgoing, db);
 
-  if (mysql_version >= 50600 && db->innodb_stats)
+  if (db->mysql_version >= 50600 && db->innodb_stats)
     mysql_read_innodb_stats(db, con);
 
   if (db->master_stats)


### PR DESCRIPTION
In MariaDB 10.5 information_schema.innodb_metrics was cleaned:
https://github.com/MariaDB/server/commit/d09aec7a15ab4be539d2b110742af544fa6b139f

String column 'status' was replaced with boolean column 'enabled'.

Therefore we need to modify request for fetching data from that table.

Fixes #3533

ChangeLog: mysql: compatibility with MariaDB >=10.5