### PR TITLE
Fix a small error due to the unreleased lock for 

### DIFF
--- a/src/perl.c
+++ b/src/perl.c
@@ -2444,6 +2444,7 @@ static int init_pi(int argc, char **argv) {
 
   if (NULL == (perl_threads->head->interp = perl_alloc())) {
     log_err("init_pi: Not enough memory.");
+    pthread_mutex_unlock(&perl_threads->mutex);
     exit(3);
   }
 


### PR DESCRIPTION
ChangeLog: Perl plugin: add unlock pthread mutex before exit.

Fix a small error due to the unreleased lock by add pthread_mutex_unlock(&perl_threads->mutex) before program exit. #3894 