### PR TITLE
nginx plugin: Add support for UNIX domain sockets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2322,6 +2322,12 @@ if test "x$with_libcurl" = "xyes"; then
       [have_curlopt_timeout="no"],
       [[#include <curl/curl.h>]]
     )
+
+    AC_CHECK_DECL(CURLOPT_UNIX_SOCKET_PATH,
+      [have_curlopt_unix_socket_path="yes"],
+      [have_curlopt_unix_socket_path="no"],
+      [[#include <curl/curl.h>]]
+    )
   fi
 fi
 
@@ -2371,6 +2377,12 @@ if test "x$with_libcurl" = "xyes"; then
   if test "x$have_curlopt_timeout" = "xyes"; then
     AC_DEFINE([HAVE_CURLOPT_TIMEOUT_MS], [1],
       [Define if libcurl supports CURLOPT_TIMEOUT_MS option.]
+    )
+  fi
+
+  if test "x$have_curlopt_unix_socket_path" = "xyes"; then
+    AC_DEFINE([HAVE_CURLOPT_UNIX_SOCKET_PATH], [1],
+      [Define if libcurl supports CURLOPT_UNIX_SOCKET_PATH option.]
     )
   fi
 fi

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6527,6 +6527,12 @@ The B<Timeout> option sets the overall timeout for HTTP requests to B<URL>, in
 milliseconds. By default, the configured B<Interval> is used to set the
 timeout.
 
+=item B<Socket> I<Path>
+
+The B<Socket> option sets the UNIX domain socket to use, if the NGINX listens
+on a UNIX domain socket instead. Note that you still need to provide the
+B<URL> option.
+
 =back
 
 =head2 Plugin C<notify_desktop>


### PR DESCRIPTION
Add support for UNIX domain sockets for NGINX servers that listen on a socket.

With this PR, one can serve the `stub_status` module on a socket, which can be more secure and faster than exposing it on a normal port. For example, I use the following NGINX configuration:

```
server {
  listen unix:/var/run/nginx.sock;

  location /stub_status {
    stub_status;
  }
}
````

ChangeLog: nginx plugin: Add support for UNIX domain sockets