### PR TITLE
Updated version of Intel PMU plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1149,6 +1149,17 @@ intel_pmu_la_SOURCES = \
 intel_pmu_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBJEVENTS_CPPFLAGS)
 intel_pmu_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBJEVENTS_LDFLAGS)
 intel_pmu_la_LIBADD = $(BUILD_WITH_LIBJEVENTS_LIBS)
+
+test_plugin_intel_pmu_SOURCES = \
+	src/intel_pmu_test.c \
+	src/utils/config_cores/config_cores.c \
+	src/daemon/configfile.c \
+	src/daemon/types_list.c
+test_plugin_intel_pmu_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBJEVENTS_CPPFLAGS)
+test_plugin_intel_pmu_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBJEVENTS_LDFLAGS)
+test_plugin_intel_pmu_LDADD = libplugin_mock.la liboconfig.la $(BUILD_WITH_LIBJEVENTS_LIBS)
+check_PROGRAMS += test_plugin_intel_pmu
+TESTS += test_plugin_intel_pmu
 endif
 
 if BUILD_PLUGIN_INTEL_RDT

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -828,9 +828,9 @@
 #</Plugin>
 
 #<Plugin intel_pmu>
-#    ReportHardwareCacheEvents true
-#    ReportKernelPMUEvents true
-#    ReportSoftwareEvents true
+##    ReportHardwareCacheEvents true
+##    ReportKernelPMUEvents true
+##    ReportSoftwareEvents true
 #    EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
 #    HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
 #    Cores "[0-3]"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -828,13 +828,10 @@
 #</Plugin>
 
 #<Plugin intel_pmu>
-##    ReportHardwareCacheEvents true
-##    ReportKernelPMUEvents true
-##    ReportSoftwareEvents true
 #    EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
 #    HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
 #    Cores "[0-3]"
-#    DispatchMultiPmu false
+#    DispatchMultiPmu true
 #</Plugin>
 
 #<Plugin "intel_rdt">

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -831,7 +831,7 @@
 #    EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
 #    HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
 #    Cores "[0-3]"
-#    DispatchMultiPmu true
+#    AggregateUncorePMUs true
 #</Plugin>
 
 #<Plugin "intel_rdt">

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -828,7 +828,7 @@
 #</Plugin>
 
 #<Plugin intel_pmu>
-#    EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
+#    EventList "/var/cache/pmu/GenuineIntel-6-55-4-core.json"
 #    HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
 #    Cores "[0-3]"
 #    AggregateUncorePMUs true

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3881,16 +3881,22 @@ Linux perf interface. All events are reported on a per core basis.
 B<Note:> When using intel_pmu plugin number of reading threads in collectd
 should be adjusted accordingly. The value should be more than a half of
 configured cores, so for 60 monitored cores the recommendation is to set
-B<ReadThreads> > 30.
+B<ReadThreads> > 30. The optimal number of B<WriteThreads> depends on volume
+of metrics from read plugins, interval and number of enabled write plugins.
+The above adjustments can help with performance scaling when monitoring a high
+number of events on many cores.
+
 
 B<Synopsis:>
 
   <Plugin intel_pmu>
-    EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
+    EventList "/var/cache/pmu/GenuineIntel-6-55-4-core.json"
     HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
     Cores "0-3" "4,6" "[12-15]"
     HardwareEvents "L2_RQSTS.PF_MISS"
     Cores "[1,2]"
+    HardwareEvents "INST_RETIRED.ANY" "CPU_CLK_UNHALTED.THREAD"
+    Cores ""
     AggregateUncorePMUs true
   </Plugin>
 
@@ -3932,13 +3938,14 @@ This option can be used once for every B<HardwareEvents> set.
 
 =item B<AggregateUncorePMUs> B<false>|B<true>
 
