### PR TITLE
Changelog: write_influxdb_udp: Implement support for multiple Server entries

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -11209,12 +11209,13 @@ traffic between collectd and the HTTP server.
 
 =head2 Plugin C<write_influxdb_udp>
 
-The write_influxdb_udp plugin sends data to a instance of InfluxDB using the
+The write_influxdb_udp plugin sends data to instances of InfluxDB using the
 "Line Protocol". Each plugin is sent as a measurement with a time precision of
 miliseconds while plugin instance, type and type instance are sent as tags.
 
  <Plugin "write_influxdb_udp">
-   Server "influxdb.internal.tld"
+   Server "influxdb.fqdn"
+   Server "influxdb2.fqdn"
    TimePrecision "ms"
    StoreRates "yes"
  </Plugin>
@@ -11223,11 +11224,13 @@ miliseconds while plugin instance, type and type instance are sent as tags.
 
 =item B<E<lt>Server> I<Host> [I<Port>]B<E<gt>>
 
-The B<Server> statement sets the server to send datagrams to.
+The B<Server> statement sets a server to send datagrams to. This statement can
+appear multiple times, once for each unique destination to send to.
 
 The argument I<Host> may be a hostname, an IPv4 address or an IPv6 address. The
 optional second argument specifies a port number or a service name. If not
-given, the default, B<8089>, is used.
+given, the default, B<8089>, is used. The arguments I<Host> and I<Port> should
+be enclosed in "quotes".
 
 =item B<TimePrecision> I<ms>|I<us>|I<ns>
 


### PR DESCRIPTION
Changelog: write_influxdb_udp: Implement support for multiple Server entries

It creates one socket for each Server row in the CFG: e.g.

```
LoadPlugin write_influxdb_udp
<Plugin write_influxdb_udp>
  Server "some.host.tld" "8585"
  Server "some.host.tld" "8686"
  Server "192.0.2.1" "8001"
  Server "192.0.2.5" "8007"
  Server "2001:db8::19" "5000"
</Plugin>
```
Tested on 5.13 and 6.0 code-base.


PS: Not sure which branch to PR against. main? master? 5.13? 6? This applies to each branch cleanly and works. 

This can go into main for release in 5.13, and @carlospeon is re-working the plugin for v6, where this PR also applies there (but small rebase for docs might be necessary).
