### PR TITLE
libcollectdclient: Don't initialize a char with 0xF8.

### DIFF
--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -258,7 +258,7 @@ static double ntohd(double val) /* {{{ */
       config = 4;
   }
 
-  if (memcmp((char[]){0, 0, 0, 0, 0, 0, 0xf8, 0x7f}, in.byte, 8) == 0) {
+  if (memcmp((uint8_t[]){0, 0, 0, 0, 0, 0, 0xf8, 0x7f}, in.byte, 8) == 0) {
     return NAN;
   } else if (config == 1) {
     return val;


### PR DESCRIPTION
Fixes the following warning:

```
"src/libcollectdclient/network_parse.c", line 261: warning: initializer does not fit or is out of range: 248
```

ChangeLog: libcollectdclient: A build error on Solaris has been fixed.