-This option toggles the event value reporting from all the uncore PMUs to
-either dispatch as aggregated value in a single metric or dispatch as
-individual values. If B<AggregateUncorePMUs> is set to 'true' uncore events are
-reported as single metric, even for multi PMU. The total value is obtained by
-summing all counters across all the units (e.g. CHAs). If B<AggregateUncorePMUs>
-is set to 'false' all cloned PMUs are dispatched separately with PMU name added
-to Collectd's I<plugin_instance>.
+This option toggles the event value reporting from all the uncore PMUs to either
+dispatch as aggregated value in a single metric or dispatch as individual
+values. If B<AggregateUncorePMUs> is set to 'true', uncore events from the
+various PMU subsystems across uncore are reported as a single metric, usually
+reported as single 'Core0' events. The total value is obtained by summing all
+counters across all the units (e.g. CHAs). If B<AggregateUncorePMUs> is set to
+'false', values from the individual PMU subsystems across uncore are dispatched
+separately with PMU name/number added to Collectd's I<plugin_instance>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3878,6 +3878,11 @@ B<except> the ones matched.
 The I<intel_pmu> plugin collects performance counters data on Intel CPUs using
 Linux perf interface. All events are reported on a per core basis.
 
+B<Note:> When using intel_pmu plugin number of reading threads in collectd
+should be adjusted accordingly. The value should be more than a half of
+configured cores, so for 60 monitored cores the recommendation is to set
+B<ReadThreads> > 30.
+
 B<Synopsis:>
 
   <Plugin intel_pmu>
@@ -3886,7 +3891,7 @@ B<Synopsis:>
     Cores "0-3" "4,6" "[12-15]"
     HardwareEvents "L2_RQSTS.PF_MISS"
     Cores "[1,2]"
-    DispatchMultiPmu false
+    DispatchMultiPmu true
   </Plugin>
 
 B<Options:>
@@ -3927,10 +3932,13 @@ This option can be used once for every B<HardwareEvents> set.
 
 =item B<DispatchMultiPmu> B<false>|B<true>
 
-Enable or disable dispatching of cloned multi PMU for uncore events. If
-disabled only total sum is dispatched as single event. If enabled separate
-metric is dispatched for every counter. Name of particular PMU counter is
-added to I<plugin_instance>.
+This option toggles the event value reporting from all the uncore PMUs to
+either dispatch as aggregated value in a single metric or dispatch as
+individual values. If DispatchMultiPmu is set to 'false' uncore events are
+reported as single metric, even for multi PMU. The total value is obtained by
+summing all counters across all the units (e.g. CHAs). If DispatchMultiPmu is
+set to 'true' all cloned PMUs are dispatched separately with 'type' value of
+PMU added to Collectd's I<type_instance>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3937,8 +3937,8 @@ either dispatch as aggregated value in a single metric or dispatch as
 individual values. If DispatchMultiPmu is set to 'false' uncore events are
 reported as single metric, even for multi PMU. The total value is obtained by
 summing all counters across all the units (e.g. CHAs). If DispatchMultiPmu is
-set to 'true' all cloned PMUs are dispatched separately with 'type' value of
-PMU added to Collectd's I<type_instance>.
+set to 'true' all cloned PMUs are dispatched separately with PMU name added to
+Collectd's I<plugin_instance>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3881,72 +3881,17 @@ Linux perf interface. All events are reported on a per core basis.
 B<Synopsis:>
 
   <Plugin intel_pmu>
-    ReportHardwareCacheEvents true
-    ReportKernelPMUEvents true
-    ReportSoftwareEvents true
     EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"
     HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS" "L2_RQSTS.ALL_CODE_RD"
     Cores "0-3" "4,6" "[12-15]"
+    HardwareEvents "L2_RQSTS.PF_MISS"
+    Cores "[1,2]"
     DispatchMultiPmu false
   </Plugin>
 
 B<Options:>
 
 =over 4
