### PR TITLE
configfile.c: Fix memory leaks in case of failure

### DIFF
--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -791,6 +791,7 @@ static oconfig_item_t *cf_read_generic(const char *path, const char *pattern,
 
     if (temp == NULL) {
       oconfig_free(root);
+      wordfree(&we);
       return NULL;
     }
 


### PR DESCRIPTION
ChangeLog: configfile.c: Fix memory leaks in case of failure