### PR TITLE
Fic smart_test.c for big endian.

### DIFF
--- a/src/smart_test.c
+++ b/src/smart_test.c
@@ -46,7 +46,7 @@ int ioctl(int __fd, unsigned long int __request, ...) {
   if (admin_cmd->opcode == NVME_ADMIN_IDENTIFY) {
     // ioctl asked about vid
     __le16 *vid = (__le16 *)addr;
-    *vid = VENDOR_ID;
+    *vid = htole16(VENDOR_ID);
     return 0;
   } else if (admin_cmd->opcode == NVME_ADMIN_GET_LOG_PAGE) {
     // ioctl asked about smart attributes


### PR DESCRIPTION
get_vendor_id from smart.c assumes that VENDOR_ID is le16, so we
need to convert it into le16 in the fake-ioctl function in smart_test.c.

Fixes #3791

Signed-off-by: Bernd Zeimetz <bernd@bzed.de>

ChangeLog: smart plugin: Fix tests for big endian architectures.