-
-=item B<ReportHardwareCacheEvents> B<false>|B<true>
-
-Enable or disable measuring of hardware CPU cache events:
-  - L1-dcache-loads
-  - L1-dcache-load-misses
-  - L1-dcache-stores
-  - L1-dcache-store-misses
-  - L1-dcache-prefetches
-  - L1-dcache-prefetch-misses
-  - L1-icache-loads
-  - L1-icache-load-misses
-  - L1-icache-prefetches
-  - L1-icache-prefetch-misses
-  - LLC-loads
-  - LLC-load-misses
-  - LLC-stores
-  - LLC-store-misses
-  - LLC-prefetches
-  - LLC-prefetch-misses
-  - dTLB-loads
-  - dTLB-load-misses
-  - dTLB-stores
-  - dTLB-store-misses
-  - dTLB-prefetches
-  - dTLB-prefetch-misses
-  - iTLB-loads
-  - iTLB-load-misses
-  - branch-loads
-  - branch-load-misses
-
-=item B<ReportKernelPMUEvents> B<false>|B<true>
-
-Enable or disable measuring of the following events:
-  - cpu-cycles
-  - instructions
-  - cache-references
-  - cache-misses
-  - branches
-  - branch-misses
-  - bus-cycles
-
-=item B<ReportSoftwareEvents> B<false>|B<true>
-
-Enable or disable measuring of software events provided by kernel:
-  - cpu-clock
-  - task-clock
-  - context-switches
-  - cpu-migrations
-  - page-faults
-  - minor-faults
-  - major-faults
-  - alignment-faults
-  - emulation-faults
 
 =item B<EventList> I<filename>
 
@@ -3957,7 +3902,10 @@ event_download.py script to download event list for current CPU.
 =item B<HardwareEvents> I<events>
 
 This field is a list of event names or groups of comma separated event names.
-This option requires B<EventList> option to be configured.
+This option requires B<EventList> option to be configured. If "All" is
+provided, all events from B<EventList> are going to be loaded. This option
+can be used multiple times in pair with B<Cores> option, as shown in example
+above.
 
 =item B<Cores> I<cores groups>
 
@@ -3975,12 +3923,14 @@ Allowed formats are:
 
 If an empty string is provided as value for this field default cores
 configuration is applied - that is separate group is created for each core.
+This option can be used once for every B<HardwareEvents> set.
 
 =item B<DispatchMultiPmu> B<false>|B<true>
 
 Enable or disable dispatching of cloned multi PMU for uncore events. If
 disabled only total sum is dispatched as single event. If enabled separate
-metric is dispatched for every counter.
+metric is dispatched for every counter. Name of particular PMU counter is
+added to I<plugin_instance>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3891,7 +3891,7 @@ B<Synopsis:>
     Cores "0-3" "4,6" "[12-15]"
     HardwareEvents "L2_RQSTS.PF_MISS"
     Cores "[1,2]"
-    DispatchMultiPmu true
+    AggregateUncorePMUs true
   </Plugin>
 
 B<Options:>
@@ -3930,15 +3930,15 @@ If an empty string is provided as value for this field default cores
 configuration is applied - that is separate group is created for each core.
 This option can be used once for every B<HardwareEvents> set.
 
-=item B<DispatchMultiPmu> B<false>|B<true>
+=item B<AggregateUncorePMUs> B<false>|B<true>
 
 This option toggles the event value reporting from all the uncore PMUs to
 either dispatch as aggregated value in a single metric or dispatch as
-individual values. If DispatchMultiPmu is set to 'false' uncore events are
+individual values. If B<AggregateUncorePMUs> is set to 'true' uncore events are
 reported as single metric, even for multi PMU. The total value is obtained by
-summing all counters across all the units (e.g. CHAs). If DispatchMultiPmu is
-set to 'true' all cloned PMUs are dispatched separately with PMU name added to
-Collectd's I<plugin_instance>.
+summing all counters across all the units (e.g. CHAs). If B<AggregateUncorePMUs>
+is set to 'false' all cloned PMUs are dispatched separately with PMU name added
+to Collectd's I<plugin_instance>.
 
 =back
 

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -718,7 +718,10 @@ static int pmu_init(void) {
   }
 
   /* parse events names from JSON file */
