### PR TITLE
Feature-redfish: enabling libredfish logs when collectd debug mode is enforced

### DIFF
--- a/src/redfish.c
+++ b/src/redfish.c
@@ -113,6 +113,10 @@ static int redfish_validate_config(void);
 static void *redfish_worker_thread(void __attribute__((unused)) * args);
 
 #if COLLECT_DEBUG
+/* Hook exposed by the libredfish library to define a printing function
+ * dedicated to logging purposes: */
+extern libRedfishDebugFunc gDebugFunc;
+
 static void redfish_print_config(void) {
   DEBUG(PLUGIN_NAME ": ====================CONFIGURATION====================");
   DEBUG(PLUGIN_NAME ": SERVICES: %d", llist_size(ctx.services));
@@ -193,6 +197,10 @@ static void redfish_job_destroy(redfish_job_t *job) {
 
 static int redfish_init(void) {
 #if COLLECT_DEBUG
+  /* Registering plugin_log as the printing function dedicated to logging
+   * purposes within libredfish: */
+  gDebugFunc = plugin_log;
+
   redfish_print_config();
 #endif
   int ret = redfish_validate_config();


### PR DESCRIPTION
Changelog: enabling libredfish logs when collectd debug mode is enforced

In order for `libredfish` to log internal information, which are more
than useful to debugging purposes, a printing function has to be
registered through a hook : a global function pointer named `gDebugFunc`.

The `plugin_log` function is registered as the printing function through
the aforementioned hook by the `redfish_init` function, when the
`--enable-debug` option is specified to the `configure` script.