### PR TITLE
Increase buffer size for oauth access token to 2048

### DIFF
--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -46,7 +46,6 @@
  * monitoring api supports up to 100K bytes in one request, 64K is reasonable
  */
 #define MAX_BUFFER_SIZE 65536
-#define MAX_ENCODE_SIZE 2048
 
 struct oauth_s {
   char *url;

--- a/src/utils/oauth/oauth.h
+++ b/src/utils/oauth/oauth.h
@@ -30,6 +30,10 @@
 #define GOOGLE_OAUTH_URL "https://www.googleapis.com/oauth2/v3/token"
 #endif
 
+#ifndef GOOGLE_OAUTH_ACCESS_TOKEN_SIZE
+#define GOOGLE_OAUTH_ACCESS_TOKEN_SIZE 2048
+#endif
+
 struct oauth_s;
 typedef struct oauth_s oauth_t;
 

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -96,8 +96,8 @@ static size_t wg_write_memory_cb(void *contents, size_t size,
 
 static char *wg_get_authorization_header(wg_callback_t *cb) { /* {{{ */
   int status = 0;
-  char access_token[256];
-  char authorization_header[256];
+  char access_token[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE];
+  char authorization_header[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE+32];
 
   assert((cb->auth != NULL) || gce_check());
   if (cb->auth != NULL)

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -97,7 +97,7 @@ static size_t wg_write_memory_cb(void *contents, size_t size,
 static char *wg_get_authorization_header(wg_callback_t *cb) { /* {{{ */
   int status = 0;
   char access_token[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE];
-  char authorization_header[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE+32];
+  char authorization_header[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE + 32];
 
   assert((cb->auth != NULL) || gce_check());
   if (cb->auth != NULL)


### PR DESCRIPTION
ChangeLog: Stackdriver plugin: increase OAuth access token buffer size to 2048 to match https://developers.google.com/identity/protocols/oauth2#size

Fixes #3897