### PR TITLE
New plugin for reading diskstats

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -996,6 +996,25 @@ disk_la_LIBADD += -lperfstat
 endif
 endif
 
+if BUILD_PLUGIN_DISKSTATS
+pkglib_LTLIBRARIES += diskstats.la
+diskstats_la_SOURCES = src/diskstats.c
+diskstats_la_CFLAGS = $(AM_CFLAGS)
+diskstats_la_CPPFLAGS = $(AM_CPPFLAGS)
+diskstats_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+diskstats_la_LIBADD = libignorelist.la
+
+test_plugin_diskstats_SOURCES = \
+        src/diskstats_test.c \
+        src/daemon/configfile.c \
+        src/daemon/types_list.c
+test_plugin_diskstats_CPPFLAGS = $(AM_CPPFLAGS)
+test_plugin_diskstats_LDFLAGS = $(PLUGIN_LDFLAGS)
+test_plugin_diskstats_LDADD = liboconfig.la libplugin_mock.la
+check_PROGRAMS += test_plugin_diskstats
+TESTS += test_plugin_diskstats
+endif
+
 if BUILD_PLUGIN_DNS
 pkglib_LTLIBRARIES += dns.la
 dns_la_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -6602,6 +6602,7 @@ plugin_curl_json="no"
 plugin_curl_xml="no"
 plugin_df="no"
 plugin_disk="no"
+plugin_diskstats="no"
 plugin_drbd="no"
 plugin_dpdkevents="no"
 plugin_dpdkstat="no"
@@ -6675,6 +6676,7 @@ if test "x$ac_system" = "xLinux"; then
   plugin_cpu="yes"
   plugin_cpufreq="yes"
   plugin_disk="yes"
+  plugin_diskstats="yes"
   plugin_drbd="yes"
   plugin_entropy="yes"
   plugin_fhcount="yes"
