### PR TITLE
bug#3924 fix

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -1090,8 +1090,8 @@ static int ovs_stats_del_interface(const char *uuid) {
   interface_list_t *prev_iface = NULL;
 
   for (interface_list_t *iface = port->iface; iface != NULL;
-       iface = port->iface) {
-    if (strncmp(iface->iface_uuid, uuid, strlen(iface->iface_uuid))) {
+       iface = iface->next) {
+    if (!strncmp(iface->iface_uuid, uuid, strlen(iface->iface_uuid))) {
 
       interface_list_t *del = iface;
 


### PR DESCRIPTION
ChangeLog: ovs_stats plugin: This commit fixes plugin failure while performing the port deletion, which occurs due to wrong incremental condition and if condition.