### PR TITLE
Add an Interval option to several plugins

### DIFF
--- a/src/apache.c
+++ b/src/apache.c
@@ -33,6 +33,8 @@
 
 enum server_enum { APACHE = 0, LIGHTTPD };
 
+static cdtime_t interval = 0;
+
 struct apache_s {
   int server_type;
   char *name;
@@ -145,6 +147,7 @@ static size_t apache_header_callback(void *buf, size_t size, size_t nmemb,
 
 /* Configuration handling functiions
  * <Plugin apache>
+ *   <Interval interval>
  *   <Instance "instance_name">
  *     URL ...
  *   </Instance>
@@ -222,7 +225,7 @@ static int config_add(oconfig_item_t *ci) {
       /* group = */ NULL,
       /* name      = */ callback_name,
       /* callback  = */ apache_read_host,
-      /* interval  = */ 0,
+      /* interval  = */ interval,
       &(user_data_t){
           .data = st,
           .free_func = apache_free,
@@ -235,6 +238,8 @@ static int config(oconfig_item_t *ci) {
 
     if (strcasecmp("Instance", child->key) == 0)
       config_add(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      cf_util_get_cdtime(child, &interval);
     else
       WARNING("apache plugin: The configuration option "
               "\"%s\" is not allowed here. Did you "

--- a/src/collectd-java.pod
+++ b/src/collectd-java.pod
@@ -8,6 +8,8 @@ collectd-java - Documentation of collectd's "java plugin"
 
  LoadPlugin "java"
  <Plugin "java">
+   Interval 30
+
    JVMArg "-verbose:jni"
    JVMArg "-Djava.class.path=/opt/collectd/lib/collectd/bindings/java"
    

--- a/src/collectd-lua.pod
+++ b/src/collectd-lua.pod
@@ -19,6 +19,7 @@ collectd-lua - Documentation of collectd's C<Lua plugin>
   LoadPlugin lua
   # ...
   <Plugin lua>
+    Interval 20
     BasePath "/path/to/your/lua/scripts"
     Script "script1.lua"
     Script "script2.lua"
@@ -41,6 +42,11 @@ The minimum required Lua version is I<5.1>.
 =item B<LoadPlugin> I<Lua>
 
 Loads the Lua plugin.
+
+=item B<Interval> I<Interval>
+
+The interval (in seconds) in which scripts will be called.
+By default the global B<Interval> setting will be used.
 
 =item B<BasePath> I<Name>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -318,6 +318,7 @@
 #</Plugin>
 
 #<Plugin apache>
+#  Interval 60
 #  <Instance "local">
 #    URL "http://localhost/status?auto"
 #    User "www-user"
@@ -690,6 +691,7 @@
 #</Plugin>
 
 #<Plugin "dpdkevents">
+#  Interval 30
 #  <EAL>
 #    Coremask "0x1"
 #    MemoryChannels "4"
@@ -711,6 +713,7 @@
 #</Plugin>
 
 #<Plugin dpdkstat>
+#  Interval 30
 #  <EAL>
 #    Coremask "0x2"
 #    MemoryChannels "4"
@@ -725,6 +728,7 @@
 #</Plugin>
 
 #<Plugin dpdk_telemetry>
+#	Interval 30
 #	ClientSocketPath "/var/run/.client"
 #	DpdkSocketPath "/var/run/dpdk/rte/telemetry"
 #</Plugin>
@@ -828,6 +832,7 @@
 #</Plugin>
 
 #<Plugin intel_pmu>
+#    Interval 30
 #    ReportHardwareCacheEvents true
 #    ReportKernelPMUEvents true
 #    ReportSoftwareEvents true
@@ -898,6 +903,7 @@
 #</Plugin>
 
 #<Plugin java>
+#	Interval 20
 #	JVMArg "-verbose:jni"
 #	JVMArg "-Djava.class.path=@prefix@/share/collectd/java/collectd-api.jar"
 #
@@ -917,6 +923,7 @@
 #</Plugin>
 
 #<Plugin logparser>
+#  Interval 60
 #  <Logfile "/var/log/syslog">
 #    FirstFullRead false
 #    <Message "pcie_errors">
@@ -1018,6 +1025,7 @@
 #</Plugin>
 
 #<Plugin memcachec>
+#	Interval 20
 #	<Page "plugin_instance">
 #		Server "localhost"
 #		Key "page_key"
@@ -1102,6 +1110,7 @@
 #</Plugin>
 
 #<Plugin mysql>
+#	Interval 60
 #	<Database db_name>
 #		Host "database.serv.er"
 #		User "db_user"
@@ -1268,6 +1277,7 @@
 #</Plugin>
 
 #<Plugin nut>
+#	Interval 31
 #	UPS "upsname@hostname:port"
 #	ForceSSL true
 #	VerifyPeer true
@@ -1290,6 +1300,7 @@
 #</Plugin>
 
 #<Plugin openldap>
+#  Interval 30
 #  <Instance "localhost">
 #    URL "ldap://localhost:389"
 #    StartTLS false
@@ -1327,6 +1338,7 @@
 #</Plugin>
 
 #<Plugin ovs_events>
+#  Interval 30
 #  Port "6640"
 #  Address "127.0.0.1"
 #  Socket "/var/run/openvswitch/db.sock"
@@ -1336,6 +1348,7 @@
 #</Plugin>
 
 #<Plugin ovs_stats>
+#  Interval 30
 #  Port "6640"
 #  Address "127.0.0.1"
 #  Socket "/var/run/openvswitch/db.sock"
@@ -1343,6 +1356,7 @@
 #</Plugin>
 
 #<Plugin pcie_errors>
+#  Interval 20
 #  Source "sysfs"
 #  ReportMasked false
 #  PersistentNotifications false
@@ -1490,6 +1504,7 @@
 #</Plugin>
 
 #<Plugin redis>
+#   Interval 60
 #   <Node example>
 #      Host "redis.example.com"
 #      Port "6379"
@@ -1504,6 +1519,7 @@
 #</Plugin>
 
 #<Plugin redfish>
+#  Interval 60
 #  <Query "fans">
 #    Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
 #    <Resource "Fans">
@@ -1541,6 +1557,7 @@
 #
 
 #<Plugin routeros>
+#	Interval 30
 #	<Router>
 #		Host "router.example.com"
 #		Port "8728"
@@ -1910,6 +1927,7 @@
 #</Plugin>
 
 #<Plugin varnish>
+#   Interval 30
 #   This tag support an argument if you want to
 #   monitor the local instance just use </Instance>
 #   If you prefer defining another instance you can do
@@ -1947,6 +1965,7 @@
 #</Plugin>
 
 #<Plugin virt>
+#	Interval 20
 #	Connection "xen:///"
 #	RefreshInterval 60
 #	Domain "name"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -978,11 +978,13 @@ Since its C<mod_status> module is very similar to Apache's, B<lighttpd> is
 also supported. It introduces a new field, called C<BusyServers>, to count the
 number of currently connected clients. This field is also supported.
 
-The configuration of the I<Apache> plugin consists of one or more
-C<E<lt>InstanceE<nbsp>/E<gt>> blocks. Each block requires one string argument
+The configuration of the I<Apache> plugin consists of an optional C<Interval>
+specification and one or more C<E<lt>InstanceE<nbsp>/E<gt>> blocks. Each
+C<E<lt>InstanceE<nbsp>/E<gt>> block requires one string argument
 as the instance name. For example:
 
  <Plugin "apache">
+   <Interval 60>
    <Instance "www1">
      URL "http://www1.example.com/mod_status?auto"
    </Instance>
@@ -3056,6 +3058,7 @@ be found here: http://dpdk.org/doc/guides/sample_app_ug/keep_alive.html
 B<Synopsis:>
 
  <Plugin "dpdkevents">
+   Interval 30
    <EAL>
      Coremask "0x1"
      MemoryChannels "4"
@@ -3078,6 +3081,14 @@ B<Synopsis:>
 
 B<Options:>
 
+=over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which values will be collected.
+By default the global B<Interval> setting will be used.
+
+=back
 
 =head3 The EAL block
 
@@ -3169,6 +3180,7 @@ extended NIC stats API in DPDK.
 B<Synopsis:>
 
  <Plugin "dpdkstat">
+   Interval 30
    <EAL>
      Coremask "0x4"
      MemoryChannels "4"
@@ -3184,6 +3196,15 @@ B<Synopsis:>
  </Plugin>
 
 B<Options:>
+
+=over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which values will be collected.
+By default the global B<Interval> setting will be used.
+
+=back
 
 =head3 The EAL block
 
@@ -3264,6 +3285,7 @@ and publishes the metric values to collectd for further use.
 B<Synopsis:>
 
   <Plugin dpdk_telemetry>
+    Interval 30
     ClientSocketPath "/var/run/.client"
     DpdkSocketPath "/var/run/dpdk/rte/telemetry"
   </Plugin>
@@ -3271,6 +3293,11 @@ B<Synopsis:>
 B<Options:>
 
 =over 2
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which values will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<ClientSocketPath> I<Client_Path>
 
@@ -3881,6 +3908,7 @@ Linux perf interface. All events are reported on a per core basis.
 B<Synopsis:>
 
   <Plugin intel_pmu>
+    Interval 30
     ReportHardwareCacheEvents true
     ReportKernelPMUEvents true
     ReportSoftwareEvents true
@@ -3893,6 +3921,11 @@ B<Synopsis:>
 B<Options:>
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which values will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<ReportHardwareCacheEvents> B<false>|B<true>
 
@@ -4120,7 +4153,8 @@ This option is only available on Solaris.
 The B<ipmi plugin> allows to monitor server platform status using the Intelligent
 Platform Management Interface (IPMI). Local and remote interfaces are supported.
 
-The plugin configuration consists of one or more B<Instance> blocks which
+The plugin configuration consists of an optional B<Interval> specification and
+one or more B<Instance> blocks which
 specify one I<ipmi> connection each. Each block requires one unique string
 argument as the instance name. If instances are not configured, an instance with
 the default option values will be created.
@@ -4353,6 +4387,7 @@ L<collectd-java(5)>.
 Synopsis:
 
  <Plugin "java">
+   Interval 20
    JVMArg "-verbose:jni"
    JVMArg "-Djava.class.path=/opt/collectd/lib/collectd/bindings/java"
    LoadPlugin "org.collectd.java.Foobar"
@@ -4364,6 +4399,11 @@ Synopsis:
 Available configuration options:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) at which plugins are called.
+By default the global B<Interval> setting will be used.
 
 =item B<JVMArg> I<Argument>
 
@@ -4462,6 +4502,7 @@ are found then it sends proper notification containing all fetched values.
 B<Synopsis:>
 
   <Plugin logparser>
+    Interval 60
     <Logfile "/var/log/syslog">
       FirstFullRead false
       <Message "pcie_errors">
@@ -4523,6 +4564,11 @@ B<Synopsis:>
 B<Options:>
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) at which log files are searched
+By default the global B<Interval> setting will be used.
 
 =item B<Logfile> I<File>
 
@@ -4863,6 +4909,7 @@ libmemcache (notice the missing `d'), which is not applicable.
 Synopsis of the configuration:
 
  <Plugin "memcachec">
+   Interval 20
    <Page "plugin_instance">
      Server "localhost"
      Key "page_key"
@@ -4879,6 +4926,11 @@ Synopsis of the configuration:
 The configuration options are:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) at which pages are queried.
+By default the global B<Interval> setting will be used.
 
 =item E<lt>B<Page> I<Name>E<gt>
 
@@ -5490,6 +5542,8 @@ I<12.5.5.31 SHOW SLAVE STATUS Syntax> for details.
 Synopsis:
 
   <Plugin mysql>
+    Interval 60
+
     <Database foo>
       Host "hostname"
       User "username"
@@ -5519,6 +5573,9 @@ Synopsis:
       WsrepStats true
    </Database>
   </Plugin>
+
+The B<Interval> option sets the interval (in seconds) at which databases
+are queried. By default the global B<Interval> setting will be used.
 
 A B<Database> block defines one connection to a MySQL database. It accepts a
 single argument which specifies the name of the database. None of the other
@@ -6673,6 +6730,13 @@ making it through.
 
 =over 4
 
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which upsd will be queried. 
+This should be at least the polling interval your UPS driver uses
+(e.g., B<pollfreq> for I<nutdrv_qx>).
+By default the global B<Interval> setting will be used.
+
 =item B<UPS> I<upsname>B<@>I<hostname>[B<:>I<port>]
 
 Add a UPS to collect data from. The format is identical to the one accepted by
@@ -6877,6 +6941,7 @@ blocks. Each block requires one string argument as the instance name. For
 example:
 
  <Plugin "openldap">
+   Interval 30
    <Instance "foo">
      URL "ldap://localhost/"
    </Instance>
@@ -6889,6 +6954,8 @@ The instance name will be used as the I<plugin instance>. To emulate the old
 (versionE<nbsp>4) behavior, you can use an empty string (""). In order for the
 plugin to work correctly, each instance name must be unique. This is not
 enforced by the plugin and it is your responsibility to ensure it is.
+
+The B<Interval> option may be used to override the global B<Interval> setting.
 
 The following options are accepted within each B<Instance> block:
 
@@ -6957,6 +7024,11 @@ So, in a nutshell you need:
 Available options:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which the values will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<StatusFile> I<File>
 
@@ -7072,6 +7144,7 @@ database to get a link state change notification.
 B<Synopsis:>
 
  <Plugin "ovs_events">
+   Interval 30
    Port 6640
    Address "127.0.0.1"
    Socket "/var/run/openvswitch/db.sock"
@@ -7083,6 +7156,11 @@ B<Synopsis:>
 The plugin provides the following configuration options:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which link status will be monitored.
+By default the global B<Interval> setting will be used.
 
 =item B<Address> I<node>
 
@@ -7140,6 +7218,7 @@ statistics from OVSDB
 B<Synopsis:>
 
  <Plugin "ovs_stats">
+   Interval 30
    Port 6640
    Address "127.0.0.1"
    Socket "/var/run/openvswitch/db.sock"
@@ -7150,6 +7229,11 @@ B<Synopsis:>
 The plugin provides the following configuration options:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which statistics will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<Address> I<node>
 
@@ -7201,6 +7285,7 @@ Fatal errors are reported as I<NOTIF_FAILURE> and all others as I<NOTIF_WARNING>
 B<Synopsis:>
 
   <Plugin "pcie_errors">
+    Interval 20
     Source "sysfs"
     AccessDir "/sys/bus/pci"
     ReportMasked false
@@ -7210,6 +7295,11 @@ B<Synopsis:>
 B<Options:>
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which values will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<Source> B<sysfs>|B<proc>
 
@@ -8202,6 +8292,7 @@ Redfish.
 B<Sample configuration:>
 
   <Plugin redfish>
+    Interval 60
     <Query "fans">
       Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
       <Resource "Fans">
@@ -8238,6 +8329,11 @@ B<Sample configuration:>
   </Plugin>
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which data will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<Query>
 
@@ -8294,6 +8390,7 @@ wireless connections of the device. The configuration supports querying
 multiple routers:
 
   <Plugin "routeros">
+    Interval 30
     <Router>
       Host "router0.example.com"
       User "collectd"
@@ -8319,6 +8416,11 @@ one or more B<E<lt>RouterE<gt>> blocks. Within each block, the following
 options are understood:
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which to query routers.
+By default the global B<Interval> setting will be used.
 
 =item B<Host> I<Host>
 
@@ -8387,6 +8489,7 @@ For each server there is a I<Node> block which configures the connection
 parameters and set of user-defined queries for this node.
 
   <Plugin redis>
+    Interval 60
     <Node "example">
         Host "localhost"
         Port "6379"
@@ -8403,6 +8506,11 @@ parameters and set of user-defined queries for this node.
   </Plugin>
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which queries will be executed.
+By default the global B<Interval> setting will be used.
 
 =item B<Node> I<Nodename>
 
@@ -10102,6 +10210,7 @@ meaning of each metric can be found in L<varnish-counters(7)>.
 Synopsis:
 
  <Plugin "varnish">
+   Interval 30
    <Instance "example">
      CollectBackend     true
      CollectBan         false
@@ -10133,8 +10242,9 @@ Synopsis:
    </Instance>
  </Plugin>
 
-The configuration consists of one or more E<lt>B<Instance>E<nbsp>I<Name>E<gt>
-blocks. I<Name> is the parameter passed to "varnishd -n". If left empty, it
+The configuration consists of an optional B<Interval> specification and
+one or more E<lt>B<Instance>E<nbsp>I<Name>E<gt> blocks.
+I<Name> is the parameter passed to "varnishd -n". If left empty, it
 will collectd statistics from the default "varnishd" instance (this should work
 fine in most cases).
 
@@ -10297,6 +10407,7 @@ Only I<Connection> is required.
 Consider the following example config:
 
  <Plugin "virt">
+   Interval 20
    Connection "qemu:///system"
    HostnameFormat "hostname"
    InterfaceFormat "address"
@@ -10329,6 +10440,11 @@ You can get information on the metric's units from the online libvirt documentat
 For instance, I<virt_cpu_total> is in nanoseconds.
 
 =over 4
+
+=item B<Interval> I<Interval>
+
+Sets the interval (in seconds) in which metrics will be collected.
+By default the global B<Interval> setting will be used.
 
 =item B<Connection> I<uri>
 

--- a/src/dpdk_telemetry.c
+++ b/src/dpdk_telemetry.c
@@ -60,6 +60,7 @@ struct client_info {
 
 typedef struct client_info client_info_t;
 
+static cdtime_t interval = 0;
 static client_info_t client;
 static char g_client_path[BUF_SIZE];
 static char g_dpdk_path[BUF_SIZE];
@@ -77,6 +78,8 @@ static int dpdk_telemetry_config(oconfig_item_t *ci) {
                                       sizeof(g_client_path));
     } else if (strcasecmp("DpdkSocketPath", child->key) == 0) {
       ret = cf_util_get_string_buffer(child, g_dpdk_path, sizeof(g_dpdk_path));
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      ret = cf_util_get_cdtime(child, &interval);
     } else {
       ERROR(PLUGIN_NAME ": Unknown configuration parameter"
                         "\"%s\"",
@@ -392,6 +395,6 @@ static int dpdk_telemetry_init(void) {
 void module_register(void) {
   plugin_register_init(PLUGIN_NAME, dpdk_telemetry_init);
   plugin_register_complex_config(PLUGIN_NAME, dpdk_telemetry_config);
-  plugin_register_complex_read(NULL, PLUGIN_NAME, dpdk_telemetry_read, 0, NULL);
+  plugin_register_complex_read(NULL, PLUGIN_NAME, dpdk_telemetry_read, interval, NULL);
   plugin_register_shutdown(PLUGIN_NAME, dpdk_telemetry_shutdown);
 }

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -113,6 +113,8 @@ typedef enum {
 #define DPDK_EVENTS_TRACE()                                                    \
   DEBUG("%s:%s:%d pid=%u", DPDK_EVENTS_PLUGIN, __FUNCTION__, __LINE__, getpid())
 
+static cdtime_t interval = 0;
+
 static dpdk_helper_ctx_t *g_hc;
 static dpdk_events_cfg_status g_state;
 
@@ -382,6 +384,8 @@ static int dpdk_events_config(oconfig_item_t *ci) {
               event_type);
         ret = -1;
       }
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      ret = cf_util_get_cdtime(child, &interval);
     } else {
       ERROR(DPDK_EVENTS_PLUGIN ": unrecognized configuration option %s.",
             child->key);
@@ -698,7 +702,7 @@ static int dpdk_events_init(void) {
 void module_register(void) {
   plugin_register_init(DPDK_EVENTS_PLUGIN, dpdk_events_init);
   plugin_register_complex_config(DPDK_EVENTS_PLUGIN, dpdk_events_config);
-  plugin_register_complex_read(NULL, DPDK_EVENTS_PLUGIN, dpdk_events_read, 0,
-                               NULL);
+  plugin_register_complex_read(NULL, DPDK_EVENTS_PLUGIN, dpdk_events_read,
+                               interval, NULL);
   plugin_register_shutdown(DPDK_EVENTS_PLUGIN, dpdk_events_shutdown);
 }

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -98,6 +98,8 @@ typedef enum {
 
 #define DPDK_STATS_CTX_GET(a) ((dpdk_stats_ctx_t *)dpdk_helper_priv_get(a))
 
+static cdtime_t interval = 0;
+
 dpdk_helper_ctx_t *g_hc = NULL;
 static char g_shm_name[DATA_MAX_NAME_LEN] = DPDK_STATS_NAME;
 static dpdk_stat_cfg_status g_state = DPDK_STAT_STATE_OKAY;
@@ -156,6 +158,8 @@ static int dpdk_stats_config(oconfig_item_t *ci) {
         ret = dpdk_stats_reinit_helper();
     } else if (strcasecmp("EAL", child->key) == 0)
       ret = dpdk_helper_eal_config_parse(g_hc, child);
+    else if (strcasecmp("Interval", child->key) == 0) 
+      ret = cf_util_get_cdtime(child, &interval);
     else if (strcasecmp("PortName", child->key) != 0) {
       ERROR(DPDK_STATS_PLUGIN ": unrecognized configuration option %s",
             child->key);
@@ -517,7 +521,7 @@ static int dpdk_stats_init(void) {
 void module_register(void) {
   plugin_register_init(DPDK_STATS_PLUGIN, dpdk_stats_init);
   plugin_register_complex_config(DPDK_STATS_PLUGIN, dpdk_stats_config);
-  plugin_register_complex_read(NULL, DPDK_STATS_PLUGIN, dpdk_stats_read, 0,
-                               NULL);
+  plugin_register_complex_read(NULL, DPDK_STATS_PLUGIN, dpdk_stats_read,
+                               interval, NULL);
   plugin_register_shutdown(DPDK_STATS_PLUGIN, dpdk_stats_shutdown);
 }

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -170,6 +170,8 @@ event_info_t g_sw_events[] = {
     {.name = "emulation-faults", .config = PERF_COUNT_SW_EMULATION_FAULTS},
 };
 
+static cdtime_t interval = 0;
+
 static intel_pmu_ctx_t g_ctx;
 
 #if COLLECT_DEBUG
@@ -329,6 +331,8 @@ static int pmu_config(oconfig_item_t *ci) {
       ret = config_cores_parse(child, &g_ctx.cores);
     } else if (strcasecmp("DispatchMultiPmu", child->key) == 0) {
       ret = cf_util_get_boolean(child, &g_ctx.dispatch_cloned_pmus);
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      ret = cf_util_get_cdtime(child, &interval);
     } else {
       ERROR(PMU_PLUGIN ": Unknown configuration parameter \"%s\".", child->key);
       ret = -1;
@@ -801,6 +805,6 @@ static int pmu_shutdown(void) {
 void module_register(void) {
   plugin_register_init(PMU_PLUGIN, pmu_init);
   plugin_register_complex_config(PMU_PLUGIN, pmu_config);
-  plugin_register_complex_read(NULL, PMU_PLUGIN, pmu_read, 0, NULL);
+  plugin_register_complex_read(NULL, PMU_PLUGIN, pmu_read, interval, NULL);
   plugin_register_shutdown(PMU_PLUGIN, pmu_shutdown);
 }

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -91,6 +91,8 @@ struct rdt_ctx_s {
 };
 typedef struct rdt_ctx_s rdt_ctx_t;
 
+static cdtime_t interval = 0;
+
 static rdt_ctx_t *g_rdt;
 
 static rdt_config_status g_state = UNKNOWN;
@@ -1174,6 +1176,10 @@ static int rdt_config(oconfig_item_t *ci) {
                        "recompile collectd with libpqos version 2.0 or newer.",
             child->key);
 #endif /* LIBPQOS2 */
+    } else if (strncasecmp("Interval", child->key,
+                           (size_t)strlen("Interval")) == 0) {
+      if (cf_util_get_cdtime(child, &interval) != 0)
+        ERROR(RDT_PLUGIN ": illegal interval \"%s\".", child->value);
     } else {
       ERROR(RDT_PLUGIN ": Unknown configuration parameter \"%s\".", child->key);
     }
@@ -1309,6 +1315,6 @@ static int rdt_shutdown(void) {
 void module_register(void) {
   plugin_register_init(RDT_PLUGIN, rdt_init);
   plugin_register_complex_config(RDT_PLUGIN, rdt_config);
-  plugin_register_complex_read(NULL, RDT_PLUGIN, rdt_read, 0, NULL);
+  plugin_register_complex_read(NULL, RDT_PLUGIN, rdt_read, interval, NULL);
   plugin_register_shutdown(RDT_PLUGIN, rdt_shutdown);
 }

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -96,6 +96,8 @@ typedef struct c_ipmi_db_type_map_s c_ipmi_db_type_map_t;
 /*
  * Module global variables
  */
+
+static cdtime_t interval = 0;
 static os_handler_t *os_handler;
 static c_ipmi_instance_t *instances;
 
@@ -1174,6 +1176,10 @@ static int c_ipmi_config(oconfig_item_t *ci) {
         return status;
 
       have_instance_block = 1;
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      int status = cf_util_get_cdtime(child, &interval);
+      if (status != 0)
+        return status;
     } else if (!have_instance_block) {
       /* Non-instance option: Assume legacy configuration (without <Instance />
        * blocks) and call c_ipmi_config_add_instance with the <Plugin /> block.
@@ -1264,7 +1270,7 @@ static int c_ipmi_init(void) {
         /* group     = */ "ipmi",
         /* name      = */ callback_name,
         /* callback  = */ c_ipmi_read,
-        /* interval  = */ 0,
+        /* interval  = */ interval,
         /* user_data = */ &ud);
 
     if (status != 0) {

--- a/src/java.c
+++ b/src/java.c
@@ -77,6 +77,7 @@ typedef struct cjni_callback_info_s cjni_callback_info_t;
 /*
  * Global variables
  */
+static cdtime_t interval = 0;
 static JavaVM *jvm;
 static pthread_key_t jvm_env_key;
 
@@ -1304,7 +1305,7 @@ static jint JNICALL cjni_api_register_read(JNIEnv *jvm_env, /* {{{ */
 
   plugin_register_complex_read(
       /* group = */ NULL, cbi->name, cjni_read,
-      /* interval = */ 0,
+      /* interval = */ interval,
       &(user_data_t){
           .data = cbi,
           .free_func = cjni_callback_info_destroy,
@@ -2166,6 +2167,12 @@ static int cjni_config_perform(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("JVMArg", child->key) == 0) {
       status = cjni_config_add_jvm_arg(child);
+      if (status == 0)
+        success++;
+      else
+        errors++;
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      status = cf_util_get_cdtime(child, &interval);
       if (status == 0)
         success++;
       else

--- a/src/logparser.c
+++ b/src/logparser.c
@@ -90,6 +90,8 @@ typedef struct logparser_ctx_s {
   size_t parsers_len;
 } logparser_ctx_t;
 
+static cdtime_t interval = 0;
+
 static logparser_ctx_t logparser_ctx;
 
 static int logparser_shutdown(void);
@@ -203,6 +205,8 @@ static int logparser_config_match(oconfig_item_t *ci, log_parser_t *parser) {
       ret = cf_util_get_string(child, &pattern->excluderegex);
     else if (strcasecmp("IsMandatory", child->key) == 0)
       ret = cf_util_get_boolean(child, &pattern->is_mandatory);
+    else if (strcasecmp("Interval", child->key) == 0)
+      ret = cf_util_get_cdtime(child, &interval);
     else if (strcasecmp(LOGPARSER_PLUGIN_INST_STR, child->key) == 0)
       ret = logparser_config_msg_item_type(child, &user_data,
                                            MSG_ITEM_PLUGIN_INST);
@@ -695,6 +699,6 @@ static int logparser_shutdown(void) {
 void module_register(void) {
   plugin_register_complex_config(PLUGIN_NAME, logparser_config);
   plugin_register_init(PLUGIN_NAME, logparser_init);
-  plugin_register_complex_read(NULL, PLUGIN_NAME, logparser_read, 0, NULL);
+  plugin_register_complex_read(NULL, PLUGIN_NAME, logparser_read, interval, NULL);
   plugin_register_shutdown(PLUGIN_NAME, logparser_shutdown);
 }

--- a/src/lua.c
+++ b/src/lua.c
@@ -55,6 +55,7 @@ typedef struct {
   int callback_id;
 } clua_callback_data_t;
 
+static cdtime_t interval = 0;
 static char base_path[PATH_MAX];
 static lua_script_t *scripts;
 
@@ -325,7 +326,7 @@ static int lua_cb_register_generic(lua_State *L, int type) /* {{{ */
     int status = plugin_register_complex_read(/* group = */ "lua",
                                               /* name      = */ function_name,
                                               /* callback  = */ clua_read,
-                                              /* interval  = */ 0,
+                                              /* interval  = */ interval,
                                               &(user_data_t){
                                                   .data = cb,
                                                   .free_func = lua_cb_free,
@@ -561,6 +562,8 @@ static int lua_config(oconfig_item_t *ci) /* {{{ */
       status = lua_config_base_path(child);
     } else if (strcasecmp("Script", child->key) == 0) {
       status = lua_config_script(child);
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      status = cf_util_get_cdtime(child, &interval);
     } else {
       ERROR("Lua plugin: Option `%s' is not allowed here.", child->key);
       status = 1;

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -52,6 +52,7 @@
 #define MCELOG_UNCORRECTED_ERR_TYPE_INS "uncorrected_memory_errors"
 
 typedef struct mcelog_config_s {
+  cdtime_t interval;          /* plugin read interval */
   char logfile[PATH_MAX];     /* mcelog logfile */
   pthread_t tid;              /* poll thread id */
   llist_t *dimms_list;        /* DIMMs list */
@@ -92,6 +93,7 @@ static int socket_receive(socket_adapter_t *self, FILE **p_file);
 static mcelog_config_t g_mcelog_config = {
     .logfile = "/var/log/mcelog",
     .persist = false,
+    .interval = 0,
 };
 
 static socket_adapter_t socket_adapter = {
@@ -222,6 +224,10 @@ static int mcelog_config(oconfig_item_t *ci) {
         }
       }
       memset(g_mcelog_config.logfile, 0, sizeof(g_mcelog_config.logfile));
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      if (cf_util_get_cdtime(child, &g_mcelog_config.interval) < 0)
+          ERROR(MCELOG_PLUGIN ": Invalid interval: \"%s\".",
+                mem_child->key);
     } else {
       ERROR(MCELOG_PLUGIN ": Invalid configuration option: \"%s\".",
             child->key);
@@ -687,6 +693,6 @@ static int mcelog_shutdown(void) {
 void module_register(void) {
   plugin_register_complex_config(MCELOG_PLUGIN, mcelog_config);
   plugin_register_init(MCELOG_PLUGIN, mcelog_init);
-  plugin_register_complex_read(NULL, MCELOG_PLUGIN, mcelog_read, 0, NULL);
+  plugin_register_complex_read(NULL, MCELOG_PLUGIN, mcelog_read, g_mcelog_config.interval, NULL);
   plugin_register_shutdown(MCELOG_PLUGIN, mcelog_shutdown);
 }

--- a/src/memcached.c
+++ b/src/memcached.c
@@ -69,6 +69,8 @@ struct memcached_s {
 };
 typedef struct memcached_s memcached_t;
 
+static cdtime_t interval = 0;
+
 static bool memcached_have_instances;
 
 static void memcached_free(void *arg) {
@@ -694,7 +696,7 @@ static int memcached_add_read_callback(memcached_t *st) {
       /* group = */ "memcached",
       /* name      = */ callback_name,
       /* callback  = */ memcached_read,
-      /* interval  = */ 0,
+      /* interval  = */ interval,
       &(user_data_t){
           .data = st,
           .free_func = memcached_free,
@@ -775,6 +777,8 @@ static int memcached_config(oconfig_item_t *ci) {
     if (strcasecmp("Instance", child->key) == 0) {
       config_add_instance(child);
       have_instance_block = 1;
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      cf_util_get_cdtime(child, &interval);
     } else if (!have_instance_block) {
       /* Non-instance option: Assume legacy configuration (without <Instance />
        * blocks) and call config_add_instance() with the <Plugin /> block. */

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -75,6 +75,8 @@ typedef struct mysql_database_s mysql_database_t; /* }}} */
 
 static int mysql_read(user_data_t *ud);
 
+static cdtime_t interval = 0;
+
 static void mysql_database_free(void *arg) /* {{{ */
 {
   mysql_database_t *db;
@@ -107,6 +109,7 @@ static void mysql_database_free(void *arg) /* {{{ */
 /* Configuration handling functions {{{
  *
  * <Plugin mysql>
+ *   <Interval 60>
  *   <Database "plugin_instance1">
  *     Host "localhost"
  *     Port 22000
@@ -224,7 +227,7 @@ static int mysql_config_database(oconfig_item_t *ci) /* {{{ */
       sstrncpy(cb_name, "mysql", sizeof(cb_name));
 
     plugin_register_complex_read(
-        /* group = */ NULL, cb_name, mysql_read, /* interval = */ 0,
+        /* group = */ NULL, cb_name, mysql_read, interval,
         &(user_data_t){
             .data = db,
             .free_func = mysql_database_free,
@@ -248,6 +251,8 @@ static int mysql_config(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Database", child->key) == 0)
       mysql_config_database(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      cf_util_get_cdtime(child, &interval);
     else
       WARNING("mysql plugin: Option \"%s\" not allowed here.", child->key);
   }

--- a/src/openldap.c
+++ b/src/openldap.c
@@ -57,6 +57,8 @@ struct cldap_s /* {{{ */
 };
 typedef struct cldap_s cldap_t; /* }}} */
 
+static cdtime_t interval = 0;
+
 static void cldap_free(void *arg) /* {{{ */
 {
   cldap_t *st = arg;
@@ -470,7 +472,7 @@ static int cldap_config_add(oconfig_item_t *ci) /* {{{ */
   return plugin_register_complex_read(/* group = */ NULL,
                                       /* name      = */ callback_name,
                                       /* callback  = */ cldap_read_host,
-                                      /* interval  = */ 0,
+                                      /* interval  = */ interval,
                                       &(user_data_t){
                                           .data = st,
                                           .free_func = cldap_free,
@@ -486,6 +488,8 @@ static int cldap_config(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Instance", child->key) == 0)
       cldap_config_add(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      cf_util_get_cdtime(child, &interval);
     else
       WARNING("openldap plugin: The configuration option "
               "\"%s\" is not allowed here. Did you "

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -232,6 +232,7 @@ static int ovs_events_config_get_interfaces(const oconfig_item_t *ci) {
  */
 static int ovs_events_plugin_config(oconfig_item_t *ci) {
   bool dispatch_values = false;
+  cdtime_t interval = 0;
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
     if (strcasecmp("SendNotification", child->key) == 0) {
@@ -273,6 +274,11 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
         ovs_events_config_free();
         return -1;
       }
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      if (cf_util_get_cdtime(child, &interval) != 0) {
+        ovs_events_config_free();
+        return -1;
+      }
     } else {
       ERROR(OVS_EVENTS_PLUGIN ": option '%s' is not allowed here", child->key);
       ovs_events_config_free();
@@ -289,7 +295,7 @@ static int ovs_events_plugin_config(oconfig_item_t *ci) {
   /* Dispatch link status values if configured */
   if (dispatch_values)
     return plugin_register_complex_read(NULL, OVS_EVENTS_PLUGIN,
-                                        ovs_events_plugin_read, 0, NULL);
+                                        ovs_events_plugin_read, interval, NULL);
 
   return 0;
 }

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -200,6 +200,9 @@ static ovs_stats_config_t ovs_stats_cfg = {
     .ovs_db_serv = "6640",      /* use default OVS DB service */
 };
 
+/* plugin interval */
+static cdtime_t interval = 0;
+
 /* flag indicating whether or not to publish individual interface statistics */
 static bool interface_stats = false;
 
@@ -1343,6 +1346,11 @@ static int ovs_stats_plugin_config(oconfig_item_t *ci) {
         ERROR("%s: parse '%s' option failed", plugin_name, child->key);
         return -1;
       }
+    } else if (strcasecmp("Interval", child->key) == 0) {
+      if (cf_util_get_cdtime(child, &interval) != 0) {
+        ERROR("%s: parse '%s' option failed", plugin_name, child->key);
+        return -1;
+      }
     } else {
       WARNING("%s: option '%s' not allowed here", plugin_name, child->key);
       goto cleanup_fail;
@@ -1419,7 +1427,7 @@ static int ovs_stats_plugin_shutdown(void) {
 void module_register(void) {
   plugin_register_complex_config(plugin_name, ovs_stats_plugin_config);
   plugin_register_init(plugin_name, ovs_stats_plugin_init);
-  plugin_register_complex_read(NULL, plugin_name, ovs_stats_plugin_read, 0,
-                               NULL);
+  plugin_register_complex_read(NULL, plugin_name, ovs_stats_plugin_read,
+                               interval, NULL);
   plugin_register_shutdown(plugin_name, ovs_stats_plugin_shutdown);
 }

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -107,6 +107,7 @@ typedef struct redfish_ctx_s redfish_ctx_t;
 
 /* Globals */
 static redfish_ctx_t ctx;
+static cdtime_t interval = 0;
 
 static int redfish_cleanup(void);
 static int redfish_validate_config(void);
@@ -553,6 +554,8 @@ static int redfish_config(oconfig_item_t *cfg_item) {
       ret = redfish_config_query(child, ctx.queries);
     else if (strcasecmp("Service", child->key) == 0)
       ret = redfish_config_service(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      ret = cf_util_get_cdtime(child, &interval); 
     else {
       ERROR(PLUGIN_NAME ": Invalid configuration option \"%s\".", child->key);
     }
@@ -974,6 +977,6 @@ static int redfish_cleanup(void) {
 void module_register(void) {
   plugin_register_init(PLUGIN_NAME, redfish_init);
   plugin_register_complex_config(PLUGIN_NAME, redfish_config);
-  plugin_register_complex_read(NULL, PLUGIN_NAME, redfish_read, 0, NULL);
+  plugin_register_complex_read(NULL, PLUGIN_NAME, redfish_read, interval, NULL);
   plugin_register_shutdown(PLUGIN_NAME, redfish_cleanup);
 }

--- a/src/redis.c
+++ b/src/redis.c
@@ -84,6 +84,7 @@ struct redis_node_s {
 };
 
 static bool redis_have_instances;
+static cdtime_t interval = 0;
 static int redis_read(user_data_t *user_data);
 
 static void redis_node_free(void *arg) {
@@ -121,7 +122,7 @@ static int redis_node_add(redis_node_t *rn) /* {{{ */
       /* group = */ "redis",
       /* name      = */ cb_name,
       /* callback  = */ redis_read,
-      /* interval  = */ 0,
+      /* interval  = */ interval,
       &(user_data_t){
           .data = rn,
           .free_func = redis_node_free,
@@ -264,6 +265,8 @@ static int redis_config(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Node", option->key) == 0)
       redis_config_node(option);
+    else if (strcasecmp("Interval", option->key) == 0)
+      cf_util_get_cdtime(option, &interval);
     else
       WARNING("redis plugin: Option `%s' not allowed in redis"
               " configuration. It will be ignored.",

--- a/src/routeros.c
+++ b/src/routeros.c
@@ -31,6 +31,8 @@
 
 #include <routeros_api.h>
 
+static cdtime_t interval = 0;
+
 struct cr_data_s {
   ros_connection_t *connection;
 
@@ -441,7 +443,7 @@ static int cr_config_router(oconfig_item_t *ci) /* {{{ */
 
   ssnprintf(read_name, sizeof(read_name), "routeros/%s", router_data->node);
   return plugin_register_complex_read(
-      /* group = */ NULL, read_name, cr_read, /* interval = */ 0,
+      /* group = */ NULL, read_name, cr_read, /* interval = */ interval,
       &(user_data_t){
           .data = router_data,
           .free_func = (void *)cr_free_data,
@@ -454,6 +456,8 @@ static int cr_config(oconfig_item_t *ci) {
 
     if (strcasecmp("Router", child->key) == 0)
       cr_config_router(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      cf_util_get_cdtime(child, &interval);
     else {
       WARNING("routeros plugin: Unknown config option `%s'.", child->key);
     }

--- a/src/varnish.c
+++ b/src/varnish.c
@@ -100,6 +100,8 @@ typedef struct user_config_s user_config_t; /* }}} */
 
 static bool have_instance;
 
+static cdtime_t interval = 0;
+
 static int varnish_submit(const char *plugin_instance, /* {{{ */
                           const char *category, const char *target,
                           const char *type, const char *type_instance,
@@ -1724,7 +1726,7 @@ static int varnish_init(void) /* {{{ */
       /* group = */ "varnish",
       /* name      = */ "varnish/localhost",
       /* callback  = */ varnish_read,
-      /* interval  = */ 0,
+      /* interval  = */ interval,
       &(user_data_t){
           .data = conf,
           .free_func = varnish_config_free,
@@ -1959,7 +1961,7 @@ static int varnish_config_instance(const oconfig_item_t *ci) /* {{{ */
       /* group = */ "varnish",
       /* name      = */ callback_name,
       /* callback  = */ varnish_read,
-      /* interval  = */ 0,
+      /* interval  = */ interval,
       &(user_data_t){
           .data = conf,
           .free_func = varnish_config_free,
@@ -1977,6 +1979,8 @@ static int varnish_config(oconfig_item_t *ci) /* {{{ */
 
     if (strcasecmp("Instance", child->key) == 0)
       varnish_config_instance(child);
+    else if (strcasecmp("Interval", child->key) == 0)
+      cf_util_get_cdtime(child, &interval);
     else {
       WARNING("Varnish plugin: Ignoring unknown "
               "configuration option: \"%s\"",


### PR DESCRIPTION
Add an `Interval` configuration option to all plugins that lacked one yet used `plugin_register_complex_read()`, i.e. _apache_, _dpdk_telemetry_, _dpdkevents_, _dpdkstat_, _intel_pmu_, _intel_rdt_, _ipmi_, _java_, _logparser_, _lua_, _mcelog_, _memcached_, _mysql_, _nut_, _openldap_, _openvpn_, _ovs_events_, _ovs_stats_, _pcie_errors_, _redfish_, _redis_, _routeros_, _varnish_, _virt_.

Note that _intel_rdt_'s documentation already claimed to have an `Interval` option despite not being actually implemented.

Most of this is not even compile-tested (I only needed it for _nut_) because I can't build the Linux-only plugins on NetBSD.

ChangeLog: multiple plugins: An "Interval" configuration option was added.