### PR TITLE
Fix #3831 by adding commas to the infiniband types

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -119,8 +119,8 @@ ib_errors               value:DERIVE:0:U
 ib_lid                  value:GAUGE:0:32767
 ib_lid_mask_count       value:GAUGE:0:7
 ib_link_error_recovery  value:DERIVE:0:U
-ib_octets               rx:DERIVE:0:U tx:DERIVE:0:U
-ib_packets              rx:DERIVE:0:U tx:DERIVE:0:U
+ib_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
+ib_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
 ib_phys_state           value:GAUGE:0:15
 ib_rate                 value:GAUGE:0:U
 ib_sm_lid               value:GAUGE:0:32767


### PR DESCRIPTION
ChangeLog: infiniband: Add missing commas  to the infiniband types.

See #3831 for a deeper discussion of this.