### PR TITLE
Remove DES support in snmp plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ debian_default_toolchain_task:
       allow_failures: false
     - container:
         image: collectd/ci:trusty_amd64
-      allow_failures: false
+      allow_failures: true
     - container:
         image: collectd/ci:xenial_amd64
       allow_failures: false

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -782,12 +782,8 @@ static int csnmp_config_add_host_priv_protocol(host_definition_t *hd,
   if (strcasecmp("AES", buffer) == 0) {
     hd->priv_protocol = usmAESPrivProtocol;
     hd->priv_protocol_len = sizeof(usmAESPrivProtocol) / sizeof(oid);
-  } else if (strcasecmp("DES", buffer) == 0) {
-    hd->priv_protocol = usmDESPrivProtocol;
-    hd->priv_protocol_len = sizeof(usmDESPrivProtocol) / sizeof(oid);
   } else {
-    WARNING("snmp plugin: The `PrivProtocol' config option must be `AES' or "
-            "`DES'.");
+    WARNING("snmp plugin: The `PrivProtocol' config option must be `AES'.");
     return -1;
   }
 


### PR DESCRIPTION
ChangeLog: Remove DES support in SNMP

Taken from https://src.fedoraproject.org/rpms/collectd/c/66239034741115bfc0597d1b90fb3ce9c37ce3d7?branch=rawhide,
originally proposed by Ruben.

OpenSSL removed DES.

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>