### PR TITLE
Report MemAvailable when present in meminfo

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -322,6 +322,7 @@ static int memory_read_internal(value_list_t *vl) {
   char *fields[8];
   int numfields;
 
+  bool mem_available_info = false;
   bool detailed_slab_info = false;
 
   gauge_t mem_total = 0;
@@ -329,6 +330,7 @@ static int memory_read_internal(value_list_t *vl) {
   gauge_t mem_buffered = 0;
   gauge_t mem_cached = 0;
   gauge_t mem_free = 0;
+  gauge_t mem_available = 0;
   gauge_t mem_slab_total = 0;
   gauge_t mem_slab_reclaimable = 0;
   gauge_t mem_slab_unreclaimable = 0;
@@ -357,6 +359,9 @@ static int memory_read_internal(value_list_t *vl) {
     } else if (strncasecmp(buffer, "SUnreclaim:", 11) == 0) {
       val = &mem_slab_unreclaimable;
       detailed_slab_info = true;
+    } else if (strncasecmp(buffer, "MemAvailable:", 13) == 0) {
+      val = &mem_available;
+      mem_available_info = true;
     } else
       continue;
 
@@ -381,7 +386,16 @@ static int memory_read_internal(value_list_t *vl) {
    * They sum up to the value of Slab, which is available on older & newer
    * kernels. So SReclaimable/SUnreclaim are submitted if available, and Slab
    * if not. */
-  if (detailed_slab_info)
+  if (mem_available_info && detailed_slab_info)
+    MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
+                  mem_cached, "free", mem_free, "available", mem_available,
+                  "slab_unrecl", mem_slab_unreclaimable, "slab_recl",
+                  mem_slab_reclaimable);
+  else if (mem_available_info)
+    MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
+                  mem_cached, "free", mem_free, "slab", mem_slab_total,
+                  "available", mem_available);
+  else if (detailed_slab_info)
     MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
                   mem_cached, "free", mem_free, "slab_unrecl",
                   mem_slab_unreclaimable, "slab_recl", mem_slab_reclaimable);


### PR DESCRIPTION
This PR introduces reporting 'available' memory for linux kernel when present in meminfo.

Right now a rough estimate to available memory based on the current metrics reported relies on summing (free, buffers, cached) metrics.

This produces an over estimate for the available memory in cases where shared memory is in use.
As the shared memory is counted towards cache, however not reclaimable.

Sample python code to show the issue, with results reported:
```
from multiprocessing import shared_memory
import psutil

def print_mem_stats() -> None:
  mem_stats = psutil.virtual_memory()
  print("Available:", mem_stats.available / 2**20)
  print("Shared:", mem_stats.shared / 2**20)
  print("Cached:", mem_stats.cached / 2**20)

def main() -> None:
  print("-- Before opening shared memory --")
  print_mem_stats()
  shm_size = 2**30 
  shm_a = shared_memory.SharedMemory(create=True, size=shm_size)
  buffer = shm_a.buf
  for i in range(shm_size):
    buffer[i] = 1
  print("-- After accessing shared memory --")
  print_mem_stats()
  shm_a.close()
  shm_a.unlink()

if __name__ == '__main__':
  main()
```

```
-- Before opening shared memory --
Available: 13041.63671875
Shared: 0.56640625
Cached: 2901.5390625
-- After accessing shared memory --
Available: 12011.625
Shared: 1024.51171875
Cached: 3925.75390625
```

Thus introducing reporting 'available' directly for kernel versions that support 'MemAvailable'

ChangeLog: memory plugin: Add reporting of 'available' memory to Linux kernels when 'MemAvailable' is supported.