### PR TITLE
Compare both PID and process start time to avoid issues with immediate PID reuse on Linux

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -177,6 +177,9 @@
 typedef struct process_entry_s {
   unsigned long id;
   char name[PROCSTAT_NAME_LEN];
+  // The time the process started after system boot.
+  // Value is in jiffies.
+  unsigned long long starttime;
 
   unsigned long num_proc;
   unsigned long num_lwp;
@@ -220,6 +223,9 @@ typedef struct process_entry_s {
 typedef struct procstat_entry_s {
   unsigned long id;
   unsigned char age;
+  // The time the process started after system boot.
+  // Value is in jiffies.
+  unsigned long long starttime;
 
   derive_t vmem_minflt_counter;
   derive_t vmem_majflt_counter;
@@ -535,13 +541,20 @@ static void ps_list_add(const char *name, const char *cmdline,
       if ((pse->id == entry->id) || (pse->next == NULL))
         break;
 
-    if ((pse == NULL) || (pse->id != entry->id)) {
+    if ((pse == NULL) || (pse->id != entry->id) ||
+        (pse->starttime != entry->starttime)) {
+      if (pse != NULL && pse->id == entry->id) {
+        WARNING("pid %lu reused between two reads, ignoring existing "
+            "procstat_entry for %s",
+            pse->id, name);
+      }
       procstat_entry_t *new;
 
       new = calloc(1, sizeof(*new));
       if (new == NULL)
         return;
       new->id = entry->id;
+      new->starttime = entry->starttime;
 
       if (pse == NULL)
         ps->instances = new;
@@ -1444,6 +1457,7 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
 
   ps->cswitch_vol = -1;
   ps->cswitch_invol = -1;
+  ps->starttime = strtoull(fields[19], NULL, 10);
 
   /* success */
   return 0;

--- a/src/processes.c
+++ b/src/processes.c
@@ -545,8 +545,8 @@ static void ps_list_add(const char *name, const char *cmdline,
         (pse->starttime != entry->starttime)) {
       if (pse != NULL && pse->id == entry->id) {
         WARNING("pid %lu reused between two reads, ignoring existing "
-            "procstat_entry for %s",
-            pse->id, name);
+                "procstat_entry for %s",
+                pse->id, name);
       }
       procstat_entry_t *new;
 


### PR DESCRIPTION
When PID is reused on Linux between two cycles, the data from the old process will not be cleared and new process will reuse the previous data. This is causing issues like negative CPU.

We have seen those issues at scale in Google Cloud, and this patch fixed the issue completely. This fix is tested at scale for 6 months already.

ChangeLog: processes.c: fix negative CPU reporting caused by PID reuse on Linux.