### PR TITLE
[collectd 6] dbi, postgresql, oracle: migration to v6.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,6 @@ env:
           --disable-network
           --disable-openldap
           --disable-perl
-          --disable-postgresql
           --disable-python
           --disable-redis
           --disable-rrdcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ script:
     --disable-network
     --disable-openldap
     --disable-perl
-    --disable-postgresql
     --disable-python
     --disable-redis
     --disable-rrdcached

--- a/solaris-ci.flags
+++ b/solaris-ci.flags
@@ -10,7 +10,6 @@
 --disable-match_value
 --disable-network
 --disable-perl
---disable-postgresql
 --disable-target_notification
 --disable-target_replace
 --disable-target_scale

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2533,9 +2533,9 @@ than those of other plugins. It usually looks something like this:
       MinVersion 50000
       <Result>
         Type "gauge"
-        InstancePrefix "out_of_stock"
-        InstancesFrom "category"
-        ValuesFrom "value"
+        Metric "out_of_stock"
+        LabelsFrom "category"
+        ValueFrom "value"
       </Result>
     </Query>
     <Database "product_information">
@@ -2579,15 +2579,16 @@ Example:
   <Query "environment">
     Statement "select station, temperature, humidity from environment"
     <Result>
-      Type "temperature"
-      # InstancePrefix "foo"
-      InstancesFrom "station"
-      ValuesFrom "temperature"
+      Type "gauge"
+      Metric "temperature"
+      LabelsFrom "station"
+      ValueFrom "temperature"
     </Result>
     <Result>
-      Type "humidity"
-      InstancesFrom "station"
-      ValuesFrom "humidity"
+      Type "gauge"
+      Metric "humidity"
+      LabelsFrom "station"
+      ValueFrom "humidity"
     </Result>
   </Query>
 
@@ -2647,64 +2648,65 @@ In the above example, there are three ranges that don't overlap. The last one
 goes from version "5.1.0" to infinity, meaning "all later versions". Versions
 before "4.0.0" are not specified.
 
-=item B<Type> I<Type>
+=item B<MetricPrefix> I<prefix>
 
-The B<type> that's used for each line returned. See L<types.db(5)> for more
-details on how types are defined. In short: A type is a predefined layout of
-data and the number of values and type of values has to match the type
-definition.
+Prepends I<prefix> to the metric name in the B<Result>.
 
-If you specify "temperature" here, you need exactly one gauge column. If you
-specify "if_octets", you will need two counter columns. See the B<ValuesFrom>
-setting below.
+=item B<Label> I<key> I<value>
 
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple time in the B<Query> block.
+
+Inside the B<Result> block, the following options are recognized:
+
+=item B<Type> I<gauge>|I<counter>|I<untyped>
+
+The B<type> that's used for each line returned. Must be I<gauge>, I<counter> or I<untyped>.
+If not set is I<untyped>.
 There must be exactly one B<Type> option inside each B<Result> block.
 
-=item B<InstancePrefix> I<prefix>
+=item B<TypeFrom> I<column>
 
-Prepends I<prefix> to the type instance. If B<InstancesFrom> (see below) is not
-given, the string is simply copied. If B<InstancesFrom> is given, I<prefix> and
-all strings returned in the appropriate columns are concatenated together,
-separated by dashes I<("-")>.
+Read the type from B<column>. It must be B<gauge>, B<counter> or B<untyped>.
 
-=item B<InstancesFrom> I<column0> [I<column1> ...]
+=item B<Help> I<help>
 
-Specifies the columns whose values will be used to create the "type-instance"
-for each row. If you specify more than one column, the value of all columns
-will be joined together with dashes I<("-")> as separation characters.
+Set the B<help> text for the metric.
 
-The plugin itself does not check whether or not all built instances are
-different. It's your responsibility to assure that each is unique. This is
-especially true, if you do not specify B<InstancesFrom>: B<You> have to make
-sure that only one row is returned in this case.
+=item B<HelpFrom> I<column>
 
-If neither B<InstancePrefix> nor B<InstancesFrom> is given, the type-instance
-will be empty.
+Read the B<help> text for the the metric from the named column.
 
-=item B<ValuesFrom> I<column0> [I<column1> ...]
+=item B<Metric> I<metric>
 
