### PR TITLE
External ids buffer

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -292,6 +292,7 @@ char *add_new_str(char sub_str[], char val[], char *add_str) {
 
 static void ovs_stats_submit_interfaces(port_list_t *port) {
   char devname[PORT_NAME_SIZE_MAX * 2];
+
   char add_str[UUID_SIZE] = {0};
   char vm_id[UUID_SIZE] = {0};
   char iface_id[UUID_SIZE];
@@ -674,6 +675,7 @@ static port_list_t *ovs_stats_new_port(bridge_list_t *bridge,
   }
   return port;
 }
+
 /* Get bridge by name*/
 static bridge_list_t *ovs_stats_get_bridge(bridge_list_t *head,
                                            const char *name) {


### PR DESCRIPTION
ChangeLog: ovs_stas plugin:These changes will enhance the feature of receiving the data in buffer.

By  including "ExternalIds true"   as a New Config parameter all the external ids will be populated in the buffer
O/P:  ovs_stats="vmId=3979a0b0-bddc-4cdd-ae87-0a4c2071d1f9,ifaceId=7e0607f6-9179-4852-aa36-b56279c3310,mac=fa:16:3e:18:a1:ff",instance=""}

which can provide the visibility of external ids if exists.