### PR TITLE
collection3: fix inappropriate usage of CGI:param

### DIFF
--- a/contrib/collection3/lib/Collectd/Graph/Common.pm
+++ b/contrib/collection3/lib/Collectd/Graph/Common.pm
@@ -526,7 +526,7 @@ sub get_selected_files
   for (qw(hostname plugin plugin_instance type type_instance))
   {
     my $part = $_;
-    my @temp = param ($part);
+    my @temp = multi_param ($part);
     if (!@temp)
     {
       next;
@@ -547,9 +547,9 @@ sub get_selected_files
 sub get_timespan_selection
 {
   my $ret = 86400;
-  if (param ('timespan'))
+  if (scalar param ('timespan'))
   {
-    my $temp = int (param ('timespan'));
+    my $temp = int (scalar param ('timespan'));
     if ($temp && ($temp > 0))
     {
       $ret = $temp;
@@ -568,7 +568,7 @@ sub get_host_selection
     $ret{$_} = 0;
   }
 
-  for (param ('hostname'))
+  for (multi_param ('hostname'))
   {
     my $host = _sanitize_generic_allow_minus ($_);
     if (defined ($ret{$host}))
@@ -597,7 +597,7 @@ sub get_plugin_selection
     $ret{$_} = 0;
   }
 
-  for (param ('plugin'))
+  for (multi_param ('plugin'))
   {
     if (defined ($ret{$_}))
     {


### PR DESCRIPTION
ChangeLog: When using collection3 as a CGI, the following error is sent to logs
repeatedly.

  FastCGI sent in stderr: "CGI::param called in list context from
  /usr/share/doc/collectd-core/examples/collection3/lib/Collectd/Graph/Common.pm
  line 529, this can lead to vulnerabilities. See the warning in
  "Fetching the value or values of a single named parameter" at
  /usr/share/perl5/CGI.pm line 412"

This is caused inappropriate usage of param(), it should be handled as
a scalar or should be treated by multi_param() explicitly.

Signed-off-by: Kentaro Hayashi <kenhys@gmail.com>