-Names the columns whose content is used as the actual data for the data sets
-that are dispatched to the daemon. How many such columns you need is determined
-by the B<Type> setting above. If you specify too many or not enough columns,
-the plugin will complain about that and no data will be submitted to the
-daemon.
+Set the metric name.
 
-The actual data type in the columns is not that important. The plugin will
-automatically cast the values to the right type if it know how to do that. So
-it should be able to handle integer an floating point types, as well as strings
-(if they include a number at the beginning).
+=item B<MetricFrom> I<column>
 
-There must be at least one B<ValuesFrom> option inside each B<Result> block.
+Read the metric name from the named column.
 
-=item B<MetadataFrom> [I<column0> I<column1> ...]
+There must be at least one B<Metric> or B<MetricFrom> option inside each B<Result> block.
 
-Names the columns whose content is used as metadata for the data sets
+=item B<MetricPrefix> I<prefix>
+
+Prepends I<prefix> to the metric name in the B<Result>.
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple times in the B<Result> block.
+
+=item B<LabelsFrom> I<column0> [I<column1> ...]
+
+Specifies the columns whose names and values will be used to create the labels.
+You can specify more than one column.
+
+=item B<ValueFrom> I<column>
+
+Name of the column whose content is used as the actual data for the metric
 that are dispatched to the daemon.
 
-The actual data type in the columns is not that important. The plugin will
-automatically cast the values to the right type if it know how to do that. So
-it should be able to handle integer an floating point types, as well as strings
-(if they include a number at the beginning).
+There must be only one B<ValueFrom> option inside each B<Result> block.
 
 =back
 
@@ -2721,10 +2723,14 @@ the daemon. Other than that, that name is not used.
 
 =over 4
 
-=item B<Plugin> I<Plugin>
+=item B<MetricPrefix> I<prefix>
 
-Use I<Plugin> as the plugin name when submitting query results from
-this B<Database>. Defaults to C<dbi>.
+Prepends I<prefix> to the metric name in the  B<Result>.
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple times in the B<Database> block.
 
 =item B<Interval> I<Interval>
 
@@ -2782,11 +2788,6 @@ Associates the query named I<QueryName> with this database connection. The
 query needs to be defined I<before> this statement, i.E<nbsp>e. all query
 blocks you want to refer to must be placed above the database block you want to
 refer to them from.
-
-=item B<Host> I<Hostname>
-
-Sets the B<host> field of I<value lists> to I<Hostname> when dispatching
-values. Defaults to the global hostname setting.
 
 =back
 
@@ -6952,9 +6953,9 @@ plugin's documentation above for details.
       Statement "SELECT category, COUNT(*) AS value FROM products WHERE in_stock = 0 GROUP BY category"
       <Result>
         Type "gauge"
-        # InstancePrefix "foo"
-        InstancesFrom "category"
-        ValuesFrom "value"
+        Metric "out_of_stock"
+        LabelsFrom "category"
+        ValueFrom "value"
       </Result>
     </Query>
     <Database "product_information">
@@ -6981,10 +6982,14 @@ values submitted to the daemon. Other than that, that name is not used.
 
 =over 4
 
-=item B<Plugin> I<Plugin>
+=item B<MetricPrefix> I<prefix>
 
-Use I<Plugin> as the plugin name when submitting query results from
-this B<Database>. Defaults to C<oracle>.
+Prepends I<prefix> to the metric name in the B<Result>
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple time in the B<Database> block.
 
 =item B<ConnectID> I<ID>
 
@@ -7372,8 +7377,8 @@ L<http://www.postgresql.org/docs/manuals/>.
       Param hostname
       <Result>
         Type gauge
-        InstancePrefix "magic"
-        ValuesFrom magic
+        Metric "magic"
+        ValueFrom magic
       </Result>
     </Query>
 
@@ -7386,14 +7391,14 @@ L<http://www.postgresql.org/docs/manuals/>.
                         GROUP BY type;"
       <Result>
         Type counter
-        InstancePrefix "rt36_tickets"
-        InstancesFrom "type"
-        ValuesFrom "count"
+        Metric "rt36_tickets"
+        LabelsFrom "type"
+        ValueFrom "count"
       </Result>
     </Query>
 
     <Writer sqlstore>
-      Statement "SELECT collectd_insert($1, $2, $3, $4, $5, $6, $7, $8, $9);"
+      Statement "SELECT collectd_insert($1, $2, $3, $4, $5);"
       StoreRates true
     </Writer>
 