@@ -7062,6 +7064,7 @@ AC_PLUGIN([dbi],                 [$with_libdbi],              [General database 
 AC_PLUGIN([dcpmm],               [$with_libpmwapi],           [Intel(R) Optane(TM) DC Persistent Memory performance and health statistics])
 AC_PLUGIN([df],                  [$plugin_df],                [Filesystem usage statistics])
 AC_PLUGIN([disk],                [$plugin_disk],              [Disk usage statistics])
+AC_PLUGIN([diskstats],           [$plugin_diskstats],         [Disk io statistics])
 AC_PLUGIN([dns],                 [$with_libpcap],             [DNS traffic analysis])
 AC_PLUGIN([dpdkevents],          [$plugin_dpdkevents],        [Events from DPDK])
 AC_PLUGIN([dpdkstat],            [$plugin_dpdkstat],          [Stats from DPDK])
@@ -7509,6 +7512,7 @@ AC_MSG_RESULT([    dbi . . . . . . . . . $enable_dbi])
 AC_MSG_RESULT([    dcpmm  . . . . . .  . $enable_dcpmm])
 AC_MSG_RESULT([    df  . . . . . . . . . $enable_df])
 AC_MSG_RESULT([    disk  . . . . . . . . $enable_disk])
+AC_MSG_RESULT([    diskstats . . . . . . $enable_diskstats])
 AC_MSG_RESULT([    dns . . . . . . . . . $enable_dns])
 AC_MSG_RESULT([    dpdkevents. . . . . . $enable_dpdkevents])
 AC_MSG_RESULT([    dpdkstat  . . . . . . $enable_dpdkstat])

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -120,6 +120,7 @@
 #@BUILD_PLUGIN_DCPMM_TRUE@LoadPlugin dcpmm
 #@BUILD_PLUGIN_DF_TRUE@LoadPlugin df
 #@BUILD_PLUGIN_DISK_TRUE@LoadPlugin disk
+#@BUILD_PLUGIN_DISKSTATS_TRUE@LoadPlugin diskstats
 #@BUILD_PLUGIN_DNS_TRUE@LoadPlugin dns
 #@BUILD_PLUGIN_DPDKEVENTS_TRUE@LoadPlugin dpdkevents
 #@BUILD_PLUGIN_DPDKSTAT_TRUE@LoadPlugin dpdkstat
@@ -681,6 +682,13 @@
 #	IgnoreSelected false
 #	UseBSDName false
 #	UdevNameAttr "DEVNAME"
+#</Plugin>
+
+#<Plugin diskstats>
+#	Disk "/^[hs]d[a-f][0-9]?$/"
+#	IgnoreSelected false
+#	AvgQueueSize 5
+#	AwaitMovingWindowSize 10
 #</Plugin>
 
 #<Plugin dns>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3023,6 +3023,62 @@ I<contrib/99-storage-collectd.rules> udev rule file instead.
 
 =back
 
+=head2 Plugin C<diskstats>
+
+The C<diskstats> plugin collects information about the usage of physical disks
+and logical disks (partitions). Values collected are the MBs read/write total
+or per second, average I/O latency and average I/O queue lenght.
+
+B<Synopsis:>
+
+  <Plugin diskstats>
+    Disk "/^[hs]d[a-f][0-9]?$/"
+    IgnoreSelected false
+    AvgQueueSize 5
+    AwaitMovingWindowSize 10
+  </Plugin>
+
+B<Options:>
+
+Using the following two options you can ignore some disks or configure the
+collection only of specific disks.
+
+=over 4
+
+=item B<Disk> I<Name>
+
+Select the disk I<Name>. Whether it is collected or ignored depends on the
+B<IgnoreSelected> setting, see below. As with other plugins that use the
+daemon's ignorelist functionality, a string that starts and ends with a slash
+is interpreted as a regular expression. Examples:
+
+  Disk "sdd"
+  Disk "/hda[34]/"
+
+See F</"IGNORELISTS"> for details.
+
+=item B<IgnoreSelected> B<true>|B<false>
+
+Sets whether selected disks, i.E<nbsp>e. the ones matches by any of the B<Disk>
+statements, are ignored or if all other disks are ignored. The behavior
+(hopefully) is intuitive: If no B<Disk> option is configured, all disks are
+collected. If at least one B<Disk> option is given and no B<IgnoreSelected> or
+set to B<false>, B<only> matching disks will be collected. If B<IgnoreSelected>
+is set to B<true>, all disks are collected B<except> the ones matched.
+
+=item B<AvgQueueSize> I<Size>
+
+Configure the lenght for moving average of I/Os currently in progress. The
+average takes sum of I<Size> last measurements of value and divide by I<Size>.
+
+=item B<AwaitMovingWindowSize> I<Size>
+
+Configure the lenght for moving window to calculate average Await for last
+I<Size> number of measurements. The Await is calculated accroding to formula:
+Await = average time spent doing IOs / average number of IOs.
+
+=back
+
 =head2 Plugin C<dns>
 
 =over 4

--- a/src/diskstats.c
+++ b/src/diskstats.c
@@ -1,0 +1,560 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ * Kamil Wiatrowski <kamilx.wiatrowski@intel.com>
+ *
+ */
+
+#include "collectd.h"
+#include "utils/common/common.h"
+#include "utils/ignorelist/ignorelist.h"
+
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+
+#define DISKSTATS_PLUGIN "diskstats"
+#define STATS_PATH "/proc/diskstats"
+#define DEFAULT_SECTOR_SIZE 512
+#define DEFAULT_QUEUE_LEN 5
+#define DS_NOT_SET 2
+
+struct diskstats_s {
+  unsigned long reads_completed;
+  unsigned long reads_merged;
+  unsigned long sectors_read;
+  unsigned int ms_spent_reading;
+  unsigned long writes_completed;
+  unsigned long writes_merged;
+  unsigned long sectors_written;
+  unsigned int ms_spent_writing;
+  unsigned int ios_in_progress;
+  unsigned int ms_spent_ios;
+  unsigned int weighted_ms_spent_ios;
+  /* Kernel 4.18+ */
+  unsigned long discards_completed;
+  unsigned long discards_merged;
+  unsigned long sectors_discared;
+  unsigned int ms_spent_discarding;
+  /* Kernel 5.5+ */
+  unsigned long flush_req_completed;
+  unsigned int ms_spent_flushing;
+};
+typedef struct diskstats_s diskstats_t;
+
+struct rolling_array_s {
+  unsigned int len;
+  unsigned int idx;
+  unsigned long *val_list;
+  unsigned long sum;
+};
+typedef struct rolling_array_s rolling_array_t;
+
+struct disklist_s {
+  const char *name;
+  bool in_progress;
+  double sectors_to_mb;
+  rolling_array_t avg_queue;
+  /* For total await */
+  rolling_array_t sum_time_ios;
+  rolling_array_t sum_nr_ios;
+  /* For await_read */
+  rolling_array_t sum_time_reading;
+  rolling_array_t sum_nr_reads;
+  /* For await_write */
+  rolling_array_t sum_time_writing;
+  rolling_array_t sum_nr_writes;
+  size_t prev; // Index of previous stats
+  diskstats_t stats[2];
+  struct disklist_s *next;
+};
+typedef struct disklist_s disklist_t;
+
+static ignorelist_t *ignorelist;
+static disklist_t *disklist;
+static unsigned int queue_avg_len = DEFAULT_QUEUE_LEN;
+static unsigned int await_avg_len = DEFAULT_QUEUE_LEN;
+
+static int diskstats_config(oconfig_item_t *ci) {
+  DEBUG(DISKSTATS_PLUGIN ": %s:%d", __FUNCTION__, __LINE__);
+
+  if (ignorelist == NULL)
+    ignorelist = ignorelist_create(/* invert = */ 1);
+  if (ignorelist == NULL) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to create ignorelist.");
+    return -1;
+  }
+
+  for (int i = 0; i < ci->children_num; i++) {
+    int ret = 0;
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("Disk", child->key) == 0) {
+      char *disk = NULL;
+      ret = cf_util_get_string(child, &disk);
+      if (ret == 0) {
+        DEBUG(DISKSTATS_PLUGIN ": adding disk: %s.", disk);
+        ret = ignorelist_add(ignorelist, disk);
+        sfree(disk);
+      }
+    } else if (strcasecmp("IgnoreSelected", child->key) == 0) {
+      bool ignore = 0;
+      ret = cf_util_get_boolean(child, &ignore);
+      if (ret == 0)
+        ignorelist_set_invert(ignorelist, ignore ? 0 : 1);
+    } else if (strcasecmp("AvgQueueSize", child->key) == 0) {
+      int len = 0;
+      ret = cf_util_get_int(child, &len);
+      if (ret == 0 && len > 0)
+        queue_avg_len = (unsigned int)len;
+      else {
+        ERROR(DISKSTATS_PLUGIN
+              ": Failed to read AvgQueueSize, it should be positive integer!");
+        ret = -1;
+      }
+    } else if (strcasecmp("AwaitMovingWindowSize", child->key) == 0) {
+      int len = 0;
+      ret = cf_util_get_int(child, &len);
+      if (ret == 0 && len > 0)
+        await_avg_len = (unsigned int)len;
+      else {
+        ERROR(DISKSTATS_PLUGIN ": Failed to read AwaitMovingWindowSize, it "
+                               "should be positive integer!");
+        ret = -1;
+      }
+    } else {
+      ERROR(DISKSTATS_PLUGIN ": Unknown configuration parameter \"%s\".",
+            child->key);
+      ret = -1;
+    }
+
+    if (ret != 0) {
+      ERROR(DISKSTATS_PLUGIN ": %s:%d ret=%d", __FUNCTION__, __LINE__, ret);
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+static int rolling_array_init(rolling_array_t *ra, unsigned int size) {
+  ra->idx = 0;
+  ra->sum = 0;
+  ra->len = size;
+  ra->val_list = calloc(size, sizeof(*ra->val_list));
+  if (ra->val_list == NULL) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to calloc rolling list.");
+    return -1;
+  }
+
+  return 0;
+}
+
+static void rolling_array_add(rolling_array_t *ra, unsigned long val) {
+  /* Subtract oldest value and add new value */
+  ra->sum = ra->sum - ra->val_list[ra->idx] + val;
+  ra->val_list[ra->idx++] = val;
+  if (ra->idx >= ra->len)
+    ra->idx = 0;
+}
+
+static inline double rolling_array_avg(rolling_array_t *ra) {
+  return (double)ra->sum / (double)ra->len;
+}
+
+static inline double rolling_arrays_ratio(rolling_array_t *ra1,
+                                          rolling_array_t *ra2) {
+  return ra2->sum == 0 ? 0.0 : (double)ra1->sum / (double)ra2->sum;
+}
+
+static void diskstats_submit_gauge(const char *dev, const char *type_instance,
+                                   gauge_t value) {
+  value_list_t vl = VALUE_LIST_INIT;
+  vl.values = &(value_t){.gauge = value};
+  vl.values_len = 1;
+
+  sstrncpy(vl.plugin, DISKSTATS_PLUGIN, sizeof(vl.plugin));
+  sstrncpy(vl.plugin_instance, dev, sizeof(vl.plugin_instance));
+  sstrncpy(vl.type, "diskstat_gauge", sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+
+  plugin_dispatch_values(&vl);
+}
+
+static void diskstats_submit_counter(const char *dev, const char *type_instance,
+                                     counter_t value) {
+  value_list_t vl = VALUE_LIST_INIT;
+  vl.values = &(value_t){.counter = value};
+  vl.values_len = 1;
+
+  sstrncpy(vl.plugin, DISKSTATS_PLUGIN, sizeof(vl.plugin));
+  sstrncpy(vl.plugin_instance, dev, sizeof(vl.plugin_instance));
+  sstrncpy(vl.type, "diskstat_counter", sizeof(vl.type));
+  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
+
+  plugin_dispatch_values(&vl);
+}
+
+static void diskstats_free_entry(disklist_t *disk) {
+  if (disk->name)
+    free((void *)disk->name);
+  if (disk->avg_queue.val_list)
+    free((void *)disk->avg_queue.val_list);
+  if (disk->sum_time_ios.val_list)
+    free((void *)disk->sum_time_ios.val_list);
+  if (disk->sum_nr_ios.val_list)
+    free((void *)disk->sum_nr_ios.val_list);
+  if (disk->sum_time_reading.val_list)
+    free((void *)disk->sum_time_reading.val_list);
+  if (disk->sum_nr_reads.val_list)
+    free((void *)disk->sum_nr_reads.val_list);
+  if (disk->sum_time_writing.val_list)
+    free((void *)disk->sum_time_writing.val_list);
+  if (disk->sum_nr_writes.val_list)
+    free((void *)disk->sum_nr_writes.val_list);
+}
+
+static disklist_t *diskstats_create_entry(const char *name, int sector_size) {
+  disklist_t *disk = calloc(1, sizeof(*disk));
+  if (disk == NULL) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to calloc disklist entry.");
+    return NULL;
+  }
+
+  disk->name = strdup(name);
+  if (disk->name == NULL) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to copy name.");
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->avg_queue, queue_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_time_ios, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_nr_ios, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_time_reading, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_nr_reads, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_time_writing, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  if (rolling_array_init(&disk->sum_nr_writes, await_avg_len) < 0) {
+    diskstats_free_entry(disk);
+    free(disk);
+    return NULL;
+  }
+  /* Get sector size in MiB */
+  disk->sectors_to_mb = (double)sector_size / (double)(1024 * 1024);
+  disk->prev = DS_NOT_SET;
+
+  disk->next = disklist;
+  disklist = disk;
+
+  return disk;
+}
+
+static disklist_t *diskstats_find_entry(const char *name) {
+  disklist_t *disk;
+  for (disk = disklist; disk != NULL; disk = disk->next) {
+    if (strcmp(disk->name, name) == 0)
+      break;
+  }
+
+  if (disk != NULL)
+    return disk;
+
+  /* Get sector size */
+  int sector_size = DEFAULT_SECTOR_SIZE;
+#ifdef BLKSSZGET
+  char dev_path[PATH_MAX];
+  ssnprintf(dev_path, sizeof(dev_path), "/dev/%s", name);
+  int fd = open(dev_path, O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to open disk device: %s.", name);
+    return NULL;
+  }
+  int rc = ioctl(fd, BLKSSZGET, &sector_size);
+
+  close(fd);
+  if (rc < 0) {
+    ERROR(DISKSTATS_PLUGIN ": Failed to read sector size: %s.", name);
+    return NULL;
+  }
+#else
+  WARNING(DISKSTATS_PLUGIN
+          ": BLKSSZGET is not supported, assuming default sector size = %d.",
+          DEFAULT_SECTOR_SIZE);
+#endif
+
+  /* For DIF/DIX, VSS */
+  if (sector_size > 512 && sector_size <= 528)
+    sector_size = 512;
+  if (sector_size > 4096 && sector_size <= 4224)
+    sector_size = 4096;
+
+  DEBUG(DISKSTATS_PLUGIN ": %s sector size = %d.", name, sector_size);
+
+  /* Create new entry in disklist */
+  disk = diskstats_create_entry(name, sector_size);
+
+  return disk;
+}
+
+static unsigned int diskstats_diff_ui(unsigned int curr, unsigned int prev) {
+  if (curr < prev)
+    return 1 + curr + (UINT_MAX - prev);
+
+  return curr - prev;
+}
+
+static unsigned long diskstats_diff_ul(unsigned long curr, unsigned long prev) {
+  if (curr < prev)
+    return 1 + curr + (ULONG_MAX - prev);
+
+  return curr - prev;
+}
+
+#define DISKSTAT_DIFF(type, name) diskstats_diff_##type(ds->name, ds_prev->name)
+
+static int diskstats_read(__attribute__((unused)) user_data_t *ud) {
+  char buff[1024];
+  FILE *fh = fopen(STATS_PATH, "r");
+  if (fh == NULL) {
+    ERROR(DISKSTATS_PLUGIN ": fopen(" STATS_PATH "): %s", STRERRNO);
+    return -1;
+  }
+
+  while (fgets(buff, sizeof(buff), fh) != NULL) {
+    char *fields[32];
+    int numfields = strsplit(buff, fields, STATIC_ARRAY_SIZE(fields));
+    /* 7 is for partition without extended statistics */
+    if (numfields != 7 && numfields < 14) {
+      WARNING(DISKSTATS_PLUGIN ": Failed to read entry from: %s.", STATS_PATH);
+      continue;
+    }
+
+    char *name = fields[2];
+    if (ignorelist_match(ignorelist, name))
+      continue;
+
+    DEBUG(DISKSTATS_PLUGIN ": dev %s, num of fields = %d.", name, numfields);
+
+    disklist_t *disk = diskstats_find_entry(name);
+    if (disk == NULL) {
+      fclose(fh);
+      return -1;
+    }
+    disk->in_progress = true;
+
+    /* On first read set index to 0, on subsequent intervals set index to
+     * reverse of previous one using XOR (0 or 1) */
+    diskstats_t *ds =
+        disk->prev == DS_NOT_SET ? disk->stats : disk->stats + (disk->prev ^ 1);
+
+    if (numfields == 7) {
+      ds->reads_completed = atoll(fields[3]);
+      ds->sectors_read = atoll(fields[4]);
+      ds->writes_completed = atoll(fields[5]);
+      ds->sectors_written = atoll(fields[6]);
+    } else if (numfields >= 14) {
+      ds->reads_completed = atoll(fields[3]);
+      ds->reads_merged = atoll(fields[4]);
+      ds->sectors_read = atoll(fields[5]);
+      ds->ms_spent_reading = (unsigned int)atoll(fields[6]);
+      ds->writes_completed = atoll(fields[7]);
+      ds->writes_merged = atoll(fields[8]);
+      ds->sectors_written = atoll(fields[9]);
+      ds->ms_spent_writing = (unsigned int)atoll(fields[10]);
+      ds->ios_in_progress = (unsigned int)atoll(fields[11]);
+      ds->ms_spent_ios = (unsigned int)atoll(fields[12]);
+      ds->weighted_ms_spent_ios = (unsigned int)atoll(fields[13]);
+
+      rolling_array_add(&disk->avg_queue, ds->ios_in_progress);
+    }
+    if (numfields >= 18) {
+      ds->discards_completed = atoll(fields[14]);
+      ds->discards_merged = atoll(fields[15]);
+      ds->sectors_discared = atoll(fields[16]);
+      ds->ms_spent_discarding = (unsigned int)atoll(fields[17]);
+    }
+    if (numfields >= 20) {
+      ds->flush_req_completed = atoll(fields[18]);
+      ds->ms_spent_flushing = (unsigned int)atoll(fields[19]);
+    }
+
+    if (disk->prev == DS_NOT_SET) {
+      /* On fisrt read just store values */
+      disk->prev = 0;
+      continue;
+    }
+
+    diskstats_t *ds_prev = disk->stats + disk->prev;
+
+    counter_t mb_read =
+        (counter_t)(ds->sectors_read * disk->sectors_to_mb + 0.5);
+    counter_t mb_wrtn =
+        (counter_t)(ds->sectors_written * disk->sectors_to_mb + 0.5);
+    diskstats_submit_counter(name, "mb_read", mb_read);
+    diskstats_submit_counter(name, "mb_wrtn", mb_wrtn);
+
+    double interval = CDTIME_T_TO_DOUBLE(plugin_get_interval());
+
+    unsigned long sectors_r_diff = DISKSTAT_DIFF(ul, sectors_read);
+    unsigned long sectors_w_diff = DISKSTAT_DIFF(ul, sectors_written);
+
+    gauge_t mb_read_s =
+        ((double)sectors_r_diff / interval) * disk->sectors_to_mb;
+    gauge_t mb_wrtn_s =
+        ((double)sectors_w_diff / interval) * disk->sectors_to_mb;
+    diskstats_submit_gauge(name, "mb_read_s", mb_read_s);
+    diskstats_submit_gauge(name, "mb_wrtn_s", mb_wrtn_s);
+
+    if (numfields == 7) {
+      /* No data for more stats */
+      disk->prev ^= 1;
+      continue;
+    }
+
+    rolling_array_add(&disk->sum_time_reading,
+                      DISKSTAT_DIFF(ui, ms_spent_reading));
+    rolling_array_add(&disk->sum_nr_reads, DISKSTAT_DIFF(ul, reads_completed));
+    rolling_array_add(&disk->sum_time_writing,
+                      DISKSTAT_DIFF(ui, ms_spent_writing));
+    rolling_array_add(&disk->sum_nr_writes,
+                      DISKSTAT_DIFF(ul, writes_completed));
+
+    unsigned int time_ios = DISKSTAT_DIFF(ui, ms_spent_reading) +
+                            DISKSTAT_DIFF(ui, ms_spent_writing) +
+                            DISKSTAT_DIFF(ui, ms_spent_discarding);
+    unsigned long nr_ios = DISKSTAT_DIFF(ul, reads_completed) +
+                           DISKSTAT_DIFF(ul, writes_completed) +
+                           DISKSTAT_DIFF(ul, discards_completed);
+    rolling_array_add(&disk->sum_time_ios, time_ios);
+    rolling_array_add(&disk->sum_nr_ios, nr_ios);
+
+    gauge_t await =
+        rolling_arrays_ratio(&disk->sum_time_ios, &disk->sum_nr_ios);
+    diskstats_submit_gauge(name, "await", await);
+
+    gauge_t await_read =
+        rolling_arrays_ratio(&disk->sum_time_reading, &disk->sum_nr_reads);
+    diskstats_submit_gauge(name, "await_read", await_read);
+
+    gauge_t await_write =
+        rolling_arrays_ratio(&disk->sum_time_writing, &disk->sum_nr_writes);
+    diskstats_submit_gauge(name, "await_write", await_write);
+
+    diskstats_submit_gauge(name, "avg_queue",
+                           rolling_array_avg(&disk->avg_queue));
+
+    if (numfields < 18) {
+      /* No data for more stats */
+      disk->prev ^= 1;
+      continue;
+    }
+
+    unsigned long sectors_d_diff = DISKSTAT_DIFF(ul, sectors_discared);
+    unsigned long discards_diff = DISKSTAT_DIFF(ul, discards_completed);
+    gauge_t mb_discarded_s =
+        ((double)sectors_d_diff / interval) * disk->sectors_to_mb;
+    gauge_t discards_s = (double)discards_diff / interval;
+    diskstats_submit_gauge(name, "mb_discarded_s", mb_discarded_s);
+    diskstats_submit_gauge(name, "discards_s", discards_s);
+
+    disk->prev ^= 1;
+  }
+  fclose(fh);
+
+  /* Clean unused devices from the list */
+  disklist_t *disk = disklist;
+  disklist_t *prev = NULL;
+  while (disk != NULL) {
+    if (disk->in_progress) {
+      disk->in_progress = false;
+      prev = disk;
+      disk = disk->next;
+      continue;
+    }
+
+    if (prev == NULL)
+      disklist = disk->next;
+    else
+      prev->next = disk->next;
+
+    disklist_t *tmp = disk;
+    disk = disk->next;
+    diskstats_free_entry(tmp);
+    free(tmp);
+  }
+
+  return 0;
+}
+
+static int diskstats_init(void) {
+  DEBUG(DISKSTATS_PLUGIN ": AvgQueueSize = %u.", queue_avg_len);
+  DEBUG(DISKSTATS_PLUGIN ": AwaitMovingWindowSize = %u.", await_avg_len);
+  return 0;
+}
+
+static int diskstats_shutdown(void) {
+  ignorelist_free(ignorelist);
+  ignorelist = NULL;
+
+  disklist_t *disk = disklist;
+  disklist_t *tmp;
+  while (disk != NULL) {
+    tmp = disk;
+    disk = disk->next;
+    diskstats_free_entry(tmp);
+    free(tmp);
+  }
+  disklist = NULL;
+
+  return 0;
+}
+
+void module_register(void) {
+  plugin_register_complex_config(DISKSTATS_PLUGIN, diskstats_config);
+  plugin_register_init(DISKSTATS_PLUGIN, diskstats_init);
+  plugin_register_complex_read(NULL, DISKSTATS_PLUGIN, diskstats_read, 0, NULL);
+  plugin_register_shutdown(DISKSTATS_PLUGIN, diskstats_shutdown);
+}

--- a/src/diskstats_test.c
+++ b/src/diskstats_test.c
@@ -57,6 +57,23 @@ char *fgets(char *s, int size, __attribute__((unused)) FILE *stream) {
 }
 
 int fclose(__attribute__((unused)) FILE *stream) { return 0; }
+
+int fileno(__attribute__((unused)) FILE *stream) { return 0; }
+
+int lstat(__attribute__((unused)) const char *pathname, struct stat *buf) {
+  buf->st_dev = 1;
+  buf->st_ino = 1;
+  buf->st_mode = S_IFREG;
+  buf->st_nlink = 1;
+  return 0;
+}
+
+int fstat(__attribute__((unused)) int fd, struct stat *buf) {
+  buf->st_dev = 1;
+  buf->st_ino = 1;
+  buf->st_nlink = 1;
+  return 0;
+}
 /* end mock functions */
 
 DEF_TEST(plugin_config_fail) {
@@ -359,6 +376,10 @@ DEF_TEST(plugin_read_stats) {
   EXPECT_EQ_UINT64(312, d1->stats[1].weighted_ms_spent_ios);
   EXPECT_EQ_UINT64(1, d1->avg_queue.val_list[0]);
   EXPECT_EQ_UINT64(3, d1->avg_queue.val_list[1]);
+
+  test_stats = "   8       0 sda t3st 35 24889 508 30 8 252 5 3 74 312";
+  ret = diskstats_read(NULL);
+  EXPECT_EQ_INT(-1, ret);
 
   return 0;
 }

--- a/src/diskstats_test.c
+++ b/src/diskstats_test.c
@@ -1,0 +1,388 @@
+/**
+ * collectd - src/diskstats_test.c
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Kamil Wiatrowski <kamilx.wiatrowski@intel.com>
+ **/
+
+#define plugin_dispatch_values plugin_dispatch_values_diskstats_test
+
+#include "diskstats.c" /* sic */
+#include "testing.h"
+
+/* mock functions */
+static value_list_t last_vl;
+static value_t last_value;
+static char *test_stats = NULL;
+
+int plugin_dispatch_values_diskstats_test(const value_list_t *vl) {
+  last_value = vl->values[0];
+  last_vl = *vl;
+  last_vl.values = &last_value;
+  return ENOTSUP;
+}
+
+FILE *fopen(__attribute__((unused)) const char *path,
+            __attribute__((unused)) const char *mode) {
+  static FILE f;
+  return &f;
+}
+
+char *fgets(char *s, int size, __attribute__((unused)) FILE *stream) {
+  char *ret = test_stats;
+  test_stats = NULL;
+  if (ret != NULL)
+    sstrncpy(s, ret, size);
+  return ret;
+}
+
+int fclose(__attribute__((unused)) FILE *stream) { return 0; }
+/* end mock functions */
+
+DEF_TEST(plugin_config_fail) {
+  oconfig_item_t test_cfg_parent = {"diskstats", NULL, 0, NULL, NULL, 0};
+  char value_buff[256] = "sda1";
+  char key_buff[256] = "Disks";
+  oconfig_value_t test_cfg_value = {{value_buff}, OCONFIG_TYPE_STRING};
+  oconfig_item_t test_cfg = {
+      key_buff, &test_cfg_value, 1, &test_cfg_parent, NULL, 0};
+
+  test_cfg_parent.children = &test_cfg;
+  test_cfg_parent.children_num = 1;
+
+  EXPECT_EQ_PTR(NULL, ignorelist);
+  int ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+  CHECK_NOT_NULL(ignorelist);
+
+  memset(&test_cfg_value.value, 0, sizeof(test_cfg_value.value));
+  sstrncpy(key_buff, "Disk", sizeof(key_buff));
+  test_cfg_value.type = OCONFIG_TYPE_BOOLEAN;
+  ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+
+  memset(&test_cfg_value.value, 0, sizeof(test_cfg_value.value));
+  sstrncpy(key_buff, "IgnoreSelected", sizeof(key_buff));
+  sstrncpy(value_buff, "test", sizeof(value_buff));
+  test_cfg_value.value.string = value_buff;
+  test_cfg_value.type = OCONFIG_TYPE_STRING;
+  ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+
+  memset(&test_cfg_value.value, 0, sizeof(test_cfg_value.value));
+  test_cfg_value.value.number = 3;
+  test_cfg_value.type = OCONFIG_TYPE_STRING;
+  sstrncpy(key_buff, "AvgQueueSize", sizeof(key_buff));
+
+  ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+
+  test_cfg_value.type = OCONFIG_TYPE_NUMBER;
+  test_cfg_value.value.number = 0;
+  ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+
+  test_cfg_value.value.number = -1;
+  ret = diskstats_config(&test_cfg_parent);
+  OK(0 != ret);
+
+  ret = diskstats_shutdown();
+  EXPECT_EQ_INT(0, ret);
+
+  return 0;
+}
+
+DEF_TEST(plugin_config) {
+  oconfig_item_t test_cfg_parent = {"diskstats", NULL, 0, NULL, NULL, 0};
+  char value_buff[256] = "sda1";
+  char key_buff[256] = "Disk";
+  oconfig_value_t test_cfg_value = {{value_buff}, OCONFIG_TYPE_STRING};
+  oconfig_item_t test_cfg = {
+      key_buff, &test_cfg_value, 1, &test_cfg_parent, NULL, 0};
+
+  test_cfg_parent.children = &test_cfg;
+  test_cfg_parent.children_num = 1;
+
+  int ret = diskstats_config(&test_cfg_parent);
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(ignorelist);
+
+  ret = ignorelist_match(ignorelist, "sda1");
+  EXPECT_EQ_INT(0, ret);
+
+  ret = ignorelist_match(ignorelist, "sda");
+  OK(0 != ret);
+
+  sstrncpy(value_buff, "/^sda/", sizeof(value_buff));
+  ret = diskstats_config(&test_cfg_parent);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = ignorelist_match(ignorelist, "sda");
+  EXPECT_EQ_INT(0, ret);
+  ret = ignorelist_match(ignorelist, "sda1");
+  EXPECT_EQ_INT(0, ret);
+  ret = ignorelist_match(ignorelist, "sda2");
+  EXPECT_EQ_INT(0, ret);
+  ret = ignorelist_match(ignorelist, "sdaABC");
+  EXPECT_EQ_INT(0, ret);
+
+  ret = ignorelist_match(ignorelist, "sdb");
+  OK(0 != ret);
+
+  memset(&test_cfg_value.value, 0, sizeof(test_cfg_value.value));
+  test_cfg_value.value.boolean = 1;
+  test_cfg_value.type = OCONFIG_TYPE_BOOLEAN;
+  sstrncpy(key_buff, "IgnoreSelected", sizeof(key_buff));
+
+  ret = diskstats_config(&test_cfg_parent);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = ignorelist_match(ignorelist, "sda");
+  OK(0 != ret);
+  ret = ignorelist_match(ignorelist, "sda1");
+  OK(0 != ret);
+  ret = ignorelist_match(ignorelist, "sdb");
+  EXPECT_EQ_INT(0, ret);
+
+  test_cfg_value.value.boolean = 0;
+  ret = diskstats_config(&test_cfg_parent);
+  EXPECT_EQ_INT(0, ret);
+
+  ret = ignorelist_match(ignorelist, "sda1");
+  EXPECT_EQ_INT(0, ret);
+
+  EXPECT_EQ_INT(DEFAULT_QUEUE_LEN, queue_avg_len);
+  memset(&test_cfg_value.value, 0, sizeof(test_cfg_value.value));
+  test_cfg_value.value.number = 3;
+  test_cfg_value.type = OCONFIG_TYPE_NUMBER;
+  sstrncpy(key_buff, "AvgQueueSize", sizeof(key_buff));
+
+  ret = diskstats_config(&test_cfg_parent);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(3, queue_avg_len);
+
+  return 0;
+}
+
+DEF_TEST(diskstat_submit) {
+  diskstats_submit_gauge("abc_test", "test_type_g", 2.5);
+  EXPECT_EQ_INT(1, last_vl.values_len);
+  EXPECT_EQ_DOUBLE(2.5, last_vl.values[0].gauge);
+  EXPECT_EQ_STR(DISKSTATS_PLUGIN, last_vl.plugin);
+  EXPECT_EQ_STR("abc_test", last_vl.plugin_instance);
+  EXPECT_EQ_STR("diskstat_gauge", last_vl.type);
+  EXPECT_EQ_STR("test_type_g", last_vl.type_instance);
+
+  diskstats_submit_counter("bcd_test", "test_type_c", 11);
+  EXPECT_EQ_INT(1, last_vl.values_len);
+  EXPECT_EQ_UINT64(11, last_vl.values[0].counter);
+  EXPECT_EQ_STR(DISKSTATS_PLUGIN, last_vl.plugin);
+  EXPECT_EQ_STR("bcd_test", last_vl.plugin_instance);
+  EXPECT_EQ_STR("diskstat_counter", last_vl.type);
+  EXPECT_EQ_STR("test_type_c", last_vl.type_instance);
+
+  return 0;
+}
+
+DEF_TEST(diskstat_find_entry) {
+  disklist_t *disk = diskstats_find_entry("abcd_test");
+  EXPECT_EQ_PTR(NULL, disk);
+  EXPECT_EQ_PTR(NULL, disklist);
+
+  disklist_t d1 = {.name = "test1"};
+  disklist_t d2 = {.name = "test2"};
+  d1.next = &d2;
+  disklist = &d1;
+
+  disk = diskstats_find_entry("test1");
+  EXPECT_EQ_PTR(&d1, disk);
+
+  disk = diskstats_find_entry("test2");
+  EXPECT_EQ_PTR(&d2, disk);
+
+  disklist = NULL;
+
+  return 0;
+}
+
+DEF_TEST(diskstat_avg_queue) {
+  rolling_array_t q;
+  queue_avg_len = 2;
+
+  int ret = rolling_array_init(&q, queue_avg_len);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(0, q.idx);
+  EXPECT_EQ_INT(2, q.len);
+  EXPECT_EQ_INT(0, q.sum);
+  CHECK_NOT_NULL(q.val_list);
+
+  rolling_array_add(&q, 2);
+  EXPECT_EQ_INT(1, q.idx);
+  EXPECT_EQ_INT(2, q.val_list[0]);
+  EXPECT_EQ_INT(2, q.sum);
+  rolling_array_add(&q, 3);
+  EXPECT_EQ_INT(0, q.idx);
+  EXPECT_EQ_INT(3, q.val_list[1]);
+  EXPECT_EQ_INT(5, q.sum);
+
+  double res = rolling_array_avg(&q);
+  EXPECT_EQ_DOUBLE(2.5, res);
+
+  rolling_array_add(&q, 4);
+  EXPECT_EQ_INT(1, q.idx);
+  EXPECT_EQ_INT(4, q.val_list[0]);
+  EXPECT_EQ_INT(7, q.sum);
+
+  res = rolling_array_avg(&q);
+  EXPECT_EQ_DOUBLE(3.5, res);
+
+  rolling_array_t q2;
+  ret = rolling_array_init(&q2, queue_avg_len);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(0, q2.idx);
+  EXPECT_EQ_INT(2, q2.len);
+  EXPECT_EQ_INT(0, q2.sum);
+  CHECK_NOT_NULL(q2.val_list);
+
+  res = rolling_arrays_ratio(&q, &q2);
+  EXPECT_EQ_DOUBLE(0, res);
+
+  rolling_array_add(&q2, 3);
+  rolling_array_add(&q2, 1);
+  EXPECT_EQ_INT(4, q2.sum);
+
+  res = rolling_arrays_ratio(&q, &q2);
+  EXPECT_EQ_DOUBLE(1.75, res);
+
+  free((void *)q.val_list);
+  free((void *)q2.val_list);
+  return 0;
+}
+
+DEF_TEST(plugin_read_stats) {
+  queue_avg_len = 3;
+  await_avg_len = 3;
+  disklist_t *d1 = diskstats_create_entry("sda", 512);
+
+  disklist_t *d2 = calloc(1, sizeof(*d2));
+  d2->name = strdup("no_disk");
+  rolling_array_init(&d2->avg_queue, queue_avg_len);
+  CHECK_NOT_NULL(d2->avg_queue.val_list);
+  rolling_array_init(&d2->sum_time_ios, await_avg_len);
+  CHECK_NOT_NULL(&d2->sum_time_ios.val_list);
+  rolling_array_init(&d2->sum_nr_ios, await_avg_len);
+  CHECK_NOT_NULL(&d2->sum_nr_ios.val_list);
+  d2->sectors_to_mb = 0.000512;
+  d2->prev = DS_NOT_SET;
+  d2->next = d1;
+  disklist = d2;
+
+  test_stats = "   8       0 sda 5";
+  d1->in_progress = 1;
+  int ret = diskstats_read(NULL);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(0, d1->in_progress);
+  EXPECT_EQ_INT(DS_NOT_SET, d1->prev);
+  CHECK_NOT_NULL(disklist);
+  EXPECT_EQ_PTR(d1, disklist);
+  EXPECT_EQ_PTR(NULL, d1->next);
+
+  test_stats = "   8       0 sda 55 44";
+  d1->in_progress = 1;
+  ret = diskstats_read(NULL);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(0, d1->in_progress);
+  EXPECT_EQ_INT(DS_NOT_SET, d1->prev);
+
+  test_stats = "   8       0 sda 467 23 14994 208 20 3 152 4 1 64 212";
+  ret = diskstats_read(NULL);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(0, d1->prev);
+  EXPECT_EQ_UINT64(467, d1->stats[0].reads_completed);
+  EXPECT_EQ_UINT64(23, d1->stats[0].reads_merged);
+  EXPECT_EQ_UINT64(14994, d1->stats[0].sectors_read);
+  EXPECT_EQ_UINT64(208, d1->stats[0].ms_spent_reading);
+  EXPECT_EQ_UINT64(20, d1->stats[0].writes_completed);
+  EXPECT_EQ_UINT64(3, d1->stats[0].writes_merged);
+  EXPECT_EQ_UINT64(152, d1->stats[0].sectors_written);
+  EXPECT_EQ_UINT64(4, d1->stats[0].ms_spent_writing);
+  EXPECT_EQ_UINT64(1, d1->stats[0].ios_in_progress);
+  EXPECT_EQ_UINT64(64, d1->stats[0].ms_spent_ios);
+  EXPECT_EQ_UINT64(212, d1->stats[0].weighted_ms_spent_ios);
+  EXPECT_EQ_UINT64(1, d1->avg_queue.val_list[0]);
+
+  test_stats = "   8       0 sda 767 35 24889 508 30 8 252 5 3 74 312";
+  ret = diskstats_read(NULL);
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_INT(1, d1->prev);
+  EXPECT_EQ_UINT64(467, d1->stats[0].reads_completed);
+  EXPECT_EQ_UINT64(23, d1->stats[0].reads_merged);
+  EXPECT_EQ_UINT64(14994, d1->stats[0].sectors_read);
+  EXPECT_EQ_UINT64(208, d1->stats[0].ms_spent_reading);
+  EXPECT_EQ_UINT64(20, d1->stats[0].writes_completed);
+  EXPECT_EQ_UINT64(3, d1->stats[0].writes_merged);
+  EXPECT_EQ_UINT64(152, d1->stats[0].sectors_written);
+  EXPECT_EQ_UINT64(4, d1->stats[0].ms_spent_writing);
+  EXPECT_EQ_UINT64(1, d1->stats[0].ios_in_progress);
+  EXPECT_EQ_UINT64(64, d1->stats[0].ms_spent_ios);
+  EXPECT_EQ_UINT64(212, d1->stats[0].weighted_ms_spent_ios);
+  EXPECT_EQ_UINT64(767, d1->stats[1].reads_completed);
+  EXPECT_EQ_UINT64(35, d1->stats[1].reads_merged);
+  EXPECT_EQ_UINT64(24889, d1->stats[1].sectors_read);
+  EXPECT_EQ_UINT64(508, d1->stats[1].ms_spent_reading);
+  EXPECT_EQ_UINT64(30, d1->stats[1].writes_completed);
+  EXPECT_EQ_UINT64(8, d1->stats[1].writes_merged);
+  EXPECT_EQ_UINT64(252, d1->stats[1].sectors_written);
+  EXPECT_EQ_UINT64(5, d1->stats[1].ms_spent_writing);
+  EXPECT_EQ_UINT64(3, d1->stats[1].ios_in_progress);
+  EXPECT_EQ_UINT64(74, d1->stats[1].ms_spent_ios);
+  EXPECT_EQ_UINT64(312, d1->stats[1].weighted_ms_spent_ios);
+  EXPECT_EQ_UINT64(1, d1->avg_queue.val_list[0]);
+  EXPECT_EQ_UINT64(3, d1->avg_queue.val_list[1]);
+
+  return 0;
+}
+
+DEF_TEST(plugin_shutdown) {
+  disklist_t *d = diskstats_create_entry("test_disk", 256);
+  EXPECT_EQ_PTR(d, disklist);
+
+  int ret = diskstats_shutdown();
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_PTR(NULL, ignorelist);
+  EXPECT_EQ_PTR(NULL, disklist);
+
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(plugin_config_fail);
+  RUN_TEST(plugin_config);
+  RUN_TEST(diskstat_submit);
+  RUN_TEST(diskstat_find_entry);
+  RUN_TEST(diskstat_avg_queue);
+  RUN_TEST(plugin_read_stats);
+  RUN_TEST(plugin_shutdown);
+
+  END_TEST;
+}

--- a/src/types.db
+++ b/src/types.db
@@ -55,6 +55,8 @@ df                      used:GAUGE:0:1125899906842623, free:GAUGE:0:112589990684
 df_complex              value:GAUGE:0:U
 df_inodes               value:GAUGE:0:U
 dilution_of_precision   value:GAUGE:0:U
+diskstat_gauge          value:GAUGE:0:U
+diskstat_counter        value:COUNTER:0:U
 disk_allocation         value:GAUGE:0:U
 disk_capacity           value:GAUGE:0:U
 disk_error              value:GAUGE:0:U


### PR DESCRIPTION
ChangeLog: New plugin providing some specific calculated disks metrics.

New Diskstats plugin is optimized for providing data allowing to determine fitness factors of workload to particular types of SSD drives (e.g. based on NAND TLC/QLC media, or Intel 3DXP or Z-NAND). The new plugin precisely calculates a number of derived metrics (like MB read/s, MB written/s, MB discarded/s, average IO latency time, average read/write IO latency time, average queue depth) on a client side providing additional accuracy. 