### PR TITLE
Rewrite problematic language where possible

### DIFF
--- a/docs/BUILD.dpdkstat.md
+++ b/docs/BUILD.dpdkstat.md
@@ -217,7 +217,7 @@ See also: http://dpdk.org/doc/guides/prog_guide/multi_proc_support.html
 
  *  The same PCI device configuration should be passed to the primary process as
     the secondary process uses the same port indexes as the primary.
- *  A deny-list / allow-list of NICs isn't supported yet.
+ *  A blocklist / allowlist of NICs isn't supported yet.
  *  Plugin initialization time depends on read interval. It requires 5 read
     cycles to set up internal buffers and states. During that time no statistics
     are submitted.

--- a/docs/BUILD.dpdkstat.md
+++ b/docs/BUILD.dpdkstat.md
@@ -217,7 +217,7 @@ See also: http://dpdk.org/doc/guides/prog_guide/multi_proc_support.html
 
  *  The same PCI device configuration should be passed to the primary process as
     the secondary process uses the same port indexes as the primary.
- *  A blacklist / whitelist of NICs isn't supported yet.
+ *  A deny-list / allow-list of NICs isn't supported yet.
  *  Plugin initialization time depends on read interval. It requires 5 read
     cycles to set up internal buffers and states. During that time no statistics
     are submitted.

--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -302,8 +302,8 @@ When B<Table> is set to I<false> then this option has no effect.
 =item B<InvertMatch> I<true|false(default)>
 
 The invertmatch value should be use in combination of the Ignore option.
-It changes the behaviour of the Ignore option, from a deny-list behaviour
-when InvertMatch is set to false, to a allow-list when specified to true.
+It changes the behaviour of the Ignore option, from a blocklist behaviour
+when InvertMatch is set to false, to a allowlist when specified to true.
 
 =item B<FilterOID> I<OID>
 

--- a/src/collectd-snmp.pod
+++ b/src/collectd-snmp.pod
@@ -302,8 +302,8 @@ When B<Table> is set to I<false> then this option has no effect.
 =item B<InvertMatch> I<true|false(default)>
 
 The invertmatch value should be use in combination of the Ignore option.
-It changes the behaviour of the Ignore option, from a blacklist behaviour
-when InvertMatch is set to false, to a whitelist when specified to true.
+It changes the behaviour of the Ignore option, from a deny-list behaviour
+when InvertMatch is set to false, to a allow-list when specified to true.
 
 =item B<FilterOID> I<OID>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5348,7 +5348,7 @@ C<Bytes_{received,sent}>, C<Com_*>, C<Handler_*>, C<Qcache_*> and C<Threads_*>
 return values. Please refer to the B<MySQL reference manual>, I<5.1.6. Server
 Status Variables> for an explanation of these values.
 
-Optionally, master and slave statistics may be collected in a MySQL
+Optionally, primary and replica statistics may be collected in a MySQL
 replication setup. In that case, information about the synchronization state
 of the nodes are collected by evaluating the C<Position> return value of the
 C<SHOW MASTER STATUS> command and the C<Seconds_Behind_Master>,
@@ -5450,7 +5450,7 @@ Disabled by default.
 
 =item B<SlaveStats> I<true|false>
 
-Enable the collection of master / slave statistics in a replication setup. In
+Enable the collection of primary / replica statistics in a replication setup. In
 order to be able to get access to these statistics, the user needs special
 privileges. See the B<User> documentation above. Defaults to B<false>.
 
@@ -10721,7 +10721,7 @@ The output format to use. Can be one of C<Graphite> or C<JSON>.
 =head2 Plugin C<write_tsdb>
 
 The C<write_tsdb> plugin writes data to I<OpenTSDB>, a scalable open-source
-time series database. The plugin connects to a I<TSD>, a masterless, no shared
+time series database. The plugin connects to a I<TSD>, a leaderless, no shared
 state daemon that ingests metrics and stores them in HBase. The plugin uses
 I<TCP> over the "line based" protocol with a default port 4242. The data will
 be sent in blocks of at most 1428 bytes to minimize the number of network

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -418,7 +418,7 @@ static int mysql_read_primary_stats(mysql_database_t *db, MYSQL *con) {
   }
 
   position = atoll(row[1]);
