### PR TITLE
Fix some gcc warnings with more strict checks

### DIFF
--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -52,7 +52,7 @@ cgroups_submit_one(char const *plugin_instance, char const *type_instance,
  * This callback reads the user/system CPU time for each cgroup.
  */
 static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
-                              void *user_data) {
+                              __attribute__((unused)) void *user_data) {
   char abs_path[PATH_MAX];
   struct stat statbuf;
   char buf[1024];
@@ -131,7 +131,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
  * read_cpuacct_procs callback on every folder it finds, such as "system".
  */
 static int read_cpuacct_root(const char *dirname, const char *filename,
-                             void *user_data) {
+                             __attribute__((unused)) void *user_data) {
   char abs_path[PATH_MAX];
   struct stat statbuf;
   int status;

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -43,7 +43,8 @@ static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static int old_files;
 
-static int conntrack_config(const char *key, const char *value) {
+static int conntrack_config(const char *key,
+                            __attribute__((unused)) const char *value) {
   if (strcmp(key, "OldFiles") == 0)
     old_files = 1;
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -670,7 +670,7 @@ int uc_get_names(char ***ret_names, cdtime_t **ret_times, size_t *ret_number) {
   return 0;
 } /* int uc_get_names */
 
-int uc_get_state(const data_set_t *ds, const value_list_t *vl) {
+int uc_get_state(const value_list_t *vl) {
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int ret = STATE_ERROR;
@@ -692,7 +692,7 @@ int uc_get_state(const data_set_t *ds, const value_list_t *vl) {
   return ret;
 } /* int uc_get_state */
 
-int uc_set_state(const data_set_t *ds, const value_list_t *vl, int state) {
+int uc_set_state(const value_list_t *vl, int state) {
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int ret = -1;
@@ -775,19 +775,7 @@ int uc_get_history_by_name(const char *name, gauge_t *ret_history,
   return 0;
 } /* int uc_get_history_by_name */
 
-int uc_get_history(const data_set_t *ds, const value_list_t *vl,
-                   gauge_t *ret_history, size_t num_steps, size_t num_ds) {
-  char name[6 * DATA_MAX_NAME_LEN];
-
-  if (FORMAT_VL(name, sizeof(name), vl) != 0) {
-    ERROR("utils_cache: uc_get_history: FORMAT_VL failed.");
-    return -1;
-  }
-
-  return uc_get_history_by_name(name, ret_history, num_steps, num_ds);
-} /* int uc_get_history */
-
-int uc_get_hits(const data_set_t *ds, const value_list_t *vl) {
+int uc_get_hits(const value_list_t *vl) {
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int ret = STATE_ERROR;
@@ -809,7 +797,7 @@ int uc_get_hits(const data_set_t *ds, const value_list_t *vl) {
   return ret;
 } /* int uc_get_hits */
 
-int uc_set_hits(const data_set_t *ds, const value_list_t *vl, int hits) {
+int uc_set_hits(const value_list_t *vl, int hits) {
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int ret = -1;
@@ -832,7 +820,7 @@ int uc_set_hits(const data_set_t *ds, const value_list_t *vl, int hits) {
   return ret;
 } /* int uc_set_hits */
 
-int uc_inc_hits(const data_set_t *ds, const value_list_t *vl, int step) {
+int uc_inc_hits(const value_list_t *vl, int step) {
   char name[6 * DATA_MAX_NAME_LEN];
   cache_entry_t *ce = NULL;
   int ret = -1;

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -50,16 +50,14 @@ value_t *uc_get_value(const data_set_t *ds, const value_list_t *vl);
 size_t uc_get_size(void);
 int uc_get_names(char ***ret_names, cdtime_t **ret_times, size_t *ret_number);
 
-int uc_get_state(const data_set_t *ds, const value_list_t *vl);
-int uc_set_state(const data_set_t *ds, const value_list_t *vl, int state);
-int uc_get_hits(const data_set_t *ds, const value_list_t *vl);
-int uc_set_hits(const data_set_t *ds, const value_list_t *vl, int hits);
-int uc_inc_hits(const data_set_t *ds, const value_list_t *vl, int step);
+int uc_get_state(const value_list_t *vl);
+int uc_set_state(const value_list_t *vl, int state);
+int uc_get_hits(const value_list_t *vl);
+int uc_set_hits(const value_list_t *vl, int hits);
+int uc_inc_hits(const value_list_t *vl, int step);
 
 int uc_set_callbacks_mask(const char *name, unsigned long callbacks_mask);
 
-int uc_get_history(const data_set_t *ds, const value_list_t *vl,
-                   gauge_t *ret_history, size_t num_steps, size_t num_ds);
 int uc_get_history_by_name(const char *name, gauge_t *ret_history,
                            size_t num_steps, size_t num_ds);
 

--- a/src/infiniband.c
+++ b/src/infiniband.c
@@ -118,7 +118,7 @@ static int ib_read_value_file_num_only(const char *device, const char *port,
   strstripnewline(buffer);
 
   // zero-out the first non-digit character
-  for (int i = 0; i < sizeof(buffer); i++) {
+  for (size_t i = 0; i < sizeof(buffer); i++) {
     if (!isdigit(buffer[i])) {
       buffer[i] = '\0';
       break;
@@ -327,7 +327,7 @@ static int infiniband_read(void) {
   char port_name[255];
 
   if (ib_glob_ports(&g) == 0) {
-    for (int i = 0; i < g.gl_pathc; ++i) {
+    for (unsigned i = 0; i < g.gl_pathc; ++i) {
       char *device = NULL, *port = NULL;
       if (ib_parse_glob_port(g.gl_pathv[i], &device, &port) == 0) {
         snprintf(port_name, sizeof(port_name), "%s:%s", device, port);

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -385,9 +385,11 @@ static int verify_sha256(void *payload, size_t payload_size,
   return !!ret;
 }
 #else /* !HAVE_GCRYPT_H */
-static int verify_sha256(void *payload, size_t payload_size,
-                         char const *username, char const *password,
-                         uint8_t hash_provided[32]) {
+static int verify_sha256(__attribute__((unused)) void *payload,
+                         __attribute__((unused)) size_t payload_size,
+                         __attribute__((unused)) char const *username,
+                         __attribute__((unused)) char const *password,
+                         __attribute__((unused)) uint8_t hash_provided[32]) {
   return ENOTSUP;
 }
 #endif
@@ -502,7 +504,9 @@ static int parse_encrypt_aes256(void *data, size_t data_size,
   return network_parse(b->data, b->len, ENCRYPT, opts);
 }
 #else /* !HAVE_GCRYPT_H */
-static int parse_encrypt_aes256(void *data, size_t data_size,
+static int parse_encrypt_aes256(__attribute__((unused)) void *data,
+                                __attribute__((unused)) size_t data_size,
+                                __attribute__((unused))
                                 lcc_network_parse_options_t const *opts) {
   return ENOTSUP;
 }

--- a/src/logparser.c
+++ b/src/logparser.c
@@ -401,7 +401,7 @@ static int logparser_validate_config(void) {
       return -1;
     }
 
-    for (int j = 0; j < parser->patterns_len; j++) {
+    for (unsigned j = 0; j < parser->patterns_len; j++) {
       message_pattern_t *pattern = parser->patterns + j;
 
       if (pattern->regex == NULL) {
@@ -562,7 +562,7 @@ static void logparser_process_msg(log_parser_t *parser, message_t *msg,
   if (parser->def_type_inst != NULL)
     sstrncpy(n.type_instance, parser->def_type_inst, sizeof(n.type_instance));
 
-  for (int i = 0; i < max_items; i++) {
+  for (unsigned i = 0; i < max_items; i++) {
     message_item_t *item = msg->message_items + i;
     if (!item->value[0])
       break;

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -283,7 +283,7 @@ static int redfish_preconfig(void) {
     goto error;
 
   /* Creating placeholder for queries */
-  ctx.queries = c_avl_create((void *)strcmp);
+  ctx.queries = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (ctx.services == NULL)
     goto free_services;
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -550,7 +550,7 @@ static int statsd_network_init(struct pollfd **ret_fds, /* {{{ */
   return 0;
 } /* }}} int statsd_network_init */
 
-static void *statsd_network_thread(void *args) /* {{{ */
+static void *statsd_network_thread(__attribute__((unused)) void *args) /* {{{ */
 {
   struct pollfd *fds = NULL;
   size_t fds_num = 0;

--- a/src/table.c
+++ b/src/table.c
@@ -392,7 +392,7 @@ static int tbl_result_dispatch(tbl_t *tbl, tbl_result_t *res, char **fields,
   return 0;
 } /* tbl_result_dispatch */
 
-static int tbl_parse_line(tbl_t *tbl, char *line, size_t len) {
+static int tbl_parse_line(tbl_t *tbl, char *line) {
   char *fields[tbl->max_colnum + 1];
   size_t i = 0;
 
@@ -438,7 +438,7 @@ static int tbl_read_table(tbl_t *tbl) {
       log_warn("Table %s: Truncated line: %s", tbl->file, buf);
     }
 
-    if (tbl_parse_line(tbl, buf, sizeof(buf)) != 0) {
+    if (tbl_parse_line(tbl, buf) != 0) {
       log_warn("Table %s: Failed to parse line: %s", tbl->file, buf);
       continue;
     }

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -289,22 +289,22 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
 
   /* Check if hits matched */
   if ((th->hits != 0)) {
-    int hits = uc_get_hits(ds, vl);
+    int hits = uc_get_hits(vl);
     /* STATE_OKAY resets hits unless PERSIST_OK flag is set. Hits resets if
      * threshold is hit. */
     if (((state == STATE_OKAY) && ((th->flags & UT_FLAG_PERSIST_OK) == 0)) ||
         (hits > th->hits)) {
       DEBUG("ut_report_state: reset uc_get_hits = 0");
-      uc_set_hits(ds, vl, 0); /* reset hit counter and notify */
+      uc_set_hits(vl, 0); /* reset hit counter and notify */
     } else {
       DEBUG("ut_report_state: th->hits = %d, uc_get_hits = %d", th->hits,
-            uc_get_hits(ds, vl));
-      (void)uc_inc_hits(ds, vl, 1); /* increase hit counter */
+            uc_get_hits(vl));
+      (void)uc_inc_hits(vl, 1); /* increase hit counter */
       return 0;
     }
   } /* end check hits */
 
-  state_old = uc_get_state(ds, vl);
+  state_old = uc_get_state(vl);
 
   /* If the state didn't change, report if `persistent' is specified. If the
    * state is `okay', then only report if `persist_ok` flag is set. */
@@ -319,7 +319,7 @@ static int ut_report_state(const data_set_t *ds, const value_list_t *vl,
   }
 
   if (state != state_old)
-    uc_set_state(ds, vl, state);
+    uc_set_state(vl, state);
 
   NOTIFICATION_INIT_VL(&n, vl);
 
@@ -476,7 +476,7 @@ static int ut_check_one_data_source(
   /* XXX: This is an experimental code, not optimized, not fast, not reliable,
    * and probably, do not work as you expect. Enjoy! :D */
   if (th->hysteresis > 0) {
-    prev_state = uc_get_state(ds, vl);
+    prev_state = uc_get_state(vl);
     /* The purpose of hysteresis is elliminating flapping state when the value
      * oscilates around the thresholds. In other words, what is important is
      * the previous state; if the new value would trigger a transition, make

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -180,7 +180,7 @@ static struct thread_data {
   unsigned int flags;
 #define CPU_IS_FIRST_THREAD_IN_CORE 0x2
 #define CPU_IS_FIRST_CORE_IN_PACKAGE 0x4
-} * thread_delta, *thread_even, *thread_odd;
+} *thread_delta, *thread_even, *thread_odd;
 
 static struct core_data {
   unsigned long long c3;
@@ -188,7 +188,7 @@ static struct core_data {
   unsigned long long c7;
   unsigned int core_temp_c;
   unsigned int core_id;
-} * core_delta, *core_even, *core_odd;
+} *core_delta, *core_even, *core_odd;
 
 static struct pkg_data {
   unsigned long long pc2;
@@ -209,7 +209,7 @@ static struct pkg_data {
   uint32_t uncore;
   unsigned int tcc_activation_temp;
   unsigned int pkg_temp_c;
-} * package_delta, *package_even, *package_odd;
+} *package_delta, *package_even, *package_odd;
 
 #define DELTA_COUNTERS thread_delta, core_delta, package_delta
 #define ODD_COUNTERS thread_odd, core_odd, package_odd
@@ -1464,9 +1464,9 @@ static void free_all_buffers(void) {
   package_delta = NULL;
 }
 
-  /**********************
-   * Collectd functions *
-   **********************/
+/**********************
+ * Collectd functions *
+ **********************/
 
 #define DO_OR_GOTO_ERR(something)                                              \
   do {                                                                         \

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -835,7 +835,8 @@ for_all_cpus_delta(const struct thread_data *thread_new_base,
  * Package Thermal Management Sensor (PTM), and thermal event thresholds.
  */
 static int __attribute__((warn_unused_result))
-set_temperature_target(struct thread_data *t, struct core_data *c,
+set_temperature_target(struct thread_data *t,
+                       __attribute__((unused)) struct core_data *c,
                        struct pkg_data *p) {
   unsigned long long msr;
   unsigned int target_c_local;

--- a/src/utils/format_json/format_json.c
+++ b/src/utils/format_json/format_json.c
@@ -605,11 +605,10 @@ static int format_alert(yajl_gen g, notification_t const *n) /* {{{ */
   CHECK_SUCCESS(yajl_gen_map_open(g)); /* BEGIN annotations */
 
   JSON_ADD(g, "severity");
-  JSON_ADD(g, (n->severity == NOTIF_FAILURE)
-                  ? "FAILURE"
-                  : (n->severity == NOTIF_WARNING)
-                        ? "WARNING"
-                        : (n->severity == NOTIF_OKAY) ? "OKAY" : "UNKNOWN");
+  JSON_ADD(g, (n->severity == NOTIF_FAILURE)   ? "FAILURE"
+              : (n->severity == NOTIF_WARNING) ? "WARNING"
+              : (n->severity == NOTIF_OKAY)    ? "OKAY"
+                                               : "UNKNOWN");
   JSON_ADD(g, "summary");
   JSON_ADD(g, n->message);
 

--- a/src/utils/format_json/format_json.c
+++ b/src/utils/format_json/format_json.c
@@ -708,8 +708,10 @@ int format_json_notification(char *buffer, size_t buffer_size, /* {{{ */
   return 0;
 } /* }}} format_json_notification */
 #else
-int format_json_notification(char *buffer, size_t buffer_size, /* {{{ */
-                             notification_t const *n) {
+int format_json_notification(__attribute__((unused)) char *buffer,
+                             __attribute__((unused))
+                             size_t buffer_size, /* {{{ */
+                             __attribute__((unused)) notification_t const *n) {
   ERROR("format_json_notification: Not available (requires libyajl).");
   return ENOTSUP;
 } /* }}} int format_json_notification */

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -493,13 +493,14 @@ sd_output_t *sd_output_create(sd_resource_t *res) /* {{{ */
     return NULL;
   }
 
-  out->staged = c_avl_create((void *)strcmp);
+  out->staged = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (out->staged == NULL) {
     sd_output_destroy(out);
     return NULL;
   }
 
-  out->metric_descriptors = c_avl_create((void *)strcmp);
+  out->metric_descriptors =
+      c_avl_create((int (*)(const void *, const void *))strcmp);
   if (out->metric_descriptors == NULL) {
     sd_output_destroy(out);
     return NULL;

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -179,7 +179,7 @@ static char *format_labels(char *buffer, size_t buffer_size,
   return buffer;
 }
 
-/* format_protobuf iterates over all metric families in "metrics" and adds them
+/* format_text iterates over all metric families in "metrics" and adds them
  * to a buffer in plain text format. */
 static void format_text(ProtobufCBuffer *buffer) {
   pthread_mutex_lock(&metrics_lock);
@@ -233,18 +233,20 @@ static void format_text(ProtobufCBuffer *buffer) {
 
 /* http_handler is the callback called by the microhttpd library. It essentially
  * handles all HTTP request aspects and creates an HTTP response. */
-static MHD_RESULT http_handler(void *cls, struct MHD_Connection *connection,
-                               const char *url, const char *method,
-                               const char *version, const char *upload_data,
-                               size_t *upload_data_size,
+static MHD_RESULT http_handler(__attribute__((unused)) void *cls,
+                               struct MHD_Connection *connection,
+                               __attribute__((unused)) const char *url,
+                               const char *method,
+                               __attribute__((unused)) const char *version,
+                               __attribute__((unused)) const char *upload_data,
+                               __attribute__((unused)) size_t *upload_data_size,
                                void **connection_state) {
   if (strcmp(method, MHD_HTTP_METHOD_GET) != 0) {
     return MHD_NO;
   }
 
-  /* On the first call for each connection, return without anything further.
-   * Apparently not everything has been initialized yet or so; the docs are not
-   * very specific on the issue. */
+  /* According to documentation, first call for each connection is after headers
+   * have been parsed, and should be used only for reporting errors */
   if (*connection_state == NULL) {
     /* keep track of connection state */
     *connection_state = &"called";

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -897,7 +897,7 @@ static int prom_config(oconfig_item_t *ci) {
 
 static int prom_init() {
   if (metrics == NULL) {
-    metrics = c_avl_create((void *)strcmp);
+    metrics = c_avl_create((int (*)(const void *, const void *))strcmp);
     if (metrics == NULL) {
       ERROR("write_prometheus plugin: c_avl_create() failed.");
       return -1;

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -83,16 +83,16 @@ static int ut_check_one_data_source(
           (!isnan(th->failure_max) &&
            ((th->failure_max - th->hysteresis) > values[ds_index])))
         return STATE_OKAY;
-      else
-        is_failure++;
+      is_failure++;
+      break;
     case STATE_WARNING:
       if ((!isnan(th->warning_min) &&
            ((th->warning_min + th->hysteresis) < values[ds_index])) ||
           (!isnan(th->warning_max) &&
            ((th->warning_max - th->hysteresis) > values[ds_index])))
         return STATE_OKAY;
-      else
-        is_warning++;
+      is_warning++;
+      break;
     }
   } else { /* no hysteresis */
     if ((!isnan(th->failure_min) && (th->failure_min > values[ds_index])) ||

--- a/src/write_riemann_threshold.c
+++ b/src/write_riemann_threshold.c
@@ -73,7 +73,7 @@ static int ut_check_one_data_source(
 
   /* XXX: This is an experimental code, not optimized, not fast, not reliable,
    * and probably, do not work as you expect. Enjoy! :D */
-  prev_state = uc_get_state(ds, vl);
+  prev_state = uc_get_state(vl);
   if ((th->hysteresis > 0) && (prev_state != STATE_OKAY) &&
       (prev_state != STATE_UNKNOWN)) {
     switch (prev_state) {

--- a/src/write_syslog.c
+++ b/src/write_syslog.c
@@ -373,7 +373,7 @@ static int ws_format_values(char *ret, size_t ret_len, int ds_num,
 }
 
 static int ws_format_name(char *ret, int ret_len, const value_list_t *vl,
-                          const struct ws_callback *cb, const char *ds_name) {
+                          const char *ds_name) {
 
   if (ds_name != NULL) {
     snprintf(ret, ret_len, "%s.%s", vl->type, ds_name);
@@ -509,7 +509,7 @@ static int ws_write_messages(const data_set_t *ds, const value_list_t *vl,
       ds_name = ds->ds[i].name;
 
     /* Copy the identifier to 'key' and escape it. */
-    status = ws_format_name(key, sizeof(key), vl, cb, ds_name);
+    status = ws_format_name(key, sizeof(key), vl, ds_name);
     if (status != 0) {
       ERROR("write_syslog plugin: error with format_name");
       return status;

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -366,7 +366,7 @@ static int wt_format_values(char *ret, size_t ret_len, int ds_num,
 }
 
 static int wt_format_name(char *ret, int ret_len, const value_list_t *vl,
-                          const struct wt_callback *cb, const char *ds_name) {
+                          const char *ds_name) {
   int status;
   char *temp = NULL;
   const char *prefix = "";
@@ -527,7 +527,7 @@ static int wt_write_messages(const data_set_t *ds, const value_list_t *vl,
       ds_name = ds->ds[i].name;
 
     /* Copy the identifier to 'key' and escape it. */
-    status = wt_format_name(key, sizeof(key), vl, cb, ds_name);
+    status = wt_format_name(key, sizeof(key), vl, ds_name);
     if (status != 0) {
       ERROR("write_tsdb plugin: error with format_name");
       return status;


### PR DESCRIPTION
ChangeLog: Build: Fix some gcc warnings with more strict checks

Fixes are based on "-O3 -Werror -Wall -Wextra -Wformat-security" output:
* Properly initialize complex struct
* Tell compiler which args are expected to be unused with attributes
* Correct write_prometheus comments and use arg more like specified in MHD doc

Somebody may want to do similar thing for rest of collectd code, but I was interested only about core & write_prometheus plugin.

This is collected "main" (v5) branch version of (already merged) v6 PR: https://github.com/collectd/collectd/pull/3970

EDIT: added link to collectd v6 PR + dropped resolved comment about stuff discussed below.