### PR TITLE
lua: support to detect LuaJIT automatically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3221,7 +3221,14 @@ else
                                     [
                                       PKG_CHECK_MODULES([LUA], [lua51],
                                         [with_liblua="yes"],
-                                        [with_liblua="no (pkg-config cannot find liblua)"]
+                                        [
+                                          PKG_CHECK_MODULES([LUA], [luajit],
+                                            [
+                                              with_liblua="yes"
+                                            ],
+                                            [with_liblua="no (pkg-config cannot find libluajit)"]
+					  )
+					]
                                       )
                                     ]
                                   )


### PR DESCRIPTION
ChangeLog: lua: add fallback to detect LuaJIT

Before:
  LIBLUA_PKG_CONFIG_NAME=luajit ./configure --enable-lua

After:
  ./configure --enable-lua

In the previous versions, for enabling LuaJIT,
it needs to specify LIBLUA_PKG_CONFIG_NAME=luajit explicitly.

In this commit, add fallback to detect LuaJIT without specifying
LIBLUA_PKG_CONFIG_NAME=luajit explicitly by default (just use
--enable-lua).

Note that if both of lua and luajit exists, then lua is used.
