### PR TITLE
Fix-configure.ac: typing error for the CPPFLAGS of libredfish

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2223,7 +2223,7 @@ LDFLAGS="$LDFLAGS $LIBREDFISH_LDFLAGS"
 
 if test "x$with_libredfish" = "xyes"; then
   if test "x$LIBREDFISH_CPPFLAGS" != "x"; then
-    AC_MSG_NOTICE([libredfish CPPFLAGS: $LIBHIREDFISH_CPPFLAGS])
+    AC_MSG_NOTICE([libredfish CPPFLAGS: $LIBREDFISH_CPPFLAGS])
   fi
   AC_CHECK_HEADERS([redfish.h],
     [with_libredfish="yes"],


### PR DESCRIPTION
Changelog: typing error in configure.ac for the CPPFLAGS of libredfish.

Probably a copy/paste error: `LIBHIREDFISH_CPPFLAGS` was used instead of
`LIBREDFISH_CPPFLAGS`.