-  derive_submit("mysql_log_position", "primary-bin", position, db);
+  derive_submit("mysql_log_position", "master-bin", position, db);
 
   row = mysql_fetch_row(res);
   if (row != NULL)
@@ -474,21 +474,21 @@ static int mysql_read_replica_stats(mysql_database_t *db, MYSQL *con) {
     unsigned long long counter;
     double gauge;
 
-    gauge_submit("bool", "replica-sql-running",
+    gauge_submit("bool", "slave-sql-running",
                  (row[SLAVE_SQL_RUNNING_IDX] != NULL) &&
                      (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") == 0),
                  db);
 
-    gauge_submit("bool", "replica-io-running",
+    gauge_submit("bool", "slave-io-running",
                  (row[SLAVE_IO_RUNNING_IDX] != NULL) &&
                      (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") == 0),
                  db);
 
     counter = atoll(row[READ_MASTER_LOG_POS_IDX]);
-    derive_submit("mysql_log_position", "replica-read", counter, db);
+    derive_submit("mysql_log_position", "slave-read", counter, db);
 
     counter = atoll(row[EXEC_MASTER_LOG_POS_IDX]);
-    derive_submit("mysql_log_position", "replica-exec", counter, db);
+    derive_submit("mysql_log_position", "slave-exec", counter, db);
 
     if (row[SECONDS_BEHIND_MASTER_IDX] != NULL) {
       gauge = atof(row[SECONDS_BEHIND_MASTER_IDX]);

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -58,14 +58,14 @@ struct mysql_database_s /* {{{ */
   int port;
   int timeout;
 
-  bool master_stats;
-  bool slave_stats;
+  bool primary_stats;
+  bool replica_stats;
   bool innodb_stats;
   bool wsrep_stats;
 
-  bool slave_notif;
-  bool slave_io_running;
-  bool slave_sql_running;
+  bool replica_notif;
+  bool replica_io_running;
+  bool replica_sql_running;
 
   MYSQL *con;
   bool is_connected;
@@ -148,8 +148,8 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
   db->timeout = 0;
 
   /* trigger a notification, if it's not running */
-  db->slave_io_running = true;
-  db->slave_sql_running = true;
+  db->replica_io_running = true;
+  db->replica_sql_running = true;
 
   status = cf_util_get_string(ci, &db->instance);
   if (status != 0) {
@@ -193,11 +193,11 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
     else if (strcasecmp("ConnectTimeout", child->key) == 0)
       status = cf_util_get_int(child, &db->timeout);
     else if (strcasecmp("MasterStats", child->key) == 0)
-      status = cf_util_get_boolean(child, &db->master_stats);
+      status = cf_util_get_boolean(child, &db->primary_stats);
     else if (strcasecmp("SlaveStats", child->key) == 0)
-      status = cf_util_get_boolean(child, &db->slave_stats);
+      status = cf_util_get_boolean(child, &db->replica_stats);
     else if (strcasecmp("SlaveNotifications", child->key) == 0)
-      status = cf_util_get_boolean(child, &db->slave_notif);
+      status = cf_util_get_boolean(child, &db->replica_notif);
     else if (strcasecmp("InnodbStats", child->key) == 0)
       status = cf_util_get_boolean(child, &db->innodb_stats);
     else if (strcasecmp("WsrepStats", child->key) == 0)
@@ -385,7 +385,7 @@ static MYSQL_RES *exec_query(MYSQL *con, const char *query) {
   return res;
 } /* exec_query */
 
-static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
+static int mysql_read_primary_stats(mysql_database_t *db, MYSQL *con) {
   MYSQL_RES *res;
   MYSQL_ROW row;
 
@@ -401,7 +401,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
 
   row = mysql_fetch_row(res);
   if (row == NULL) {
-    ERROR("mysql plugin: Failed to get master statistics: "
+    ERROR("mysql plugin: Failed to get primary statistics: "
           "`%s' did not return any rows.",
           query);
     mysql_free_result(res);
@@ -410,7 +410,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
 
   field_num = mysql_num_fields(res);
   if (field_num < 2) {
-    ERROR("mysql plugin: Failed to get master statistics: "
+    ERROR("mysql plugin: Failed to get primary statistics: "
           "`%s' returned less than two columns.",
           query);
     mysql_free_result(res);
@@ -418,7 +418,7 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
   }
 
   position = atoll(row[1]);
-  derive_submit("mysql_log_position", "master-bin", position, db);
+  derive_submit("mysql_log_position", "primary-bin", position, db);
 
   row = mysql_fetch_row(res);
   if (row != NULL)
@@ -429,9 +429,9 @@ static int mysql_read_master_stats(mysql_database_t *db, MYSQL *con) {
   mysql_free_result(res);
 
   return 0;
-} /* mysql_read_master_stats */
+} /* mysql_read_primary_stats */
 
-static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
+static int mysql_read_replica_stats(mysql_database_t *db, MYSQL *con) {
   MYSQL_RES *res;
   MYSQL_ROW row;
 
@@ -454,7 +454,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
 
   row = mysql_fetch_row(res);
   if (row == NULL) {
-    ERROR("mysql plugin: Failed to get slave statistics: "
+    ERROR("mysql plugin: Failed to get replica statistics: "
           "`%s' did not return any rows.",
           query);
     mysql_free_result(res);
@@ -463,32 +463,32 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
 
   field_num = mysql_num_fields(res);
   if (field_num < 33) {
-    ERROR("mysql plugin: Failed to get slave statistics: "
+    ERROR("mysql plugin: Failed to get replica statistics: "
           "`%s' returned less than 33 columns.",
           query);
     mysql_free_result(res);
     return -1;
   }
 
-  if (db->slave_stats) {
+  if (db->replica_stats) {
     unsigned long long counter;
     double gauge;
 
-    gauge_submit("bool", "slave-sql-running",
+    gauge_submit("bool", "replica-sql-running",
                  (row[SLAVE_SQL_RUNNING_IDX] != NULL) &&
                      (strcasecmp(row[SLAVE_SQL_RUNNING_IDX], "yes") == 0),
                  db);
 
-    gauge_submit("bool", "slave-io-running",
+    gauge_submit("bool", "replica-io-running",
                  (row[SLAVE_IO_RUNNING_IDX] != NULL) &&
                      (strcasecmp(row[SLAVE_IO_RUNNING_IDX], "yes") == 0),
                  db);
 
     counter = atoll(row[READ_MASTER_LOG_POS_IDX]);
-    derive_submit("mysql_log_position", "slave-read", counter, db);
+    derive_submit("mysql_log_position", "replica-read", counter, db);
 
     counter = atoll(row[EXEC_MASTER_LOG_POS_IDX]);
-    derive_submit("mysql_log_position", "slave-exec", counter, db);
+    derive_submit("mysql_log_position", "replica-exec", counter, db);
 
     if (row[SECONDS_BEHIND_MASTER_IDX] != NULL) {
       gauge = atof(row[SECONDS_BEHIND_MASTER_IDX]);
@@ -496,7 +496,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     }
   }
 
-  if (db->slave_notif) {
+  if (db->replica_notif) {
     notification_t n = {0,  cdtime(),      "", "",  "mysql",
                         "", "time_offset", "", NULL};
 
@@ -512,33 +512,33 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
     sstrncpy(n.plugin_instance, db->instance, sizeof(n.plugin_instance));
 
     if (((io == NULL) || (strcasecmp(io, "yes") != 0)) &&
-        (db->slave_io_running)) {
+        (db->replica_io_running)) {
       n.severity = NOTIF_WARNING;
       ssnprintf(n.message, sizeof(n.message),
-                "slave I/O thread not started or not connected to master");
+                "replica I/O thread not started or not connected to primary");
       plugin_dispatch_notification(&n);
-      db->slave_io_running = false;
+      db->replica_io_running = false;
     } else if (((io != NULL) && (strcasecmp(io, "yes") == 0)) &&
-               (!db->slave_io_running)) {
+               (!db->replica_io_running)) {
       n.severity = NOTIF_OKAY;
       ssnprintf(n.message, sizeof(n.message),
-                "slave I/O thread started and connected to master");
+                "replica I/O thread started and connected to primary");
       plugin_dispatch_notification(&n);
-      db->slave_io_running = true;
+      db->replica_io_running = true;
     }
 
     if (((sql == NULL) || (strcasecmp(sql, "yes") != 0)) &&
-        (db->slave_sql_running)) {
+        (db->replica_sql_running)) {
       n.severity = NOTIF_WARNING;
-      ssnprintf(n.message, sizeof(n.message), "slave SQL thread not started");
+      ssnprintf(n.message, sizeof(n.message), "replica SQL thread not started");
       plugin_dispatch_notification(&n);
-      db->slave_sql_running = false;
+      db->replica_sql_running = false;
     } else if (((sql != NULL) && (strcasecmp(sql, "yes") == 0)) &&
-               (!db->slave_sql_running)) {
+               (!db->replica_sql_running)) {
       n.severity = NOTIF_OKAY;
-      ssnprintf(n.message, sizeof(n.message), "slave SQL thread started");
+      ssnprintf(n.message, sizeof(n.message), "replica SQL thread started");
       plugin_dispatch_notification(&n);
-      db->slave_sql_running = true;
+      db->replica_sql_running = true;
     }
   }
 
@@ -551,7 +551,7 @@ static int mysql_read_slave_stats(mysql_database_t *db, MYSQL *con) {
   mysql_free_result(res);
 
   return 0;
-} /* mysql_read_slave_stats */
+} /* mysql_read_replica_stats */
 
 static int mysql_read_innodb_stats(mysql_database_t *db, MYSQL *con) {
   MYSQL_RES *res;
@@ -950,11 +950,11 @@ static int mysql_read(user_data_t *ud) {
   if (db->mysql_version >= 50600 && db->innodb_stats)
     mysql_read_innodb_stats(db, con);
 
-  if (db->master_stats)
-    mysql_read_master_stats(db, con);
+  if (db->primary_stats)
+    mysql_read_primary_stats(db, con);
 
-  if ((db->slave_stats) || (db->slave_notif))
-    mysql_read_slave_stats(db, con);
+  if ((db->replica_stats) || (db->replica_notif))
+    mysql_read_replica_stats(db, con);
 
   if (db->wsrep_stats)
     mysql_read_wsrep_stats(db, con);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -182,7 +182,7 @@ static int sensors_load_conf(void) {
       if (feature == NULL)
         break;
 
-      /* "master features" only */
+      /* "main features" only */
       if (feature->mapping != SENSORS_NO_MAPPING) {
         DEBUG("sensors plugin: sensors_load_conf: "
               "Ignoring subfeature `%s', "

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -217,12 +217,12 @@ static int metric_type(char *buffer, size_t buffer_size, data_set_t const *ds,
     ssnprintf(buffer, buffer_size, GCM_PREFIX "%s/%s", vl->plugin, vl->type);
   }
 
-  char const *whitelist = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  char const *allowlist = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                           "abcdefghijklmnopqrstuvwxyz"
                           "0123456789_/";
   char *ptr = buffer + strlen(GCM_PREFIX);
   size_t ok_len;
-  while ((ok_len = strspn(ptr, whitelist)) != strlen(ptr)) {
+  while ((ok_len = strspn(ptr, allowlist)) != strlen(ptr)) {
     ptr[ok_len] = '_';
     ptr += ok_len;
   }


### PR DESCRIPTION
This patch leaves out rewrite master/slave from mysql and also
master from snmp.

This repaces blacklist with blocklist, whitelist with allowlist.

ChangeLog: collectd: Fix problematic use of language where possible.