@@ -7486,11 +7491,14 @@ specific or global B<Interval> options).
 Please note that parameters are only supported by PostgreSQL's protocol
 version 3 and above which was introduced in version 7.4 of PostgreSQL.
 
-=item B<PluginInstanceFrom> I<column>
+=item B<MetricPrefix> I<prefix>
 
-Specify how to create the "PluginInstance" for reporting this query results.
-Only one column is supported. You may concatenate fields and string values in
-the query statement to get the required results.
+Prepends I<prefix> to the metric name in the B<Result>.
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple time in the B<Statement> block.
 
 =item B<MinVersion> I<version>
 
@@ -7514,38 +7522,52 @@ the daemon.
 
 =over 4
 
-=item B<Type> I<type>
+=item B<Type> I<gauge>|I<counter>|I<untyped>
 
-The I<type> name to be used when dispatching the values. The type describes
-how to handle the data and where to store it. See L<types.db(5)> for more
-details on types and their configuration. The number and type of values (as
-selected by the B<ValuesFrom> option) has to match the type of the given name.
+The B<type> that's used for each line returned. Must be I<gauge>, I<counter> or I<untyped>.
+If not set is I<untyped>.
+There must be exactly one B<Type> option inside each B<Result> block.
 
-This option is mandatory.
+=item B<TypeFrom> I<column>
 
-=item B<InstancePrefix> I<prefix>
+Read the type from B<column>. It must be B<gauge>, B<counter> or B<untyped>.
 
-=item B<InstancesFrom> I<column0> [I<column1> ...]
+=item B<Help> I<help>
 
-Specify how to create the "TypeInstance" for each data set (i.E<nbsp>e. line).
-B<InstancePrefix> defines a static prefix that will be prepended to all type
-instances. B<InstancesFrom> defines the column names whose values will be used
-to create the type instance. Multiple values will be joined together using the
-hyphen (C<->) as separation character.
+Set the B<help> text for the metric.
 
-The plugin itself does not check whether or not all built instances are
-different. It is your responsibility to assure that each is unique.
+=item B<HelpFrom> I<column>
 
-Both options are optional. If none is specified, the type instance will be
-empty.
+Read the B<help> text for the the metric from the named column.
 
-=item B<ValuesFrom> I<column0> [I<column1> ...]
+=item B<Metric> I<metric>
 
-Names the columns whose content is used as the actual data for the data sets
-that are dispatched to the daemon. How many such columns you need is
-determined by the B<Type> setting as explained above. If you specify too many
-or not enough columns, the plugin will complain about that and no data will be
-submitted to the daemon.
+Set the metric name.
+
+=item B<MetricFrom> I<column>
+
+Read the metric name from the named column.
+
+There must be at least one B<Metric> or B<MetricFrom> option inside each B<Result> block.
+
+=item B<MetricPrefix> I<prefix>
+
+Prepends I<prefix> to the metric name in the B<Result>.
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple times in the B<Result> block.
+
+=item B<LabelsFrom> I<column0> [I<column1> ...]
+
+Specifies the columns whose names and values will be used to create the labels.
+You can specify more than one column.
+
+=item B<ValueFrom> I<column>
+
+Name of the column whose content is used as the actual data for the metric
+that are dispatched to the daemon.
 
 The actual data type, as seen by PostgreSQL, is not that important as long as
 it represents numbers. The plugin will automatically cast the values to the
@@ -7553,9 +7575,8 @@ right type if it know how to do that. For that, it uses the L<strtoll(3)> and
 L<strtod(3)> functions, so anything supported by those functions is supported
 by the plugin as well.
 
-This option is required inside a B<Result> block and may be specified multiple
-times. If multiple B<ValuesFrom> options are specified, the columns are read
-in the given order.
+This option is required inside a B<Result> block and must be specified only
+once.
 
 =back
 
@@ -7642,42 +7663,19 @@ The timestamp of the queried value as an RFC 3339-formatted local time.
 
 =item B<$2>
 
-The hostname of the queried value.
+The metric name of the queried value.
 
 =item B<$3>
 
-The plugin name of the queried value.
+The labels of the queried value as an array of pairs of key, value.
 
 =item B<$4>
 
-The plugin instance of the queried value. This value may be B<NULL> if there
-is no plugin instance.
+The type of the queried metric: I<GAUGE>, I<COUNTER> or I<UNTYPED>
 
 =item B<$5>
 
