### PR TITLE
Redfish plugin: complete rework and enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,9 @@ bindings/perl/pm_to_blib
 # lint stuff
 *.ln
 
-#ide stuff
+# IDE stuff:
 .vscode
+.ycm_extra_conf.py
 
 # cscope stuff
 cscope.*

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1495,6 +1495,72 @@
 #	DB_Path "/var/lib/rasdaemon/ras-mc_event.db"
 #</Plugin>
 
+#<Plugin redfish>
+#  <Service "mock1U">
+#    Host "localhost:10000"
+#    User ""
+#    Passwd ""
+#    Queries "thermal" "voltages" "temperatures" "ps1_voltage" "storage"
+#  </Service>
+#  <Query "thermal">
+#    Endpoint "/Chassis[0]/Thermal"
+#    <Resource "Fans">
+#      <Property "Reading">
+#        PluginInstance "Fans"
+#        Type "fanspeed"
+#        TypeInstanceAttr "Name"
+#        SelectIDs 1
+#      </Property>
+#    </Resource>
+#    <Resource "Temperatures">
+#      <Property "ReadingCelsius">
+#        PluginInstance "Temperatures"
+#        Type "temperature"
+#        SelectAttrValue "PhysicalContext" "Intake"
+#      </Property>
+#    </Resource>
+#  </Query>
+#  <Query "voltages">
+#    Endpoint "/Chassis[0]/Power"
+#    <Resource "Voltages">
+#      <Property "ReadingVolts">
+#        PluginInstance "Voltages"
+#        Type "voltage"
+#        TypeInstance "VRM"
+#        TypeInstancePrefixID true
+#      </Property>
+#    </Resource>
+#  </Query>
+#  <Query "temperatures">
+#    Endpoint "/Chassis[0]/ThermalSubsystem/ThermalMetrics"
+#    <Resource "TemperatureReadingsCelsius">
+#      <Property "Reading">
+#        PluginInstance "Temperatures"
+#        Type "temperature"
+#        TypeInstanceAttr "DeviceName"
+#      </Property>
+#    </Resource>
+#  </Query>
+#  <Query "ps1_voltage">
+#    Endpoint "/Chassis[0]/Sensors[15]"
+#    <Attribute "Reading">
+#      PluginInstance "Voltages"
+#      Type "voltage"
+#      TypeInstance "PS1 Voltage"
+#    </Attribute>
+#  </Query>
+#  <Query "storage">
+#    Endpoint "/Systems[0]/SimpleStorage[0]"
+#      <Resource "Devices">
+#        <Property "CapacityBytes">
+#          PluginInstance "Storage"
+#          Type "capacity"
+#          SelectAttrs "Model" "Name"
+#        </Property>
+#    </Resource>
+#  </Query>
+#</Plugin>
+
 #<Plugin redis>
 #   <Node example>
 #      Host "redis.example.com"
@@ -1509,42 +1575,6 @@
 #   </Node>
 #</Plugin>
 
-#<Plugin redfish>
-#  <Query "fans">
-#    Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
-#    <Resource "Fans">
-#      <Property "ReadingRPM">
-#        PluginInstance "chassis-1"
-#        Type "rpm"
-#      </Property>
-#    </Resource>
-#  </Query>
-#  <Query "temperatures">
-#    Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
-#    <Resource "Temperatures">
-#      <Property "ReadingCelsius">
-#        PluginInstance "chassis-1"
-#        Type "degrees"
-#      </Property>
-#    </Resource>
-#  </Query>
-#  <Query "voltages">
-#    Endpoint "/redfish/v1/Chassis/Chassis-1/Power"
-#    <Resource "Voltages">
-#      <Property "ReadingVolts">
-#        PluginInstance "chassis-1"
-#        Type "volts"
-#      </Property>
-#    </Resource>
-#  </Query>
-#  <Service "local">
-#    Host "127.0.0.1:5000"
-#    User "user"
-#    Passwd "passwd"
-#    Queries "fans" "voltages" "temperatures"
-#  </Service>
-#</Plugin>
-#
 
 #<Plugin routeros>
 #	<Router>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8221,94 +8221,400 @@ permissions to this database. Example and default setting:
 
 =head2 Plugin C<redfish>
 
-The C<redfish> plugin collects sensor data using REST protocol called
-Redfish.
+The C<redfish> plugin was designed to collect data and metrics exposed by a
+Redfish interface, which implements a structured REST API specified by the
+L<DMTF|https://www.dmtf.org/standards/redfish>.
 
