### PR TITLE
use derive_t instead of int inside ovs_stats_get_port_stat_value

### DIFF
--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -371,12 +371,12 @@ static void ovs_stats_submit_interfaces(port_list_t *port) {
   }
 }
 
-static int ovs_stats_get_port_stat_value(port_list_t *port,
-                                         iface_counter index) {
+static derive_t ovs_stats_get_port_stat_value(port_list_t *port,
+                                              iface_counter index) {
   if (port == NULL)
     return 0;
 
-  int value = 0;
+  derive_t value = 0;
 
   for (interface_list_t *iface = port->iface; iface != NULL;
        iface = iface->next) {


### PR DESCRIPTION
ChangeLog: ovs_stats: fix stat value rollover

`iface->stats` is an `int64_t`, `ovs_stats_submit_one` expects a `derive_t` for the value parameter and  `derive_t` is `typedef int64_t`. 

The use of the intermediate `int` 32-bit variable `value` in `ovs_stats_get_port_stat_value` will cause rollovers every 2 GiB when trying to monitor octets sent via an interface, causing the next 2GiB to have negative data, from which no sensible graphs can be generated. This patch fixes that issue.