### PR TITLE
.cirrus.yml: Remove Debian Jessie.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,9 +28,6 @@ debian_default_toolchain_task:
   matrix:
     - allow_failures: false
       container:
-        image: collectd/ci:jessie_amd64
-    - allow_failures: false
-      container:
         image: collectd/ci:stretch_amd64
     - allow_failures: false
       container:


### PR DESCRIPTION
Regular support for Jessie ended in 2018, LTS in June 2020.