-B<Sample configuration:>
+B<Example of a Redfish resource>
+
+The following example of a resource exposed by a Redfish interface stems from
+a mockup of a simple rack-mounted server, provided by DMTF (available
+L<here|https://redfish.dmtf.org/redfish/mockups/v1/1100>). The latter can be
+emulated on any host system capable of running C<Python-3.5+> thanks to 
+C<Redfish-Interface-Emulator>, which is available on 
+L<GitHub|https://github.com/DMTF/Redfish-Interface-Emulator>.
+
+  {
+    "@odata.type": "#ThermalMetrics.v1_0_0.ThermalMetrics",
+    "Id": "ThermalMetrics",
+    "Name": "Chassis Thermal Metrics",
+    "TemperatureSummaryCelsius": {
+      "Internal": {
+        "Reading": 39,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/CPU1Temp"
+      },
+      "Intake": {
+        "Reading": 24.8,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp"
+      },
+      "Ambient": {
+        "Reading": 22.5,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/AmbientTemp"
+      },
+      "Exhaust": {
+        "Reading": 40.5,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp"
+      }
+    },
+    "TemperatureReadingsCelsius": [
+      {
+        "Reading": 24.8,
+        "DeviceName": "Intake",
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp"
+      },
+      {
+        "Reading": 40.5,
+        "DeviceName": "Exhaust",
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp"
+      }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/ThermalMetrics",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+  }
+
+B<Sample plugin configuration>
+
+The following sample configuration was designed to collect several metrics
+through the hereinabove Redfish interface mockup of a simple rack-mounted
+server.
 
   <Plugin redfish>
-    <Query "fans">
-      Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
+    <Service "mock1U">
+      Host "localhost:10000"
+      User ""
+      Passwd ""
+      Queries "thermal" "voltages" "temperatures" "ps1_voltage" "storage"
+    </Service>
+    <Query "thermal">
+      Endpoint "/Chassis[0]/Thermal"
       <Resource "Fans">
-        <Property "ReadingRPM">
-          PluginInstance "chassis-1"
-          Type "rpm"
+        <Property "Reading">
+          PluginInstance "Fans"
+          Type "fanspeed"
+          TypeInstanceAttr "Name"
+          SelectIDs 1
         </Property>
       </Resource>
-    </Query>
-    <Query "temperatures">
-      Endpoint "/redfish/v1/Chassis/Chassis-1/Thermal"
       <Resource "Temperatures">
         <Property "ReadingCelsius">
-          PluginInstance "chassis-1"
-          Type "degrees"
+          PluginInstance "Temperatures"
+          Type "temperature"
+          SelectAttrValue "PhysicalContext" "Intake"
         </Property>
       </Resource>
     </Query>
     <Query "voltages">
-      Endpoint "/redfish/v1/Chassis/Chassis-1/Power"
+      Endpoint "/Chassis[0]/Power"
       <Resource "Voltages">
         <Property "ReadingVolts">
-          PluginInstance "chassis-1"
-          Type "volts"
+          PluginInstance "Voltages"
+          Type "voltage"
+          TypeInstance "VRM"
+          TypeInstancePrefixID true
         </Property>
       </Resource>
     </Query>
-    <Service "local">
-      Host "127.0.0.1:5000"
-      User "user"
-      Passwd "passwd"
-      Queries "fans" "voltages" "temperatures"
-    </Service>
+    <Query "temperatures">
+      Endpoint "/Chassis[0]/ThermalSubsystem/ThermalMetrics"
+      <Resource "TemperatureReadingsCelsius">
+        <Property "Reading">
+          PluginInstance "Temperatures"
+          Type "temperature"
+          TypeInstanceAttr "DeviceName"
+        </Property>
+      </Resource>
+    </Query>
+    <Query "ps1_voltage">
+      Endpoint "/Chassis[0]/Sensors[15]"
+      <Attribute "Reading">
+        PluginInstance "Voltages"
+        Type "voltage"
+        TypeInstance "PS1 Voltage"
+      </Attribute>
+    </Query>
+    <Query "storage">
+      Endpoint "/Systems[0]/SimpleStorage[0]"
+        <Resource "Devices">
+          <Property "CapacityBytes">
+            PluginInstance "Storage"
+            Type "capacity"
+            SelectAttrs "Model" "Name"
+          </Property>
+      </Resource>
+    </Query>
   </Plugin>
+
+=over 2
+
+=item B<Service> <string>
+
+A B<Service> groups the information associated with a host exhibiting a Redfish
+interface to query. Each declared B<Service> should be identified by a unique
+key (here C<"mock1U">).
+
+If a B<User> field is specified, a B<Passwd> field must be specified too.
+
+Either a B<User> field or a B<Token> field must be specified.
+
+Several services can be specified. If there is none, nothing will be collected.
 
 =over 4
 
-=item B<Query>
+=item B<Host> <string> [REQUIRED]
 
-Section defining a query performed on Redfish interface
+B<Host> is the FQDN of the node exhibiting a Redfish interface to query.
 
-=item B<Endpoint>
+=item B<User> <string> [REQUIRED/OPTIONAL]
 
-URI of the REST API Endpoint for accessing the BMC
+B<User> is the username of an account with appropriate privileges to submit the
+intended queries to the concerned Redfish interface. If there is no need for
+credentials to submit the intended queries, C<""> can be used.
 
-=item B<Resource>
+=item B<Passwd> <string> [REQUIRED/OPTIONAL]
 
-Selects single resource or array to collect data.
+B<Passwd> is the password of an account with appropriate privileges to submit
+the intended queries to the concerned Redfish interface. If there is no need for
+credentials to submit the intended queries, C<""> can be used.
 
-=item B<Property>
+=item B<Token> <string> [REQUIRED/OPTIONAL]
 
-Selects property from which data is gathered
+B<Token> is the C<X-Auth> token associated with a session opened on the target
+Redfish interface.
 
-=item B<PluginInstance>
+=item B<Queries> <list of strings> [REQUIRED]
 
-Plugin instance of dispatched collectd metric
-
-=item B<Type>
-
-Type of dispatched collectd metric
-
-=item B<TypeInstance>
-
-Type instance of collectd metric
-
-=item B<Service>
-
-Section defining service to be sent requests
-
-=item B<Username>
-
-BMC username
-
-=item B<Password>
-
-BMC password
-
-=item B<Queries>
-
-Queries to run
+B<Queries> should contain the space-separated list of unique keys associated
+with the queries to be submitted to the concerned Redfish interface.
 
 =back
+
+=item B<Query> <string>
+
+A B<Query> is identified by a unique key (e.g. C<"thermal"> for the first query
+of the sample configuration), and groups B<Resource> and B<Attribute> objects
+associated with a given endpoint.
+
+A B<Query> is shared by all the services.
+
+For each query specified in the B<Queries> field of a B<Service>, there must be
+a matching B<Query>.
+
+=over 4
+
+=item B<Endpoint> <string>
+
+An B<Endpoint> is a partial URI designated one specific resource exposed by the
+Redfish interface to query.
+
+This URI is qualified as "partial" since the root path of every resource exposed
+by a Redfish interface (namely C</redfish/v1> for the first version of the
+protocol) should be omitted.
+
+On top of that, this URI must be formatted according to the
+L<C<XPath>|https://www.w3.org/TR/xpath-31/> specifications.
+
+As a result, for instance, to access the first member of the named collection
+C<Chassis> exposed by the root of the Redfish service, the proper URI is
+C</Chassis[0]>.
+
+=item B<Attribute> <string>
+
+An B<Attribute> represents one attribute of a resource exposed by a Redfish
+interface. For instance, in the initial example, C<Name> and
+C<@Redfish.Copyright> are attributes.
+
+The complete path to the collection in which the collected metric is inserted is
+C<ServiceKey/PluginName-PluginInstance/Type-TypeInstance>.
+
+=over 6
+
+=item B<PluginInstance> <string> [REQUIRED]
+
+Name of the instance of the plugin C<redfish> in which the collected metric
+represented by the considered B<Attribute> should be stored.
+
+=item B<Type> <string> [REQUIRED]
+
+A valid C<collectd> type to use as when submitting the result of the query
+See L<types.db(5)> for additional details on types.
+
+=item B<TypeInstance> <string> [REQUIRED]
+
+Name of the instance of the type in which the collected metric represented by
+the considered B<Attribute> should be stored.
+
+=back
+
+=item B<Resource> <string>
+
+A B<Resource> represents one composite object or an anonymous collection of a
+resource exposed by a Redfish interface. For instance, in the initial example,
+C<TemperatureSummaryCelsius> is a composite object, and
+C<TemperatureReadingsCelsius> is an anonymous collection.
+
+A B<Resource> should contain at least one B<Property>, but possibly more than
+one, just as the C<thermal> query of the sample configuration files shows it.
+
+=over 6
+
+=item B<Property> <string>
+
+A B<Property> represents one property of a composite object or of a member of an
+anonymous collection which should value should be collected as a metric. For
+instance, in the initial example, C<Reading> is a property of the members of
+the anonymous collection C<TemperatureReadingsCelsius>.
+
+Among the below possible fields of a B<Property>, those marked as belonging to
+[GROUP 1] are related to the definition of the type instance associated with the
+generated metric. If the B<Property> contains a B<TypeInstance> field, the value
+of the latter is used as type instance. Otherwise, if it contains a
+B<TypeInstanceAttr> field, the value of the property it designates is used as 
+type instance (e.g. in the sample configuration file, for the query
+C<temperature>, the type instance of the metric associated to a member of the
+anonymous collection C<TemperatureReadingsCelsius> is the value of its
+C<DeviceName> property, hence "Intake" for the first member). Lastly, if a
+B<Property> does not have neither a B<TypeInstance> field nor a
+B<TypeInstanceAttr> field, its default behaviour is to "add" a
+B<TypeInstanceAttr> field which value is "Name". Consequently, if the considered
+composite object or the members of the considered anonymous collection do not
+exhibit a property named "Name", the associated B<Property> must contain at
+least one of the two fields B<TypeInstance> and B<TypeInstanceAttr>.
+
+The complete path to the collection in which the collected metric is inserted is
+C<ServiceKey/PluginName-PluginInstance/Type-(ID-)TypeInstance>.
+
+=over 8
+
+=item B<PluginInstance> <string> [REQUIRED]
+
+Name of the instance of the plugin C<redfish> in which the collected metric
+represented by the considered B<Property> should be stored.
+
+=item B<Type> <string> [REQUIRED]
+
+A valid C<collectd> type to use as when submitting the result of the query. See
+L<types.db(5)> for additional details on types.
+
+=item B<TypeInstance> <string> [GROUP 1]
+
+Name of the instance of the type in which the collected metric represented by
+the considered B<Property> should be stored.
+
+=item B<TypeInstanceAttr> <string> [GROUP 1]
+
+Name of the property of the considered composite object or anonymous collection
+which value should be used as type instance.
+
+=item B<TypeInstancePrefixID> <boolean> [OPTIONAL]
+
+If the "item" associated with the B<Property> is an anonymous collection,
+setting this field to C<true> means that the type instance of each member of the
+aforementioned anonymous collection should be prefixed by the ID of the
+considered member in the collection. Note that the IDs start at 0.
+
+If the "item" associated with the B<Property> is a composite object, this field
+is ignored.
+
+=item B<SelectIDs> <list of unsigned integers> [OPTIONAL]
+
+If the "item" associated with the B<Property> is an anonymous collection,
+only the members which IDs belong to the specified list are selected. Note that
+the IDs start at 0, and are the same as those inserted by
+B<TypeInstancePrefixID> in the type instance.
+
+If the "item" associated with the B<Property> is a composite object, this field
+is ignored.
+
+=item B<SelectAttrs> <list of strings> [OPTIONAL]
+
+If the "item" associated with the B<Property> is an anonymous collection,
+only the members which exhibit attributes which names belong to the specified
+list are selected. In other words, this field makes it possible to select
+members of anonymous collections based on a set of attributes they must have.
+
+If the "item" associated with the B<Property> is a composite object, this field
+is ignored.
+
+=item B<SelectAttrValue> <two strings: key value> [OPTIONAL]
+
+If the "item" associated with the B<Property> is an anonymous collection, only
+the members which exhibit an attribute which name is C<key> and value is
+C<value>. In other words, this field makes it possible to select members of
+anonymous collections based on the fact that they have a specific attribute,
+which is equal to a specific value. Note that it is possible to specify several
+B<SelectAttrValue> fields so as to base the member selection on several
+attributes.
+
+If the "item" associated with the B<Property> is a composite object, this field
+is ignored.
+
+=back
+
+=back
+
+=back
+
+=back
+
+B<How to compile and test the C<redfish> plugin>
+
+Hereinbelow, the dependency tree associated with the C<redfish> plugin, and its
+tests:
+
+=encoding utf-8
+
+  plugin_redfish
+  |-> (collectd internals)
+  |-> libredfish
+      |-> libcurl
+      |-> libczmq
+      |   |-> libzmq
+      |-> libjansson
+      |-> libreadline
+
+  test_plugin_redfish
+  |-> (collectd internals)
+  |-> libjansson
+  |-> libredfish
+      |-> libcurl
+      |-> libczmq
+      |   |-> libzmq
+      |-> libjansson
+      |-> libreadline
+
+In order to enable the build of the C<redfish> plugin, the C<--enable-redfish>
+switch has to be specified to the C<configure> script. Note that the optional
+switch C<--with-redfish> makes it possible to specify the installation path of
+the C<libredfish> library, and that the optional switch C<--enable-debug> makes
+it possible to enable the debug mode, which is "forwarded" to the C<libredfish>.
+
+The tests associated with the C<redfish> plugin can be compiled thanks to the
+C<Makefile>, and then executed:
+
+  make test_plugin_redfish
+  ./test_plugin_redfish
+
+If C<collectd> was compiled in debug mode, it is possible to enable the printing
+of the configuration file used by the tests by defining the preprocessing
+variable C<REDFISH_TEST_PRINT_CONFIG>:
+
+  make CPPFLAGS="-DREDFISH_TEST_PRINT_CONFIG" test_plugin_redfish
+
+B<Limitations>
+
+Currently, the C<redfish> plugin suffers from two main limitations.
+
+Firstly, the Redfish resources pointed at by B<Resource> and B<Property> objects
+must be terminal. As a result, it is for instance impossible to collect a metric
+which is an attribute of a composite object encapsulated in another composite
+object.
+
+Secondly, the Redfish requests are inserted in the job queue of a B<sole> worker
+thread, which is spawned at the initialisation of the plugin. By doing so, it is
+possible to execute the Redfish requests asynchronously. However, this might act
+as a bottleneck on performance when lots of equipments should be monitored
+concurrently.
 
 =head2 Plugin C<routeros>
 

--- a/src/liboconfig/oconfig.c
+++ b/src/liboconfig/oconfig.c
@@ -22,6 +22,7 @@
  *
  * Authors:
  *   Florian Forster <octo at collectd.org>
+ *   Mathieu Stoffel <mathieu.stoffel at atos.net>
  **/
 
 #include <assert.h>
@@ -29,6 +30,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "utils_llist.h"
 
 #include "oconfig.h"
 
@@ -195,3 +198,237 @@ void oconfig_free(oconfig_item_t *ci) {
   oconfig_free_all(ci);
   free(ci);
 }
+
+#if defined(COLLECT_DEBUG)
+/* Fills "indent_str" with "nb_spaces" space characters, for indentation
+ * purposes (plus the terminating null-character).
+ * No check neither on the number of spaces nor on the string specifics is
+ * performed: */
+static inline void generate_indent_str(char *indent_str,
+                                       const uint64_t nb_spaces) {
+  memset(indent_str, ' ', nb_spaces);
+  indent_str[nb_spaces] = '\0';
+}
+
+/*******/
+
+void oconfig_print_tree(const oconfig_item_t *const ci,
+                        const uint64_t indent_max_lvl,
+                        const uint64_t indent_in_spaces, FILE *io_stream) {
+  /**************************************************************************
+   * Checking that input parameters are compliant with pre-requisites:
+   **************************************************************************/
+  if (ci == NULL)
+    return;
+  if (io_stream == NULL)
+    return;
+
+  /**************************************************************************
+   * Structures:
+   **************************************************************************/
+  /* Encapsulates the address of the considered node which children are to be
+   * processed, together with the associated indentation level and the ID of
+   * the child to be processed: */
+  typedef struct node_info_t {
+    const oconfig_item_t *address;
+    uint64_t indent_lvl;
+    int child_id;
+  } node_info_t;
+
+  /**************************************************************************
+   * Variables:
+   **************************************************************************/
+  /* In order to keep track of the indent level while parsing the
+   * configuration tree: */
+  char *indent = NULL;
+  uint64_t indent_lvl = 0;
+
+  /* List used as a stack to store the descending exploring path within the
+   * configuration tree: */
+  llist_t *node_stack = NULL;
+
+  /* Pointer to be used to roam the configuration tree: */
+  const oconfig_item_t *config_roamer = ci;
+
+  /**************************************************************************
+   * Initialisation:
+   **************************************************************************/
+  /* Allocating "indent": */
+  indent = calloc(indent_max_lvl * indent_in_spaces + 1, sizeof(char));
+  /***/
+  if (indent == NULL)
+    goto lbl_oconfig_print_tree_cleanup;
+
+  /* Allocating "node_stack": */
+  node_stack = llist_create();
+  /***/
+  if (node_stack == NULL)
+    goto lbl_oconfig_print_tree_cleanup;
+
+  /**************************************************************************
+   * Core:
+   **************************************************************************/
+  /* Printing an header: */
+  fprintf(io_stream, "\n=======[ Start of configuration tree ]=======\n\n");
+
+  /* Roaming the configuration tree starting from its root: */
+  while (config_roamer != NULL) {
+    /* If the current line should be indented, generating the indentation
+     * string, and printing it: */
+    if (indent_lvl > 0) {
+      generate_indent_str(indent, indent_lvl * indent_in_spaces);
+      fprintf(io_stream, "%s", indent);
+    }
+
+    /* Printing the key of the currently considered node: */
+    fprintf(io_stream, "%s:", config_roamer->key);
+
+    /* Roaming all the values associated with the currently considered
+     * node: */
+    for (int i = 0; i < config_roamer->values_num; i++) {
+      /* Determining the type of the currently considered value, and
+       * printing it: */
+      switch (config_roamer->values[i].type) {
+      case OCONFIG_TYPE_NUMBER:
+        fprintf(io_stream, " %f", config_roamer->values[i].value.number);
+        break;
+
+      case OCONFIG_TYPE_BOOLEAN:
+        fprintf(io_stream, " %s",
+                (config_roamer->values[i].value.boolean ? "true" : "false"));
+        break;
+
+      /* The default case corresponds to the value being a string: */
+      default:
+        fprintf(io_stream, " %s", config_roamer->values[i].value.string);
+        break;
+      }
+    }
+
+    /* Newline character to end the printing of the currently considered
+     * node: */
+    fprintf(io_stream, "%s", "\n");
+
+    /* Determining which node is the next one to be considered.
+     *
+     * Branch (1)
+     * The configuration tree is roamed from top to bottom.
+     * After a node is processed, the subtrees of its children are processed
+     * in order.
+     * When going down the tree to handle the subtree associated with a
+     * child of the considered node, the latter is stored in a stack (i.e.
+     * "node_stack").
+     * By doing so, it is possible to process the subtrees of other chidren
+     * of the considered node once the considered subtree is processed.
+     *
+     * Branch (2)
+     * When the considered node does not have children, popping out of the
+     * stack the parent node to go back to.
+     * Its next child, and the associated subtree, then become the node and
+     * subtree to be processed.
+     *
+     * Branch(3)
+     * When the stack is empty, and the currently considered node does not
+     * have children, the whole tree was processed (i.e. terminaison
+     * criteria). */
+
+    /* Branch (1): */
+    if (config_roamer->children_num > 0) {
+      /* Allocating the structure in which the information associated with
+       * the considered parent node are to be stored.
+       * It is then appended to the stack: */
+      node_info_t *node_info = malloc(sizeof(*node_info));
+      if (node_info == NULL)
+        goto lbl_oconfig_print_tree_cleanup;
+      /***/
+      node_info->address = config_roamer;
+      node_info->indent_lvl = indent_lvl;
+      node_info->child_id = 0;
+      /***/
+      llentry_t *node_entry = llentry_create(NULL, node_info);
+      if (node_entry == NULL)
+        goto lbl_oconfig_print_tree_cleanup;
+      /***/
+      llist_append(node_stack, node_entry);
+
+      /* The next node to be considered is the first children of the
+       * considered node: */
+      config_roamer = &(config_roamer->children[0]);
+
+      /* Increasing the indentation level since we go deeper into the
+       * configuration tree, except if the maximum indentation level was
+       * reached: */
+      if (indent_lvl < indent_max_lvl)
+        indent_lvl++;
+    }
+    /* Branch (2): */
+    else if (llist_size(node_stack) > 0) {
+      /* The stack will be roamed to find a parent node which still has
+       * at least one child which subtree should be roamed.
+       * If none is found, the tree was completely roamed (which
+       * translates in "config_roamer" being set to "NULL": */
+      config_roamer = NULL;
+
+      /* Roaming all the stack until one parent node with a child which
+       * subtree should be roamed: */
+      do {
+        /* Analysing the node on top of the stack: */
+        llentry_t *node_entry = llist_tail(node_stack);
+        /***/
+        node_info_t *node_info = (node_info_t *)(node_entry->value);
+
+        /* Does the considered node still have at least one child to
+         * process? */
+        if (node_info->address->children_num > (node_info->child_id + 1)) {
+          /* The next node to process was found: */
+          config_roamer =
+              &(node_info->address->children[node_info->child_id + 1]);
+
+          /* Increasing the indentation level since we go deeper into
+           * the configuration tree, except if the maximum indentation
+           * level was reached: */
+          if (indent_lvl < indent_max_lvl) {
+            indent_lvl = node_info->indent_lvl + 1;
+          }
+
+          /* Next child to be considered: */
+          (node_info->child_id)++;
+
+          break;
+        } else {
+          /* Since all the children of the considered parent node were
+           * processed, it is no longer useful to keep it in the
+           * stack, hence popping and deallocating it: */
+          llist_remove(node_stack, node_entry);
+          if (node_entry->value != NULL)
+            free(node_entry->value);
+          llentry_destroy(node_entry);
+        }
+      } while (llist_size(node_stack) > 0);
+    }
+    /* Branch (3): */
+    else
+      config_roamer = NULL;
+  }
+
+  /* Printing a footer: */
+  fprintf(io_stream, "\n=======[ End of configuration tree ]=======\n\n");
+
+lbl_oconfig_print_tree_cleanup:
+  /* Deallocating "indent": */
+  if (indent != NULL)
+    free(indent);
+
+  /* Deallocating "node_stack": */
+  if (node_stack != NULL) {
+    /* Deallocating the content of each node: */
+    for (llentry_t *le = llist_head(node_stack); le != NULL; le = le->next) {
+      if (le->value != NULL)
+        free(le->value);
+    }
+
+    /* Deallocating the list itself: */
+    llist_destroy(node_stack);
+  }
+}
+#endif

--- a/src/liboconfig/oconfig.h
+++ b/src/liboconfig/oconfig.h
@@ -22,12 +22,22 @@
  *
  * Authors:
  *   Florian Forster <octo at collectd.org>
+ *   Mathieu Stoffel <mathieu.stoffel at atos.net>
  */
 
 #ifndef OCONFIG_H
 #define OCONFIG_H 1
 
+#include <stdint.h>
 #include <stdio.h>
+
+#include "config.h"
+
+/*
+ * Constants:
+ */
+#define OCONFIG_PRINT_TREE_INDENT_MAX_LVL (16)
+#define OCONFIG_PRINT_TREE_INDENT_IN_SPACES (4)
 
 /*
  * Types
@@ -66,5 +76,42 @@ oconfig_item_t *oconfig_parse_file(const char *file);
 oconfig_item_t *oconfig_clone(const oconfig_item_t *ci);
 
 void oconfig_free(oconfig_item_t *ci);
+
+#if defined(COLLECT_DEBUG)
+/*******
+ * Prints the configuration tree which root is supplied, onto the I/O stream
+ * which is specified.
+ * Two configuration variables are exposed to adapt the way the nodes of the
+ * configuration tree are indented when printed.
+ *
+ * Parameters:
+ * ===========
+ *  # ci:
+ *      Address of the root node of the configuration tree to be printed.
+ *
+ *  # indent_max_lvl:
+ *      Maximum level of indentation to be used when printing the configuration
+ *      tree.
+ *      For instance, if it is equal to 5, it means that each time the
+ *      configuration tree is roamed down, the indentation level is incremented.
+ *      Until it reaches 5 (starting at 0 for the root node), then all the nodes
+ *      which are deeper in the tree are indented with an indentation level of
+ *      5.
+ *
+ *  # indent_in_spaces:
+ *      Each indentation level is translated to an initial indendation of
+ *      "indent_in_spaces" space characters.
+ *
+ *  # fd:
+ *      The I/O stream in which the configuration tree should be printed.
+ *
+ * Pre-requisites:
+ * ###############
+ *  + rep_pattern->id only initialised field
+ */
+void oconfig_print_tree(const oconfig_item_t *const ci,
+                        const uint64_t indent_max_lvl,
+                        const uint64_t indent_in_spaces, FILE *fd);
+#endif
 
 #endif /* OCONFIG_H */

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -2,6 +2,7 @@
  * collectd - src/redfish.c
  *
  * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ * Copyright(c) 2021 Atos. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,11 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Authors:
- *   Marcin Mozejko <marcinx.mozejko@intel.com>
- *   Martin Kennelly <martin.kennelly@intel.com>
- *   Adrian Boczkowski <adrianx.boczkowski@intel.com>
+ * Original authors:
+ *      Marcin Mozejko <marcinx.mozejko@intel.com>
+ *      Martin Kennelly <martin.kennelly@intel.com>
+ *      Adrian Boczkowski <adrianx.boczkowski@intel.com>
+ *
+ * Refactoring and enhancement author:
+ *      Mathieu Stoffel <mathieu.stoffel@atos.net>
  **/
+#include <unistd.h>
 
 #include "collectd.h"
 
@@ -35,16 +40,52 @@
 #include "utils_llist.h"
 
 #include <redfish.h>
+
 #define PLUGIN_NAME "redfish"
 #define MAX_STR_LEN 128
+
+/* For the purpose of mocking the type/data source inference interface in the
+ * test framework: */
+#if defined(REDFISH_PLUGIN_TEST)
+static const data_set_t *
+redfish_test_plugin_get_ds_mock(const char *const type);
+#endif
+
+/* For the purpose of mocking the dispatching interface in the test
+ * framework: */
+#if defined(REDFISH_PLUGIN_TEST)
+static int redfish_test_plugin_dispatch_values_mock(value_list_t const *vl);
+#endif
+
+/******************************************************************************
+ * Data structures:
+ ******************************************************************************/
+struct redfish_attribute_s {
+  char *name;
+  char *plugin_inst;
+  char *type;
+  char *type_inst;
+};
+typedef struct redfish_attribute_s redfish_attribute_t;
+
+/*******/
 
 struct redfish_property_s {
   char *name;
   char *plugin_inst;
   char *type;
   char *type_inst;
+  char *type_inst_attr;
+  bool type_inst_prefix_id;
+  uint64_t *select_ids;
+  uint64_t nb_select_ids;
+  char **select_attrs;
+  uint64_t nb_select_attrs;
+  llist_t *select_attrvalues;
 };
 typedef struct redfish_property_s redfish_property_t;
+
+/*******/
 
 struct redfish_resource_s {
   char *name;
@@ -52,12 +93,17 @@ struct redfish_resource_s {
 };
 typedef struct redfish_resource_s redfish_resource_t;
 
+/*******/
+
 struct redfish_query_s {
   char *name;
   char *endpoint;
   llist_t *resources;
+  llist_t *attributes;
 };
 typedef struct redfish_query_s redfish_query_t;
+
+/*******/
 
 struct redfish_service_s {
   char *name;
@@ -74,28 +120,41 @@ struct redfish_service_s {
 };
 typedef struct redfish_service_s redfish_service_t;
 
+/*******/
+
 struct redfish_payload_ctx_s {
   redfish_service_t *service;
   redfish_query_t *query;
 };
 typedef struct redfish_payload_ctx_s redfish_payload_ctx_t;
 
+/*******/
+
 enum redfish_value_type_e { VAL_TYPE_STR = 0, VAL_TYPE_INT, VAL_TYPE_REAL };
 typedef enum redfish_value_type_e redfish_value_type_t;
 
+/*******/
+
 union redfish_value_u {
   double real;
-  int integer;
+  int64_t integer;
   char *string;
 };
 typedef union redfish_value_u redfish_value_t;
 
-typedef struct redfish_job_s {
+/*******/
+
+struct redfish_job_s {
   DEQ_LINKS(struct redfish_job_s);
   redfish_payload_ctx_t *service_query;
-} redfish_job_t;
+};
+typedef struct redfish_job_s redfish_job_t;
+
+/*******/
 
 DEQ_DECLARE(redfish_job_t, redfish_job_list_t);
+
+/*******/
 
 struct redfish_ctx_s {
   llist_t *services;
@@ -105,12 +164,19 @@ struct redfish_ctx_s {
 };
 typedef struct redfish_ctx_s redfish_ctx_t;
 
-/* Globals */
+/******************************************************************************
+ * Global variables:
+ ******************************************************************************/
 static redfish_ctx_t ctx;
 
+/******************************************************************************
+ * Functions:
+ ******************************************************************************/
 static int redfish_cleanup(void);
 static int redfish_validate_config(void);
-static void *redfish_worker_thread(void __attribute__((unused)) * args);
+static void *redfish_worker_thread(void *__attribute__((unused)) args);
+
+/*******/
 
 #if COLLECT_DEBUG
 /* Hook exposed by the libredfish library to define a printing function
@@ -118,8 +184,10 @@ static void *redfish_worker_thread(void __attribute__((unused)) * args);
 extern libRedfishDebugFunc gDebugFunc;
 
 static void redfish_print_config(void) {
-  DEBUG(PLUGIN_NAME ": ====================CONFIGURATION====================");
+  DEBUG(PLUGIN_NAME ": "
+                    "====================CONFIGURATION====================");
   DEBUG(PLUGIN_NAME ": SERVICES: %d", llist_size(ctx.services));
+
   for (llentry_t *le = llist_head(ctx.services); le != NULL; le = le->next) {
     redfish_service_t *s = (redfish_service_t *)le->value;
     char queries_str[MAX_STR_LEN];
@@ -133,14 +201,17 @@ static void redfish_print_config(void) {
     if (s->user && s->passwd) {
       DEBUG(PLUGIN_NAME ":   User: %s", s->user);
       DEBUG(PLUGIN_NAME ":   Passwd: %s", s->passwd);
-    } else if (s->token)
+    } else if (s->token) {
       DEBUG(PLUGIN_NAME ":   Token: %s", s->token);
+    }
 
-    DEBUG(PLUGIN_NAME ":   Queries[%" PRIsz "]: (%s)", s->queries_num,
-          queries_str);
+    DEBUG(PLUGIN_NAME ": "
+                      "Queries[%" PRIsz "]: (%s)",
+          s->queries_num, queries_str);
   }
 
-  DEBUG(PLUGIN_NAME ": =====================================================");
+  DEBUG(PLUGIN_NAME ": "
+                    "=====================================================");
 
   c_avl_iterator_t *i = c_avl_get_iterator(ctx.queries);
   char *key;
@@ -148,37 +219,94 @@ static void redfish_print_config(void) {
 
   DEBUG(PLUGIN_NAME ": QUERIES: %d", c_avl_size(ctx.queries));
 
-  while (c_avl_iterator_next(i, (void *)&key, (void *)&q) == 0) {
+  while (c_avl_iterator_next(i, (void *)(&key), (void *)(&q)) == 0) {
     DEBUG(PLUGIN_NAME ": --------------------");
     DEBUG(PLUGIN_NAME ": Query: %s", q->name);
     DEBUG(PLUGIN_NAME ":   Endpoint: %s", q->endpoint);
+
     for (llentry_t *le = llist_head(q->resources); le != NULL; le = le->next) {
       redfish_resource_t *r = (redfish_resource_t *)le->value;
+
       DEBUG(PLUGIN_NAME ":   Resource: %s", r->name);
+
       for (llentry_t *le = llist_head(r->properties); le != NULL;
            le = le->next) {
         redfish_property_t *p = (redfish_property_t *)le->value;
         DEBUG(PLUGIN_NAME ":     Property: %s", p->name);
+
         DEBUG(PLUGIN_NAME ":       PluginInstance: %s", p->plugin_inst);
         DEBUG(PLUGIN_NAME ":       Type: %s", p->type);
-        DEBUG(PLUGIN_NAME ":       TypeInstance: %s", p->type_inst);
+
+        if (p->type_inst != NULL) {
+          DEBUG(PLUGIN_NAME ":       TypeInstance: %s", p->type_inst);
+        }
+
+        if (p->type_inst_attr != NULL) {
+          DEBUG(PLUGIN_NAME ":       "
+                            "TypeInstanceAttr: %s",
+                p->type_inst_attr);
+        }
+
+        DEBUG(PLUGIN_NAME ":       "
+                          "TypeInstancePrefixID: %s",
+              (p->type_inst_prefix_id ? "true" : "false"));
+
+        if (p->nb_select_ids > 0) {
+          DEBUG(PLUGIN_NAME ":       SelectIDs:");
+
+          for (uint64_t i = 0; i < p->nb_select_ids; i++) {
+            DEBUG(PLUGIN_NAME ":         -> %lu", p->select_ids[i]);
+          }
+        }
+
+        if (p->nb_select_attrs > 0) {
+          DEBUG(PLUGIN_NAME ":       SelectAttrs:");
+
+          for (uint64_t i = 0; i < p->nb_select_attrs; i++) {
+            DEBUG(PLUGIN_NAME ":         -> %s", p->select_attrs[i]);
+          }
+        }
+
+        if (llist_size(p->select_attrvalues) > 0) {
+          DEBUG(PLUGIN_NAME ":       SelectAttrValue:");
+
+          for (llentry_t *le = llist_head(p->select_attrvalues); le != NULL;
+               le = le->next) {
+            DEBUG(PLUGIN_NAME ":         -> %s = %s", le->key,
+                  (char *)(le->value));
+          }
+        }
       }
+    }
+
+    for (llentry_t *le = llist_head(q->attributes); le != NULL; le = le->next) {
+      redfish_attribute_t *attr = (redfish_attribute_t *)le->value;
+
+      DEBUG(PLUGIN_NAME ":   Attribute: %s", attr->name);
+
+      DEBUG(PLUGIN_NAME ":     PluginInstance: %s", attr->plugin_inst);
+      DEBUG(PLUGIN_NAME ":     Type: %s", attr->type);
+      DEBUG(PLUGIN_NAME ":     TypeInstance: %s", attr->type_inst);
     }
   }
 
   c_avl_iterator_destroy(i);
-  DEBUG(PLUGIN_NAME ": =====================================================");
+  DEBUG(PLUGIN_NAME ": "
+                    "=====================================================");
 }
 #endif
 
+/*******/
+
 static void redfish_service_destroy(redfish_service_t *service) {
   /* This is checked internally by cleanupServiceEnumerator() also,
-   * but as long as it's a third-party library let's be a little 'defensive' */
+   * but as long as it's a third-party library let's be a little
+   * 'defensive': */
   if (service->redfish != NULL)
     cleanupServiceEnumerator(service->redfish);
 
   /* Destroy all service members, sfree() as well as strarray_free()
-   * and llist_destroy() are safe to call on NULL argument */
+   * and llist_destroy() are safe to call on NULL argument: */
   sfree(service->name);
   sfree(service->host);
   sfree(service->user);
@@ -190,10 +318,18 @@ static void redfish_service_destroy(redfish_service_t *service) {
   sfree(service);
 }
 
-static void redfish_job_destroy(redfish_job_t *job) {
+/*******/
+
+#if defined(REDFISH_PLUGIN_TEST)
+__attribute__((unused))
+#endif
+static void
+redfish_job_destroy(redfish_job_t *job) {
   sfree(job->service_query);
   sfree(job);
 }
+
+/*******/
 
 static int redfish_init(void) {
 #if COLLECT_DEBUG
@@ -203,6 +339,7 @@ static int redfish_init(void) {
 
   redfish_print_config();
 #endif
+
   int ret = redfish_validate_config();
 
   if (ret != 0) {
@@ -220,10 +357,11 @@ static int redfish_init(void) {
 
   for (llentry_t *le = llist_head(ctx.services); le != NULL; le = le->next) {
     redfish_service_t *service = (redfish_service_t *)le->value;
-    /* Ignore redfish version */
+
+    /* Ignore redfish version: */
     service->flags |= REDFISH_FLAG_SERVICE_NO_VERSION_DOC;
 
-    /* Preparing struct for authentication */
+    /* Preparing struct for authentication: */
     if (service->user && service->passwd) {
       service->auth.authCodes.userPass.username = service->user;
       service->auth.authCodes.userPass.password = service->passwd;
@@ -240,14 +378,18 @@ static int redfish_init(void) {
     }
 
     service->query_ptrs = llist_create();
+
     if (service->query_ptrs == NULL) {
-      ERROR(PLUGIN_NAME ": Failed to allocate memory for service query list");
+      ERROR(PLUGIN_NAME ": "
+                        "Failed to allocate memory for service query list");
+
       goto error;
     }
 
     /* Preparing query pointers list for every service */
     for (size_t i = 0; i < service->queries_num; i++) {
       redfish_query_t *ptr;
+
       if (c_avl_get(ctx.queries, (void *)service->queries[i], (void *)&ptr) !=
           0) {
         ERROR(PLUGIN_NAME ": Cannot find a service query in a context");
@@ -255,10 +397,12 @@ static int redfish_init(void) {
       }
 
       llentry_t *entry = llentry_create(ptr->name, ptr);
-      if (entry != NULL)
+
+      if (entry != NULL) {
         llist_append(service->query_ptrs, entry);
-      else {
-        ERROR(PLUGIN_NAME ": Failed to allocate memory for a query list entry");
+      } else {
+        ERROR(PLUGIN_NAME ": "
+                          "Failed to allocate memory for a query list entry");
         goto error;
       }
     }
@@ -267,22 +411,25 @@ static int redfish_init(void) {
   return 0;
 
 error:
-  /* Freeing libredfish resources & llists */
+  /* Freeing libredfish resources & llists: */
   for (llentry_t *le = llist_head(ctx.services); le != NULL; le = le->next) {
     redfish_service_t *service = (redfish_service_t *)le->value;
 
     redfish_service_destroy(service);
   }
+
   return -ENOMEM;
 }
 
+/*******/
+
 static int redfish_preconfig(void) {
-  /* Creating placeholder for services */
+  /* Creating placeholder for services: */
   ctx.services = llist_create();
   if (ctx.services == NULL)
     goto error;
 
-  /* Creating placeholder for queries */
+  /* Creating placeholder for queries: */
   ctx.queries = c_avl_create((void *)strcmp);
   if (ctx.services == NULL)
     goto free_services;
@@ -291,10 +438,13 @@ static int redfish_preconfig(void) {
 
 free_services:
   llist_destroy(ctx.services);
+
 error:
   ERROR(PLUGIN_NAME ": Failed to allocate memory for plugin context");
   return -ENOMEM;
 }
+
+/*******/
 
 static int redfish_config_property(redfish_resource_t *resource,
                                    oconfig_item_t *cfg_item) {
@@ -302,51 +452,168 @@ static int redfish_config_property(redfish_resource_t *resource,
   assert(cfg_item != NULL);
 
   redfish_property_t *property = calloc(1, sizeof(*property));
-
+  /***/
   if (property == NULL) {
     ERROR(PLUGIN_NAME ": Failed to allocate memory for property");
     return -ENOMEM;
   }
+  /***/
+  property->type_inst_prefix_id = false;
 
   int ret = cf_util_get_string(cfg_item, &property->name);
+
   if (ret != 0) {
-    ERROR(PLUGIN_NAME ": Could not get property argument in resource section "
-                      "named \"%s\"",
+    ERROR(PLUGIN_NAME
+          ": "
+          "Could not get property argument in resource section named \"%s\"",
           resource->name);
+
     ret = -EINVAL;
     goto free_all;
   }
 
   for (int i = 0; i < cfg_item->children_num; i++) {
     oconfig_item_t *opt = cfg_item->children + i;
-    if (strcasecmp("PluginInstance", opt->key) == 0)
-      ret = cf_util_get_string(opt, &property->plugin_inst);
-    else if (strcasecmp("Type", opt->key) == 0)
-      ret = cf_util_get_string(opt, &property->type);
-    else if (strcasecmp("TypeInstance", opt->key) == 0)
-      ret = cf_util_get_string(opt, &property->type_inst);
-    else {
-      ERROR(PLUGIN_NAME ": Invalid option \"%s\" in property \"%s\" "
-                        "in resource \"%s\"",
+
+    if (strcasecmp("PluginInstance", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(property->plugin_inst));
+    } else if (strcasecmp("Type", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(property->type));
+    } else if (strcasecmp("TypeInstance", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(property->type_inst));
+    } else if (strcasecmp("TypeInstanceAttr", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(property->type_inst_attr));
+    } else if (strcasecmp("TypeInstancePrefixID", opt->key) == 0) {
+      ret = cf_util_get_boolean(opt, &(property->type_inst_prefix_id));
+    } else if (strcasecmp("SelectIDs", opt->key) == 0) {
+      property->select_ids = calloc(opt->values_num, sizeof(uint64_t));
+      /***/
+      if (property->select_ids == NULL) {
+        ret = -ENOMEM;
+        goto free_all;
+      }
+
+      for (int j = 0; j < opt->values_num; j++) {
+        property->select_ids[j] = ((uint64_t)(opt->values[j].value.number));
+
+        (property->nb_select_ids)++;
+      }
+    } else if (strcasecmp("SelectAttrs", opt->key) == 0) {
+      for (int j = 0; j < opt->values_num; j++) {
+        strarray_add(&(property->select_attrs), &(property->nb_select_attrs),
+                     opt->values[j].value.string);
+      }
+
+      ret = (((uint64_t)(opt->values_num) == property->nb_select_attrs)
+                 ? 0
+                 : -ENOMEM);
+    } else if (strcasecmp("SelectAttrValue", opt->key) == 0) {
+      /* If required, allocating the array storing the attribute/value
+       * pairs for member selection: */
+      if (property->select_attrvalues == NULL) {
+        property->select_attrvalues = llist_create();
+        /***/
+        if (property->select_attrvalues == NULL) {
+          ERROR(PLUGIN_NAME ": "
+                            "Could not allocate memory for the name/value "
+                            "list associated\nwith property \"%s\" in resource "
+                            "\"%s\"",
+                property->name, resource->name);
+
+          ret = -ENOMEM;
+          goto free_all;
+        }
+      }
+
+      /* In order to get the attribute name and value: */
+      char *name = NULL;
+      char *value = NULL;
+
+      /* Getting the attribute name: */
+      name = strdup(opt->values[0].value.string);
+
+      if (name == NULL) {
+        ERROR(PLUGIN_NAME
+              ": "
+              "Could not parse the name of the name/value pair of an "
+              "array member selection associated\nwith property \"%s\" "
+              "in resource \"%s\"",
+              property->name, resource->name);
+
+        ret = -EINVAL;
+        goto free_all;
+      }
+
+      /* Getting the attribute value: */
+      value = strdup(opt->values[1].value.string);
+
+      if (value == NULL) {
+        ERROR(PLUGIN_NAME
+              ": "
+              "Could not parse the value of the name/value pair of an "
+              "array member selection associated\nwith property \"%s\" "
+              "in resource \"%s\"",
+              property->name, resource->name);
+
+        ret = -EINVAL;
+
+        sfree(name);
+
+        goto free_all;
+      }
+
+      /* Creating the entry associated with the considered name/value
+       * pair: */
+      llentry_t *entry_attrvalue = llentry_create(name, value);
+
+      if (entry_attrvalue == NULL) {
+        ERROR(PLUGIN_NAME
+              ": "
+              "Could not allocate memory for the list entry associated "
+              "with the name/value pair of\nan array member selection "
+              "associated\nwith property \"%s\" in resource \"%s\"",
+              property->name, resource->name);
+
+        ret = -ENOMEM;
+
+        sfree(name);
+        sfree(value);
+
+        goto free_all;
+      }
+
+      /* Appending the newly created entry to the list of name/value pairs
+       * associated with array member selection: */
+      llist_append(property->select_attrvalues, entry_attrvalue);
+    } else {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Invalid option \"%s\" in property \"%s\" in resource \"%s\"",
             opt->key, property->name, resource->name);
+
       ret = -EINVAL;
       goto free_all;
     }
 
     if (ret != 0) {
-      ERROR(PLUGIN_NAME ": Something went wrong going through attributes in "
-                        "property named \"%s\" in resource named \"%s\"",
+      ERROR(PLUGIN_NAME ": "
+                        "Something went wrong going through fields in property "
+                        "named \"%s\" in resource named \"%s\"",
             property->name, resource->name);
+
       goto free_all;
     }
   }
 
   llentry_t *entry = llentry_create(property->name, property);
+
   if (entry == NULL) {
     ERROR(PLUGIN_NAME ": Failed to allocate memory for property");
+
     ret = -ENOMEM;
     goto free_all;
   }
+
   llist_append(resource->properties, entry);
 
   return 0;
@@ -356,9 +623,27 @@ free_all:
   sfree(property->plugin_inst);
   sfree(property->type);
   sfree(property->type_inst);
+  sfree(property->type_inst_attr);
+  strarray_free(property->select_attrs, property->nb_select_attrs);
+  sfree(property->select_ids);
+
+  llentry_t *current = llist_head(property->select_attrvalues);
+  /***/
+  while (current != NULL) {
+    sfree(current->key);
+    sfree(current->value);
+
+    current = current->next;
+  }
+  /***/
+  llist_destroy(property->select_attrvalues);
+
   sfree(property);
+
   return ret;
 }
+
+/*******/
 
 static int redfish_config_resource(redfish_query_t *query,
                                    oconfig_item_t *cfg_item) {
@@ -375,43 +660,130 @@ static int redfish_config_resource(redfish_query_t *query,
   resource->properties = llist_create();
 
   if (resource->properties == NULL)
-    goto free_memory;
+    goto redfish_config_resource_free_memory;
 
   int ret = cf_util_get_string(cfg_item, &resource->name);
+
   if (ret != 0) {
     ERROR(PLUGIN_NAME ": Could not get resource name for query named \"%s\"",
           query->name);
-    goto free_memory;
+
+    goto redfish_config_resource_free_memory;
   }
+
   for (int i = 0; i < cfg_item->children_num; i++) {
     oconfig_item_t *opt = cfg_item->children + i;
     if (strcasecmp("Property", opt->key) != 0) {
-      WARNING(PLUGIN_NAME ": Invalid configuration option \"%s\".", opt->key);
+      WARNING(PLUGIN_NAME ": "
+                          "Invalid configuration option \"%s\".",
+              opt->key);
+
       continue;
     }
 
     ret = redfish_config_property(resource, opt);
 
-    if (ret != 0) {
-      goto free_memory;
-    }
+    if (ret != 0)
+      goto redfish_config_resource_free_memory;
   }
 
   llentry_t *entry = llentry_create(resource->name, resource);
   if (entry == NULL) {
-    ERROR(PLUGIN_NAME ": Failed to allocate memory for resource list entry");
-    goto free_memory;
+    ERROR(PLUGIN_NAME ": "
+                      "Failed to allocate memory for resource list entry");
+
+    goto redfish_config_resource_free_memory;
   }
+
   llist_append(query->resources, entry);
 
   return 0;
 
-free_memory:
+redfish_config_resource_free_memory:
   sfree(resource->name);
   llist_destroy(resource->properties);
   sfree(resource);
+
   return -1;
 }
+
+/*******/
+
+static int redfish_config_attribute(redfish_query_t *query,
+                                    oconfig_item_t *cfg_item) {
+  assert(query != NULL);
+  assert(cfg_item != NULL);
+
+  redfish_attribute_t *attr = calloc(1, sizeof(*attr));
+
+  if (attr == NULL) {
+    ERROR(PLUGIN_NAME ": Failed to allocate memory for a query attribute");
+    return -ENOMEM;
+  }
+
+  int ret = cf_util_get_string(cfg_item, &(attr->name));
+
+  if (ret != 0) {
+    ERROR(PLUGIN_NAME ": Could not get the name of an attribute for query "
+                      "named \"%s\"",
+          query->name);
+
+    goto redfish_config_attribute_free_memory;
+  }
+
+  for (int i = 0; i < cfg_item->children_num; i++) {
+    oconfig_item_t *opt = cfg_item->children + i;
+
+    if (strcasecmp("PluginInstance", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(attr->plugin_inst));
+    } else if (strcasecmp("Type", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(attr->type));
+    } else if (strcasecmp("TypeInstance", opt->key) == 0) {
+      ret = cf_util_get_string(opt, &(attr->type_inst));
+    } else {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Invalid field \"%s\" in attribute \"%s\" of query \"%s\"",
+            opt->key, attr->name, query->name);
+
+      ret = -EINVAL;
+      goto redfish_config_attribute_free_memory;
+    }
+
+    if (ret != 0) {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Something went wrong going through fields in attribute "
+            "named \"%s\" in query named \"%s\"",
+            attr->name, query->name);
+
+      goto redfish_config_attribute_free_memory;
+    }
+  }
+
+  llentry_t *entry = llentry_create(attr->name, attr);
+  if (entry == NULL) {
+    ERROR(PLUGIN_NAME ": "
+                      "Failed to allocate memory for an attribute list entry");
+
+    goto redfish_config_attribute_free_memory;
+  }
+
+  llist_append(query->attributes, entry);
+
+  return 0;
+
+redfish_config_attribute_free_memory:
+  sfree(attr->name);
+  sfree(attr->plugin_inst);
+  sfree(attr->type);
+  sfree(attr->type_inst);
+  sfree(attr);
+
+  return -1;
+}
+
+/*******/
 
 static int redfish_config_query(oconfig_item_t *cfg_item,
                                 c_avl_tree_t *queries) {
@@ -419,6 +791,7 @@ static int redfish_config_query(oconfig_item_t *cfg_item,
 
   if (query == NULL) {
     ERROR(PLUGIN_NAME ": Failed to allocate memory for query");
+
     return -ENOMEM;
   }
 
@@ -430,9 +803,17 @@ static int redfish_config_query(oconfig_item_t *cfg_item,
     goto free_all;
   }
 
+  query->attributes = llist_create();
+
+  if (query->attributes == NULL) {
+    ret = -ENOMEM;
+    goto free_all;
+  }
+
   ret = cf_util_get_string(cfg_item, &query->name);
   if (ret != 0) {
     ERROR(PLUGIN_NAME ": Unable to get query name. Query ignored");
+
     ret = -EINVAL;
     goto free_all;
   }
@@ -440,19 +821,26 @@ static int redfish_config_query(oconfig_item_t *cfg_item,
   for (int i = 0; i < cfg_item->children_num; i++) {
     oconfig_item_t *opt = cfg_item->children + i;
 
-    if (strcasecmp("Endpoint", opt->key) == 0)
+    if (strcasecmp("Endpoint", opt->key) == 0) {
       ret = cf_util_get_string(opt, &query->endpoint);
-    else if (strcasecmp("Resource", opt->key) == 0)
+    } else if (strcasecmp("Resource", opt->key) == 0) {
       ret = redfish_config_resource(query, opt);
-    else {
-      ERROR(PLUGIN_NAME ": Invalid configuration option \"%s\".", opt->key);
+    } else if (strcasecmp("Attribute", opt->key) == 0) {
+      ret = redfish_config_attribute(query, opt);
+    } else {
+      ERROR(PLUGIN_NAME ": "
+                        "Invalid configuration option \"%s\".",
+            opt->key);
+
       ret = -EINVAL;
       goto free_all;
     }
 
     if (ret != 0) {
-      ERROR(PLUGIN_NAME ": Something went wrong processing query \"%s\"",
+      ERROR(PLUGIN_NAME ": "
+                        "Something went wrong processing query \"%s\"",
             query->name);
+
       ret = -EINVAL;
       goto free_all;
     }
@@ -469,9 +857,13 @@ free_all:
   sfree(query->name);
   sfree(query->endpoint);
   llist_destroy(query->resources);
+  llist_destroy(query->attributes);
   sfree(query);
+
   return ret;
 }
+
+/*******/
 
 static int redfish_read_queries(oconfig_item_t *cfg_item, char ***queries_ptr) {
   char **queries = NULL;
@@ -484,49 +876,59 @@ static int redfish_read_queries(oconfig_item_t *cfg_item, char ***queries_ptr) {
   if (queries_num != (size_t)cfg_item->values_num) {
     ERROR(PLUGIN_NAME ": Failed to allocate memory for query list");
     strarray_free(queries, queries_num);
+
     return -ENOMEM;
   }
 
   *queries_ptr = queries;
+
   return 0;
 }
+
+/*******/
 
 static int redfish_config_service(oconfig_item_t *cfg_item) {
   redfish_service_t *service = calloc(1, sizeof(*service));
 
   if (service == NULL) {
     ERROR(PLUGIN_NAME ": Failed to allocate memory for service");
+
     return -ENOMEM;
   }
 
   int ret = cf_util_get_string(cfg_item, &service->name);
   if (ret != 0) {
     ERROR(PLUGIN_NAME ": A service was defined without an argument");
+
     goto free_service;
   }
 
   for (int i = 0; i < cfg_item->children_num; i++) {
     oconfig_item_t *opt = cfg_item->children + i;
 
-    if (strcasecmp("Host", opt->key) == 0)
+    if (strcasecmp("Host", opt->key) == 0) {
       ret = cf_util_get_string(opt, &service->host);
-    else if (strcasecmp("User", opt->key) == 0)
+    } else if (strcasecmp("User", opt->key) == 0) {
       ret = cf_util_get_string(opt, &service->user);
-    else if (strcasecmp("Passwd", opt->key) == 0)
+    } else if (strcasecmp("Passwd", opt->key) == 0) {
       ret = cf_util_get_string(opt, &service->passwd);
-    else if (strcasecmp("Token", opt->key) == 0)
+    } else if (strcasecmp("Token", opt->key) == 0) {
       ret = cf_util_get_string(opt, &service->token);
-    else if (strcasecmp("Queries", opt->key) == 0) {
+    } else if (strcasecmp("Queries", opt->key) == 0) {
       ret = redfish_read_queries(opt, &service->queries);
       service->queries_num = opt->values_num;
     } else {
-      ERROR(PLUGIN_NAME ": Invalid configuration option \"%s\".", opt->key);
+      ERROR(PLUGIN_NAME ": "
+                        "Invalid configuration option \"%s\".",
+            opt->key);
     }
 
     if (ret != 0) {
-      ERROR(PLUGIN_NAME ": Something went wrong processing the service named \
-            \"%s\"",
+      ERROR(PLUGIN_NAME
+            ": "
+            "Something went wrong processing the service named \"%s\"",
             service->name);
+
       goto free_service;
     }
   }
@@ -536,8 +938,10 @@ static int redfish_config_service(oconfig_item_t *cfg_item) {
   if (entry != NULL)
     llist_append(ctx.services, entry);
   else {
-    ERROR(PLUGIN_NAME ": Failed to create list for service name \"%s\"",
+    ERROR(PLUGIN_NAME ": "
+                      "Failed to create list for service name \"%s\"",
           service->name);
+
     goto free_service;
   }
 
@@ -548,6 +952,8 @@ free_service:
   return -1;
 }
 
+/*******/
+
 static int redfish_config(oconfig_item_t *cfg_item) {
   int ret = redfish_preconfig();
 
@@ -557,16 +963,19 @@ static int redfish_config(oconfig_item_t *cfg_item) {
   for (int i = 0; i < cfg_item->children_num; i++) {
     oconfig_item_t *child = cfg_item->children + i;
 
-    if (strcasecmp("Query", child->key) == 0)
+    if (strcasecmp("Query", child->key) == 0) {
       ret = redfish_config_query(child, ctx.queries);
-    else if (strcasecmp("Service", child->key) == 0)
+    } else if (strcasecmp("Service", child->key) == 0) {
       ret = redfish_config_service(child);
-    else {
-      ERROR(PLUGIN_NAME ": Invalid configuration option \"%s\".", child->key);
+    } else {
+      ERROR(PLUGIN_NAME ": "
+                        "Invalid configuration option \"%s\".",
+            child->key);
     }
 
     if (ret != 0) {
       redfish_cleanup();
+
       return ret;
     }
   }
@@ -574,54 +983,74 @@ static int redfish_config(oconfig_item_t *cfg_item) {
   return 0;
 }
 
+/*******/
+
 static int redfish_validate_config(void) {
   /* Service validation */
   for (llentry_t *llserv = llist_head(ctx.services); llserv != NULL;
        llserv = llserv->next) {
     redfish_service_t *service = llserv->value;
+
     if (service->name == NULL) {
       ERROR(PLUGIN_NAME ": A service has no name");
+
       return -EINVAL;
     }
+
     if (service->host == NULL) {
       ERROR(PLUGIN_NAME ": Service \"%s\" has no host attribute",
             service->name);
-      return -EINVAL;
-    }
-    if ((service->user == NULL) ^ (service->passwd == NULL)) {
-      ERROR(PLUGIN_NAME ": Service \"%s\" does not have user and/or password "
-                        "defined",
-            service->name);
-      return -EINVAL;
-    }
-    if (service->user == NULL && service->token == NULL) {
-      ERROR(PLUGIN_NAME ": Service \"%s\" does not have an user/pass or "
-                        "token defined",
-            service->name);
-      return -EINVAL;
-    }
-    if (service->queries_num == 0)
-      WARNING(PLUGIN_NAME ": Service \"%s\" does not have queries",
-              service->name);
 
-    for (int i = 0; i < service->queries_num; i++) {
+      return -EINVAL;
+    }
+
+    if ((service->user == NULL) ^ (service->passwd == NULL)) {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Service \"%s\" does not have user and/or password defined",
+            service->name);
+
+      return -EINVAL;
+    }
+
+    if ((service->user == NULL) && (service->token == NULL)) {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Service \"%s\" does not have an user/pass or token defined",
+            service->name);
+
+      return -EINVAL;
+    }
+
+    if (service->queries_num == 0) {
+      WARNING(PLUGIN_NAME ": "
+                          "Service \"%s\" does not have queries",
+              service->name);
+    }
+
+    for (uint64_t i = 0; i < service->queries_num; i++) {
       redfish_query_t *query_query;
+
       bool found = false;
       char *key;
       c_avl_iterator_t *query_iter = c_avl_get_iterator(ctx.queries);
-      while (c_avl_iterator_next(query_iter, (void *)&key,
-                                 (void *)&query_query) == 0 &&
+
+      while ((c_avl_iterator_next(query_iter, (void *)(&key),
+                                  (void *)(&query_query)) == 0) &&
              !found) {
-        if (query_query->name != NULL && service->queries[i] != NULL &&
-            strcmp(query_query->name, service->queries[i]) == 0) {
+        if ((query_query->name != NULL) && (service->queries[i] != NULL) &&
+            (strcmp(query_query->name, service->queries[i]) == 0)) {
           found = true;
         }
       }
 
       if (!found) {
-        ERROR(PLUGIN_NAME ": Query named \"%s\" in service \"%s\" not found",
+        ERROR(PLUGIN_NAME ": "
+                          "Query named \"%s\" in service \"%s\" not found",
               service->queries[i], service->name);
+
         c_avl_iterator_destroy(query_iter);
+
         return -EINVAL;
       }
 
@@ -634,45 +1063,93 @@ static int redfish_validate_config(void) {
   redfish_query_t *query;
 
   /* Query validation */
-  while (c_avl_iterator_next(queries_iter, (void *)&key, (void *)&query) == 0) {
+  while (c_avl_iterator_next(queries_iter, (void *)(&key), (void *)(&query)) ==
+         0) {
     if (query->name == NULL) {
       ERROR(PLUGIN_NAME ": A query does not have a name");
       goto error;
     }
+
     if (query->endpoint == NULL) {
-      ERROR(PLUGIN_NAME ": Query \"%s\" does not have a valid endpoint",
+      ERROR(PLUGIN_NAME ": "
+                        "Query \"%s\" does not have a valid endpoint",
             query->name);
+
       goto error;
     }
+
     for (llentry_t *llres = llist_head(query->resources); llres != NULL;
          llres = llres->next) {
       redfish_resource_t *resource = (redfish_resource_t *)llres->value;
+
       /* Resource validation */
       if (resource->name == NULL) {
         WARNING(PLUGIN_NAME ": A resource in query \"%s\" is not named",
                 query->name);
       }
+
       /* Property validation */
       for (llentry_t *llprop = llist_head(resource->properties); llprop != NULL;
            llprop = llprop->next) {
         redfish_property_t *prop = (redfish_property_t *)llprop->value;
+
         if (prop->name == NULL) {
           ERROR(PLUGIN_NAME ": A property has no name in query \"%s\"",
                 query->name);
+
           goto error;
         }
+
         if (prop->plugin_inst == NULL) {
-          ERROR(PLUGIN_NAME ": A plugin instance is not defined in property "
-                            "\"%s\" in query \"%s\"",
+          ERROR(PLUGIN_NAME
+                ": "
+                "A plugin instance is not defined in property \"%s\" "
+                "in query \"%s\"",
                 prop->name, query->name);
+
           goto error;
         }
+
         if (prop->type == NULL) {
-          ERROR(PLUGIN_NAME ": Type is not defined in property \"%s\" in "
-                            "query \"%s\"",
+          ERROR(PLUGIN_NAME ": "
+                            "Type is not defined in property \"%s\" in query "
+                            "\"%s\"",
                 prop->name, query->name);
+
           goto error;
         }
+      }
+    }
+
+    for (llentry_t *llres = llist_head(query->attributes); llres != NULL;
+         llres = llres->next) {
+      redfish_attribute_t *attr = (redfish_attribute_t *)llres->value;
+
+      /* Attribute validation: */
+      if (attr->name == NULL) {
+        ERROR(PLUGIN_NAME ": An attribute in query \"%s\" is not named",
+              query->name);
+
+        goto error;
+      }
+
+      if (attr->plugin_inst == NULL) {
+        ERROR(PLUGIN_NAME
+              ": "
+              "A plugin instance is not defined in attribute \"%s\" "
+              "of query \"%s\"",
+              attr->name, query->name);
+
+        goto error;
+      }
+
+      if (attr->type == NULL) {
+        ERROR(PLUGIN_NAME ": "
+                          "Type is not defined in attribute \"%s\" in query "
+                          "\"%s\"",
+              attr->name, query->name);
+
+        goto error;
       }
     }
   }
@@ -683,58 +1160,77 @@ static int redfish_validate_config(void) {
 
 error:
   c_avl_iterator_destroy(queries_iter);
+
   return -EINVAL;
 }
+
+/*******/
 
 static int redfish_convert_val(redfish_value_t *value,
                                redfish_value_type_t src_type, value_t *vl,
                                int dst_type) {
   switch (dst_type) {
   case DS_TYPE_GAUGE:
-    if (src_type == VAL_TYPE_STR)
+    if (src_type == VAL_TYPE_STR) {
       vl->gauge = strtod(value->string, NULL);
-    else if (src_type == VAL_TYPE_INT)
+    } else if (src_type == VAL_TYPE_INT) {
       vl->gauge = (gauge_t)value->integer;
-    else if (src_type == VAL_TYPE_REAL)
+    } else if (src_type == VAL_TYPE_REAL) {
       vl->gauge = value->real;
+    }
+
     break;
+
   case DS_TYPE_DERIVE:
-    if (src_type == VAL_TYPE_STR)
+    if (src_type == VAL_TYPE_STR) {
       vl->derive = strtoll(value->string, NULL, 0);
-    else if (src_type == VAL_TYPE_INT)
+    } else if (src_type == VAL_TYPE_INT) {
       vl->derive = (derive_t)value->integer;
-    else if (src_type == VAL_TYPE_REAL)
+    } else if (src_type == VAL_TYPE_REAL) {
       vl->derive = (derive_t)value->real;
+    }
+
     break;
+
   case DS_TYPE_COUNTER:
-    if (src_type == VAL_TYPE_STR)
+    if (src_type == VAL_TYPE_STR) {
       vl->derive = strtoull(value->string, NULL, 0);
-    else if (src_type == VAL_TYPE_INT)
+    } else if (src_type == VAL_TYPE_INT) {
       vl->derive = (derive_t)value->integer;
-    else if (src_type == VAL_TYPE_REAL)
+    } else if (src_type == VAL_TYPE_REAL) {
       vl->derive = (derive_t)value->real;
+    }
+
     break;
+
   case DS_TYPE_ABSOLUTE:
-    if (src_type == VAL_TYPE_STR)
+    if (src_type == VAL_TYPE_STR) {
       vl->absolute = strtoull(value->string, NULL, 0);
-    else if (src_type == VAL_TYPE_INT)
+    } else if (src_type == VAL_TYPE_INT) {
       vl->absolute = (absolute_t)value->integer;
-    else if (src_type == VAL_TYPE_REAL)
+    } else if (src_type == VAL_TYPE_REAL) {
       vl->absolute = (absolute_t)value->real;
+    }
+
     break;
+
   default:
     ERROR(PLUGIN_NAME ": Invalid data set type. Cannot convert value");
+
     return -EINVAL;
   }
 
   return 0;
 }
 
+/*******/
+
 static int redfish_json_get_string(char *const value, const size_t value_len,
                                    const json_t *const json) {
   if (json_is_string(json)) {
     const char *str_val = json_string_value(json);
     sstrncpy(value, str_val, value_len);
+
     return 0;
   } else if (json_is_integer(json)) {
     snprintf(value, value_len, "%d", (int)json_integer_value(json));
@@ -742,87 +1238,350 @@ static int redfish_json_get_string(char *const value, const size_t value_len,
   }
 
   ERROR(PLUGIN_NAME ": Expected JSON value to be a string or an integer");
+
   return -EINVAL;
 }
 
-static void redfish_process_payload_property(const redfish_property_t *prop,
-                                             const json_t *json_array,
-                                             const redfish_resource_t *res,
-                                             const redfish_service_t *serv) {
-  /* Iterating through array of sensor(s) */
-  for (int i = 0; i < json_array_size(json_array); i++) {
-    json_t *item = json_array_get(json_array, i);
-    if (item == NULL) {
-      ERROR(PLUGIN_NAME ": Failure retrieving array member for resource \"%s\"",
-            res->name);
-      continue;
-    }
-    json_t *object = json_object_get(item, prop->name);
-    if (object == NULL) {
+/*******/
+
+static void redfish_process_payload_attribute(
+    const redfish_attribute_t *attr, const json_t *json_payload,
+    const redfish_query_t *query, const redfish_service_t *service) {
+  json_t *json_attr = json_object_get(json_payload, attr->name);
+
+  if (json_attr == NULL) {
+    ERROR(PLUGIN_NAME
+          ": Could not find the attribute \"%s\" in the payload associated "
+          "with the query \"%s\"",
+          attr->name, query->name);
+
+    return;
+  }
+
+  value_list_t v1 = VALUE_LIST_INIT;
+  v1.values_len = 1;
+
+  if (attr->plugin_inst != NULL) {
+    sstrncpy(v1.plugin_instance, attr->plugin_inst, sizeof(v1.plugin_instance));
+  }
+
+  /* If the "TypeInstance" was not specified, then the name of the attribute
+   * is used as default value: */
+  sstrncpy(v1.type_instance,
+           ((attr->type_inst != NULL) ? attr->type_inst : attr->name),
+           sizeof(v1.type_instance));
+
+  /* Determining the type of the content associated with the attribute: */
+  redfish_value_t redfish_value;
+  redfish_value_type_t type = VAL_TYPE_STR;
+
+  if (json_is_string(json_attr)) {
+    redfish_value.string = (char *)json_string_value(json_attr);
+  } else if (json_is_integer(json_attr)) {
+    type = VAL_TYPE_INT;
+    redfish_value.integer = json_integer_value(json_attr);
+  } else if (json_is_real(json_attr)) {
+    type = VAL_TYPE_REAL;
+    redfish_value.real = json_real_value(json_attr);
+  }
+
+#if !defined(REDFISH_PLUGIN_TEST)
+  const data_set_t *ds = plugin_get_ds(attr->type);
+#else
+  const data_set_t *ds = redfish_test_plugin_get_ds_mock(attr->type);
+#endif
+
+  /* Checking if the collectd type associated with the attribute exists: */
+  if (ds == NULL)
+    return;
+
+  value_t values = {0};
+  v1.values = &values;
+  redfish_convert_val(&redfish_value, type, v1.values, ds->ds[0].type);
+
+  sstrncpy(v1.host, service->name, sizeof(v1.host));
+  sstrncpy(v1.plugin, PLUGIN_NAME, sizeof(v1.plugin));
+  sstrncpy(v1.type, attr->type, sizeof(v1.type));
+
+#if !defined(REDFISH_PLUGIN_TEST)
+  plugin_dispatch_values(&v1);
+#else
+  redfish_test_plugin_dispatch_values_mock(&v1);
+#endif
+
+  /* Clear values assigned in case of leakage */
+  v1.values = NULL;
+  v1.values_len = 0;
+}
+
+/*******/
+
+static void redfish_process_payload_object(const redfish_property_t *prop,
+                                           const json_t *json_object,
+                                           const uint64_t json_object_id,
+                                           const redfish_resource_t *res,
+                                           const redfish_service_t *serv) {
+  json_t *json_property = json_object_get(json_object, prop->name);
+
+  if (json_property == NULL) {
+    ERROR(PLUGIN_NAME
+          ": Failure retreiving property \"%s\" from resource \"%s\"",
+          prop->name, res->name);
+
+    return;
+  }
+
+  value_list_t v1 = VALUE_LIST_INIT;
+  v1.values_len = 1;
+
+  if (prop->plugin_inst != NULL) {
+    sstrncpy(v1.plugin_instance, prop->plugin_inst, sizeof(v1.plugin_instance));
+  }
+
+  /* Determining the "TypeInstance" of the metric in collectd and storing it
+   * in a temporary string, in order to be able to later prefix it with the ID
+   * of the considered member of the array. */
+  char type_inst[DATA_MAX_NAME_LEN] = {0};
+
+  /* First alternative - it was specified in the configuration file of
+   * collectd: */
+  if (prop->type_inst != NULL) {
+    sstrncpy(type_inst, prop->type_inst, sizeof(type_inst));
+  } else if (prop->type_inst_attr != NULL) {
+    /* Second alternative - the name of a property of the target JSON object
+     * which content should be used as "TypeInstance" was specified in the
+     * configuration file of collectd through "TypeInstanceAttr":
+     * NB: "tia" stands for "TypeInstanceAttr".*/
+    json_t *json_tia = json_object_get(json_object, prop->type_inst_attr);
+
+    if (json_tia == NULL) {
       ERROR(PLUGIN_NAME
-            ": Failure retreiving property \"%s\" from resource \"%s\"",
+            ": "
+            "Could not find the property \"%s\" which was specified as the "
+            "\"TypeInstanceAttr\"\nof the target property \"%s\" in the "
+            "resource \"%s\".",
+            prop->type_inst_attr, prop->name, res->name);
+
+      return;
+    }
+
+    int ret = redfish_json_get_string(type_inst, sizeof(type_inst), json_tia);
+
+    if (ret != 0) {
+      ERROR(PLUGIN_NAME
+            ": Could not convert the content of the \"%s\" property to a "
+            "type instance.",
+            prop->type_inst_attr);
+
+      return;
+    }
+  } else {
+    /* Last alternative - if the target JSON object contains a property
+     * named "Name", it should be used as the "TypeInstance" of the metric
+     * in collectd: */
+    json_t *json_name = json_object_get(json_object, "Name");
+
+    if (json_name == NULL) {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Neither \"TypeInstance\" nor \"TypeInstanceAttr\" "
+            "specified.\n"
+            "Failed to get \"Name\" property associated with the target "
+            "property \"%s\" in resource \"%s\".",
             prop->name, res->name);
-      continue;
+
+      return;
     }
-    value_list_t v1 = VALUE_LIST_INIT;
-    v1.values_len = 1;
-    if (prop->plugin_inst != NULL)
-      sstrncpy(v1.plugin_instance, prop->plugin_inst,
-               sizeof(v1.plugin_instance));
-    if (prop->type_inst != NULL)
-      sstrncpy(v1.type_instance, prop->type_inst, sizeof(v1.type_instance));
-    else {
-      /* Retrieving MemberId of sensor */
-      json_t *member_id = json_object_get(item, "MemberId");
-      if (member_id == NULL) {
-        ERROR(PLUGIN_NAME
-              ": Failed to get MemberId for property \"%s\" in resource "
-              "\"%s\"",
+
+    int ret = redfish_json_get_string(type_inst, sizeof(type_inst), json_name);
+
+    if (ret != 0) {
+      ERROR(PLUGIN_NAME
+            ": "
+            "Could not convert the \"Name\" attribute of the property "
+            "\"%s\" property of the \"%s\" resource to a type instance.",
+            prop->name, res->name);
+
+      return;
+    }
+  }
+
+  /* If required, prefixing the "TypeInstance" by the ID of the considered
+   * member of the array: */
+  if (prop->type_inst_prefix_id) {
+    uint64_t nb_written_chars =
+        snprintf(v1.type_instance, sizeof(v1.type_instance), "%lu-%s",
+                 json_object_id, type_inst);
+
+    if (nb_written_chars > sizeof(v1.type_instance)) {
+      WARNING(PLUGIN_NAME
+              " - property \"%s\" of the \"%s\" resource :\n"
+              "The \"TypeInstance\" generated by ID prefixing was longer "
+              "than the maximum number of characters, and was thus"
+              "truncated.",
               prop->name, res->name);
+    }
+  } else {
+    /* No need for length checking since "v1.type_instance" and
+     * "type_instance" have the same length: */
+    sstrncpy(v1.type_instance, type_inst, sizeof(v1.type_instance));
+  }
+
+  /* Determining the type of the value of the monitored metric, which is the
+   * type of the associated JSON property: */
+  redfish_value_t value;
+  redfish_value_type_t type = VAL_TYPE_STR;
+
+  if (json_is_string(json_property)) {
+    value.string = (char *)json_string_value(json_property);
+  } else if (json_is_integer(json_property)) {
+    type = VAL_TYPE_INT;
+    value.integer = json_integer_value(json_property);
+  } else if (json_is_real(json_property)) {
+    type = VAL_TYPE_REAL;
+    value.real = json_real_value(json_property);
+  }
+
+#if !defined(REDFISH_PLUGIN_TEST)
+  const data_set_t *ds = plugin_get_ds(prop->type);
+#else
+  const data_set_t *ds = redfish_test_plugin_get_ds_mock(prop->type);
+#endif
+
+  /* Check if data set found */
+  if (ds == NULL)
+    return;
+
+  value_t tmp = {0};
+  v1.values = &tmp;
+  redfish_convert_val(&value, type, v1.values, ds->ds[0].type);
+
+  sstrncpy(v1.host, serv->name, sizeof(v1.host));
+  sstrncpy(v1.plugin, PLUGIN_NAME, sizeof(v1.plugin));
+  sstrncpy(v1.type, prop->type, sizeof(v1.type));
+
+#if !defined(REDFISH_PLUGIN_TEST)
+  plugin_dispatch_values(&v1);
+#else
+  redfish_test_plugin_dispatch_values_mock(&v1);
+#endif
+
+  /* Clear values assigned in case of leakage */
+  v1.values = NULL;
+  v1.values_len = 0;
+}
+
+/*******/
+
+static void redfish_process_payload_resource_property(
+    const redfish_property_t *prop, const json_t *json_resource,
+    const redfish_resource_t *res, const redfish_service_t *serv) {
+  /* Testing if the resource to process is an array, or if it is an object: */
+  if (json_array_size(json_resource) == 0) {
+    /* It is an object. */
+    redfish_process_payload_object(prop, json_resource, 0, res, serv);
+  } else {
+    /* It is an array. */
+    /* Iterating through an array of objects: */
+    for (uint64_t i = 0; i < json_array_size(json_resource); i++) {
+      /* Checking if an ID-based member selection should be performed: */
+      if ((prop->select_ids != NULL) && (prop->nb_select_ids > 0)) {
+        /* Roaming all the specified IDs to determine whether or not the
+         * currently considered one is among them: */
+        bool id_selected = false;
+        /***/
+        for (uint64_t j = 0; j < prop->nb_select_ids; j++) {
+          if (i == (prop->select_ids)[j]) {
+            id_selected = true;
+            break;
+          }
+        }
+        /***/
+        if (!id_selected)
+          continue;
+      }
+
+      json_t *json_object = json_array_get(json_resource, i);
+
+      if (json_object == NULL) {
+        ERROR(PLUGIN_NAME ": Failure retrieving array member for "
+                          "resource \"%s\"",
+              res->name);
+
         continue;
       }
 
-      int ret = redfish_json_get_string(v1.type_instance,
-                                        sizeof(v1.type_instance), member_id);
+      /* Checking if an attribute-based member selection should be
+       * performed: */
+      if ((prop->select_attrs != NULL) && (prop->nb_select_attrs > 0)) {
+        /* Roaming all the specified attributes to determine whether or
+         * not the currently considered member defines the former: */
+        bool member_selected = true;
+        /***/
+        for (uint64_t j = 0; j < prop->nb_select_attrs; j++) {
+          json_t *json_attr =
+              json_object_get(json_object, prop->select_attrs[j]);
 
-      if (ret != 0) {
-        ERROR(PLUGIN_NAME ": Cannot convert \"%s\" to a type instance",
-              prop->type_inst);
-        continue;
+          if (json_attr == NULL) {
+            member_selected = false;
+            break;
+          }
+        }
+        /***/
+        if (!member_selected)
+          continue;
       }
+
+      /* Checking if the members of the considered array should be
+       * filtered according to the values of some of their attributes: */
+      if (prop->select_attrvalues != NULL) {
+        bool member_selected = true;
+
+        /* Roaming all the selection/filtering criteria: */
+        for (llentry_t *attrvalue = llist_head(prop->select_attrvalues);
+             attrvalue != NULL; attrvalue = attrvalue->next) {
+          /* Getting the JSON object associated with the considered
+           * attribute: */
+          json_t *json_attr = json_object_get(json_object, attrvalue->key);
+          /***/
+          if (json_attr == NULL) {
+            member_selected = false;
+            break;
+          }
+
+          /* Getting the value associated with the considered
+           * attribute: */
+          char attrvalue_value[DATA_MAX_NAME_LEN] = {0};
+          /***/
+          int ret = redfish_json_get_string(attrvalue_value,
+                                            sizeof(attrvalue_value), json_attr);
+          /***/
+          if (ret != 0) {
+            WARNING(PLUGIN_NAME ": Could not convert the content of the \"%s\" "
+                                "attribute to a string for property \"%s\".",
+                    attrvalue->key, prop->name);
+
+            member_selected = false;
+            break;
+          }
+
+          /* Checking if the attribute as the proper value: */
+          if (strcmp(attrvalue_value, attrvalue->value) != 0) {
+            member_selected = false;
+            break;
+          }
+        }
+
+        if (!member_selected)
+          continue;
+      }
+
+      redfish_process_payload_object(prop, json_object, i, res, serv);
     }
-
-    /* Checking whether real or integer value */
-    redfish_value_t value;
-    redfish_value_type_t type = VAL_TYPE_STR;
-    if (json_is_string(object)) {
-      value.string = (char *)json_string_value(object);
-    } else if (json_is_integer(object)) {
-      type = VAL_TYPE_INT;
-      value.integer = json_integer_value(object);
-    } else if (json_is_real(object)) {
-      type = VAL_TYPE_REAL;
-      value.real = json_real_value(object);
-    }
-    const data_set_t *ds = plugin_get_ds(prop->type);
-
-    /* Check if data set found */
-    if (ds == NULL)
-      continue;
-
-    value_t tmp = {0};
-    v1.values = &tmp;
-    redfish_convert_val(&value, type, v1.values, ds->ds[0].type);
-
-    sstrncpy(v1.host, serv->name, sizeof(v1.host));
-    sstrncpy(v1.plugin, PLUGIN_NAME, sizeof(v1.plugin));
-    sstrncpy(v1.type, prop->type, sizeof(v1.type));
-    plugin_dispatch_values(&v1);
-    /* Clear values assigned in case of leakage */
-    v1.values = NULL;
-    v1.values_len = 0;
   }
 }
+
+/*******/
 
 static void redfish_process_payload(bool success, unsigned short http_code,
                                     redfishPayload *payload, void *context) {
@@ -830,7 +1589,11 @@ static void redfish_process_payload(bool success, unsigned short http_code,
 
   if (!success) {
     WARNING(PLUGIN_NAME ": Query has failed, HTTP code = %u\n", http_code);
+#if !defined(REDFISH_PLUGIN_TEST)
     goto free_job;
+#else
+    return;
+#endif
   }
 
   redfish_service_t *serv = job->service_query->service;
@@ -838,15 +1601,19 @@ static void redfish_process_payload(bool success, unsigned short http_code,
   if (!payload) {
     WARNING(PLUGIN_NAME ": Failed to get payload for service name \"%s\"",
             serv->name);
+#if !defined(REDFISH_PLUGIN_TEST)
     goto free_job;
+#else
+    return;
+#endif
   }
 
   for (llentry_t *llres = llist_head(job->service_query->query->resources);
        llres != NULL; llres = llres->next) {
     redfish_resource_t *res = (redfish_resource_t *)llres->value;
-    json_t *json_array = json_object_get(payload->json, res->name);
+    json_t *json_resource = json_object_get(payload->json, res->name);
 
-    if (json_array == NULL) {
+    if (json_resource == NULL) {
       WARNING(PLUGIN_NAME ": Could not find resource \"%s\"", res->name);
       continue;
     }
@@ -855,16 +1622,28 @@ static void redfish_process_payload(bool success, unsigned short http_code,
          llprop = llprop->next) {
       redfish_property_t *prop = (redfish_property_t *)llprop->value;
 
-      redfish_process_payload_property(prop, json_array, res, serv);
+      redfish_process_payload_resource_property(prop, json_resource, res, serv);
     }
   }
 
+  for (llentry_t *llattr = llist_head(job->service_query->query->attributes);
+       llattr != NULL; llattr = llattr->next) {
+    redfish_attribute_t *attr = (redfish_attribute_t *)(llattr->value);
+
+    redfish_process_payload_attribute(attr, payload->json,
+                                      job->service_query->query, serv);
+  }
+
+#if !defined(REDFISH_PLUGIN_TEST)
 free_job:
   cleanupPayload(payload);
   redfish_job_destroy(job);
+#endif
 }
 
-static void *redfish_worker_thread(void __attribute__((unused)) * args) {
+/*******/
+
+static void *redfish_worker_thread(void *__attribute__((unused)) args) {
   INFO(PLUGIN_NAME ": Worker is running");
 
   for (;;) {
@@ -876,17 +1655,22 @@ static void *redfish_worker_thread(void __attribute__((unused)) * args) {
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 
     redfish_job_t *job = DEQ_HEAD(ctx.jobs);
+
     getPayloadByPathAsync(job->service_query->service->redfish,
                           job->service_query->query->endpoint, NULL,
                           redfish_process_payload, job);
+
     DEQ_REMOVE_HEAD(ctx.jobs);
 
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
   }
 
   pthread_exit(NULL);
+
   return NULL;
 }
+
+/*******/
 
 static int redfish_read(__attribute__((unused)) user_data_t *ud) {
   for (llentry_t *le = llist_head(ctx.services); le != NULL; le = le->next) {
@@ -907,8 +1691,10 @@ static int redfish_read(__attribute__((unused)) user_data_t *ud) {
       redfish_payload_ctx_t *serv_res = calloc(1, sizeof(*serv_res));
 
       if (serv_res == NULL) {
-        WARNING(PLUGIN_NAME ": Failed to allocate memory for task's context");
+        WARNING(PLUGIN_NAME ": "
+                            "Failed to allocate memory for task's context");
         sfree(job);
+
         continue;
       }
 
@@ -919,65 +1705,153 @@ static int redfish_read(__attribute__((unused)) user_data_t *ud) {
       DEQ_INSERT_TAIL(ctx.jobs, job);
     }
   }
+
   return 0;
 }
 
+/*******/
+
+static void redfish_destroy_property(redfish_property_t *property) {
+  /* Freeing the fields of the considered property: */
+  sfree(property->name);
+  sfree(property->plugin_inst);
+  sfree(property->type);
+  sfree(property->type_inst);
+  sfree(property->type_inst_attr);
+  strarray_free(property->select_attrs, property->nb_select_attrs);
+  sfree(property->select_ids);
+
+  llentry_t *current = llist_head(property->select_attrvalues);
+  /***/
+  while (current != NULL) {
+    sfree(current->key);
+    sfree(current->value);
+
+    current = current->next;
+  }
+  /***/
+  llist_destroy(property->select_attrvalues);
+
+  /* Freeing the property itself: */
+  sfree(property);
+}
+
+/*******/
+
+static void redfish_destroy_resource(redfish_resource_t *resource) {
+  /* Roaming all the properties of the considered resource: */
+  for (llentry_t *le = llist_head(resource->properties); le != NULL;
+       le = le->next) {
+    /* Getting the considered property: */
+    redfish_property_t *property = (redfish_property_t *)le->value;
+
+    /* Freeing the considered property: */
+    redfish_destroy_property(property);
+  }
+
+  /* Freeing the fields of the resource and the resource itself: */
+  sfree(resource->name);
+  llist_destroy(resource->properties);
+  sfree(resource);
+}
+
+/*******/
+
+static void redfish_destroy_attribute(redfish_attribute_t *attribute) {
+  /* Freeing the fields of the attribute: */
+  sfree(attribute->name);
+  sfree(attribute->plugin_inst);
+  sfree(attribute->type);
+  sfree(attribute->type_inst);
+
+  /* Freeing the attributeibute itself: */
+  sfree(attribute);
+}
+
+/*******/
+
+static void redfish_destroy_query(redfish_query_t *query) {
+  /* Roaming all the resources of the considered query: */
+  for (llentry_t *le = llist_head(query->resources); le != NULL;
+       le = le->next) {
+    /* Getting the considered resource: */
+    redfish_resource_t *resource = (redfish_resource_t *)le->value;
+
+    /* Freeing the considered resource: */
+    redfish_destroy_resource(resource);
+  }
+
+  /* Roaming all the attribute of the considered query: */
+  for (llentry_t *le = llist_head(query->attributes); le != NULL;
+       le = le->next) {
+    /* Getting the considered attribute: */
+    redfish_attribute_t *attribute = (redfish_attribute_t *)(le->value);
+
+    /* Freeing the considered attribute: */
+    redfish_destroy_attribute(attribute);
+  }
+
+  /* Freeing the fields of the query, and the query itself: */
+  sfree(query->name);
+  sfree(query->endpoint);
+  llist_destroy(query->resources);
+  llist_destroy(query->attributes);
+  sfree(query);
+}
+
+/*******/
+
 static int redfish_cleanup(void) {
+#if !defined(REDFISH_PLUGIN_TEST)
   INFO(PLUGIN_NAME ": Cleaning up");
-  /* Shutting down a worker thread */
-  if (pthread_cancel(ctx.worker_thread) != 0)
-    ERROR(PLUGIN_NAME ": Failed to cancel the worker thread");
 
-  if (pthread_join(ctx.worker_thread, NULL) != 0)
-    ERROR(PLUGIN_NAME ": Failed to join the worker thread");
+  /* Shutting down the worker thread, if it was spawned: */
+  if (ctx.worker_thread != 0) {
+    if (pthread_cancel(ctx.worker_thread) != 0) {
+      ERROR(PLUGIN_NAME ": Failed to cancel the worker thread");
+    }
 
-  /* Cleaning worker's queue */
+    if (pthread_join(ctx.worker_thread, NULL) != 0) {
+      ERROR(PLUGIN_NAME ": Failed to join the worker thread");
+    }
+  }
+
+  /* Cleaning worker's queue: */
   while (!DEQ_IS_EMPTY(ctx.jobs)) {
     redfish_job_t *job = DEQ_HEAD(ctx.jobs);
     DEQ_REMOVE_HEAD(ctx.jobs);
     redfish_job_destroy(job);
   }
+#endif
 
+  /* Roaming all the services to destroy them: */
   for (llentry_t *le = llist_head(ctx.services); le; le = le->next) {
     redfish_service_t *service = (redfish_service_t *)le->value;
-
     redfish_service_destroy(service);
   }
+
+  /* Destroying the list of services itself: */
   llist_destroy(ctx.services);
 
+  /* Roaming all the queries to destroy them: */
   c_avl_iterator_t *i = c_avl_get_iterator(ctx.queries);
-
+  /***/
   char *key;
   redfish_query_t *query;
-
-  while (c_avl_iterator_next(i, (void *)&key, (void *)&query) == 0) {
-    for (llentry_t *le = llist_head(query->resources); le != NULL;
-         le = le->next) {
-      redfish_resource_t *resource = (redfish_resource_t *)le->value;
-      for (llentry_t *le = llist_head(resource->properties); le != NULL;
-           le = le->next) {
-        redfish_property_t *property = (redfish_property_t *)le->value;
-        sfree(property->name);
-        sfree(property->plugin_inst);
-        sfree(property->type);
-        sfree(property->type_inst);
-        sfree(property);
-      }
-      sfree(resource->name);
-      llist_destroy(resource->properties);
-      sfree(resource);
-    }
-    sfree(query->name);
-    sfree(query->endpoint);
-    llist_destroy(query->resources);
-    sfree(query);
+  /***/
+  while (c_avl_iterator_next(i, (void *)(&key), (void *)(&query)) == 0) {
+    redfish_destroy_query(query);
   }
-
+  /***/
   c_avl_iterator_destroy(i);
+
+  /* Destroying the AVL tree storing the queries itself: */
   c_avl_destroy(ctx.queries);
 
   return 0;
 }
+
+/*******/
 
 void module_register(void) {
   plugin_register_init(PLUGIN_NAME, redfish_init);

--- a/src/redfish_test.c
+++ b/src/redfish_test.c
@@ -2,6 +2,7 @@
  * collectd - src/redfish_test.c
  *
  * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ * Copyright(c) 2021 Atos. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,71 +22,1747 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Authors:
+ * Original authors:
  *   Martin Kennelly <martin.kennelly@intel.com>
  *   Marcin Mozejko <marcinx.mozejko@intel.com>
  *   Adrian Boczkowski <adrianx.boczkowski@intel.com>
+ *
+ * Refactoring and enhancement author:
+ *      Mathieu Stoffel <mathieu.stoffel@atos.net>
  **/
+/* So as to use the "test-dedicated" version of the source code of the Redfish
+ * plugin: */
+#define REDFISH_PLUGIN_TEST
 
-#define plugin_dispatch_values redfish_test_plugin_dispatch_values_mock
+#include <math.h>
+
 #include "redfish.c"
 #include "testing.h"
 
-#define VALUE_CACHE_SIZE (1)
+/******************************************************************************
+ * Mocking of the type/data source inference interface:
+ ******************************************************************************/
+#define DS_FANSPEED_NUM_DSOURCES (1)
+/***/
+static data_source_t fanspeed_dsources[DS_FANSPEED_NUM_DSOURCES] = {
+    {.name = "value", .type = DS_TYPE_GAUGE, .min = 0.0, .max = NAN}};
+/***/
+static data_set_t fanspeed_dset = {
+    .type = "fanspeed", .ds_num = 1, .ds = fanspeed_dsources};
 
-static value_list_t last_dispatched_value_list;
-static value_t last_dispatched_values[VALUE_CACHE_SIZE];
-int redfish_test_plugin_dispatch_values_mock(value_list_t const *vl) {
-  last_dispatched_value_list = *vl;
-  size_t len = MIN(vl->values_len, VALUE_CACHE_SIZE);
-  for (size_t i = 0; i < len; ++i) {
-    last_dispatched_values[i] = vl->values[i];
+/*******/
+
+#define DS_VOLTAGE_NUM_DSOURCES (1)
+/***/
+static data_source_t voltage_dsources[DS_VOLTAGE_NUM_DSOURCES] = {
+    {.name = "value", .type = DS_TYPE_GAUGE, .min = NAN, .max = NAN}};
+/***/
+static data_set_t voltage_dset = {
+    .type = "voltage", .ds_num = 1, .ds = voltage_dsources};
+
+/*******/
+
+#define DS_TEMPERATURE_NUM_DSOURCES (1)
+/***/
+static data_source_t temperature_dsources[DS_TEMPERATURE_NUM_DSOURCES] = {
+    {.name = "value", .type = DS_TYPE_GAUGE, .min = NAN, .max = NAN}};
+/***/
+static data_set_t temperature_dset = {
+    .type = "temperature", .ds_num = 1, .ds = temperature_dsources};
+
+/*******/
+
+#define DS_CAPACITY_NUM_DSOURCES (1)
+/***/
+static data_source_t capacity_dsources[DS_CAPACITY_NUM_DSOURCES] = {
+    {.name = "value", .type = DS_TYPE_GAUGE, .min = 0.0, .max = NAN}};
+/***/
+static data_set_t capacity_dset = {
+    .type = "capacity", .ds_num = 1, .ds = capacity_dsources};
+
+/*******/
+
+/* Mocking the type/data source inference: */
+static const data_set_t *
+redfish_test_plugin_get_ds_mock(const char *const type) {
+  /* Determining which type was specified, and returning the associated data
+   * set: */
+  if (strcasecmp(type, "fanspeed") == 0)
+    return (&fanspeed_dset);
+  else if (strcasecmp(type, "voltage") == 0)
+    return (&voltage_dset);
+  else if (strcasecmp(type, "temperature") == 0)
+    return (&temperature_dset);
+  else if (strcasecmp(type, "capacity") == 0)
+    return (&capacity_dset);
+
+  return NULL;
+}
+
+/******************************************************************************
+ * Mocking of the dispatching interface:
+ ******************************************************************************/
+/* List, used as a queue, of the lastly dispatched values: */
+static llist_t *last_dispatched_values_list;
+
+/*******/
+
+/* Mocking the dispatch of sampled values: */
+static int
+redfish_test_plugin_dispatch_values_mock(const value_list_t *dispatched_vl) {
+  /* Allocating a new "value_lisit_t" so as to deep-copy "dispatched_vl": */
+  value_list_t *vl = malloc(sizeof(*vl));
+  /***/
+  if (vl == NULL)
+    return EXIT_FAILURE;
+  /***/
+  memset(vl, 0, sizeof(*vl));
+
+  /* Performing the deep-copy of "dispatched_vl" into "vl" (which includes the
+   * (potential) allocation of "vl->values"): */
+  sstrncpy(vl->plugin, dispatched_vl->plugin, sizeof(dispatched_vl->plugin));
+  /***/
+  sstrncpy(vl->host, dispatched_vl->host, sizeof(dispatched_vl->host));
+  /***/
+  sstrncpy(vl->plugin_instance, dispatched_vl->plugin_instance,
+           sizeof(dispatched_vl->plugin_instance));
+  /***/
+  sstrncpy(vl->type, dispatched_vl->type, sizeof(dispatched_vl->type));
+  /***/
+  sstrncpy(vl->type_instance, dispatched_vl->type_instance,
+           sizeof(dispatched_vl->type_instance));
+  /***/
+  vl->values_len = dispatched_vl->values_len;
+  /***/
+  vl->values = malloc(vl->values_len * sizeof(*(vl->values)));
+  /****/
+  if (vl->values == NULL) {
+    free(vl);
+    return EXIT_FAILURE;
   }
-  last_dispatched_value_list.values = last_dispatched_values;
-  return 0;
+  /****/
+  memcpy(vl->values, dispatched_vl->values,
+         vl->values_len * sizeof(*(vl->values)));
+
+  /* Allocating a new entry for these dispatched values to be inserted into
+   * "last_dispatched_values_list": */
+  llentry_t *le = llentry_create("", vl);
+  /***/
+  if (le == NULL) {
+    free(vl->values);
+    free(vl);
+  }
+  /***/
+  llist_append(last_dispatched_values_list, le);
+
+  return EXIT_SUCCESS;
 }
 
-static value_list_t *redfish_test_get_last_dispatched_value_list() {
-  return &last_dispatched_value_list;
+/*******/
+
+/* Getting the next dispatched values to be consumed, using the associated list
+ * of dispatched values as a queue: */
+static value_list_t *redfish_test_get_next_dispatched_values() {
+  return (llist_head(last_dispatched_values_list)->value);
 }
 
-DEF_TEST(read_queries) {
-  oconfig_item_t *ci = calloc(1, sizeof(*ci));
+/*******/
 
-  assert(ci != NULL);
-  ci->values = calloc(3, sizeof(*ci->values));
-  assert(ci->values != NULL);
-  ci->values_num = 3;
-  ci->values[0].value.string = "temperatures";
-  ci->values[0].type = OCONFIG_TYPE_STRING;
-  ci->values[1].value.string = "fans";
-  ci->values[1].type = OCONFIG_TYPE_STRING;
-  ci->values[2].value.string = "power";
-  ci->values[2].type = OCONFIG_TYPE_STRING;
+/* Removes the head values from the list of dispatched values to notify that it
+ * has been consumed: */
+static void redfish_test_remove_next_dispatched_values() {
+  llentry_t *head = llist_head(last_dispatched_values_list);
 
-  char **queries;
-  int ret = redfish_read_queries(ci, &queries);
+  value_list_t *vl = head->value;
+  /***/
+  if (vl != NULL) {
+    if (vl->values != NULL)
+      free(vl->values);
+    free(vl);
+  }
 
-  EXPECT_EQ_INT(0, ret);
-  EXPECT_EQ_STR("temperatures", queries[0]);
-  EXPECT_EQ_STR("fans", queries[1]);
-  EXPECT_EQ_STR("power", queries[2]);
-
-  sfree(ci->values);
-  sfree(ci);
-
-  for (int j = 0; j < 3; j++)
-    sfree(queries[j]);
-  sfree(queries);
-  return 0;
+  llist_remove(last_dispatched_values_list, head);
+  llentry_destroy(head);
 }
 
-DEF_TEST(convert_val) {
+/******************************************************************************
+ * In-memory configuration file:
+ ******************************************************************************/
+/* To be allocated to build a configuration file: */
+static oconfig_item_t *config_file = NULL;
+
+/* Pointers to specific sub-parts of interest of the configuration file built
+ * in memory: */
+#define CONFIG_FILE_SERVICES (1)
+#define CONFIG_FILE_QUERIES (5)
+#define CONFIG_FILE_SUBPARTS (CONFIG_FILE_SERVICES + CONFIG_FILE_QUERIES)
+static oconfig_item_t *cf_service = NULL;
+static oconfig_item_t *cf_query_thermal = NULL;
+static oconfig_item_t *cf_query_voltages = NULL;
+static oconfig_item_t *cf_query_temperatures = NULL;
+static oconfig_item_t *cf_query_ps1_voltage = NULL;
+static oconfig_item_t *cf_query_storage = NULL;
+
+/*******/
+
+/* In order to test the plugin by hand during its implementation, the "Simple
+ * Rack-mounted Server" mockup developed by the DMTF was used:
+ *          https://redfish.dmtf.org/redfish/mockups/v1/1100
+ *
+ * To be complete, it was emulated through the "Redfish-Interface-Emulator":
+ *          https://github.com/DMTF/Redfish-Interface-Emulator
+ *
+ * Consequently, it seemed appropriated to use this same mockup for the
+ * automated test suite associated with the plugin.
+ * To do so:
+ *      + An in-memory copy of the configuration file used to collect metrics
+ *        from the emulated mockup was built through "oconfig";
+ *      + The JSON payloads associated with the queries defined by the
+ *        aforementioned configuration file were replicated.
+ */
+static char *json_payloads[CONFIG_FILE_QUERIES] = {
+    "{\n"
+    "\"@odata.type\": \"#Thermal.v1_7_0.Thermal\",\n"
+    "\"Id\": \"Thermal\",\n"
+    "\"Name\": \"Thermal\",\n"
+    "\"Temperatures\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Temperatures/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"CPU1 Temp\",\n"
+    "\"SensorNumber\": 5,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"ReadingCelsius\": 41,\n"
+    "\"UpperThresholdNonCritical\": 42,\n"
+    "\"UpperThresholdCritical\": 45,\n"
+    "\"UpperThresholdFatal\": 48,\n"
+    "\"MinReadingRangeTemp\": 0,\n"
+    "\"MaxReadingRangeTemp\": 60,\n"
+    "\"PhysicalContext\": \"CPU\",\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2/Processors/CPU1\"\n"
+    "}\n"
+    "]\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Temperatures/1\",\n"
+    "\"MemberId\": \"1\",\n"
+    "\"Name\": \"CPU2 Temp\",\n"
+    "\"SensorNumber\": 6,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Disabled\"\n"
+    "},\n"
+    "\"UpperThresholdNonCritical\": 42,\n"
+    "\"UpperThresholdCritical\": 45,\n"
+    "\"UpperThresholdFatal\": 48,\n"
+    "\"MinReadingRangeTemp\": 0,\n"
+    "\"MaxReadingRangeTemp\": 60,\n"
+    "\"PhysicalContext\": \"CPU\",\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2/Processors/CPU2\"\n"
+    "}\n"
+    "]\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Temperatures/2\",\n"
+    "\"MemberId\": \"2\",\n"
+    "\"Name\": \"Chassis Intake Temp\",\n"
+    "\"SensorNumber\": 9,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"ReadingCelsius\": 25,\n"
+    "\"UpperThresholdNonCritical\": 30,\n"
+    "\"UpperThresholdCritical\": 40,\n"
+    "\"UpperThresholdFatal\": 50,\n"
+    "\"LowerThresholdNonCritical\": 10,\n"
+    "\"LowerThresholdCritical\": 5,\n"
+    "\"LowerThresholdFatal\": 0,\n"
+    "\"MinReadingRangeTemp\": 0,\n"
+    "\"MaxReadingRangeTemp\": 60,\n"
+    "\"PhysicalContext\": \"Intake\",\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "}\n"
+    "]\n"
+    "}\n"
+    "],\n"
+    "\"Fans\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Fans/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"BaseBoard System Fan\",\n"
+    "\"PhysicalContext\": \"Backplane\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"Reading\": 2100,\n"
+    "\"ReadingUnits\": \"RPM\",\n"
+    "\"LowerThresholdFatal\": 0,\n"
+    "\"MinReadingRange\": 0,\n"
+    "\"MaxReadingRange\": 5000,\n"
+    "\"Redundancy\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Redundancy/0\"\n"
+    "}\n"
+    "],\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "]\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Fans/1\",\n"
+    "\"MemberId\": \"1\",\n"
+    "\"Name\": \"BaseBoard System Fan Backup\",\n"
+    "\"PhysicalContext\": \"Backplane\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"Reading\": 2050,\n"
+    "\"ReadingUnits\": \"RPM\",\n"
+    "\"LowerThresholdFatal\": 0,\n"
+    "\"MinReadingRange\": 0,\n"
+    "\"MaxReadingRange\": 5000,\n"
+    "\"Redundancy\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Redundancy/0\"\n"
+    "}\n"
+    "],\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "]\n"
+    "}\n"
+    "],\n"
+    "\"Redundancy\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Redundancy/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"BaseBoard System Fans\",\n"
+    "\"RedundancySet\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Fans/0\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal#/Fans/1\"\n"
+    "}\n"
+    "],\n"
+    "\"Mode\": \"N+m\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"MinNumNeeded\": 1,\n"
+    "\"MaxNumSupported\": 2\n"
+    "}\n"
+    "],\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Thermal\",\n"
+    "\"@Redfish.Copyright\": \"Copyright 2014-2021 DMTF. For the full DMTF "
+    "copyright policy, see http://www.dmtf.org/about/policies/copyright.\"\n"
+    "}",
+    "{\n"
+    "\"@odata.type\": \"#Power.v1_7_0.Power\",\n"
+    "\"Id\": \"Power\",\n"
+    "\"Name\": \"Power\",\n"
+    "\"PowerControl\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Power#/PowerControl/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"System Input Power\",\n"
+    "\"PowerConsumedWatts\": 344,\n"
+    "\"PowerRequestedWatts\": 800,\n"
+    "\"PowerAvailableWatts\": 0,\n"
+    "\"PowerCapacityWatts\": 800,\n"
+    "\"PowerAllocatedWatts\": 800,\n"
+    "\"PowerMetrics\": {\n"
+    "\"IntervalInMin\": 30,\n"
+    "\"MinConsumedWatts\": 271,\n"
+    "\"MaxConsumedWatts\": 489,\n"
+    "\"AverageConsumedWatts\": 319\n"
+    "},\n"
+    "\"PowerLimit\": {\n"
+    "\"LimitInWatts\": 500,\n"
+    "\"LimitException\": \"LogEventOnly\",\n"
+    "\"CorrectionInMs\": 50\n"
+    "},\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "],\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"Oem\": {}\n"
+    "}\n"
+    "],\n"
+    "\"Voltages\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Power#/Voltages/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"VRM1 Voltage\",\n"
+    "\"SensorNumber\": 11,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"ReadingVolts\": 12,\n"
+    "\"UpperThresholdNonCritical\": 12.5,\n"
+    "\"UpperThresholdCritical\": 13,\n"
+    "\"UpperThresholdFatal\": 15,\n"
+    "\"LowerThresholdNonCritical\": 11.5,\n"
+    "\"LowerThresholdCritical\": 11,\n"
+    "\"LowerThresholdFatal\": 10,\n"
+    "\"MinReadingRange\": 0,\n"
+    "\"MaxReadingRange\": 20,\n"
+    "\"PhysicalContext\": \"VoltageRegulator\",\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "]\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Power#/Voltages/1\",\n"
+    "\"MemberId\": \"1\",\n"
+    "\"Name\": \"VRM2 Voltage\",\n"
+    "\"SensorNumber\": 12,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"ReadingVolts\": 5,\n"
+    "\"UpperThresholdNonCritical\": 5.5,\n"
+    "\"UpperThresholdCritical\": 7,\n"
+    "\"LowerThresholdNonCritical\": 4.75,\n"
+    "\"LowerThresholdCritical\": 4.5,\n"
+    "\"MinReadingRange\": 0,\n"
+    "\"MaxReadingRange\": 20,\n"
+    "\"PhysicalContext\": \"VoltageRegulator\",\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2\"\n"
+    "},\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "]\n"
+    "}\n"
+    "],\n"
+    "\"PowerSupplies\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Power#/PowerSupplies/0\",\n"
+    "\"MemberId\": \"0\",\n"
+    "\"Name\": \"Power Supply Bay\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"Warning\"\n"
+    "},\n"
+    "\"Oem\": {},\n"
+    "\"PowerSupplyType\": \"AC\",\n"
+    "\"LineInputVoltageType\": \"ACWideRange\",\n"
+    "\"LineInputVoltage\": 120,\n"
+    "\"PowerCapacityWatts\": 800,\n"
+    "\"LastPowerOutputWatts\": 325,\n"
+    "\"Model\": \"499253-B21\",\n"
+    "\"Manufacturer\": \"ManufacturerName\",\n"
+    "\"FirmwareVersion\": \"1.00\",\n"
+    "\"SerialNumber\": \"1Z0000001\",\n"
+    "\"PartNumber\": \"0000001A3A\",\n"
+    "\"SparePartNumber\": \"0000001A3A\",\n"
+    "\"InputRanges\": [\n"
+    "{\n"
+    "\"InputType\": \"AC\",\n"
+    "\"MinimumVoltage\": 100,\n"
+    "\"MaximumVoltage\": 120,\n"
+    "\"OutputWattage\": 800\n"
+    "},\n"
+    "{\n"
+    "\"InputType\": \"AC\",\n"
+    "\"MinimumVoltage\": 200,\n"
+    "\"MaximumVoltage\": 240,\n"
+    "\"OutputWattage\": 1300\n"
+    "}\n"
+    "],\n"
+    "\"RelatedItem\": [\n"
+    "{\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U\"\n"
+    "}\n"
+    "]\n"
+    "}\n"
+    "],\n"
+    "\"Oem\": {},\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Power\",\n"
+    "\"@Redfish.Copyright\": \"Copyright 2014-2021 DMTF. For the full DMTF "
+    "copyright policy, see http://www.dmtf.org/about/policies/copyright.\"\n"
+    "}",
+    "{\n"
+    "\"@odata.type\": \"#ThermalMetrics.v1_0_0.ThermalMetrics\",\n"
+    "\"Id\": \"ThermalMetrics\",\n"
+    "\"Name\": \"Chassis Thermal Metrics\",\n"
+    "\"TemperatureSummaryCelsius\": {\n"
+    "\"Internal\": {\n"
+    "\"Reading\": 39,\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/CPU1Temp\"\n"
+    "},\n"
+    "\"Intake\": {\n"
+    "\"Reading\": 24.8,\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/IntakeTemp\"\n"
+    "},\n"
+    "\"Ambient\": {\n"
+    "\"Reading\": 22.5,\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/AmbientTemp\"\n"
+    "},\n"
+    "\"Exhaust\": {\n"
+    "\"Reading\": 40.5,\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/ExhaustTemp\"\n"
+    "}\n"
+    "},\n"
+    "\"TemperatureReadingsCelsius\": [\n"
+    "{\n"
+    "\"Reading\": 24.8,\n"
+    "\"DeviceName\": \"Intake\",\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/IntakeTemp\"\n"
+    "},\n"
+    "{\n"
+    "\"Reading\": 40.5,\n"
+    "\"DeviceName\": \"Exhaust\",\n"
+    "\"DataSourceUri\": \"/redfish/v1/Chassis/1U/Sensors/ExhaustTemp\"\n"
+    "}\n"
+    "],\n"
+    "\"Oem\": {},\n"
+    "\"@odata.id\": "
+    "\"/redfish/v1/Chassis/1U/ThermalSubsystem/ThermalMetrics\",\n"
+    "\"@Redfish.Copyright\": \"Copyright 2014-2021 DMTF. For the full DMTF "
+    "copyright policy, see http://www.dmtf.org/about/policies/copyright.\"\n"
+    "}\n",
+    "{\n"
+    "\"@odata.type\": \"#Sensor.v1_2_0.Sensor\",\n"
+    "\"Id\": \"PS1InputVoltage\",\n"
+    "\"Name\": \"Power Supply #1 Input Voltage\",\n"
+    "\"ReadingType\": \"Voltage\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "},\n"
+    "\"ElectricalContext\": \"Total\",\n"
+    "\"Reading\": 119.27,\n"
+    "\"ReadingUnits\": \"V\",\n"
+    "\"ReadingRangeMin\": 0,\n"
+    "\"ReadingRangeMax\": 260,\n"
+    "\"Accuracy\": 0.02,\n"
+    "\"Precision\": 2,\n"
+    "\"SensingInterval\": \"PT0.125S\",\n"
+    "\"PhysicalContext\": \"PowerSupply\",\n"
+    "\"PhysicalSubContext\": \"Input\",\n"
+    "\"Thresholds\": {\n"
+    "\"UpperCritical\": {\n"
+    "\"Reading\": 125,\n"
+    "\"Activation\": \"Increasing\",\n"
+    "\"DwellTime\": \"PT1M\"\n"
+    "},\n"
+    "\"UpperCaution\": {\n"
+    "\"Reading\": 122,\n"
+    "\"DwellTime\": \"PT10M\"\n"
+    "},\n"
+    "\"LowerCaution\": {\n"
+    "\"Reading\": 118,\n"
+    "\"DwellTime\": \"PT5M\"\n"
+    "},\n"
+    "\"LowerCritical\": {\n"
+    "\"Reading\": 115,\n"
+    "\"DwellTime\": \"PT1M\"\n"
+    "}\n"
+    "},\n"
+    "\"Oem\": {},\n"
+    "\"@odata.id\": \"/redfish/v1/Chassis/1U/Sensors/PS1InputVoltage\",\n"
+    "\"@Redfish.Copyright\": \"Copyright 2014-2021 DMTF. For the full DMTF "
+    "copyright policy, see http://www.dmtf.org/about/policies/copyright.\"\n"
+    "}\n",
+    "{\n"
+    "\"@odata.type\": \"#SimpleStorage.v1_0_2.SimpleStorage\",\n"
+    "\"Id\": \"1\",\n"
+    "\"Name\": \"Simple Storage Controller\",\n"
+    "\"Description\": \"System SATA\",\n"
+    "\"UEFIDevicePath\": "
+    "\"Acpi(PNP0A03,0)/Pci(1F|1)/Ata(Primary,Master)/HD(Part3, "
+    "Sig00110011)\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\",\n"
+    "\"HealthRollUp\": \"Degraded\"\n"
+    "},\n"
+    "\"Devices\": [\n"
+    "{\n"
+    "\"Name\": \"SATA Bay 1\",\n"
+    "\"Manufacturer\": \"Contoso\",\n"
+    "\"Model\": \"3000GT8\",\n"
+    "\"CapacityBytes\": 8000000000000,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"OK\"\n"
+    "}\n"
+    "},\n"
+    "{\n"
+    "\"Name\": \"SATA Bay 2\",\n"
+    "\"Manufacturer\": \"Contoso\",\n"
+    "\"Model\": \"3000GT7\",\n"
+    "\"CapacityBytes\": 4000000000000,\n"
+    "\"Status\": {\n"
+    "\"State\": \"Enabled\",\n"
+    "\"Health\": \"Degraded\"\n"
+    "}\n"
+    "},\n"
+    "{\n"
+    "\"Name\": \"SATA Bay 3\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Absent\"\n"
+    "}\n"
+    "},\n"
+    "{\n"
+    "\"Name\": \"SATA Bay 4\",\n"
+    "\"Status\": {\n"
+    "\"State\": \"Absent\"\n"
+    "}\n"
+    "}\n"
+    "],\n"
+    "\"@odata.context\": "
+    "\"/redfish/v1/$metadata#Systems/Members/437XR1138R2/SimpleStorage/Members/"
+    "$entity\",\n"
+    "\"@odata.id\": \"/redfish/v1/Systems/437XR1138R2/SimpleStorage/1\",\n"
+    "\"@Redfish.Copyright\": \"Copyright 2014-2016 DMTF. For the full DMTF "
+    "copyright policy, see http://www.dmtf.org/about/policies/copyright.\"\n"
+    "}\n"};
+
+/*******/
+
+/* Builds a configuration file in memory so as to be able to properly test each
+ * individual feature of the plugin.
+ * The built configuration file is to be cleaned up by "destroy_config_file": */
+static uint64_t build_config_file(void) {
+  /* Utilitary pointers to be used later on in order to make the code
+   * associated with the building of the configuration file clearer: */
+  oconfig_item_t *cf_resource = NULL;
+  oconfig_item_t *cf_property = NULL;
+  oconfig_item_t *cf_attribute = NULL;
+
+  /**************************************************************************
+   * Root:
+   **************************************************************************/
+  /* Allocating the root of the configuration file: */
+  config_file = calloc(1, sizeof(*config_file));
+  if (config_file == NULL)
+    return EXIT_FAILURE;
+  /***/
+  config_file->key = "redfish";
+  config_file->parent = NULL;
+
+  /* Allocating the queries and services belonging to the configuration file,
+   * which are the children of its root: */
+  config_file->children_num = CONFIG_FILE_SUBPARTS;
+  /***/
+  config_file->children =
+      calloc(config_file->children_num, sizeof(*(config_file->children)));
+  /***/
+  if (config_file->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Assigning the pointers specific to sub-parts of the configuration
+   * files: */
+  cf_service = &(config_file->children[0]);
+  cf_query_thermal = &(config_file->children[1]);
+  cf_query_voltages = &(config_file->children[2]);
+  cf_query_temperatures = &(config_file->children[3]);
+  cf_query_ps1_voltage = &(config_file->children[4]);
+  cf_query_storage = &(config_file->children[5]);
+
+  /**************************************************************************
+   * Service subpart:
+   **************************************************************************/
+  /* Allocating the root of the Service subpart of the configuration file: */
+  cf_service->key = "Service";
+  cf_service->parent = config_file;
+  /***/
+  cf_service->values_num = 1;
+  cf_service->values =
+      calloc(cf_service->values_num, sizeof(*(cf_service->values)));
+  /***/
+  if (cf_service->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_service->values[0].type = OCONFIG_TYPE_STRING;
+  cf_service->values[0].value.string = "mock1U";
+
+  /* Allocating the children of the Service subpart: */
+  cf_service->children_num = 4;
+  cf_service->children =
+      calloc(cf_service->children_num, sizeof(*(cf_service->children)));
+  /***/
+  if (cf_service->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the host: */
+  cf_service->children[0].key = "Host";
+  cf_service->children[0].parent = cf_service;
+  /***/
+  cf_service->children[0].values_num = 1;
+  cf_service->children[0].values =
+      calloc(cf_service->children[0].values_num,
+             sizeof(*(cf_service->children[0].values)));
+  /***/
+  if (cf_service->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_service->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_service->children[0].values[0].value.string = "localhost:10000";
+
+  /* Filling in the information related to the user: */
+  cf_service->children[1].key = "User";
+  cf_service->children[1].parent = cf_service;
+  /***/
+  cf_service->children[1].values_num = 1;
+  cf_service->children[1].values =
+      calloc(cf_service->children[1].values_num,
+             sizeof(*(cf_service->children[1].values)));
+  /***/
+  if (cf_service->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_service->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_service->children[1].values[0].value.string = "";
+
+  /* Filling in the information related to the password: */
+  cf_service->children[2].key = "Passwd";
+  cf_service->children[2].parent = cf_service;
+  /***/
+  cf_service->children[2].values_num = 1;
+  cf_service->children[2].values =
+      calloc(cf_service->children[2].values_num,
+             sizeof(*(cf_service->children[2].values)));
+  /***/
+  if (cf_service->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_service->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_service->children[2].values[0].value.string = "";
+
+  /* Filling in the information related to the queries: */
+  cf_service->children[3].key = "Queries";
+  cf_service->children[3].parent = cf_service;
+  /***/
+  cf_service->children[3].values_num = CONFIG_FILE_QUERIES;
+  cf_service->children[3].values =
+      calloc(cf_service->children[3].values_num,
+             sizeof(*(cf_service->children[3].values)));
+  /***/
+  if (cf_service->children[3].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_service->children[3].values[0].type = OCONFIG_TYPE_STRING;
+  cf_service->children[3].values[0].value.string = "thermal";
+  /***/
+  cf_service->children[3].values[1].type = OCONFIG_TYPE_STRING;
+  cf_service->children[3].values[1].value.string = "voltages";
+  /***/
+  cf_service->children[3].values[2].type = OCONFIG_TYPE_STRING;
+  cf_service->children[3].values[2].value.string = "temperatures";
+  /***/
+  cf_service->children[3].values[3].type = OCONFIG_TYPE_STRING;
+  cf_service->children[3].values[3].value.string = "ps1_voltage";
+  /***/
+  cf_service->children[3].values[4].type = OCONFIG_TYPE_STRING;
+  cf_service->children[3].values[4].value.string = "storage";
+
+  /**************************************************************************
+   * Query "fans" subpart:
+   **************************************************************************/
+  /* Allocating the root of the Query "thermal" subpart of the configuration
+   * file: */
+  cf_query_thermal->key = "Query";
+  cf_query_thermal->parent = config_file;
+  /***/
+  cf_query_thermal->values_num = 1;
+  cf_query_thermal->values =
+      calloc(cf_query_thermal->values_num, sizeof(*(cf_query_thermal->values)));
+  /***/
+  if (cf_query_thermal->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_thermal->values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_thermal->values[0].value.string = "thermal";
+
+  /* Allocating the children of the Query "thermal" subpart: */
+  cf_query_thermal->children_num = 3;
+  cf_query_thermal->children = calloc(cf_query_thermal->children_num,
+                                      sizeof(*(cf_query_thermal->children)));
+  /***/
+  if (cf_query_thermal->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the endpoint: */
+  cf_query_thermal->children[0].key = "Endpoint";
+  cf_query_thermal->children[0].parent = cf_query_thermal;
+  /***/
+  cf_query_thermal->children[0].values_num = 1;
+  cf_query_thermal->children[0].values =
+      calloc(cf_query_thermal->children[0].values_num,
+             sizeof(*(cf_query_thermal->children[0].values)));
+  /***/
+  if (cf_query_thermal->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_thermal->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_thermal->children[0].values[0].value.string = "/Chassis[0]/Thermal";
+
+  /* Filling in the information related to the resource: */
+  cf_resource = &(cf_query_thermal->children[1]);
+  cf_resource->key = "Resource";
+  cf_resource->parent = cf_query_thermal;
+  /***/
+  cf_resource->values_num = 1;
+  cf_resource->values =
+      calloc(cf_resource->values_num, sizeof(*(cf_resource->values)));
+  /***/
+  if (cf_resource->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_resource->values[0].type = OCONFIG_TYPE_STRING;
+  cf_resource->values[0].value.string = "Fans";
+
+  /* Allocating the property associated with the first resource: */
+  cf_resource->children_num = 1;
+  cf_resource->children =
+      calloc(cf_resource->children_num, sizeof(*(cf_resource->children)));
+  /***/
+  if (cf_resource->children == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property = &(cf_resource->children[0]);
+
+  /* Filling in the information related to the property: */
+  cf_property->key = "Property";
+  cf_property->parent = cf_resource;
+  /***/
+  cf_property->values_num = 1;
+  cf_property->values =
+      calloc(cf_property->values_num, sizeof(*(cf_property->values)));
+  /***/
+  if (cf_property->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->values[0].value.string = "Reading";
+
+  /* Allocating the fields (i.e. children) of the property: */
+  cf_property->children_num = 4;
+  cf_property->children =
+      calloc(cf_property->children_num, sizeof(*(cf_property->children)));
+  /***/
+  if (cf_property->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * property: */
+  cf_property->children[0].parent = cf_property;
+  cf_property->children[0].key = "PluginInstance";
+  /***/
+  cf_property->children[0].values_num = 1;
+  cf_property->children[0].values =
+      calloc(cf_property->children[0].values_num,
+             sizeof(*(cf_property->children[0].values)));
+  /***/
+  if (cf_property->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[0].values[0].value.string = "Fans";
+
+  /* Filling in the information related to the Type field of the property: */
+  cf_property->children[1].parent = cf_property;
+  cf_property->children[1].key = "Type";
+  /***/
+  cf_property->children[1].values_num = 1;
+  cf_property->children[1].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[1].values)));
+  /***/
+  if (cf_property->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[1].values[0].value.string = "fanspeed";
+
+  /* Filling in the information related to the TypeInstanceAttr field of the
+   * property: */
+  cf_property->children[2].parent = cf_property;
+  cf_property->children[2].key = "TypeInstanceAttr";
+  /***/
+  cf_property->children[2].values_num = 1;
+  cf_property->children[2].values =
+      calloc(cf_property->children[2].values_num,
+             sizeof(*(cf_property->children[2].values)));
+  /***/
+  if (cf_property->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[0].value.string = "Name";
+
+  /* Filling in the information related to the SelectIDs field of the
+   * property: */
+  cf_property->children[3].parent = cf_property;
+  cf_property->children[3].key = "SelectIDs";
+  /***/
+  cf_property->children[3].values_num = 1;
+  cf_property->children[3].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[3].values)));
+  /***/
+  if (cf_property->children[3].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[3].values[0].type = OCONFIG_TYPE_NUMBER;
+  cf_property->children[3].values[0].value.number = 1;
+
+  /* Filling in the information related to the second resource: */
+  cf_resource = &(cf_query_thermal->children[2]);
+  cf_resource->key = "Resource";
+  cf_resource->parent = cf_query_thermal;
+  /***/
+  cf_resource->values_num = 1;
+  cf_resource->values =
+      calloc(cf_resource->values_num, sizeof(*(cf_resource->values)));
+  /***/
+  if (cf_resource->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_resource->values[0].type = OCONFIG_TYPE_STRING;
+  cf_resource->values[0].value.string = "Temperatures";
+
+  /* Allocating the property associated with the resource: */
+  cf_resource->children_num = 1;
+  cf_resource->children =
+      calloc(cf_resource->children_num, sizeof(*(cf_resource->children)));
+  /***/
+  if (cf_resource->children == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property = &(cf_resource->children[0]);
+
+  /* Filling in the information related to the property: */
+  cf_property->key = "Property";
+  cf_property->parent = cf_resource;
+  /***/
+  cf_property->values_num = 1;
+  cf_property->values =
+      calloc(cf_property->values_num, sizeof(*(cf_property->values)));
+  /***/
+  if (cf_property->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->values[0].value.string = "ReadingCelsius";
+
+  /* Allocating the fields (i.e. children) of the property: */
+  cf_property->children_num = 3;
+  cf_property->children =
+      calloc(cf_property->children_num, sizeof(*(cf_property->children)));
+  /***/
+  if (cf_property->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * property: */
+  cf_property->children[0].parent = cf_property;
+  cf_property->children[0].key = "PluginInstance";
+  /***/
+  cf_property->children[0].values_num = 1;
+  cf_property->children[0].values =
+      calloc(cf_property->children[0].values_num,
+             sizeof(*(cf_property->children[0].values)));
+  /***/
+  if (cf_property->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[0].values[0].value.string = "Temperatures";
+
+  /* Filling in the information related to the Type field of the property: */
+  cf_property->children[1].parent = cf_property;
+  cf_property->children[1].key = "Type";
+  /***/
+  cf_property->children[1].values_num = 1;
+  cf_property->children[1].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[1].values)));
+  /***/
+  if (cf_property->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[1].values[0].value.string = "temperature";
+
+  /* Filling in the information related to the SelectAttrValue field of the
+   * property: */
+  cf_property->children[2].parent = cf_property;
+  cf_property->children[2].key = "SelectAttrValue";
+  /***/
+  cf_property->children[2].values_num = 2;
+  cf_property->children[2].values =
+      calloc(cf_property->children[2].values_num,
+             sizeof(*(cf_property->children[2].values)));
+  /***/
+  if (cf_property->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[0].value.string = "PhysicalContext";
+  /***/
+  cf_property->children[2].values[1].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[1].value.string = "Intake";
+
+  /**************************************************************************
+   * Query "voltages" subpart:
+   **************************************************************************/
+  /* Allocating the root of the Query "voltages" subpart of the
+   * configuration file: */
+  cf_query_voltages->key = "Query";
+  cf_query_voltages->parent = config_file;
+  /***/
+  cf_query_voltages->values_num = 1;
+  cf_query_voltages->values = calloc(cf_query_voltages->values_num,
+                                     sizeof(*(cf_query_voltages->values)));
+  /***/
+  if (cf_query_voltages->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_voltages->values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_voltages->values[0].value.string = "voltages";
+
+  /* Allocating the children of the Query "voltages" subpart: */
+  cf_query_voltages->children_num = 2;
+  cf_query_voltages->children = calloc(cf_query_voltages->children_num,
+                                       sizeof(*(cf_query_voltages->children)));
+  /***/
+  if (cf_query_voltages->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the endpoint: */
+  cf_query_voltages->children[0].key = "Endpoint";
+  cf_query_voltages->children[0].parent = cf_query_voltages;
+  /***/
+  cf_query_voltages->children[0].values_num = 1;
+  cf_query_voltages->children[0].values =
+      calloc(cf_query_voltages->children[0].values_num,
+             sizeof(*(cf_query_voltages->children[0].values)));
+  /***/
+  if (cf_query_voltages->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_voltages->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_voltages->children[0].values[0].value.string = "/Chassis[0]/Power";
+
+  /* Filling in the information related to the resource: */
+  cf_resource = &(cf_query_voltages->children[1]);
+  cf_resource->key = "Resource";
+  cf_resource->parent = cf_query_voltages;
+  /***/
+  cf_resource->values_num = 1;
+  cf_resource->values =
+      calloc(cf_resource->values_num, sizeof(*(cf_resource->values)));
+  /***/
+  if (cf_resource->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_resource->values[0].type = OCONFIG_TYPE_STRING;
+  cf_resource->values[0].value.string = "Voltages";
+
+  /* Allocating the property associated with the resource: */
+  cf_resource->children_num = 1;
+  cf_resource->children =
+      calloc(cf_resource->children_num, sizeof(*(cf_resource->children)));
+  /***/
+  if (cf_resource->children == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property = &(cf_resource->children[0]);
+
+  /* Filling in the information related to the property: */
+  cf_property->key = "Property";
+  cf_property->parent = cf_resource;
+  /***/
+  cf_property->values_num = 1;
+  cf_property->values =
+      calloc(cf_property->values_num, sizeof(*(cf_property->values)));
+  /***/
+  if (cf_property->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->values[0].value.string = "ReadingVolts";
+
+  /* Allocating the fields (i.e. children) of the property: */
+  cf_property->children_num = 4;
+  cf_property->children =
+      calloc(cf_property->children_num, sizeof(*(cf_property->children)));
+  /***/
+  if (cf_property->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * property: */
+  cf_property->children[0].parent = cf_property;
+  cf_property->children[0].key = "PluginInstance";
+  /***/
+  cf_property->children[0].values_num = 1;
+  cf_property->children[0].values =
+      calloc(cf_property->children[0].values_num,
+             sizeof(*(cf_property->children[0].values)));
+  /***/
+  if (cf_property->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[0].values[0].value.string = "Voltages";
+
+  /* Filling in the information related to the Type field of the property: */
+  cf_property->children[1].parent = cf_property;
+  cf_property->children[1].key = "Type";
+  /***/
+  cf_property->children[1].values_num = 1;
+  cf_property->children[1].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[1].values)));
+  /***/
+  if (cf_property->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[1].values[0].value.string = "voltage";
+
+  /* Filling in the information related to the TypeInstance field of the
+   * property: */
+  cf_property->children[2].parent = cf_property;
+  cf_property->children[2].key = "TypeInstance";
+  /***/
+  cf_property->children[2].values_num = 1;
+  cf_property->children[2].values =
+      calloc(cf_property->children[2].values_num,
+             sizeof(*(cf_property->children[2].values)));
+  /***/
+  if (cf_property->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[0].value.string = "VRM";
+
+  /* Filling in the information related to the TypeInstance field of the
+   * property: */
+  cf_property->children[3].parent = cf_property;
+  cf_property->children[3].key = "TypeInstancePrefixID";
+  /***/
+  cf_property->children[3].values_num = 1;
+  cf_property->children[3].values =
+      calloc(cf_property->children[3].values_num,
+             sizeof(*(cf_property->children[3].values)));
+  /***/
+  if (cf_property->children[3].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[3].values[0].type = OCONFIG_TYPE_BOOLEAN;
+  cf_property->children[3].values[0].value.boolean = true;
+
+  /**************************************************************************
+   * Query "temperatures" subpart:
+   **************************************************************************/
+  /* Allocating the root of the Query "temperatures" subpart of the
+   * configuration file: */
+  cf_query_temperatures->key = "Query";
+  cf_query_temperatures->parent = config_file;
+  /***/
+  cf_query_temperatures->values_num = 1;
+  cf_query_temperatures->values =
+      calloc(cf_query_temperatures->values_num,
+             sizeof(*(cf_query_temperatures->values)));
+  /***/
+  if (cf_query_temperatures->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_temperatures->values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_temperatures->values[0].value.string = "temperatures";
+
+  /* Allocating the children of the Query "temperatures" subpart: */
+  cf_query_temperatures->children_num = 2;
+  cf_query_temperatures->children =
+      calloc(cf_query_temperatures->children_num,
+             sizeof(*(cf_query_temperatures->children)));
+  /***/
+  if (cf_query_temperatures->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the endpoint: */
+  cf_query_temperatures->children[0].key = "Endpoint";
+  cf_query_temperatures->children[0].parent = cf_query_temperatures;
+  /***/
+  cf_query_temperatures->children[0].values_num = 1;
+  cf_query_temperatures->children[0].values =
+      calloc(cf_query_temperatures->children[0].values_num,
+             sizeof(*(cf_query_temperatures->children[0].values)));
+  /***/
+  if (cf_query_temperatures->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_temperatures->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_temperatures->children[0].values[0].value.string =
+      "/Chassis[0]/ThermalSubsystem/ThermalMetrics";
+
+  /* Filling in the information related to the resource: */
+  cf_resource = &(cf_query_temperatures->children[1]);
+  cf_resource->key = "Resource";
+  cf_resource->parent = cf_query_temperatures;
+  /***/
+  cf_resource->values_num = 1;
+  cf_resource->values =
+      calloc(cf_resource->values_num, sizeof(*(cf_resource->values)));
+  /***/
+  if (cf_resource->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_resource->values[0].type = OCONFIG_TYPE_STRING;
+  cf_resource->values[0].value.string = "TemperatureReadingsCelsius";
+
+  /* Allocating the property associated with the resource: */
+  cf_resource->children_num = 1;
+  cf_resource->children =
+      calloc(cf_resource->children_num, sizeof(*(cf_resource->children)));
+  /***/
+  if (cf_resource->children == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property = &(cf_resource->children[0]);
+
+  /* Filling in the information related to the property: */
+  cf_property->key = "Property";
+  cf_property->parent = cf_resource;
+  /***/
+  cf_property->values_num = 1;
+  cf_property->values =
+      calloc(cf_property->values_num, sizeof(*(cf_property->values)));
+  /***/
+  if (cf_property->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->values[0].value.string = "Reading";
+
+  /* Allocating the fields (i.e. children) of the property: */
+  cf_property->children_num = 3;
+  cf_property->children =
+      calloc(cf_property->children_num, sizeof(*(cf_property->children)));
+  /***/
+  if (cf_property->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * property: */
+  cf_property->children[0].parent = cf_property;
+  cf_property->children[0].key = "PluginInstance";
+  /***/
+  cf_property->children[0].values_num = 1;
+  cf_property->children[0].values =
+      calloc(cf_property->children[0].values_num,
+             sizeof(*(cf_property->children[0].values)));
+  /***/
+  if (cf_property->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[0].values[0].value.string = "Temperatures";
+
+  /* Filling in the information related to the Type field of the property: */
+  cf_property->children[1].parent = cf_property;
+  cf_property->children[1].key = "Type";
+  /***/
+  cf_property->children[1].values_num = 1;
+  cf_property->children[1].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[1].values)));
+  /***/
+  if (cf_property->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[1].values[0].value.string = "temperature";
+
+  /* Filling in the information related to the TypeInstanceAttr field of the
+   * property: */
+  cf_property->children[2].parent = cf_property;
+  cf_property->children[2].key = "TypeInstanceAttr";
+  /***/
+  cf_property->children[2].values_num = 1;
+  cf_property->children[2].values =
+      calloc(cf_property->children[2].values_num,
+             sizeof(*(cf_property->children[2].values)));
+  /***/
+  if (cf_property->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[0].value.string = "DeviceName";
+
+  /**************************************************************************
+   * Query "ps1_voltage" subpart:
+   **************************************************************************/
+  /* Allocating the root of the Query "ps1_voltage" subpart of the
+   * configuration file: */
+  cf_query_ps1_voltage->key = "Query";
+  cf_query_ps1_voltage->parent = config_file;
+  /***/
+  cf_query_ps1_voltage->values_num = 1;
+  cf_query_ps1_voltage->values =
+      calloc(cf_query_ps1_voltage->values_num,
+             sizeof(*(cf_query_ps1_voltage->values)));
+  /***/
+  if (cf_query_ps1_voltage->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_ps1_voltage->values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_ps1_voltage->values[0].value.string = "ps1_voltage";
+
+  /* Allocating the children of the Query "ps1_voltage" subpart: */
+  cf_query_ps1_voltage->children_num = 2;
+  cf_query_ps1_voltage->children =
+      calloc(cf_query_ps1_voltage->children_num,
+             sizeof(*(cf_query_ps1_voltage->children)));
+  /***/
+  if (cf_query_ps1_voltage->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the endpoint: */
+  cf_query_ps1_voltage->children[0].key = "Endpoint";
+  cf_query_ps1_voltage->children[0].parent = cf_query_ps1_voltage;
+  /***/
+  cf_query_ps1_voltage->children[0].values_num = 1;
+  cf_query_ps1_voltage->children[0].values =
+      calloc(cf_query_ps1_voltage->children[0].values_num,
+             sizeof(*(cf_query_ps1_voltage->children[0].values)));
+  /***/
+  if (cf_query_ps1_voltage->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_ps1_voltage->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_ps1_voltage->children[0].values[0].value.string =
+      "/Chassis[0]/Sensors[15]";
+
+  /* Filling in the information related to the attribute: */
+  cf_attribute = &(cf_query_ps1_voltage->children[1]);
+  cf_attribute->key = "Attribute";
+  cf_attribute->parent = cf_query_ps1_voltage;
+  /***/
+  cf_attribute->values_num = 1;
+  cf_attribute->values =
+      calloc(cf_attribute->values_num, sizeof(*(cf_attribute->values)));
+  /***/
+  if (cf_attribute->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_attribute->values[0].type = OCONFIG_TYPE_STRING;
+  cf_attribute->values[0].value.string = "Reading";
+
+  /* Allocating the fields (i.e. children) of the attribute: */
+  cf_attribute->children_num = 3;
+  cf_attribute->children =
+      calloc(cf_attribute->children_num, sizeof(*(cf_attribute->children)));
+  /***/
+  if (cf_attribute->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * attribute: */
+  cf_attribute->children[0].parent = cf_attribute;
+  cf_attribute->children[0].key = "PluginInstance";
+  /***/
+  cf_attribute->children[0].values_num = 1;
+  cf_attribute->children[0].values =
+      calloc(cf_attribute->children[0].values_num,
+             sizeof(*(cf_attribute->children[0].values)));
+  /***/
+  if (cf_attribute->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_attribute->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_attribute->children[0].values[0].value.string = "Voltages";
+
+  /* Filling in the information related to the Type field of the attribute: */
+  cf_attribute->children[1].parent = cf_attribute;
+  cf_attribute->children[1].key = "Type";
+  /***/
+  cf_attribute->children[1].values_num = 1;
+  cf_attribute->children[1].values =
+      calloc(cf_attribute->children[1].values_num,
+             sizeof(*(cf_attribute->children[1].values)));
+  /***/
+  if (cf_attribute->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_attribute->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_attribute->children[1].values[0].value.string = "voltage";
+
+  /* Filling in the information related to the TypeInstance field of the
+   * attribute: */
+  cf_attribute->children[2].parent = cf_attribute;
+  cf_attribute->children[2].key = "TypeInstance";
+  /***/
+  cf_attribute->children[2].values_num = 1;
+  cf_attribute->children[2].values =
+      calloc(cf_attribute->children[2].values_num,
+             sizeof(*(cf_attribute->children[2].values)));
+  /***/
+  if (cf_attribute->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_attribute->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_attribute->children[2].values[0].value.string = "PS1 Voltage";
+
+  /**************************************************************************
+   * Query "storage" subpart:
+   **************************************************************************/
+  /* Allocating the root of the Query "storage" subpart of the configuration
+   * file: */
+  cf_query_storage->key = "Query";
+  cf_query_storage->parent = config_file;
+  /***/
+  cf_query_storage->values_num = 1;
+  cf_query_storage->values =
+      calloc(cf_query_storage->values_num, sizeof(*(cf_query_storage->values)));
+  /***/
+  if (cf_query_storage->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_storage->values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_storage->values[0].value.string = "storage";
+
+  /* Allocating the children of the Query "storage" subpart: */
+  cf_query_storage->children_num = 2;
+  cf_query_storage->children = calloc(cf_query_storage->children_num,
+                                      sizeof(*(cf_query_storage->children)));
+  /***/
+  if (cf_query_storage->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the endpoint: */
+  cf_query_storage->children[0].key = "Endpoint";
+  cf_query_storage->children[0].parent = cf_query_storage;
+  /***/
+  cf_query_storage->children[0].values_num = 1;
+  cf_query_storage->children[0].values =
+      calloc(cf_query_storage->children[0].values_num,
+             sizeof(*(cf_query_storage->children[0].values)));
+  /***/
+  if (cf_query_storage->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_query_storage->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_query_storage->children[0].values[0].value.string =
+      "/Systems[0]/SimpleStorage[0]";
+
+  /* Filling in the information related to the resource: */
+  cf_resource = &(cf_query_storage->children[1]);
+  cf_resource->key = "Resource";
+  cf_resource->parent = cf_query_storage;
+  /***/
+  cf_resource->values_num = 1;
+  cf_resource->values =
+      calloc(cf_resource->values_num, sizeof(*(cf_resource->values)));
+  /***/
+  if (cf_resource->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_resource->values[0].type = OCONFIG_TYPE_STRING;
+  cf_resource->values[0].value.string = "Devices";
+
+  /* Allocating the property associated with the resource: */
+  cf_resource->children_num = 1;
+  cf_resource->children =
+      calloc(cf_resource->children_num, sizeof(*(cf_resource->children)));
+  /***/
+  if (cf_resource->children == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property = &(cf_resource->children[0]);
+
+  /* Filling in the information related to the property: */
+  cf_property->key = "Property";
+  cf_property->parent = cf_resource;
+  /***/
+  cf_property->values_num = 1;
+  cf_property->values =
+      calloc(cf_property->values_num, sizeof(*(cf_property->values)));
+  /***/
+  if (cf_property->values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->values[0].value.string = "CapacityBytes";
+
+  /* Allocating the fields (i.e. children) of the property: */
+  cf_property->children_num = 3;
+  cf_property->children =
+      calloc(cf_property->children_num, sizeof(*(cf_property->children)));
+  /***/
+  if (cf_property->children == NULL)
+    return EXIT_FAILURE;
+
+  /* Filling in the information related to the PluginInstance field of the
+   * property: */
+  cf_property->children[0].parent = cf_property;
+  cf_property->children[0].key = "PluginInstance";
+  /***/
+  cf_property->children[0].values_num = 1;
+  cf_property->children[0].values =
+      calloc(cf_property->children[0].values_num,
+             sizeof(*(cf_property->children[0].values)));
+  /***/
+  if (cf_property->children[0].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[0].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[0].values[0].value.string = "Storage";
+
+  /* Filling in the information related to the Type field of the property: */
+  cf_property->children[1].parent = cf_property;
+  cf_property->children[1].key = "Type";
+  /***/
+  cf_property->children[1].values_num = 1;
+  cf_property->children[1].values =
+      calloc(cf_property->children[1].values_num,
+             sizeof(*(cf_property->children[1].values)));
+  /***/
+  if (cf_property->children[1].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[1].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[1].values[0].value.string = "capacity";
+
+  /* Filling in the information related to the SelectAttrs field of the
+   * property: */
+  cf_property->children[2].parent = cf_property;
+  cf_property->children[2].key = "SelectAttrs";
+  /***/
+  cf_property->children[2].values_num = 2;
+  cf_property->children[2].values =
+      calloc(cf_property->children[2].values_num,
+             sizeof(*(cf_property->children[2].values)));
+  /***/
+  if (cf_property->children[2].values == NULL)
+    return EXIT_FAILURE;
+  /***/
+  cf_property->children[2].values[0].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[0].value.string = "Model";
+  /***/
+  cf_property->children[2].values[1].type = OCONFIG_TYPE_STRING;
+  cf_property->children[2].values[1].value.string = "Name";
+
+  return EXIT_SUCCESS;
+}
+
+/*******/
+
+static void
+destroy_config_file_attribute(const oconfig_item_t *const cf_attribute) {
+  /* Deallocating the attribute's values: */
+  if (cf_attribute->values != NULL)
+    free(cf_attribute->values);
+
+  /* Deallocating the attribute's children/fields: */
+  if (cf_attribute->children != NULL) {
+    for (int i = 0; i < cf_attribute->children_num; i++) {
+      if (cf_attribute->children[i].values != NULL) {
+        free(cf_attribute->children[i].values);
+      }
+    }
+
+    free(cf_attribute->children);
+  }
+}
+
+/*******/
+
+static void
+destroy_config_file_property(const oconfig_item_t *const cf_property) {
+  /* Deallocating the property's values: */
+  if (cf_property->values != NULL)
+    free(cf_property->values);
+
+  /* Deallocating the property's children/fields: */
+  if (cf_property->children != NULL) {
+    for (int i = 0; i < cf_property->children_num; i++) {
+      if (cf_property->children[i].values != NULL) {
+        free(cf_property->children[i].values);
+      }
+    }
+
+    free(cf_property->children);
+  }
+}
+
+/*******/
+
+static void
+destroy_config_file_resource(const oconfig_item_t *const cf_resource) {
+  /* Deallocating the resource's values: */
+  if (cf_resource->values != NULL)
+    free(cf_resource->values);
+
+  /* Deallocating the resource's children, which are properties: */
+  if (cf_resource->children != NULL) {
+    for (int i = 0; i < cf_resource->children_num; i++) {
+      destroy_config_file_property(&(cf_resource->children[i]));
+    }
+
+    free(cf_resource->children);
+  }
+}
+
+/*******/
+
+static void destroy_config_file_query(const oconfig_item_t *const cf_query) {
+  /* Checking that the specified query should be deallocated: */
+  if (cf_query != NULL) {
+    /* Deallocating the values associated with the query: */
+    if (cf_query->values != NULL)
+      free(cf_query->values);
+
+    /* Deallocating the children of the query, after individually
+     * deallocating their content: */
+    if (cf_query->children != NULL) {
+      /* Deallocating all the children of the query: */
+      for (int i = 0; i < cf_query->children_num; i++) {
+        /* Deallocating the endpoint: */
+        if (strcmp("Endpoint", cf_query->children[i].key) == 0) {
+          if (cf_query->children[0].values != NULL) {
+            free(cf_query->children[0].values);
+          }
+        }
+        /* Deallocating the considered resource: */
+        else if (strcmp("Resource", cf_query->children[i].key) == 0) {
+          destroy_config_file_resource(&(cf_query->children[i]));
+        }
+        /* Deallocating the considered attribute: */
+        else if (strcmp("Attribute", cf_query->children[i].key) == 0) {
+          destroy_config_file_attribute(&(cf_query->children[i]));
+        }
+      }
+
+      free(cf_query->children);
+    }
+  }
+}
+
+/*******/
+
+/* Destroys the in-memory configuration file built by "build_config_file".
+ * To do so, this function deallocates, if required, each sub-part (queries and
+ * services) of the configuration file, before deallocating its root: */
+static void destroy_config_file(void) {
+  /**************************************************************************
+   * Service:
+   **************************************************************************/
+  if (cf_service != NULL) {
+    /* Deallocating the values associated with the Service: */
+    if (cf_service->values != NULL)
+      free(cf_service->values);
+
+    /* Deallocating the children of the service, after individually
+     * deallocating their content: */
+    if (cf_service->children != NULL) {
+      for (int i = 0; i < cf_service->children_num; i++) {
+        if (cf_service->children[i].values != NULL) {
+          free(cf_service->children[i].values);
+        }
+      }
+
+      free(cf_service->children);
+    }
+  }
+
+  /**************************************************************************
+   * Queries:
+   **************************************************************************/
+  destroy_config_file_query(cf_query_thermal);
+  destroy_config_file_query(cf_query_voltages);
+  destroy_config_file_query(cf_query_temperatures);
+  destroy_config_file_query(cf_query_ps1_voltage);
+  destroy_config_file_query(cf_query_storage);
+
+  /**************************************************************************
+   * Root:
+   **************************************************************************/
+  if (config_file != NULL) {
+    /* Deallocating the values associated with the root: */
+    if (config_file->values != NULL)
+      free(config_file->values);
+
+    /* Deallocating the children associated with the root, that is to say
+     * the service and queries, which content was already deallocated: */
+    if (config_file->children != NULL)
+      free(config_file->children);
+
+    /* Deallocating the root itself: */
+    free(config_file);
+  }
+
+  /**************************************************************************
+   * Global reset:
+   **************************************************************************/
+  config_file = NULL;
+  cf_service = NULL;
+  cf_query_thermal = NULL;
+  cf_query_voltages = NULL;
+  cf_query_temperatures = NULL;
+  cf_query_ps1_voltage = NULL;
+  cf_query_storage = NULL;
+}
+
+/******************************************************************************
+ * Tests:
+ ******************************************************************************/
+/* Conversion of parsed data types to collectd's data types: */
+DEF_TEST(redfish_convert_val) {
   redfish_value_t val = {.string = "1"};
   redfish_value_type_t src_type = VAL_TYPE_STR;
   int dst_type = DS_TYPE_GAUGE;
   value_t vl = {0};
   int ret = redfish_convert_val(&val, src_type, &vl, dst_type);
+
   EXPECT_EQ_INT(0, ret);
   OK(vl.gauge == 1.0);
 
@@ -169,8 +1846,10 @@ DEF_TEST(convert_val) {
   return 0;
 }
 
-/* Testing allocation of memory for ctx struct. Creation of services list
- * & queries avl tree */
+/*******/
+
+/* Testing the memory allocation for the context structure.
+ * Creation of services list & queries AVL tree: */
 DEF_TEST(redfish_preconfig) {
   int ret = redfish_preconfig();
 
@@ -178,439 +1857,892 @@ DEF_TEST(redfish_preconfig) {
   CHECK_NOT_NULL(ctx.queries);
   CHECK_NOT_NULL(ctx.services);
 
-  llist_destroy(ctx.services);
-  c_avl_destroy(ctx.queries);
+  redfish_cleanup();
 
   return 0;
 }
 
-/* Testing correct input of properties from conf file */
-DEF_TEST(config_property) {
-  redfish_resource_t *resource = calloc(1, sizeof(*resource));
-  assert(resource != NULL);
-  resource->name = "test property";
-  resource->properties = llist_create();
-  oconfig_item_t *ci = calloc(1, sizeof(*ci));
+/*******/
 
-  assert(ci != NULL);
-  ci->values_num = 1;
-  ci->values = calloc(1, sizeof(*ci->values));
-  ci->values[0].type = OCONFIG_TYPE_STRING;
-  ci->values[0].value.string = "ReadingRPM";
+DEF_TEST(redfish_config) {
+  redfish_query_t *query = NULL;
 
-  ci->children_num = 3;
-  ci->children = calloc(1, sizeof(*ci->children) * ci->children_num);
-
-  ci->children[0].key = "PluginInstance";
-  ci->children[0].parent = ci;
-  ci->children[0].values = calloc(1, sizeof(*ci->children[0].values));
-  assert(ci->children[0].values != NULL);
-  ci->children[0].values_num = 1;
-  ci->children[0].values->value.string = "chassis1";
-  ci->children[0].values->type = OCONFIG_TYPE_STRING;
-
-  ci->children[1].key = "Type";
-  ci->children[1].parent = ci;
-  ci->children[1].values = calloc(1, sizeof(*ci->children[1].values));
-  assert(ci->children[1].values != NULL);
-  ci->children[1].values_num = 1;
-  ci->children[1].values->value.string = "degrees";
-  ci->children[1].values->type = OCONFIG_TYPE_STRING;
-
-  ci->children[2].key = "TypeInstance";
-  ci->children[2].parent = ci;
-  ci->children[2].values = calloc(1, sizeof(*ci->children[2].values));
-  assert(ci->children[2].values != NULL);
-  ci->children[2].values_num = 1;
-  ci->children[2].values->value.string = "0";
-  ci->children[2].values->type = OCONFIG_TYPE_STRING;
-
-  int ret = redfish_config_property(resource, ci);
-
-  EXPECT_EQ_INT(0, ret);
-  EXPECT_EQ_INT(1, llist_size(resource->properties));
-
-  sfree(ci->children[0].values);
-  sfree(ci->children[1].values);
-  sfree(ci->children[2].values);
-
-  sfree(ci->children);
-  sfree(ci->values);
-  sfree(ci);
-
-  for (llentry_t *llprop = llist_head(resource->properties); llprop != NULL;
-       llprop = llprop->next) {
-    redfish_property_t *property = (redfish_property_t *)llprop->value;
-    sfree(property->name);
-    sfree(property->plugin_inst);
-    sfree(property->type);
-    sfree(property->type_inst);
-    sfree(property);
-  }
-  llist_destroy(resource->properties);
-  free(resource);
-  return 0;
-}
-
-DEF_TEST(config_resource) {
-  oconfig_item_t *ci = calloc(1, sizeof(*ci));
-  assert(ci != NULL);
-
-  ci->values_num = 1;
-  ci->values = calloc(1, sizeof(*ci->values));
-  assert(ci->values != NULL);
-  ci->values[0].value.string = "Temperatures";
-
-  ci->children_num = 1;
-  ci->children = calloc(1, sizeof(*ci->children));
-  assert(ci->children != NULL);
-  ci->children[0].children_num = 1;
-  ci->children[0].parent = ci;
-  ci->children[0].key = "Property";
-  ci->children[0].values_num = 1;
-  ci->children[0].values = calloc(1, sizeof(*ci->children[0].values));
-  ci->children[0].values->value.string = "ReadingRPM";
-  assert(ci->children[0].values != NULL);
-
-  oconfig_item_t *ci_prop = calloc(1, sizeof(*ci_prop));
-  assert(ci_prop != NULL);
-
-  ci->children[0].children = ci_prop;
-  ci->children_num = 1;
-
-  ci_prop->key = "PluginInstance";
-  ci_prop->parent = ci;
-  ci_prop->values_num = 1;
-  ci_prop->values = calloc(1, sizeof(*ci_prop->values));
-  assert(ci_prop->values != NULL);
-  ci_prop->values[0].type = OCONFIG_TYPE_STRING;
-  ci_prop->values[0].value.string = "chassis-1";
-
-  redfish_query_t *query = calloc(1, sizeof(*query));
-  query->endpoint = "/redfish/v1/Chassis/Chassis-1/Thermal";
-  query->name = "fans";
-  query->resources = llist_create();
-
-  int ret = redfish_config_resource(query, ci);
-  EXPECT_EQ_INT(0, ret);
-  EXPECT_EQ_INT(1, llist_size(query->resources));
-
-  sfree(ci_prop->values);
-  sfree(ci_prop);
-
-  sfree(ci->values);
-  sfree(ci->children[0].values);
-  sfree(ci->children);
-  sfree(ci);
-
-  for (llentry_t *llres = llist_head(query->resources); llres != NULL;
-       llres = llres->next) {
-    redfish_resource_t *resource = (redfish_resource_t *)llres->value;
-    for (llentry_t *llprop = llist_head(resource->properties); llprop != NULL;
-         llprop = llprop->next) {
-      redfish_property_t *property = (redfish_property_t *)llprop->value;
-      sfree(property->name);
-      sfree(property->plugin_inst);
-      sfree(property->type);
-      sfree(property->type_inst);
-      free(property);
-    }
-    llist_destroy(resource->properties);
-    free(resource->name);
-    free(resource);
-  }
-  llist_destroy(query->resources);
-  sfree(query);
-  return 0;
-}
-
-DEF_TEST(config_query) {
-  oconfig_item_t *qci = calloc(1, sizeof(*qci));
-  assert(qci != NULL);
-  qci->key = "Query";
-  qci->values_num = 1;
-  qci->values = calloc(1, sizeof(*qci->values));
-  assert(qci->values != NULL);
-  qci->values->type = OCONFIG_TYPE_STRING;
-  qci->values->value.string = "fans";
-
-  qci->children_num = 2;
-  qci->children = calloc(1, sizeof(*qci->children) * qci->children_num);
-  assert(qci->children != NULL);
-
-  qci->children[0].key = "Endpoint";
-  qci->children[0].values = calloc(1, sizeof(*qci->children[0].values));
-  assert(qci->children[0].values != NULL);
-  qci->children[0].values->type = OCONFIG_TYPE_STRING;
-  qci->children[0].values_num = 1;
-  qci->children[0].values->value.string =
-      "/redfish/v1/Chassis/Chassis-1/Thermal";
-
-  qci->children[1].key = "Resource";
-  qci->children[1].values_num = 1;
-  qci->children[1].values = calloc(1, sizeof(*qci->children[1].values));
-  assert(qci->children[1].values != NULL);
-  qci->children[1].values->type = OCONFIG_TYPE_STRING;
-  qci->children[1].values->value.string = "Temperature";
-  qci->children[1].children_num = 1;
-
-  oconfig_item_t *ci = calloc(1, sizeof(*ci));
-  assert(ci != NULL);
-
-  qci->children[1].children = ci;
-
-  ci->key = "Property";
-  ci->values_num = 1;
-  ci->values = calloc(1, sizeof(*ci->values));
-  assert(ci->values != NULL);
-  ci->values->type = OCONFIG_TYPE_STRING;
-  ci->values->value.string = "ReadingRPM";
-
-  oconfig_item_t *ci_prop = calloc(1, sizeof(*ci_prop));
-  assert(ci_prop != NULL);
-
-  ci->children = ci_prop;
-  ci->children_num = 1;
-
-  ci_prop->key = "PluginInstance";
-  ci_prop->parent = ci;
-  ci_prop->values_num = 1;
-  ci_prop->values = calloc(1, sizeof(*ci_prop->values));
-  assert(ci_prop->values != NULL);
-  ci_prop->values[0].type = OCONFIG_TYPE_STRING;
-  ci_prop->values[0].value.string = "chassis-1";
-
-  c_avl_tree_t *queries =
-      c_avl_create((int (*)(const void *, const void *))strcmp);
-
-  int ret = redfish_config_query(qci, queries);
-  EXPECT_EQ_INT(0, ret);
-
-  sfree(ci_prop->values);
-  sfree(ci_prop);
-
-  sfree(ci->values);
-  sfree(ci);
-  sfree(qci->children[0].values);
-  sfree(qci->children[1].values);
-  sfree(qci->children);
-  sfree(qci->values);
-  sfree(qci);
-
-  redfish_query_t *query;
-  char *key;
-  c_avl_iterator_t *query_iter = c_avl_get_iterator(queries);
-  while (c_avl_iterator_next(query_iter, (void **)&key, (void **)&query) == 0) {
-    for (llentry_t *llres = llist_head(query->resources); llres != NULL;
-         llres = llres->next) {
-      redfish_resource_t *resource = (redfish_resource_t *)llres->value;
-      for (llentry_t *llprop = llist_head(resource->properties); llprop != NULL;
-           llprop = llprop->next) {
-        redfish_property_t *property = (redfish_property_t *)llprop->value;
-        sfree(property->name);
-        sfree(property->plugin_inst);
-        sfree(property->type);
-        sfree(property->type_inst);
-        sfree(property);
-      }
-      llist_destroy(resource->properties);
-      sfree(resource->name);
-      sfree(resource);
-    }
-    llist_destroy(query->resources);
-    sfree(query->name);
-    sfree(query->endpoint);
-  }
-  sfree(query_iter);
-  c_avl_destroy(queries);
-  return 0;
-}
-
-DEF_TEST(config_service) {
-  oconfig_item_t *ci = calloc(1, sizeof(*ci));
-  assert(ci != NULL);
-  ci->key = "Service";
-  ci->values_num = 1;
-  ci->values = calloc(1, sizeof(*ci->values));
-  ci->values->type = OCONFIG_TYPE_STRING;
-  ci->values->value.string = "Server 5";
-  ci->children_num = 4;
-  ci->children = calloc(1, sizeof(*ci->children) * ci->children_num);
-  ci->children[0].key = "Host";
-  ci->children[0].values_num = 1;
-  ci->children[0].values = calloc(1, sizeof(*ci->children[0].values));
-  ci->children[0].values->type = OCONFIG_TYPE_STRING;
-  ci->children[0].values->value.string = "127.0.0.1:5000";
-  ci->children[1].key = "User";
-  ci->children[1].values_num = 1;
-  ci->children[1].values = calloc(1, sizeof(*ci->children[1].values));
-  ci->children[1].values->type = OCONFIG_TYPE_STRING;
-  ci->children[1].values->value.string = "user";
-  ci->children[2].key = "Passwd";
-  ci->children[2].values_num = 1;
-  ci->children[2].values = calloc(1, sizeof(*ci->children[2].values));
-  ci->children[2].values->type = OCONFIG_TYPE_STRING;
-  ci->children[2].values->value.string = "passwd";
-  ci->children[3].key = "Queries";
-  ci->children[3].values_num = 1;
-  ci->children[3].values = calloc(1, sizeof(*ci->children[2].values));
-  ci->children[3].values->type = OCONFIG_TYPE_STRING;
-  ci->children[3].values->value.string = "fans";
-
-  ctx.services = llist_create();
-
-  int ret = redfish_config_service(ci);
+  int ret = redfish_config(config_file);
 
   EXPECT_EQ_INT(0, ret);
 
-  for (llentry_t *llserv = llist_head(ctx.services); llserv != NULL;
-       llserv = llserv->next) {
-    redfish_service_t *serv = (redfish_service_t *)llserv->value;
-    sfree(serv->name);
-    sfree(serv->host);
-    sfree(serv->user);
-    sfree(serv->passwd);
-    for (int i = 0; i < serv->queries_num; i++)
-      sfree(serv->queries[i]);
-    sfree(serv->queries);
-    sfree(serv);
-  }
-  llist_destroy(ctx.services);
+  EXPECT_EQ_INT(1, llist_size(ctx.services));
+  EXPECT_EQ_STR("mock1U", llist_head(ctx.services)->key);
 
-  sfree(ci->children[3].values);
-  sfree(ci->children[2].values);
-  sfree(ci->children[1].values);
-  sfree(ci->children[0].values);
-  sfree(ci->children);
-  sfree(ci->values);
-  sfree(ci);
+  EXPECT_EQ_INT(5, c_avl_size(ctx.queries));
+  /***/
+  c_avl_get(ctx.queries, "thermal", (void **)(&query));
+  EXPECT_EQ_STR("thermal", query->name);
+  /***/
+  c_avl_get(ctx.queries, "voltages", (void **)(&query));
+  EXPECT_EQ_STR("voltages", query->name);
+  /***/
+  c_avl_get(ctx.queries, "temperatures", (void **)(&query));
+  EXPECT_EQ_STR("temperatures", query->name);
+  /***/
+  c_avl_get(ctx.queries, "ps1_voltage", (void **)(&query));
+  EXPECT_EQ_STR("ps1_voltage", query->name);
+  /***/
+  c_avl_get(ctx.queries, "storage", (void **)(&query));
+  EXPECT_EQ_STR("storage", query->name);
+
+  redfish_cleanup();
+
   return 0;
 }
 
-DEF_TEST(process_payload_property) {
-  redfish_property_t property;
-  property.name = "Abc";
-  property.plugin_inst = "TestPluginInstance";
-  property.type = "MAGIC";
-  property.type_inst = "TestTypeInstance";
+/*******/
 
-  redfish_resource_t resource;
-  resource.name = "ResourceName";
+DEF_TEST(redfish_config_service) {
 
-  redfish_service_t service;
-  service.name = "localhost";
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
 
-  const char *json_text = "["
-                          "  { \"Abc\": 4567 }"
-                          "]";
+  ret = redfish_config_service(cf_service);
+  EXPECT_EQ_INT(0, ret);
+  /***/
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  EXPECT_EQ_STR("mock1U", service->name);
+  EXPECT_EQ_STR("localhost:10000", service->host);
+  EXPECT_EQ_STR("", service->user);
+  EXPECT_EQ_STR("", service->passwd);
+  EXPECT_EQ_PTR(NULL, service->token);
+  EXPECT_EQ_INT(5, service->queries_num);
+  CHECK_NOT_NULL(service->queries);
+  EXPECT_EQ_PTR(NULL, service->query_ptrs);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+/* Reading the names of the queries from the configuration files: */
+DEF_TEST(redfish_read_queries) {
+  char **queries = NULL;
+  int ret = redfish_read_queries(&(cf_service->children[3]), &queries);
+
+  EXPECT_EQ_INT(0, ret);
+  EXPECT_EQ_STR("thermal", queries[0]);
+  EXPECT_EQ_STR("voltages", queries[1]);
+  EXPECT_EQ_STR("temperatures", queries[2]);
+  EXPECT_EQ_STR("ps1_voltage", queries[3]);
+  EXPECT_EQ_STR("storage", queries[4]);
+
+  for (int j = 0; j < cf_service->children[3].values_num; j++) {
+    sfree(queries[j]);
+  }
+  /***/
+  sfree(queries);
+
+  return 0;
+}
+
+/*******/
+
+static redfish_query_t *
+redfish_config_get_query_struct(oconfig_item_t *cf_query,
+                                const char *const query_name) {
+  /* Initialisation of the global data structures: */
+  redfish_preconfig();
+
+  /* Populating the data structure associated with the specified query.
+   * The latter will be inserted into an AVL tree: */
+  redfish_config_query(cf_query, ctx.queries);
+
+  /* Extracting the data structure representing the query from the AVL
+   * tree: */
+  redfish_query_t *query = NULL;
+  /***/
+  c_avl_get(ctx.queries, query_name, (void **)(&query));
+
+  /* Returning the data structure associated with the query: */
+  return query;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_query_thermal) {
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
+
+  ret = redfish_config_query(cf_query_thermal, ctx.queries);
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_query_t *query = NULL;
+  /***/
+  ret = c_avl_get(ctx.queries, "thermal", (void **)(&query));
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(query);
+  /***/
+  EXPECT_EQ_STR("thermal", query->name);
+  EXPECT_EQ_STR("/Chassis[0]/Thermal", query->endpoint);
+  CHECK_NOT_NULL(query->resources);
+  EXPECT_EQ_UINT64(2, llist_size(query->resources));
+  CHECK_NOT_NULL(query->attributes);
+  EXPECT_EQ_UINT64(0, llist_size(query->attributes));
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_resource_thermal_fans) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_thermal, "thermal");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *fans = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(fans);
+  EXPECT_EQ_STR("Fans", fans->name);
+  CHECK_NOT_NULL(fans->properties);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_property_thermal_fans_reading) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_thermal, "thermal");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *fans = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(fans);
+
+  redfish_property_t *reading = llist_head(fans->properties)->value;
+  /***/
+  CHECK_NOT_NULL(reading);
+  EXPECT_EQ_STR("Reading", reading->name);
+  EXPECT_EQ_STR("Fans", reading->plugin_inst);
+  EXPECT_EQ_STR("fanspeed", reading->type);
+  EXPECT_EQ_PTR(NULL, reading->type_inst);
+  EXPECT_EQ_STR("Name", reading->type_inst_attr);
+  OK(!reading->type_inst_prefix_id);
+  EXPECT_EQ_UINT64(1, reading->nb_select_ids);
+  /***/
+  CHECK_NOT_NULL(reading->select_ids);
+  EXPECT_EQ_UINT64(1, reading->select_ids[0]);
+  /***/
+  EXPECT_EQ_UINT64(0, reading->nb_select_attrs);
+  EXPECT_EQ_PTR(NULL, reading->select_attrs);
+  EXPECT_EQ_PTR(NULL, reading->select_attrvalues);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_resource_thermal_temperatures) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_thermal, "thermal");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *temperatures = llist_head(query->resources)->next->value;
+  /***/
+  CHECK_NOT_NULL(temperatures);
+  EXPECT_EQ_STR("Temperatures", temperatures->name);
+  CHECK_NOT_NULL(temperatures->properties);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_property_thermal_temperatures_readingcelsius) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_thermal, "thermal");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *temperatures = llist_head(query->resources)->next->value;
+  /***/
+  CHECK_NOT_NULL(temperatures);
+
+  redfish_property_t *reading_celsius =
+      llist_head(temperatures->properties)->value;
+  /***/
+  CHECK_NOT_NULL(reading_celsius);
+  EXPECT_EQ_STR("ReadingCelsius", reading_celsius->name);
+  EXPECT_EQ_STR("Temperatures", reading_celsius->plugin_inst);
+  EXPECT_EQ_STR("temperature", reading_celsius->type);
+  EXPECT_EQ_PTR(NULL, reading_celsius->type_inst);
+  EXPECT_EQ_PTR(NULL, reading_celsius->type_inst_attr);
+  OK(!reading_celsius->type_inst_prefix_id);
+  EXPECT_EQ_UINT64(0, reading_celsius->nb_select_ids);
+  EXPECT_EQ_PTR(NULL, reading_celsius->select_ids);
+  EXPECT_EQ_UINT64(0, reading_celsius->nb_select_attrs);
+  EXPECT_EQ_PTR(NULL, reading_celsius->select_attrs);
+
+  CHECK_NOT_NULL(reading_celsius->select_attrvalues);
+  /***/
+  llentry_t *le = llist_head(reading_celsius->select_attrvalues);
+  /***/
+  EXPECT_EQ_STR("PhysicalContext", le->key);
+  EXPECT_EQ_STR("Intake", le->value);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_query_voltages) {
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
+
+  ret = redfish_config_query(cf_query_voltages, ctx.queries);
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_query_t *query = NULL;
+  /***/
+  ret = c_avl_get(ctx.queries, "voltages", (void **)(&query));
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(query);
+  /***/
+  EXPECT_EQ_STR("voltages", query->name);
+  EXPECT_EQ_STR("/Chassis[0]/Power", query->endpoint);
+  CHECK_NOT_NULL(query->resources);
+  EXPECT_EQ_UINT64(1, llist_size(query->resources));
+  CHECK_NOT_NULL(query->attributes);
+  EXPECT_EQ_UINT64(0, llist_size(query->attributes));
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_resource_voltages_voltages) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_voltages, "voltages");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *voltages = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(voltages);
+  EXPECT_EQ_STR("Voltages", voltages->name);
+  CHECK_NOT_NULL(voltages->properties);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_property_voltages_voltages_readingvolts) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_voltages, "voltages");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *voltages = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(voltages);
+
+  redfish_property_t *reading_volts = llist_head(voltages->properties)->value;
+  /***/
+  CHECK_NOT_NULL(reading_volts);
+  EXPECT_EQ_STR("ReadingVolts", reading_volts->name);
+  EXPECT_EQ_STR("Voltages", reading_volts->plugin_inst);
+  EXPECT_EQ_STR("voltage", reading_volts->type);
+  EXPECT_EQ_STR("VRM", reading_volts->type_inst);
+  EXPECT_EQ_PTR(NULL, reading_volts->type_inst_attr);
+  OK(reading_volts->type_inst_prefix_id);
+  EXPECT_EQ_UINT64(0, reading_volts->nb_select_ids);
+  EXPECT_EQ_PTR(NULL, reading_volts->select_ids);
+  EXPECT_EQ_UINT64(0, reading_volts->nb_select_attrs);
+  EXPECT_EQ_PTR(NULL, reading_volts->select_attrs);
+  EXPECT_EQ_PTR(NULL, reading_volts->select_attrvalues);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_query_temperatures) {
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
+
+  ret = redfish_config_query(cf_query_temperatures, ctx.queries);
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_query_t *query = NULL;
+  /***/
+  ret = c_avl_get(ctx.queries, "temperatures", (void **)(&query));
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(query);
+  /***/
+  EXPECT_EQ_STR("temperatures", query->name);
+  EXPECT_EQ_STR("/Chassis[0]/ThermalSubsystem/ThermalMetrics", query->endpoint);
+  CHECK_NOT_NULL(query->resources);
+  EXPECT_EQ_UINT64(1, llist_size(query->resources));
+  CHECK_NOT_NULL(query->attributes);
+  EXPECT_EQ_UINT64(0, llist_size(query->attributes));
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_resource_temperatures_trc) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_temperatures, "temperatures");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *trc = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(trc);
+  EXPECT_EQ_STR("TemperatureReadingsCelsius", trc->name);
+  CHECK_NOT_NULL(trc->properties);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_property_temperatures_trc_reading) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_temperatures, "temperatures");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *trc = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(trc);
+
+  redfish_property_t *reading = llist_head(trc->properties)->value;
+  /***/
+  CHECK_NOT_NULL(reading);
+  EXPECT_EQ_STR("Reading", reading->name);
+  EXPECT_EQ_STR("Temperatures", reading->plugin_inst);
+  EXPECT_EQ_STR("temperature", reading->type);
+  EXPECT_EQ_PTR(NULL, reading->type_inst);
+  EXPECT_EQ_STR("DeviceName", reading->type_inst_attr);
+  OK(!reading->type_inst_prefix_id);
+  EXPECT_EQ_UINT64(0, reading->nb_select_ids);
+  EXPECT_EQ_PTR(NULL, reading->select_ids);
+  EXPECT_EQ_UINT64(0, reading->nb_select_attrs);
+  EXPECT_EQ_PTR(NULL, reading->select_attrs);
+  EXPECT_EQ_PTR(NULL, reading->select_attrvalues);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_query_ps1_voltage) {
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
+
+  ret = redfish_config_query(cf_query_ps1_voltage, ctx.queries);
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_query_t *query = NULL;
+  /***/
+  ret = c_avl_get(ctx.queries, "ps1_voltage", (void **)(&query));
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(query);
+  /***/
+  EXPECT_EQ_STR("ps1_voltage", query->name);
+  EXPECT_EQ_STR("/Chassis[0]/Sensors[15]", query->endpoint);
+  CHECK_NOT_NULL(query->resources);
+  EXPECT_EQ_UINT64(0, llist_size(query->resources));
+  CHECK_NOT_NULL(query->attributes);
+  EXPECT_EQ_UINT64(1, llist_size(query->attributes));
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_attribute_ps1_voltage_reading) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_ps1_voltage, "ps1_voltage");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_attribute_t *reading = llist_head(query->attributes)->value;
+  /***/
+  CHECK_NOT_NULL(reading);
+  EXPECT_EQ_STR("Reading", reading->name);
+  EXPECT_EQ_STR("Voltages", reading->plugin_inst);
+  EXPECT_EQ_STR("voltage", reading->type);
+  EXPECT_EQ_STR("PS1 Voltage", reading->type_inst);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_query_storage) {
+  int ret = redfish_preconfig();
+  EXPECT_EQ_INT(0, ret);
+
+  ret = redfish_config_query(cf_query_storage, ctx.queries);
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_query_t *query = NULL;
+  /***/
+  ret = c_avl_get(ctx.queries, "storage", (void **)(&query));
+  EXPECT_EQ_INT(0, ret);
+  CHECK_NOT_NULL(query);
+  /***/
+  EXPECT_EQ_STR("storage", query->name);
+  EXPECT_EQ_STR("/Systems[0]/SimpleStorage[0]", query->endpoint);
+  CHECK_NOT_NULL(query->resources);
+  EXPECT_EQ_UINT64(1, llist_size(query->resources));
+  CHECK_NOT_NULL(query->attributes);
+  EXPECT_EQ_UINT64(0, llist_size(query->attributes));
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_resource_storage_devices) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_storage, "storage");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *devices = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(devices);
+  EXPECT_EQ_STR("Devices", devices->name);
+  CHECK_NOT_NULL(devices->properties);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(redfish_config_property_storage_devices_capacitybytes) {
+  redfish_query_t *query =
+      redfish_config_get_query_struct(cf_query_storage, "storage");
+  /***/
+  CHECK_NOT_NULL(query);
+
+  redfish_resource_t *devices = llist_head(query->resources)->value;
+  /***/
+  CHECK_NOT_NULL(devices);
+
+  redfish_property_t *capacity_bytes = llist_head(devices->properties)->value;
+  /***/
+  CHECK_NOT_NULL(capacity_bytes);
+  EXPECT_EQ_STR("CapacityBytes", capacity_bytes->name);
+  EXPECT_EQ_STR("Storage", capacity_bytes->plugin_inst);
+  EXPECT_EQ_STR("capacity", capacity_bytes->type);
+  EXPECT_EQ_PTR(NULL, capacity_bytes->type_inst);
+  EXPECT_EQ_PTR(NULL, capacity_bytes->type_inst_attr);
+  OK(!capacity_bytes->type_inst_prefix_id);
+  EXPECT_EQ_UINT64(0, capacity_bytes->nb_select_ids);
+  EXPECT_EQ_PTR(NULL, capacity_bytes->select_ids);
+  /***/
+  EXPECT_EQ_UINT64(2, capacity_bytes->nb_select_attrs);
+  CHECK_NOT_NULL(capacity_bytes->select_attrs);
+  EXPECT_EQ_STR("Model", capacity_bytes->select_attrs[0]);
+  EXPECT_EQ_STR("Name", capacity_bytes->select_attrs[1]);
+  /***/
+  EXPECT_EQ_PTR(NULL, capacity_bytes->select_attrvalues);
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(process_payload_query_thermal) {
+  int ret = redfish_config(config_file);
+  /***/
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  redfish_query_t *query = NULL;
+  c_avl_get(ctx.queries, "thermal", (void **)(&query));
+  /***/
+  redfish_payload_ctx_t payload = {.service = service, .query = query};
+  /***/
+  redfish_job_t job = {.next = NULL, .prev = NULL, .service_query = &payload};
+
   json_error_t error;
-  json_t *root = json_loads(json_text, 0, &error);
-
-  if (!root) {
+  json_t *root = json_loads(json_payloads[0], 0, &error);
+  /***/
+  if (!root)
     return -1;
-  }
 
-  redfish_process_payload_property(&property, root, &resource, &service);
+  redfishPayload redfish_payload = {.json = root};
+
+  redfish_process_payload(true, 200, &redfish_payload, &job);
 
   json_decref(root);
 
-  value_list_t *v = redfish_test_get_last_dispatched_value_list();
+  value_list_t *v = redfish_test_get_next_dispatched_values();
+  /***/
   EXPECT_EQ_INT(1, v->values_len);
-  EXPECT_EQ_STR("MAGIC", v->type);
-  EXPECT_EQ_INT(4567, v->values->derive);
-  EXPECT_EQ_STR("TestPluginInstance", v->plugin_instance);
-  EXPECT_EQ_STR("TestTypeInstance", v->type_instance);
-  EXPECT_EQ_STR("localhost", v->host);
+  /***/
   EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Fans", v->plugin_instance);
+  EXPECT_EQ_STR("fanspeed", v->type);
+  EXPECT_EQ_STR("BaseBoard System Fan Backup", v->type_instance);
+  EXPECT_EQ_DOUBLE(2050, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Temperatures", v->plugin_instance);
+  EXPECT_EQ_STR("temperature", v->type);
+  EXPECT_EQ_STR("Chassis Intake Temp", v->type_instance);
+  EXPECT_EQ_DOUBLE(25, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  redfish_cleanup();
+
   return 0;
 }
 
-DEF_TEST(service_destroy) {
-  /* Check for memory leaks when a service is destroyed */
-  redfish_service_t *service = calloc(1, sizeof(*service));
+/*******/
 
-  service->name = strdup("Name");
-  service->host = strdup("http://localhost:1234");
-  service->user = strdup("User");
-  service->passwd = strdup("Password");
-  service->token = strdup("Token");
+DEF_TEST(process_payload_query_voltages) {
+  int ret = redfish_config(config_file);
+  /***/
+  EXPECT_EQ_INT(0, ret);
 
-  service->queries = calloc(2, sizeof(*service->queries));
-  service->queries[0] = strdup("Query1");
-  service->queries[1] = strdup("Query2");
-  service->queries_num = 2;
-
-  service->query_ptrs = llist_create();
-
-  service->flags |= REDFISH_FLAG_SERVICE_NO_VERSION_DOC;
-  service->auth.authCodes.userPass.username = service->user;
-  service->auth.authCodes.userPass.password = service->passwd;
-  service->redfish = createServiceEnumerator(service->host, NULL,
-                                             &service->auth, service->flags);
-
-  redfish_service_destroy(service);
-  return 0;
-}
-
-DEF_TEST(job_destroy) {
-  /* Check for memory leaks when a job is destroyed */
-  redfish_job_t *job = calloc(1, sizeof(*job));
-  redfish_job_destroy(job);
-  return 0;
-}
-
-DEF_TEST(json_get_string_1) {
-  const char *json_text = "{ \"MemberId\": \"1234\" }";
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  redfish_query_t *query = NULL;
+  c_avl_get(ctx.queries, "voltages", (void **)(&query));
+  /***/
+  redfish_payload_ctx_t payload = {.service = service, .query = query};
+  /***/
+  redfish_job_t job = {.next = NULL, .prev = NULL, .service_query = &payload};
 
   json_error_t error;
-  json_t *root = json_loads(json_text, 0, &error);
-
-  if (!root) {
+  json_t *root = json_loads(json_payloads[1], 0, &error);
+  /***/
+  if (!root)
     return -1;
-  }
 
-  char str[20];
-  json_t *json = json_object_get(root, "MemberId");
-  redfish_json_get_string(str, sizeof(str), json);
+  redfishPayload redfish_payload = {.json = root};
+
+  redfish_process_payload(true, 200, &redfish_payload, &job);
 
   json_decref(root);
 
-  EXPECT_EQ_STR("1234", str);
+  value_list_t *v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Voltages", v->plugin_instance);
+  EXPECT_EQ_STR("voltage", v->type);
+  EXPECT_EQ_STR("0-VRM", v->type_instance);
+  EXPECT_EQ_DOUBLE(12, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Voltages", v->plugin_instance);
+  EXPECT_EQ_STR("voltage", v->type);
+  EXPECT_EQ_STR("1-VRM", v->type_instance);
+  EXPECT_EQ_DOUBLE(5, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  redfish_cleanup();
+
   return 0;
 }
 
-DEF_TEST(json_get_string_2) {
-  const char *json_text = "{ \"MemberId\": 9876 }";
+/*******/
+
+DEF_TEST(process_payload_query_temperatures) {
+  int ret = redfish_config(config_file);
+  /***/
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  redfish_query_t *query = NULL;
+  c_avl_get(ctx.queries, "temperatures", (void **)(&query));
+  /***/
+  redfish_payload_ctx_t payload = {.service = service, .query = query};
+  /***/
+  redfish_job_t job = {.next = NULL, .prev = NULL, .service_query = &payload};
 
   json_error_t error;
-  json_t *root = json_loads(json_text, 0, &error);
-
-  if (!root) {
+  json_t *root = json_loads(json_payloads[2], 0, &error);
+  /***/
+  if (!root)
     return -1;
-  }
 
-  char str[20];
-  json_t *json = json_object_get(root, "MemberId");
-  redfish_json_get_string(str, sizeof(str), json);
+  redfishPayload redfish_payload = {.json = root};
+
+  redfish_process_payload(true, 200, &redfish_payload, &job);
 
   json_decref(root);
 
-  EXPECT_EQ_STR("9876", str);
+  value_list_t *v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Temperatures", v->plugin_instance);
+  EXPECT_EQ_STR("temperature", v->type);
+  EXPECT_EQ_STR("Intake", v->type_instance);
+  EXPECT_EQ_DOUBLE(24.8, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Temperatures", v->plugin_instance);
+  EXPECT_EQ_STR("temperature", v->type);
+  EXPECT_EQ_STR("Exhaust", v->type_instance);
+  EXPECT_EQ_DOUBLE(40.5, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  redfish_cleanup();
+
   return 0;
 }
 
+/*******/
+
+DEF_TEST(process_payload_query_ps1_voltage) {
+  int ret = redfish_config(config_file);
+  /***/
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  redfish_query_t *query = NULL;
+  c_avl_get(ctx.queries, "ps1_voltage", (void **)(&query));
+  /***/
+  redfish_payload_ctx_t payload = {.service = service, .query = query};
+  /***/
+  redfish_job_t job = {.next = NULL, .prev = NULL, .service_query = &payload};
+
+  json_error_t error;
+  json_t *root = json_loads(json_payloads[3], 0, &error);
+  /***/
+  if (!root)
+    return -1;
+
+  redfishPayload redfish_payload = {.json = root};
+
+  redfish_process_payload(true, 200, &redfish_payload, &job);
+
+  json_decref(root);
+
+  value_list_t *v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Voltages", v->plugin_instance);
+  EXPECT_EQ_STR("voltage", v->type);
+  EXPECT_EQ_STR("PS1 Voltage", v->type_instance);
+  EXPECT_EQ_DOUBLE(119.27, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/*******/
+
+DEF_TEST(process_payload_query_storage) {
+  int ret = redfish_config(config_file);
+  /***/
+  EXPECT_EQ_INT(0, ret);
+
+  redfish_service_t *service = llist_head(ctx.services)->value;
+  /***/
+  redfish_query_t *query = NULL;
+  c_avl_get(ctx.queries, "storage", (void **)(&query));
+  /***/
+  redfish_payload_ctx_t payload = {.service = service, .query = query};
+  /***/
+  redfish_job_t job = {.next = NULL, .prev = NULL, .service_query = &payload};
+
+  json_error_t error;
+  json_t *root = json_loads(json_payloads[4], 0, &error);
+  /***/
+  if (!root)
+    return -1;
+
+  redfishPayload redfish_payload = {.json = root};
+
+  redfish_process_payload(true, 200, &redfish_payload, &job);
+
+  json_decref(root);
+
+  value_list_t *v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Storage", v->plugin_instance);
+  EXPECT_EQ_STR("capacity", v->type);
+  EXPECT_EQ_STR("SATA Bay 1", v->type_instance);
+  EXPECT_EQ_DOUBLE(8000000000000, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  v = redfish_test_get_next_dispatched_values();
+  /***/
+  EXPECT_EQ_INT(1, v->values_len);
+  /***/
+  EXPECT_EQ_STR("redfish", v->plugin);
+  EXPECT_EQ_STR("mock1U", v->host);
+  EXPECT_EQ_STR("Storage", v->plugin_instance);
+  EXPECT_EQ_STR("capacity", v->type);
+  EXPECT_EQ_STR("SATA Bay 2", v->type_instance);
+  EXPECT_EQ_DOUBLE(4000000000000, v->values[0].gauge);
+  /***/
+  redfish_test_remove_next_dispatched_values();
+
+  redfish_cleanup();
+
+  return 0;
+}
+
+/******************************************************************************
+ * Main:
+ ******************************************************************************/
 int main(void) {
-  RUN_TEST(read_queries);
-  RUN_TEST(convert_val);
+  /* Initialisation of the list of dispatched values: */
+  last_dispatched_values_list = llist_create();
+  /***/
+  if (last_dispatched_values_list == NULL)
+    return EXIT_FAILURE;
+
+  /* Building the in-memory version of the configuration file: */
+  if (EXIT_FAILURE == build_config_file()) {
+    destroy_config_file();
+    return EXIT_FAILURE;
+  }
+
+#if defined(COLLECT_DEBUG) && defined(REDFISH_TEST_PRINT_CONFIG)
+  /* If the dedicated preprocessing variable was defined, printing the
+   * configuration tree, notably for debug purposes: */
+  oconfig_print_tree(config_file, OCONFIG_PRINT_TREE_INDENT_MAX_LVL,
+                     OCONFIG_PRINT_TREE_INDENT_IN_SPACES, stderr);
+#endif
+
+  /* Running the tests: */
+  RUN_TEST(redfish_convert_val);
   RUN_TEST(redfish_preconfig);
-  RUN_TEST(config_property);
-  RUN_TEST(config_resource);
-  RUN_TEST(config_query);
-  RUN_TEST(config_service);
-  RUN_TEST(process_payload_property);
-  RUN_TEST(service_destroy);
-  RUN_TEST(job_destroy);
-  RUN_TEST(json_get_string_1);
-  RUN_TEST(json_get_string_2);
+  RUN_TEST(redfish_config);
+  RUN_TEST(redfish_config_service);
+  RUN_TEST(redfish_read_queries);
+  RUN_TEST(redfish_config_query_thermal);
+  RUN_TEST(redfish_config_resource_thermal_fans);
+  RUN_TEST(redfish_config_property_thermal_fans_reading);
+  RUN_TEST(redfish_config_resource_thermal_temperatures);
+  RUN_TEST(redfish_config_property_thermal_temperatures_readingcelsius);
+  RUN_TEST(redfish_config_query_voltages);
+  RUN_TEST(redfish_config_resource_voltages_voltages);
+  RUN_TEST(redfish_config_property_voltages_voltages_readingvolts);
+  RUN_TEST(redfish_config_query_temperatures);
+  RUN_TEST(redfish_config_resource_temperatures_trc);
+  RUN_TEST(redfish_config_property_temperatures_trc_reading);
+  RUN_TEST(redfish_config_query_ps1_voltage);
+  RUN_TEST(redfish_config_attribute_ps1_voltage_reading);
+  RUN_TEST(redfish_config_query_storage);
+  RUN_TEST(redfish_config_resource_storage_devices);
+  RUN_TEST(redfish_config_property_storage_devices_capacitybytes);
+  RUN_TEST(process_payload_query_thermal);
+  RUN_TEST(process_payload_query_voltages);
+  RUN_TEST(process_payload_query_temperatures);
+  RUN_TEST(process_payload_query_ps1_voltage);
+  RUN_TEST(process_payload_query_storage);
+
+  /* Destroying the in-memory version of the configuration file: */
+  destroy_config_file();
+
+  /* Destroying the list of dispatched values: */
+  for (llentry_t *le = llist_head(last_dispatched_values_list); le != NULL;
+       le = le->next) {
+    value_list_t *vl = le->value;
+    /***/
+    if (vl != NULL) {
+      if (vl->values != NULL)
+        free(vl->values);
+      free(vl);
+      le->value = NULL;
+    }
+  }
+  /***/
+  llist_destroy(last_dispatched_values_list);
+
+  /* Termination and summary of the test suite: */
   END_TEST;
 }


### PR DESCRIPTION
ChangeLog: Redfish plugin: complete rework and enhancement

The Redfish plugin of Collectd was, in the facts, unusable.
Indeed, it suffered from several heavy limitations which made it impossible to
monitor standard "recent" IT components (such as HPC compute blades):

+ Only members of anonymous collections could be collected;
+ Those members had to have a `DeviceName` attribute (this criteria was
  hard-coded and, thus, not configurable).
  The value of this attribute was compulsorily the type instance associated
  with the metric;
+ There was no way to select/filter which members of an anonymous collection
  should be collected;
+ The plugin could generate segmentation errors, and induced memory leaks;
+ The test suite and the documentation associated with the plugin were greatly
  incomplete.

Consequently, the Redfish plugin of Collectd was refactored and extensively
enhanced to make it possible and easy to monitor metrics and collect information
exposed by Redfish interfaces.

Hereinbelow are the main features of this refined Redfish plugin, when compared
to its previous implementation:

+ Attributes of any Redfish resource, together with attributes of non-nested
  composite objects, and attributes of members of non-nested anonymous
  collections can be collected (without any constraint on their attributes);
+ Possibility to select members of anonymous collections to be monitored
  based on their IDs, the fact that they have specific attributes, and/or the
  values of those attributes;
+ Possibility to prefix the type instance of a member of an anonymous collection
  with its ID in the collection;
+ Possibility to use the value of a configurable attribute of the members of an
  anonymous collection as their type instances;
+ As a result, by combining the two previous features, it is even possible to
  use an attribute for which the values exhibited by the members of the
  anonymous collection are not unique to define the type instance of the
  associated metrics, without any risk of overwriting;
+ The source of segmentation errors and memory leaks within the plugin were
  corrected (though, there are still some memory leaks which seems unrelated to
  the plugin);
+ A complete and effective test suite, based on an up-to-date mockup Redfish
  interface developed by the DMTF, was implemented;
+ A thorough documentation of the plugin was written.

On top of that, the function `oconfig_print_tree`, which prints the `oconfig`
configuration tree which root was specified, was implemented.
The latter is effectively compiled in `liboconfig` only if the debug
mode of `Collectd` is enabled.