### PR TITLE
nut.c: add support for ups.realpower

### DIFF
--- a/src/nut.c
+++ b/src/nut.c
@@ -326,6 +326,8 @@ static int nut_read(user_data_t *user_data) {
         nut_submit(ups, "percent", "load", value);
       else if (strcmp("ups.power", key) == 0)
         nut_submit(ups, "power", "ups", value);
+      else if (strcmp("ups.realpower", key) == 0)
+        nut_submit(ups, "power", "watt-ups", value);
       else if (strcmp("ups.temperature", key) == 0)
         nut_submit(ups, "temperature", "ups", value);
     }


### PR DESCRIPTION
ChangeLog: plugin nut: add support for ups.realpower

Some UPS report a global "realpower" value corresponding to actual Watts
instead of VA as part of the "ups." key.
The Eaton Ellipse series is such an example: where the device does not
report current values but only voltages, watts and VA.
This commit makes that value available in reported statistics using the
"watt-ups" type_instance, matching 64321ae

```
% upsc ups
battery.charge: 100
battery.charge.low: 10
battery.runtime: 942
battery.type: PbAc
device.mfr: EATON
device.model: Ellipse PRO 650 
device.serial:
device.type: ups
driver.flag.pollonly: enabled
driver.name: usbhid-ups
input.voltage: 233.0
input.voltage.extended: no
outlet.1.desc: PowerShare Outlet 1
outlet.1.id: 2
outlet.1.status: on
outlet.1.switchable: no
outlet.2.desc: PowerShare Outlet 2
outlet.2.id: 3
outlet.2.status: on
outlet.2.switchable: no
outlet.desc: Main Outlet
outlet.id: 1
outlet.switchable: no
output.frequency: 50.0
output.frequency.nominal: 50
output.voltage: 229.0
output.voltage.nominal: 230
ups.beeper.status: enabled
ups.delay.shutdown: 20
ups.delay.start: 30
ups.firmware: 01.04.0012
ups.load: 24
ups.mfr: EATON
ups.model: Ellipse PRO 650 
ups.power: 147
ups.power.nominal: 650
ups.productid: ffff
ups.realpower: 110
ups.serial:
ups.status: OL
ups.timer.shutdown: 0
ups.timer.start: 0
ups.vendorid: 0463
```