### PR TITLE
Fix debug print of excluderegex if NULL

### DIFF
--- a/src/utils/match/match.c
+++ b/src/utils/match/match.c
@@ -204,7 +204,7 @@ match_create_callback(const char *regex, const char *excluderegex,
   int status;
 
   DEBUG("utils_match: match_create_callback: regex = %s, excluderegex = %s",
-        regex, excluderegex);
+        regex, excluderegex != NULL ? excluderegex : "");
 
   obj = calloc(1, sizeof(*obj));
   if (obj == NULL)


### PR DESCRIPTION
ChangeLog: ExcludeRegex in logparser plugin is optional, hence can be NULL. This change fixes debug logging causing CRITICAL error for NULL excluderegex, if debug is enabled.