### PR TITLE
Install a dummy SIGPIPE handler instead of ignoring the signal

### DIFF
--- a/src/daemon/cmd.c
+++ b/src/daemon/cmd.c
@@ -45,6 +45,10 @@ static void sig_term_handler(int __attribute__((unused)) signal) {
   stop_collectd();
 }
 
+/* dummy SIGPIPE handler that will vanish on exec */
+static void sig_pipe_handler(int __attribute__((unused)) signal) {
+}
+
 static void sig_usr1_handler(int __attribute__((unused)) signal) {
   pthread_t thread;
   pthread_attr_t attr;
@@ -229,7 +233,12 @@ int main(int argc, char **argv) {
   }    /* if (config.daemonize) */
 #endif /* COLLECT_DAEMON */
 
-  struct sigaction sig_pipe_action = {.sa_handler = SIG_IGN};
+  /*
+   * install a dummy handler for SIGPIPE instead of ignoring the signal
+   * so that exec()ed sub-processes will not unexpectedly be run
+   * with SIGPIPE ignored.
+   */
+  struct sigaction sig_pipe_action = {.sa_handler = sig_pipe_handler};
 
   sigaction(SIGPIPE, &sig_pipe_action, NULL);
 


### PR DESCRIPTION
Instead of ignoring `SIGPIPE`, install a dummy signal handler for it.
That way, on `exec()`, default behaviour will be restored which may be what external programs (e.g. those run via the _exec_ plugin) implicitly expect.
Most prominently, in case of collectd exiting ungracefully, long-running _exec_ plugins will receive `SIGPIPE` on the next try to send output to the now defunct collectd process.

ChangeLog: SIGPIPE handling has been changed from ignoring to installing a dummy handler so that exec plugins will be run with default SIGPIPE handling.