### PR TITLE
Fix broken "-t" option of collectd

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -395,9 +395,6 @@ struct cmdline_config init_config(int argc, char **argv) {
 
   read_cmdline(argc, argv, &config);
 
-  if (config.test_config)
-    exit(EXIT_SUCCESS);
-
   if (optind < argc)
     exit_usage(EXIT_FAILURE);
 
@@ -405,6 +402,9 @@ struct cmdline_config init_config(int argc, char **argv) {
 
   if (configure_collectd(&config) != 0)
     exit(EXIT_FAILURE);
+
+  if (config.test_config)
+    exit(EXIT_SUCCESS);
 
   return config;
 }


### PR DESCRIPTION
Changelog: Fix broken "-t" option of collectd command

"-t" option should test config file but it always returns 0 with no
message even if a broken config file is specified.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>