### PR TITLE
Avoid deadlocks.

### DIFF
--- a/src/daemon/distribution.c
+++ b/src/daemon/distribution.c
@@ -247,8 +247,10 @@ double distribution_percentile(distribution_t *dist, double percent) {
     return NAN;
   }
   pthread_mutex_lock(&dist->mutex);
-  if (dist->tree[0].bucket_counter == 0)
+  if (dist->tree[0].bucket_counter == 0) {
+    pthread_mutex_unlock(&dist->mutex);
     return NAN;
+  }
   uint64_t counter = ceil(dist->tree[0].bucket_counter * percent / 100.0);
   double percentile =
       tree_get_counter(dist, 0, 0, dist->num_buckets - 1, counter);
@@ -261,6 +263,7 @@ double distribution_average(distribution_t *dist) {
     return NAN;
   pthread_mutex_lock(&dist->mutex);
   if (dist->tree[0].bucket_counter == 0) {
+    pthread_mutex_unlock(&dist->mutex);
     return NAN;
   }
   double average = dist->total_sum / dist->tree[0].bucket_counter;

--- a/src/daemon/distribution_test.c
+++ b/src/daemon/distribution_test.c
@@ -390,6 +390,9 @@ DEF_TEST(average) {
     }
     EXPECT_EQ_DOUBLE(cases[i].want_average,
                      distribution_average(cases[i].dist));
+    /* Check it second time for deadlocks. */
+    EXPECT_EQ_DOUBLE(cases[i].want_average,
+                     distribution_average(cases[i].dist));
     distribution_destroy(cases[i].dist);
   }
   return 0;
@@ -445,6 +448,9 @@ DEF_TEST(percentile) {
     for (size_t j = 0; j < cases[i].num_gauges; j++) {
       distribution_update(cases[i].dist, cases[i].update_gauges[j]);
     }
+    EXPECT_EQ_DOUBLE(cases[i].want_percentile,
+                     distribution_percentile(cases[i].dist, cases[i].percent));
+    /* Check it second time for deadlocks. */
     EXPECT_EQ_DOUBLE(cases[i].want_percentile,
                      distribution_percentile(cases[i].dist, cases[i].percent));
     if (cases[i].want_err != 0)


### PR DESCRIPTION
ChangeLog: Distribution data structure: Avoid deadlocks.
- Unlock locks in `distribution_percentile` and `distribution_average` when `bucket_counter` is 0.
- Call tests second time for deadlocks detection.