-  ret = read_events(g_ctx.event_list_fn);
+  if (g_ctx.event_list_fn[0] == '\0')
+    ret = read_events(NULL); // Let jevents choose default file
+  else
+    ret = read_events(g_ctx.event_list_fn);
   if (ret != 0) {
     ERROR(PMU_PLUGIN ": Failed to read event list file '%s'.",
           g_ctx.event_list_fn);

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -41,7 +41,7 @@ intel_pmu_ctx_t *stub_pmu_init() {
 }
 
 void stub_pmu_teardown(intel_pmu_ctx_t *pmu_ctx) {
-  for(int i = 0; i < pmu_ctx->entl->hw_events_count; i++) {
+  for (int i = 0; i < pmu_ctx->entl->hw_events_count; i++) {
     sfree(pmu_ctx->entl->hw_events[i]);
   }
   sfree(pmu_ctx->entl->hw_events);

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -29,7 +29,6 @@
 #include "testing.h"
 
 // Helper functions
-// static int ctx_entl_size = 0;
 
 intel_pmu_ctx_t *stub_pmu_init() {
   intel_pmu_ctx_t *pmu_ctx = calloc(1, sizeof(*pmu_ctx));

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -1,0 +1,114 @@
+/**
+ * collectd - src/logparser_test.c
+ *
+ * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Pawel Tomaszewski <pawelx.tomaszewski@intel.com>
+ **/
+
+#include "intel_pmu.c"
+#include "testing.h"
+
+// Helper functions
+// static int ctx_entl_size = 0;
+
+intel_pmu_ctx_t* stub_pmu_init() {
+  intel_pmu_ctx_t* pmu_ctx = calloc(1, sizeof(*pmu_ctx));
+  intel_pmu_entity_t* entl = calloc(1, sizeof(*entl));
+
+  pmu_ctx->entl = entl;
+
+  return pmu_ctx;
+}
+
+void stub_pmu_teardown(intel_pmu_ctx_t* pmu_ctx) {
+  free(pmu_ctx->entl);
+  free(pmu_ctx);
+}
+
+DEF_TEST(pmu_config_hw_events__all_events) {
+  // setup
+  intel_pmu_ctx_t* pmu_ctx = stub_pmu_init();
+  intel_pmu_entity_t* ent = pmu_ctx->entl;
+
+  oconfig_value_t values[] = {
+      {.value.string = "All", .type = OCONFIG_TYPE_STRING},
+  };
+  oconfig_item_t config_item = {
+      .key = "HardwareEvents",
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
+  };
+
+  // check
+  int result = pmu_config_hw_events(&config_item, ent);
+  EXPECT_EQ_INT(0, result);
+  EXPECT_EQ_INT(1, ent->all_events);
+
+  // cleanup
+  stub_pmu_teardown(pmu_ctx);
+  return 0;
+}
+
+DEF_TEST(pmu_config_hw_events__few_events) {
+  // setup
+  intel_pmu_ctx_t* pmu_ctx = stub_pmu_init();
+  intel_pmu_entity_t* ent = pmu_ctx->entl;
+
+  oconfig_value_t values[] = {
+      {.value.string = "event0", .type = OCONFIG_TYPE_STRING},
+      {.value.string = "event1", .type = OCONFIG_TYPE_STRING},
+      {.value.string = "event2", .type = OCONFIG_TYPE_STRING},
+      {.value.string = "event3", .type = OCONFIG_TYPE_STRING},
+      {.value.string = "event4", .type = OCONFIG_TYPE_STRING}
+  };
+  oconfig_item_t config_item = {
+      .key = "HardwareEvents",
+      .values = values,
+      .values_num = STATIC_ARRAY_SIZE(values),
+  };
+
+  // check
+  int result = pmu_config_hw_events(&config_item, ent);
+  EXPECT_EQ_INT(0, result);
+  EXPECT_EQ_INT(config_item.values_num, ent->hw_events_count);
+  for(int i = 0; i < ent->hw_events_count; i++) {
+    EXPECT_EQ_STR(values[i].value.string, ent->hw_events[i]);
+  }
+
+  // cleanup
+  stub_pmu_teardown(pmu_ctx);
+  return 0;
+}
+
+DEF_TEST(config_cores_parse) {
+
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(pmu_config_hw_events__all_events);
+  RUN_TEST(pmu_config_hw_events__few_events);
+  RUN_TEST(config_cores_parse);
+
+  END_TEST;
+}

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -1,7 +1,7 @@
 /**
- * collectd - src/logparser_test.c
+ * collectd - src/intel_pmu_test.c
  *
- * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -41,8 +41,12 @@ intel_pmu_ctx_t *stub_pmu_init() {
 }
 
 void stub_pmu_teardown(intel_pmu_ctx_t *pmu_ctx) {
-  free(pmu_ctx->entl);
-  free(pmu_ctx);
+  for(int i = 0; i < pmu_ctx->entl->hw_events_count; i++) {
+    sfree(pmu_ctx->entl->hw_events[i]);
+  }
+  sfree(pmu_ctx->entl->hw_events);
+  sfree(pmu_ctx->entl);
+  sfree(pmu_ctx);
 }
 
 DEF_TEST(pmu_config_hw_events__all_events) {

--- a/src/intel_pmu_test.c
+++ b/src/intel_pmu_test.c
@@ -31,24 +31,24 @@
 // Helper functions
 // static int ctx_entl_size = 0;
 
-intel_pmu_ctx_t* stub_pmu_init() {
-  intel_pmu_ctx_t* pmu_ctx = calloc(1, sizeof(*pmu_ctx));
-  intel_pmu_entity_t* entl = calloc(1, sizeof(*entl));
+intel_pmu_ctx_t *stub_pmu_init() {
+  intel_pmu_ctx_t *pmu_ctx = calloc(1, sizeof(*pmu_ctx));
+  intel_pmu_entity_t *entl = calloc(1, sizeof(*entl));
 
   pmu_ctx->entl = entl;
 
   return pmu_ctx;
 }
 
-void stub_pmu_teardown(intel_pmu_ctx_t* pmu_ctx) {
+void stub_pmu_teardown(intel_pmu_ctx_t *pmu_ctx) {
   free(pmu_ctx->entl);
   free(pmu_ctx);
 }
 
 DEF_TEST(pmu_config_hw_events__all_events) {
   // setup
-  intel_pmu_ctx_t* pmu_ctx = stub_pmu_init();
-  intel_pmu_entity_t* ent = pmu_ctx->entl;
+  intel_pmu_ctx_t *pmu_ctx = stub_pmu_init();
+  intel_pmu_entity_t *ent = pmu_ctx->entl;
 
   oconfig_value_t values[] = {
       {.value.string = "All", .type = OCONFIG_TYPE_STRING},
@@ -71,16 +71,15 @@ DEF_TEST(pmu_config_hw_events__all_events) {
 
 DEF_TEST(pmu_config_hw_events__few_events) {
   // setup
-  intel_pmu_ctx_t* pmu_ctx = stub_pmu_init();
-  intel_pmu_entity_t* ent = pmu_ctx->entl;
+  intel_pmu_ctx_t *pmu_ctx = stub_pmu_init();
+  intel_pmu_entity_t *ent = pmu_ctx->entl;
 
   oconfig_value_t values[] = {
       {.value.string = "event0", .type = OCONFIG_TYPE_STRING},
       {.value.string = "event1", .type = OCONFIG_TYPE_STRING},
       {.value.string = "event2", .type = OCONFIG_TYPE_STRING},
       {.value.string = "event3", .type = OCONFIG_TYPE_STRING},
-      {.value.string = "event4", .type = OCONFIG_TYPE_STRING}
-  };
+      {.value.string = "event4", .type = OCONFIG_TYPE_STRING}};
   oconfig_item_t config_item = {
       .key = "HardwareEvents",
       .values = values,
@@ -91,7 +90,7 @@ DEF_TEST(pmu_config_hw_events__few_events) {
   int result = pmu_config_hw_events(&config_item, ent);
   EXPECT_EQ_INT(0, result);
   EXPECT_EQ_INT(config_item.values_num, ent->hw_events_count);
-  for(int i = 0; i < ent->hw_events_count; i++) {
+  for (int i = 0; i < ent->hw_events_count; i++) {
     EXPECT_EQ_STR(values[i].value.string, ent->hw_events[i]);
   }
 
@@ -100,10 +99,7 @@ DEF_TEST(pmu_config_hw_events__few_events) {
   return 0;
 }
 
-DEF_TEST(config_cores_parse) {
-
-  return 0;
-}
+DEF_TEST(config_cores_parse) { return 0; }
 
 int main(void) {
   RUN_TEST(pmu_config_hw_events__all_events);

--- a/src/types.db
+++ b/src/types.db
@@ -42,6 +42,7 @@ controller              value:GAUGE:0:18446744073709551615
 cookies                 value:DERIVE:0:U
 count                   value:GAUGE:0:U
 counter                 value:COUNTER:U:U
+#pmu_counter             scaled:COUNTER:U:U, raw:COUNTER:U:U, enabled:COUNTER:U:U ,running:COUNTER:U:U
 cpu                     value:DERIVE:0:U
 cpu_affinity            value:GAUGE:0:1
 cpufreq                 value:GAUGE:0:U

--- a/src/types.db
+++ b/src/types.db
@@ -42,7 +42,6 @@ controller              value:GAUGE:0:18446744073709551615
 cookies                 value:DERIVE:0:U
 count                   value:GAUGE:0:U
 counter                 value:COUNTER:U:U
-#pmu_counter             scaled:COUNTER:U:U, raw:COUNTER:U:U, enabled:COUNTER:U:U ,running:COUNTER:U:U
 cpu                     value:DERIVE:0:U
 cpu_affinity            value:GAUGE:0:1
 cpufreq                 value:GAUGE:0:U
@@ -220,6 +219,7 @@ ping                    value:GAUGE:0:65535
 ping_droprate           value:GAUGE:0:1
 ping_stddev             value:GAUGE:0:65535
 players                 value:GAUGE:0:1000000
+pmu_counter             scaled:COUNTER:0:U, raw:COUNTER:0:U, enabled:COUNTER:0:U ,running:COUNTER:0:U
 pools                   value:GAUGE:0:U
 power                   value:GAUGE:U:U
 pressure                value:GAUGE:0:U

--- a/src/types.db
+++ b/src/types.db
@@ -219,7 +219,7 @@ ping                    value:GAUGE:0:65535
 ping_droprate           value:GAUGE:0:1
 ping_stddev             value:GAUGE:0:65535
 players                 value:GAUGE:0:1000000
-pmu_counter             scaled:COUNTER:0:U, raw:COUNTER:0:U, enabled:COUNTER:0:U ,running:COUNTER:0:U
+pmu_counter             scaled:COUNTER:0:U, raw:COUNTER:0:U, enabled:COUNTER:0:U, running:COUNTER:0:U
 pools                   value:GAUGE:0:U
 power                   value:GAUGE:U:U
 pressure                value:GAUGE:0:U


### PR DESCRIPTION
ChangeLog: Updated version of Intel PMU plugin.

- It is now possible to set different cores for different sets of events
- Removed predefined perf events
- Provide more data with the mertric (raw value and time enabled/running)
- Updated plugin_instance to distinguish between separate and summed-up cloned events
- Possibility to load all events from specified file
- Improved errors logging/handling
- Other minor improvements