### PR TITLE
src/netlink.c: remove REG_NOERROR

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -240,7 +240,7 @@ static int check_ignorelist(const char *dev, const char *type,
   for (ir_ignorelist_t *i = ir_ignorelist_head; i != NULL; i = i->next) {
 #if HAVE_REGEX_H
     if (i->rdevice != NULL) {
-      if (regexec(i->rdevice, dev, 0, NULL, 0) != REG_NOERROR)
+      if (regexec(i->rdevice, dev, 0, NULL, 0))
         continue;
     } else
 #endif


### PR DESCRIPTION
ChangeLog: netlink: fix use of REG_NOERROR.

`REG_NOERROR` is used since version 5.12.0 and https://github.com/collectd/collectd/commit/f7fd32e5209e188db7985a42054252fc4cbfe7c1

However, `REG_NOERROR` is not defined by musl, even GNU regex do not mention `REG_NOERROR`, so just remove it to avoid the following build failure:

```
src/netlink.c: In function 'check_ignorelist':
src/netlink.c:243:51: error: 'REG_NOERROR' undeclared (first use in this function); did you mean 'REG_NOTBOL'?
       if (regexec(i->rdevice, dev, 0, NULL, 0) != REG_NOERROR)
                                                   ^~~~~~~~~~~
                                                   REG_NOTBOL
```

Fixes:
 - http://autobuild.buildroot.org/results/cd4d75888b5259b028132dd224be34f69bcbb702

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>