### PR TITLE
[collectd 6] Fix some gcc warnings with more strict checks

### DIFF
--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -52,7 +52,7 @@ cgroups_submit_one(char const *plugin_instance, char const *type_instance,
  * This callback reads the user/system CPU time for each cgroup.
  */
 static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
-                              void *user_data) {
+                              __attribute__((unused)) void *user_data) {
   char abs_path[PATH_MAX];
   struct stat statbuf;
   char buf[1024];
@@ -131,7 +131,7 @@ static int read_cpuacct_procs(const char *dirname, char const *cgroup_name,
  * read_cpuacct_procs callback on every folder it finds, such as "system".
  */
 static int read_cpuacct_root(const char *dirname, const char *filename,
-                             void *user_data) {
+                             __attribute__((unused)) void *user_data) {
   char abs_path[PATH_MAX];
   struct stat statbuf;
   int status;

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -43,7 +43,8 @@ static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static int old_files;
 
-static int conntrack_config(const char *key, const char *value) {
+static int conntrack_config(const char *key,
+                            __attribute__((unused)) const char *value) {
   if (strcmp(key, "OldFiles") == 0)
     old_files = 1;
 

--- a/src/daemon/types_list.c
+++ b/src/daemon/types_list.c
@@ -101,7 +101,7 @@ static void parse_line(char *buf) {
   if (fields[0][0] == '#')
     return;
 
-  data_set_t ds = {{0}};
+  data_set_t ds = {{0}, 0, NULL};
 
   sstrncpy(ds.type, fields[0], sizeof(ds.type));
 

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -995,23 +995,3 @@ int uc_meta_data_get_double(metric_t const *m, const char *key, double *value)
 int uc_meta_data_get_boolean(metric_t const *m, const char *key, bool *value)
     UC_WRAP(meta_data_get_boolean);
 #undef UC_WRAP
-
-int uc_meta_data_get_signed_int_vl(value_list_t const *vl, char const *key,
-                                   int64_t *value) {
-  return ENOTSUP;
-}
-
-int uc_meta_data_get_unsigned_int_vl(value_list_t const *vl, char const *key,
-                                     uint64_t *value) {
-  return ENOTSUP;
-}
-
-int uc_meta_data_add_signed_int_vl(value_list_t const *vl, char const *key,
-                                   int64_t value) {
-  return ENOTSUP;
-}
-
-int uc_meta_data_add_unsigned_int_vl(value_list_t const *vl, char const *key,
-                                     uint64_t value) {
-  return ENOTSUP;
-}

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -142,15 +142,4 @@ int uc_meta_data_get_unsigned_int(metric_t const *m, const char *key,
 int uc_meta_data_get_double(metric_t const *m, const char *key, double *value);
 int uc_meta_data_get_boolean(metric_t const *m, const char *key, bool *value);
 
-/* TODO(octo): Remove these dummy functions after format_stackdriver has been
- * migrated. */
-int uc_meta_data_get_signed_int_vl(value_list_t const *vl, char const *key,
-                                   int64_t *value);
-int uc_meta_data_get_unsigned_int_vl(value_list_t const *vl, char const *key,
-                                     uint64_t *value);
-int uc_meta_data_add_signed_int_vl(value_list_t const *vl, char const *key,
-                                   int64_t value);
-int uc_meta_data_add_unsigned_int_vl(value_list_t const *vl, char const *key,
-                                     uint64_t value);
-
 #endif /* !UTILS_CACHE_H */

--- a/src/infiniband.c
+++ b/src/infiniband.c
@@ -118,7 +118,7 @@ static int ib_read_value_file_num_only(const char *device, const char *port,
   strstripnewline(buffer);
 
   // zero-out the first non-digit character
-  for (int i = 0; i < sizeof(buffer); i++) {
+  for (unsigned i = 0; i < sizeof(buffer); i++) {
     if (!isdigit(buffer[i])) {
       buffer[i] = '\0';
       break;
@@ -327,7 +327,7 @@ static int infiniband_read(void) {
   char port_name[255];
 
   if (ib_glob_ports(&g) == 0) {
-    for (int i = 0; i < g.gl_pathc; ++i) {
+    for (unsigned i = 0; i < g.gl_pathc; ++i) {
       char *device = NULL, *port = NULL;
       if (ib_parse_glob_port(g.gl_pathv[i], &device, &port) == 0) {
         snprintf(port_name, sizeof(port_name), "%s:%s", device, port);

--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -385,9 +385,11 @@ static int verify_sha256(void *payload, size_t payload_size,
   return !!ret;
 }
 #else /* !HAVE_GCRYPT_H */
-static int verify_sha256(void *payload, size_t payload_size,
-                         char const *username, char const *password,
-                         uint8_t hash_provided[32]) {
+static int verify_sha256(__attribute__((unused)) void *payload,
+                         __attribute__((unused)) size_t payload_size,
+                         __attribute__((unused)) char const *username,
+                         __attribute__((unused)) char const *password,
+                         __attribute__((unused)) uint8_t hash_provided[32]) {
   return ENOTSUP;
 }
 #endif
@@ -502,7 +504,9 @@ static int parse_encrypt_aes256(void *data, size_t data_size,
   return network_parse(b->data, b->len, ENCRYPT, opts);
 }
 #else /* !HAVE_GCRYPT_H */
-static int parse_encrypt_aes256(void *data, size_t data_size,
+static int parse_encrypt_aes256(__attribute__((unused)) void *data,
+                                __attribute__((unused)) size_t data_size,
+                                __attribute__((unused))
                                 lcc_network_parse_options_t const *opts) {
   return ENOTSUP;
 }

--- a/src/logparser.c
+++ b/src/logparser.c
@@ -401,7 +401,7 @@ static int logparser_validate_config(void) {
       return -1;
     }
 
-    for (int j = 0; j < parser->patterns_len; j++) {
+    for (unsigned j = 0; j < parser->patterns_len; j++) {
       message_pattern_t *pattern = parser->patterns + j;
 
       if (pattern->regex == NULL) {
@@ -562,7 +562,7 @@ static void logparser_process_msg(log_parser_t *parser, message_t *msg,
   if (parser->def_type_inst != NULL)
     sstrncpy(n.type_instance, parser->def_type_inst, sizeof(n.type_instance));
 
-  for (int i = 0; i < max_items; i++) {
+  for (unsigned i = 0; i < max_items; i++) {
     message_item_t *item = msg->message_items + i;
     if (!item->value[0])
       break;

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -553,7 +553,7 @@ static int statsd_network_init(struct pollfd **ret_fds, /* {{{ */
   return 0;
 } /* }}} int statsd_network_init */
 
-static void *statsd_network_thread(void *args) /* {{{ */
+static void *statsd_network_thread(__attribute__((unused)) void *args) /* {{{ */
 {
   struct pollfd *fds = NULL;
   size_t fds_num = 0;

--- a/src/table.c
+++ b/src/table.c
@@ -392,7 +392,7 @@ static int tbl_result_dispatch(tbl_t *tbl, tbl_result_t *res, char **fields,
   return 0;
 } /* tbl_result_dispatch */
 
-static int tbl_parse_line(tbl_t *tbl, char *line, size_t len) {
+static int tbl_parse_line(tbl_t *tbl, char *line) {
   char *fields[tbl->max_colnum + 1];
   size_t i = 0;
 
@@ -438,7 +438,7 @@ static int tbl_read_table(tbl_t *tbl) {
       log_warn("Table %s: Truncated line: %s", tbl->file, buf);
     }
 
-    if (tbl_parse_line(tbl, buf, sizeof(buf)) != 0) {
+    if (tbl_parse_line(tbl, buf) != 0) {
       log_warn("Table %s: Failed to parse line: %s", tbl->file, buf);
       continue;
     }

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -835,7 +835,8 @@ for_all_cpus_delta(const struct thread_data *thread_new_base,
  * Package Thermal Management Sensor (PTM), and thermal event thresholds.
  */
 static int __attribute__((warn_unused_result))
-set_temperature_target(struct thread_data *t, struct core_data *c,
+set_temperature_target(struct thread_data *t,
+                       __attribute__((unused)) struct core_data *c,
                        struct pkg_data *p) {
   unsigned long long msr;
   unsigned int target_c_local;

--- a/src/turbostat.c
+++ b/src/turbostat.c
@@ -1464,9 +1464,9 @@ static void free_all_buffers(void) {
   package_delta = NULL;
 }
 
-  /**********************
-   * Collectd functions *
-   **********************/
+/**********************
+ * Collectd functions *
+ **********************/
 
 #define DO_OR_GOTO_ERR(something)                                              \
   do {                                                                         \

--- a/src/utils/cmds/flush.c
+++ b/src/utils/cmds/flush.c
@@ -141,10 +141,11 @@ cmd_status_t cmd_handle_flush(FILE *fh, char *buffer) {
 
       if (cmd.cmd.flush.identifiers_num != 0) {
         identifier_t *id = cmd.cmd.flush.identifiers + j;
-        if (snprintf(buf, sizeof(buf), "%s/%s/%s",
-                     (id->host == NULL) ? "" : id->host,
-                     (id->plugin == NULL) ? "" : id->plugin,
-                     (id->type == NULL) ? "" : id->type) > sizeof(buf)) {
+        if ((unsigned)snprintf(buf, sizeof(buf), "%s/%s/%s",
+                               (id->host == NULL) ? "" : id->host,
+                               (id->plugin == NULL) ? "" : id->plugin,
+                               (id->type == NULL) ? "" : id->type) >
+            sizeof(buf)) {
           error++;
           continue;
         }

--- a/src/utils/cmds/putmetric.c
+++ b/src/utils/cmds/putmetric.c
@@ -37,7 +37,7 @@
 
 /* TODO(octo): add an option to set metric->value_type */
 static int set_option(metric_t *m, char const *key, char const *value,
-                      cmd_error_handler_t *err) {
+                      __attribute__((unused)) cmd_error_handler_t *err) {
   if ((m == NULL) || (key == NULL) || (value == NULL))
     return -1;
 

--- a/src/utils/cmds/putval.c
+++ b/src/utils/cmds/putval.c
@@ -36,7 +36,7 @@
  */
 
 static int set_option(value_list_t *vl, char const *key, char const *value,
-                      cmd_error_handler_t *errhndl) {
+                      __attribute__((unused)) cmd_error_handler_t *errhndl) {
   if ((vl == NULL) || (key == NULL) || (value == NULL)) {
     return EINVAL;
   }

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -120,21 +120,23 @@ static void format_text(strbuf_t *buf) {
 
 /* http_handler is the callback called by the microhttpd library. It essentially
  * handles all HTTP request aspects and creates an HTTP response. */
-static MHD_RESULT http_handler(void *cls, struct MHD_Connection *connection,
-                               const char *url, const char *method,
-                               const char *version, const char *upload_data,
-                               size_t *upload_data_size,
+static MHD_RESULT http_handler(__attribute__((unused)) void *cls,
+                               struct MHD_Connection *connection,
+                               __attribute__((unused)) const char *url,
+                               const char *method,
+                               __attribute__((unused)) const char *version,
+                               __attribute__((unused)) const char *upload_data,
+                               __attribute__((unused)) size_t *upload_data_size,
                                void **connection_state) {
   if (strcmp(method, MHD_HTTP_METHOD_GET) != 0) {
     return MHD_NO;
   }
 
-  /* On the first call for each connection, return without anything further.
-   * Apparently not everything has been initialized yet or so; the docs are not
-   * very specific on the issue. */
+  /* According to documentation, first call for each connection is after headers
+   * have been parsed, and should be used only for reporting errors */
   if (*connection_state == NULL) {
-    /* set to a random non-NULL pointer. */
-    *connection_state = &(int){42};
+    /* keep track of connection state */
+    *connection_state = &"called";
     return MHD_YES;
   }
 
@@ -491,6 +493,7 @@ static int prom_missing(metric_family_t const *fam,
         continue;
       }
       metric_family_free(prom_fam);
+      break;
     }
   }
 

--- a/src/write_syslog.c
+++ b/src/write_syslog.c
@@ -371,7 +371,7 @@ static int ws_format_values(char *ret, size_t ret_len, int ds_num,
 }
 
 static int ws_format_name(char *ret, int ret_len, const value_list_t *vl,
-                          const struct ws_callback *cb, const char *ds_name) {
+                          const char *ds_name) {
 
   if (ds_name != NULL) {
     snprintf(ret, ret_len, "%s.%s", vl->type, ds_name);
@@ -507,7 +507,7 @@ static int ws_write_messages(const data_set_t *ds, const value_list_t *vl,
       ds_name = ds->ds[i].name;
 
     /* Copy the identifier to 'key' and escape it. */
-    status = ws_format_name(key, sizeof(key), vl, cb, ds_name);
+    status = ws_format_name(key, sizeof(key), vl, ds_name);
     if (status != 0) {
       ERROR("write_syslog plugin: error with format_name");
       return status;

--- a/src/write_tsdb.c
+++ b/src/write_tsdb.c
@@ -364,7 +364,7 @@ static int wt_format_values(char *ret, size_t ret_len, int ds_num,
 }
 
 static int wt_format_name(char *ret, int ret_len, const value_list_t *vl,
-                          const struct wt_callback *cb, const char *ds_name) {
+                          const char *ds_name) {
   int status;
   char *temp = NULL;
   const char *prefix = "";
@@ -525,7 +525,7 @@ static int wt_write_messages(const data_set_t *ds, const value_list_t *vl,
       ds_name = ds->ds[i].name;
 
     /* Copy the identifier to 'key' and escape it. */
-    status = wt_format_name(key, sizeof(key), vl, cb, ds_name);
+    status = wt_format_name(key, sizeof(key), vl, ds_name);
     if (status != 0) {
       ERROR("write_tsdb plugin: error with format_name");
       return status;


### PR DESCRIPTION
ChangeLog: Build: Fix some gcc warnings with more strict checks

Fixes are based on "-O3 -Werror -Wall -Wextra -Wformat-security" output, and partly shared with the v5 fixes in https://github.com/collectd/collectd/pull/3917:

* Properly initialize complex struct
* Fix signed vs unsigned comparison warnings
* Correct "write_prometheus" comment and fix metric family freeing in a loop
* Remove unused functions and function arguments, and when latter cannot be removed, tell compiler that they're not used