-The type of the queried value (cf. L<types.db(5)>).
-
-=item B<$6>
-
-The type instance of the queried value. This value may be B<NULL> if there is
-no type instance.
-
-=item B<$7>
-
-An array of names for the submitted values (i.E<nbsp>e., the name of the data
-sources of the submitted value-list).
-
-=item B<$8>
-
-An array of types for the submitted values (i.E<nbsp>e., the type of the data
-sources of the submitted value-list; C<counter>, C<gauge>, ...). Note, that if
-B<StoreRates> is enabled (which is the default, see below), all types will be
-C<gauge>.
-
-=item B<$9>
-
-An array of the submitted values. The dimensions of the value name and value
-arrays match.
+The submitted value.
 
 =back
 
@@ -7720,19 +7718,14 @@ activating this option. The draw-back is, that data covering the specified
 amount of time will be lost, for example, if a single statement within the
 transaction fails or if the database server crashes.
 
-=item B<Plugin> I<Plugin>
+=item B<MetricPrefix> I<prefix>
 
-Use I<Plugin> as the plugin name when submitting query results from
-this B<Database>. Defaults to C<postgresql>.
+Prepends I<prefix> to the metric name in the B<Result>.
 
-=item B<Instance> I<name>
+=item B<Label> I<key> I<value>
 
-Specify the plugin instance name that should be used instead of the database
-name (which is the default, if this option has not been specified). This
-allows one to query multiple databases of the same name on the same host (e.g.
-when running multiple database server versions in parallel).
-The plugin instance name can also be set from the query result using
-the B<PluginInstanceFrom> option in B<Query> block.
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple time in the B<Database> block.
 
 =item B<Host> I<hostname>
 
@@ -7787,13 +7780,6 @@ First, try to connect using SSL. If that fails, try without using SSL.
 Use SSL only.
 
 =back
-
-=item B<Instance> I<name>
-
-Specify the plugin instance name that should be used instead of the database
-name (which is the default, if this option has not been specified). This
-allows one to query multiple databases of the same name on the same host (e.g.
-when running multiple database server versions in parallel).
 
 =item B<KRBSrvName> I<kerberos_service_name>
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -1260,3 +1260,40 @@ int cf_util_get_cdtime(const oconfig_item_t *ci, cdtime_t *ret_value) /* {{{ */
 
   return 0;
 } /* }}} int cf_util_get_cdtime */
+
+int cf_util_get_label(const oconfig_item_t *ci, label_set_t *labels) /* {{{ */
+{
+  if ((ci->values_num != 2) ||
+      ((ci->values_num == 2) &&
+       ((ci->values[0].type != OCONFIG_TYPE_STRING) ||
+        (ci->values[1].type != OCONFIG_TYPE_STRING)))) {
+    P_ERROR("The `%s' option requires exactly two string arguments.", ci->key);
+    return -1;
+  }
+
+  return label_set_create(labels, ci->values[0].value.string,
+                          ci->values[1].value.string);
+} /* }}} int cf_util_get_label */
+
+int cf_util_get_metric_type(const oconfig_item_t *ci,
+                            metric_type_t *ret_metric) /* {{{ */
+{
+  if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
+    P_ERROR("The `%s' option requires exactly one string argument.", ci->key);
+    return -1;
+  }
+
+  if (!strcasecmp(ci->values[0].value.string, "gauge"))
+    *ret_metric = METRIC_TYPE_GAUGE;
+  else if (!strcasecmp(ci->values[0].value.string, "untyped"))
+    *ret_metric = METRIC_TYPE_UNTYPED;
+  else if (!strcasecmp(ci->values[0].value.string, "counter"))
+    *ret_metric = METRIC_TYPE_COUNTER;
+  else {
+    P_ERROR("The `%s' option must be: `gauge', `untyped' or `counter' ",
+            ci->key);
+    return -1;
+  }
+
+  return 0;
+} /* }}} int cf_util_get_metric_type */

--- a/src/daemon/configfile.h
+++ b/src/daemon/configfile.h
@@ -29,6 +29,7 @@
 
 #include "collectd.h"
 
+#include "daemon/metric.h"
 #include "liboconfig/oconfig.h"
 #include "utils_time.h"
 
