### PR TITLE
[collectd 6] tail_csv: migration to v6.0

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9575,13 +9575,13 @@ B<Synopsis:>
 
  <Plugin "tail_csv">
    <Metric "snort-dropped">
-       Type "percent"
-       Instance "dropped"
+       Type "gauge"
+       Metric "dropped_precent"
        ValueFrom 1
    </Metric>
    <File "/var/log/snort/snort.stats">
-       Plugin "snortstats"
-       Instance "eth0"
+       MetricPrefix "snort_"
+       Label "interface" "eth0"
        Interval 600
        Collect "snort-dropped"
        FieldSeparator ","
@@ -9606,25 +9606,44 @@ one B<Metric> block for multiple CSV files.
 
 =over 4
 
-=item B<Type> I<Type>
+=item B<Type> I<gauge>|I<counter>|I<untyped>
 
-Configures which I<Type> to use when dispatching this metric. Types are defined
-in the L<types.db(5)> file, see the appropriate manual page for more
-information on specifying types. Only types with a single I<data source> are
-supported by the I<tail_csv plugin>. The information whether the value is an
-absolute value (i.e. a C<GAUGE>) or a rate (i.e. a C<DERIVE>) is taken from the
-I<Type's> definition.
+Configures which I<Type> to use when dispatching this metric. Must be
+I<gauge>, I<counter> or I<untyped>.  If not set is I<untyped>.
+There must be exactly one B<Type> option inside each B<Metric> block.
 
-=item B<Instance> I<TypeInstance>
+=item B<Help> I<help>
 
-If set, I<TypeInstance> is used to populate the type instance field of the
-created value lists. Otherwise, no type instance is used.
+Set the B<help> text for the metric.
+
+=item B<Metric> I<metric>
+
+Set the metric name.
+
+=item B<MetricFrom> I<Index>
+
+Read the metric name from the field with the zero-based index I<Index> .
+
+There must be at least one B<Metric> or B<MetricFrom> option inside each B<Metric> block.
+
+=item B<MetricPrefix> I<prefix>
+
+Prepends I<prefix> to the metric name in the B<Metric> block.
+
+=item B<Label> I<key> I<value>
+
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple times in the B<Result> block.
+
+=item B<LabelFrom> I<key> I<Index>
+
+Specifies the column number whose value will be used to create a label.
 
 =item B<ValueFrom> I<Index>
 
 Configure to read the value from the field with the zero-based index I<Index>.
-If the value is parsed as signed integer, unsigned integer or double depends on
-the B<Type> setting, see above.
+If the value is parsed as unsigned integer or double depends on the B<Type>
+ setting, see above.
 
 =back
 
@@ -9635,14 +9654,14 @@ I<File> block but there can be multiple if you have multiple CSV files.
 
 =over 4
 
-=item B<Plugin> I<Plugin>
+=item B<MetricPrefix> I<prefix>
 
-Use I<Plugin> as the plugin name when submitting values.
-Defaults to C<tail_csv>.
+Prepends I<prefix> to the metric name in the B<Metric> block.
 
-=item B<Instance> I<PluginInstance>
+=item B<Label> I<key> I<value>
 
-Sets the I<plugin instance> used when dispatching the values.
+Append the label I<Key>=I<Value> to the submitting metrics. Can appear
+multiple time in the B<File> block.
 
 =item B<Collect> I<Metric>
 

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -1260,3 +1260,40 @@ int cf_util_get_cdtime(const oconfig_item_t *ci, cdtime_t *ret_value) /* {{{ */
 
   return 0;
 } /* }}} int cf_util_get_cdtime */
