### PR TITLE
Fix bug inside write_http plugin

### DIFF
--- a/src/write_http.c
+++ b/src/write_http.c
@@ -334,7 +334,7 @@ static int wh_write_command(metric_family_t const *fam, wh_callback_t *cb) {
 
   int ret = 0;
   for (size_t i = 0; i < fam->metric.num; i++) {
-    metric_t const *m = fam->metric.ptr;
+    metric_t const *m = fam->metric.ptr + i;
 
     int status = cmd_format_putmetric(&cb->send_buffer, m);
     if (status != 0) {


### PR DESCRIPTION
Fix the probable bug inside write_http plugin. For loop by i variable every time takes the same metric from the metric family. Due to the iteration by i, it looks like we should take ith element every time.

ChangeLog: write_http plugin: A bug when iterating over metrics in a metric family has been fixed.