### PR TITLE
exec plugin: remove check against running scripts as root.

### DIFF
--- a/src/collectd-exec.pod
+++ b/src/collectd-exec.pod
@@ -287,11 +287,6 @@ to make use of collectd's more powerful interface.
 
 =item *
 
-The user, the binary is executed as, may not have root privileges, i.E<nbsp>e.
-must have an UID that is non-zero. This is for your own good.
-
-=item *
-
 Early versions of the plugin did not use a command but treated all lines as if
 they were arguments to the I<PUTVAL> command. When the I<PUTNOTIF> command was
 implemented, this behavior was kept for lines which start with an unknown

--- a/src/exec.c
+++ b/src/exec.c
@@ -445,10 +445,6 @@ static int fork_child(program_list_t *pl, int *fd_in, int *fd_out,
 
   uid = sp.pw_uid;
   gid = sp.pw_gid;
-  if (uid == 0) {
-    ERROR("exec plugin: Cowardly refusing to exec program as root.");
-    goto failed;
-  }
 
   /* The group configured in the configfile is set as effective group, because
    * this way the forked process can (re-)gain the user's primary group. */


### PR DESCRIPTION
*Every other plugin* can run with full root privileges. Collectd even asks to be run as root! Python, Perl - is there any reason Bash scripts are inherently less safe than Python scripts? The python plugin doesn't even *let you* drop privileges. This check adds extra effort for no documented reason, especially on docker where by default only a root account is created. At least, this limit needs to be better justified.