### PR TITLE
add CounterGauge option in statsd

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1714,6 +1714,7 @@
 #  DeleteGauges   false
 #  DeleteSets     false
 #  CounterSum     false
+#  CounterGauge   false
 #  TimerPercentile 90.0
 #  TimerPercentile 95.0
 #  TimerPercentile 99.0

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -9130,6 +9130,13 @@ When enabled, creates a C<count> metric which reports the change since the last
 read. This option primarily exists for compatibility with the I<statsd>
 implementation by Etsy.
 
+=item B<CounterSum> B<false>|B<true>
+
+When enabled, creates a C<gauge> metric which reports counters as a "gauge"
+of the differential, resetting the counter between flush intervals.  This
+option primarily exists for compatibility with the I<statsd> implementation
+in GitHub Enterprise Server.
+
 =item B<TimerPercentile> I<Percent>
 
 Calculate and dispatch the configured percentile, i.e. compute the latency, so


### PR DESCRIPTION
This PR introduces the `CounterGauge` option for the `statsd` plugin.

This enables compatibility with the reference StatsD implementation, aggregating the increase during the flushing interval, reporting the current value as a differential, and resetting the counter.

Originally this was written by @vmg as a patch against version 5.5.3 to make this the standard behavior. I've adapted it so this behavior is optional and does not interfere with reporting `derive` metrics, similarly to what I saw done with the Etsy option `CounterSum`. We found use for this while performing a Debian dist-upgrade from stretch to buster where we're using a patched collectd version 5.10.0.

ChangeLog: statsd plugin: The CounterGauge option has been added. Thanks to Casey Tucker and Vicent Marti.