@@ -136,5 +137,10 @@ int cf_util_get_port_number(const oconfig_item_t *ci);
 int cf_util_get_service(const oconfig_item_t *ci, char **ret_string);
 
 int cf_util_get_cdtime(const oconfig_item_t *ci, cdtime_t *ret_value);
+
+int cf_util_get_label(const oconfig_item_t *ci, label_set_t *labels);
+
+int cf_util_get_metric_type(const oconfig_item_t *ci,
+                            metric_type_t *ret_metric);
 
 #endif /* defined(CONFIGFILE_H) */

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -60,7 +60,7 @@ static int label_pair_compare(void const *a, void const *b) {
                 ((label_pair_t const *)b)->name);
 }
 
-static label_pair_t *label_set_read(label_set_t labels, char const *name) {
+label_pair_t *label_set_read(label_set_t labels, char const *name) {
   if (name == NULL) {
     errno = EINVAL;
     return NULL;
@@ -83,8 +83,7 @@ static label_pair_t *label_set_read(label_set_t labels, char const *name) {
   return ret;
 }
 
-static int label_set_create(label_set_t *labels, char const *name,
-                            char const *value) {
+int label_set_create(label_set_t *labels, char const *name, char const *value) {
   if ((labels == NULL) || (name == NULL) || (value == NULL)) {
     return EINVAL;
   }
@@ -132,7 +131,7 @@ static int label_set_create(label_set_t *labels, char const *name,
   return 0;
 }
 
-static int label_set_delete(label_set_t *labels, label_pair_t *elem) {
+int label_set_delete(label_set_t *labels, label_pair_t *elem) {
   if ((labels == NULL) || (elem == NULL)) {
     return EINVAL;
   }
@@ -161,7 +160,7 @@ static int label_set_delete(label_set_t *labels, label_pair_t *elem) {
   return 0;
 }
 
-static void label_set_reset(label_set_t *labels) {
+void label_set_reset(label_set_t *labels) {
   if (labels == NULL) {
     return;
   }
@@ -175,7 +174,7 @@ static void label_set_reset(label_set_t *labels) {
   labels->num = 0;
 }
 
-static int label_set_clone(label_set_t *dest, label_set_t src) {
+int label_set_clone(label_set_t *dest, label_set_t src) {
   if (src.num == 0) {
     return 0;
   }

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -165,4 +165,18 @@ void metric_family_free(metric_family_t *fam);
  * metric_family_free(). */
 metric_family_t *metric_family_clone(metric_family_t const *fam);
 
+/*
+ * Label set
+ */
+
+label_pair_t *label_set_read(label_set_t labels, char const *name);
+
+int label_set_create(label_set_t *labels, char const *name, char const *value);
+
+int label_set_delete(label_set_t *labels, label_pair_t *elem);
+
+void label_set_reset(label_set_t *labels);
+
+int label_set_clone(label_set_t *dest, label_set_t src);
+
 #endif

--- a/src/postgresql.c
+++ b/src/postgresql.c
@@ -653,24 +653,16 @@ static int c_psql_write(metric_family_t const *fam, user_data_t *ud) {
       return -1;
     }
 
-    switch (fam->type) {
-    case METRIC_TYPE_COUNTER:
-      type_str = "COUNTER";
-      break;
-    case METRIC_TYPE_GAUGE:
-      type_str = "GAUGE";
-      break;
-    case METRIC_TYPE_UNTYPED:
-      type_str = "UNTYPED";
-      break;
-    }
-
+    type_str = "UNTYPED";
     switch (fam->type) {
     case METRIC_TYPE_GAUGE:
     case METRIC_TYPE_UNTYPED:
+      if (fam->type == METRIC_TYPE_GAUGE)
+        type_str = "GAUGE";
       ssnprintf(value_str, sizeof(value_str), GAUGE_FORMAT, m->value.gauge);
       break;
     case METRIC_TYPE_COUNTER:
+      type_str = "UNTYPED";
       ssnprintf(value_str, sizeof(value_str), "%" PRIu64, m->value.counter);
       break;
     default:

--- a/src/postgresql_default.conf
+++ b/src/postgresql_default.conf
@@ -13,8 +13,9 @@
 	Param database
 
 	<Result>
-		Type "pg_numbackends"
-		ValuesFrom "count"
+		Type "gauge"
+		Metric "pg_numbackends"
+		ValueFrom "count"
 	</Result>
 </Query>
 
@@ -26,14 +27,14 @@
 	Param database
 
 	<Result>
-		Type "pg_xact"
-		InstancePrefix "commit"
-		ValuesFrom "xact_commit"
+		Type "counter"
+		Metric "pg_xact_commit_total"
+		ValueFrom "xact_commit"
 	</Result>
 	<Result>
-		Type "pg_xact"
-		InstancePrefix "rollback"
-		ValuesFrom "xact_rollback"
+		Type "counter"
+		Metric "pg_xact_rollback_total"
+		ValueFrom "xact_rollback"
 	</Result>
 </Query>
 
@@ -44,19 +45,19 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "ins"
-		ValuesFrom "ins"
+		Type "counter"
+		Metric "pg_n_tup_ins_total"
+		ValueFrom "ins"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "upd"
-		ValuesFrom "upd"
+		Type "counter"
+		Metric "pg_n_tup_upd_total"
+		ValueFrom "upd"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "del"
-		ValuesFrom "del"
+		Type "counter"
+		Metric "pg_n_tup_del_total"
+		ValueFrom "del"
 	</Result>
 
 	MaxVersion 80299
@@ -70,24 +71,24 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "ins"
-		ValuesFrom "ins"
+		Type "counter"
+		Metric "pg_n_tup_ins_total"
+		ValueFrom "ins"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "upd"
-		ValuesFrom "upd"
+		Type "counter"
+		Metric "pg_n_tup_upd_total"
+		ValueFrom "upd"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "del"
-		ValuesFrom "del"
+		Type "counter"
+		Metric "pg_n_tup_del_total"
+		ValueFrom "del"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "hot_upd"
-		ValuesFrom "hot_upd"
+		Type "counter"
+		Metric "pg_n_tup_hot_upd_total"
+		ValueFrom "hot_upd"
 	</Result>
 
 	MinVersion 80300
@@ -101,22 +102,22 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "ins"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "ins"
+		Type "counter"
+		Metric "pg_n_tup_ins_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "ins"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "upd"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "upd"
+		Type "counter"
+		Metric "pg_n_tup_upd_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "upd"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "del"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "del"
+		Type "counter"
+		Metric "pg_n_tup_del_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "del"
 	</Result>
 
 	MaxVersion 80299
@@ -131,28 +132,28 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "ins"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "ins"
+		Type "counter"
+		Metric "pg_n_tup_ins_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "ins"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "upd"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "upd"
+		Type "counter"
+		Metric "pg_n_tup_upd_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "upd"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "del"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "del"
+		Type "counter"
+		Metric "pg_n_tup_del_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "del"
 	</Result>
 	<Result>
-		Type "pg_n_tup_c"
-		InstancePrefix "hot_upd"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "hot_upd"
+		Type "counter"
+		Metric "pg_n_tup_hot_upd_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "hot_upd"
 	</Result>
 
 	MinVersion 80300
@@ -166,24 +167,24 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "seq"
-		ValuesFrom "seq"
+		Type "counter"
+		Metric "pg_scan_seq_total"
+		ValueFrom "seq"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "seq_tup_read"
-		ValuesFrom "seq_tup_read"
+		Type "counter"
+		Metric "pg_scan_seq_tup_read_total"
+		ValueFrom "seq_tup_read"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "idx"
-		ValuesFrom "idx"
+		Type "counter"
+		Metric "pg_scan_idx_total"
+		ValueFrom "idx"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "idx_tup_fetch"
-		ValuesFrom "idx_tup_fetch"
+		Type "counter"
+		Metric "pg_scan_idx_tup_fetch_total"
+		ValueFrom "idx_tup_fetch"
 	</Result>
 </Query>
 
@@ -193,14 +194,14 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_g"
-		InstancePrefix "live"
-		ValuesFrom "live"
+		Type "gauge"
+		Metric "pg_n_tup_live"
+		ValueFrom "live"
 	</Result>
 	<Result>
-		Type "pg_n_tup_g"
-		InstancePrefix "dead"
-		ValuesFrom "dead"
+		Type "gauge"
+		Metric "pg_n_tup_dead"
+		ValueFrom "dead"
 	</Result>
 
 	MinVersion 80300
@@ -215,28 +216,28 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "seq"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "seq"
+		Type "counter"
+		Metric "pg_scan_seq_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "seq"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "seq_tup_read"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "seq_tup_read"
+		Type "counter"
+		Metric "pg_scan_seq_tup_read_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "seq_tup_read"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "idx"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "idx"
+		Type "counter"
+		Metric "pg_scan_idx_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "idx"
 	</Result>
 	<Result>
-		Type "pg_scan"
-		InstancePrefix "idx_tup_fetch"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "idx_tup_fetch"
+		Type "counter"
+		Metric "pg_scan_idx_tup_fetch_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "idx_tup_fetch"
 	</Result>
 </Query>
 
@@ -246,16 +247,16 @@
 		FROM pg_stat_user_tables;"
 
 	<Result>
-		Type "pg_n_tup_g"
-		InstancePrefix "live"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "live"
+		Type "gauge"
+		Metric "pg_n_tup_live"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "live"
 	</Result>
 	<Result>
-		Type "pg_n_tup_g"
-		InstancePrefix "dead"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "dead"
+		Type "gauge"
+		Metric "pg_n_tup_dead"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "dead"
 	</Result>
 
 	MinVersion 80300
@@ -273,44 +274,44 @@
 		FROM pg_statio_user_tables;"
 
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "heap_read"
-		ValuesFrom "heap_read"
+		Type "counter"
+		Metric "pg_blks_heap_read_total"
+		ValueFrom "heap_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "heap_hit"
-		ValuesFrom "heap_hit"
+		Type "counter"
+		Metric "pg_blks_heap_hit_total"
+		ValueFrom "heap_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "idx_read"
-		ValuesFrom "idx_read"
+		Type "counter"
+		Metric "pg_blks_idx_read_total"
+		ValueFrom "idx_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "idx_hit"
-		ValuesFrom "idx_hit"
+		Type "counter"
+		Metric "pg_blks_idx_hit_total"
+		ValueFrom "idx_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "toast_read"
-		ValuesFrom "toast_read"
+		Type "counter"
+		Metric "pg_blks_toast_read_total"
+		ValueFrom "toast_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "toast_hit"
-		ValuesFrom "toast_hit"
+		Type "counter"
+		Metric "pg_blks_toast_hit_total"
+		ValueFrom "toast_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "tidx_read"
-		ValuesFrom "tidx_read"
+		Type "counter"
+		Metric "pg_blks_tidx_read_total"
+		ValueFrom "tidx_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "tidx_hit"
-		ValuesFrom "tidx_hit"
+		Type "counter"
+		Metric "pg_blks_tidx_hit_total"
+		ValueFrom "tidx_hit"
 	</Result>
 </Query>
 
@@ -327,52 +328,52 @@
 		FROM pg_statio_user_tables;"
 
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "heap_read"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "heap_read"
+		Type "counter"
+		Metric "pg_blks_heap_read_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "heap_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "heap_hit"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "heap_hit"
+		Type "counter"
+		Metric "pg_blks_heap_hit_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "heap_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "idx_read"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "idx_read"
+		Type "counter"
+		Metric "pg_blks_idx_read_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "idx_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "idx_hit"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "idx_hit"
+		Type "counter"
+		Metric "pg_blks_idx_hit_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "idx_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "toast_read"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "toast_read"
+		Type "counter"
+		Metric "pg_blks_toast_read_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "toast_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "toast_hit"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "toast_hit"
+		Type "counter"
+		Metric "pg_blks_toast_hit_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "toast_hit"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "tidx_read"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "tidx_read"
+		Type "counter"
+		Metric "pg_blks_tidx_read_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "tidx_read"
 	</Result>
 	<Result>
-		Type "pg_blks"
-		InstancePrefix "tidx_hit"
-		InstancesFrom "schemaname" "relname"
-		ValuesFrom "tidx_hit"
+		Type "counter"
+		Metric "pg_blks_tidx_hit_total"
+		LabelsFrom "schemaname" "relname"
+		ValueFrom "tidx_hit"
 	</Result>
 </Query>
 
@@ -382,10 +383,10 @@
 	Param database
 
 	<Result>
-		Type pg_db_size
-		ValuesFrom "size"
+		Type "gauge"
+		Metric "pg_db_size"
+		ValueFrom "size"
 	</Result>
 </Query>
 
 # vim: set ft=config :
-

--- a/src/utils/db_query/db_query.c
+++ b/src/utils/db_query/db_query.c
@@ -708,10 +708,7 @@ int udb_query_pick_from_list_by_name(const char *name, /* {{{ */
   for (size_t i = 0; i < src_list_len; i++) {
     udb_query_t **tmp_list;
     size_t tmp_list_len;
-    fprintf(
-        stderr,
-        "udb_query_pick_from_list_by_name: name: %s src_list[%d]->name: %s\n",
-        name, (int)i, src_list[i]->name);
+
     if (strcasecmp(name, src_list[i]->name) != 0)
       continue;
 

--- a/src/utils/db_query/db_query.c
+++ b/src/utils/db_query/db_query.c
@@ -291,11 +291,15 @@ static int udb_result_prepare_result(udb_result_t const *r, /* {{{ */
     return -EINVAL;
 
 #if COLLECT_DEBUG
-  assert(prep_area->ds == NULL);
-  assert(prep_area->instances_pos == NULL);
-  assert(prep_area->values_pos == NULL);
-  assert(prep_area->instances_buffer == NULL);
-  assert(prep_area->values_buffer == NULL);
+  assert(prep_area->type_str == NULL);
+  assert(prep_area->metric_pos == 0);
+  assert(prep_area->metric_str == NULL);
+  assert(prep_area->help_pos == 0);
+  assert(prep_area->help_str == NULL);
+  assert(prep_area->labels_pos == NULL);
+  assert(prep_area->labels_buffer == NULL);
+  assert(prep_area->value_pos == 0);
+  assert(prep_area->value_str == NULL);
 #endif
 
 #define BAIL_OUT(status)                                                       \

--- a/src/utils/db_query/db_query.c
+++ b/src/utils/db_query/db_query.c
@@ -187,18 +187,21 @@ static int udb_result_submit(udb_result_t *r, /* {{{ */
   }
 
   strbuf_t buf = STRBUF_CREATE;
+
+  if (q_area->metric_prefix != NULL)
+    strbuf_print(&buf, q_area->metric_prefix);
+  if (q->metric_prefix != NULL)
+    strbuf_print(&buf, q->metric_prefix);
+  if (r->metric_prefix != NULL)
+    strbuf_print(&buf, r->metric_prefix);
+
   if (r->metric_from != NULL) {
-    if (q_area->metric_prefix != NULL)
-      strbuf_print(&buf, q_area->metric_prefix);
-    if (q->metric_prefix != NULL)
-      strbuf_print(&buf, q->metric_prefix);
-    if (r->metric_prefix != NULL)
-      strbuf_print(&buf, r->metric_prefix);
     strbuf_print(&buf, r_area->metric_str);
-    fam.name = buf.ptr;
   } else {
-    fam.name = r->metric;
+    strbuf_print(&buf, r->metric);
   }
+
+  fam.name = buf.ptr;
 
   if (r->help_from != NULL) {
     fam.help = r_area->help_str;

--- a/src/utils/db_query/db_query.h
+++ b/src/utils/db_query/db_query.h
@@ -69,9 +69,10 @@ int udb_query_check_version(udb_query_t *q, unsigned int version);
 
 int udb_query_prepare_result(udb_query_t const *q,
                              udb_query_preparation_area_t *prep_area,
-                             const char *host, const char *plugin,
+                             char *metric_prefix, label_set_t *labels,
                              const char *db_name, char **column_names,
                              size_t column_num);
+
 int udb_query_handle_result(udb_query_t const *q,
                             udb_query_preparation_area_t *prep_area,
                             char **column_values);


### PR DESCRIPTION
ChangeLog: dbi, postgresql, oracle plugins: migration to v6.0

**TODO:**
- [ ]  test oracle plugin
- [ ]  improve documentation
- [ ]  change `contrib/postgresql/collectd_insert.sql` to support new metrics format
- [ ]  implement the `storerate` option for the postgresql writer

The changes in the config to generate the metrics are:

- The **Database** block:
  - **MetricPrefix** "db_"
  - **Label** "key" "value"
   
- The **Query** block:
  - **MetricPrefix** "query_"
  - **Label** "key" "value"

- The **Result** block:
  - **Type** gauge|counter|untyped
  - **TypeFrom** column
  - **Help** "help text"
  - **HelpFrom** column
  - **Metric** "name"
  - **MetricFrom** column
  - **MetricPrefix** "metric_"
  - **Label** "key" "value"
  - **LabelsFrom** column1 column2 ...
  - **ValueFrom** column