+
+int cf_util_get_label(const oconfig_item_t *ci, label_set_t *labels) /* {{{ */
+{
+  if ((ci->values_num != 2) ||
+      ((ci->values_num == 2) &&
+       ((ci->values[0].type != OCONFIG_TYPE_STRING) ||
+        (ci->values[1].type != OCONFIG_TYPE_STRING)))) {
+    P_ERROR("The `%s' option requires exactly two string arguments.", ci->key);
+    return -1;
+  }
+
+  return label_set_create(labels, ci->values[0].value.string,
+                          ci->values[1].value.string);
+} /* }}} int cf_util_get_label */
+
+int cf_util_get_metric_type(const oconfig_item_t *ci,
+                            metric_type_t *ret_metric) /* {{{ */
+{
+  if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
+    P_ERROR("The `%s' option requires exactly one string argument.", ci->key);
+    return -1;
+  }
+
+  if (!strcasecmp(ci->values[0].value.string, "gauge"))
+    *ret_metric = METRIC_TYPE_GAUGE;
+  else if (!strcasecmp(ci->values[0].value.string, "untyped"))
+    *ret_metric = METRIC_TYPE_UNTYPED;
+  else if (!strcasecmp(ci->values[0].value.string, "counter"))
+    *ret_metric = METRIC_TYPE_COUNTER;
+  else {
+    P_ERROR("The `%s' option must be: `gauge', `untyped' or `counter' ",
+            ci->key);
+    return -1;
+  }
+
+  return 0;
+} /* }}} int cf_util_get_metric_type */

--- a/src/daemon/configfile.h
+++ b/src/daemon/configfile.h
@@ -29,6 +29,7 @@
 
 #include "collectd.h"
 
+#include "daemon/metric.h"
 #include "liboconfig/oconfig.h"
 #include "utils_time.h"
 
@@ -136,5 +137,10 @@ int cf_util_get_port_number(const oconfig_item_t *ci);
 int cf_util_get_service(const oconfig_item_t *ci, char **ret_string);
 
 int cf_util_get_cdtime(const oconfig_item_t *ci, cdtime_t *ret_value);
+
+int cf_util_get_label(const oconfig_item_t *ci, label_set_t *labels);
+
+int cf_util_get_metric_type(const oconfig_item_t *ci,
+                            metric_type_t *ret_metric);
 
 #endif /* defined(CONFIGFILE_H) */

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -60,7 +60,7 @@ static int label_pair_compare(void const *a, void const *b) {
                 ((label_pair_t const *)b)->name);
 }
 
-static label_pair_t *label_set_read(label_set_t labels, char const *name) {
+label_pair_t *label_set_read(label_set_t labels, char const *name) {
   if (name == NULL) {
     errno = EINVAL;
     return NULL;
@@ -83,8 +83,7 @@ static label_pair_t *label_set_read(label_set_t labels, char const *name) {
   return ret;
 }
 
-static int label_set_create(label_set_t *labels, char const *name,
-                            char const *value) {
+int label_set_create(label_set_t *labels, char const *name, char const *value) {
   if ((labels == NULL) || (name == NULL) || (value == NULL)) {
     return EINVAL;
   }
@@ -132,7 +131,7 @@ static int label_set_create(label_set_t *labels, char const *name,
   return 0;
 }
 
-static int label_set_delete(label_set_t *labels, label_pair_t *elem) {
+int label_set_delete(label_set_t *labels, label_pair_t *elem) {
   if ((labels == NULL) || (elem == NULL)) {
     return EINVAL;
   }
@@ -161,7 +160,7 @@ static int label_set_delete(label_set_t *labels, label_pair_t *elem) {
   return 0;
 }
 
-static void label_set_reset(label_set_t *labels) {
+void label_set_reset(label_set_t *labels) {
   if (labels == NULL) {
     return;
   }
@@ -175,7 +174,7 @@ static void label_set_reset(label_set_t *labels) {
   labels->num = 0;
 }
 
-static int label_set_clone(label_set_t *dest, label_set_t src) {
+int label_set_clone(label_set_t *dest, label_set_t src) {
   if (src.num == 0) {
     return 0;
   }

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -165,4 +165,18 @@ void metric_family_free(metric_family_t *fam);
  * metric_family_free(). */
 metric_family_t *metric_family_clone(metric_family_t const *fam);
 
+/*
+ * Label set
+ */
+
+label_pair_t *label_set_read(label_set_t labels, char const *name);
+
+int label_set_create(label_set_t *labels, char const *name, char const *value);
+
+int label_set_delete(label_set_t *labels, label_pair_t *elem);
+
+void label_set_reset(label_set_t *labels);
+
+int label_set_clone(label_set_t *dest, label_set_t src);
+
 #endif


### PR DESCRIPTION
ChangeLog: tail_csv plugin: migration to v6.0

**TODO:**

- [ ] maybe rename **Metric** block to **Result** to avoid confusion with _Metric_ keys