### PR TITLE
[ci][cirrus] Replace trusty with bionic/focal in debian_default_toolc…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,12 +81,15 @@ debian_default_toolchain_task:
         image: collectd/ci:stretch_i386
       allow_failures: false
     - container:
-        image: collectd/ci:trusty_amd64
-      allow_failures: false
-    - container:
         image: collectd/ci:xenial_amd64
       allow_failures: false
-    # debian/unstable is expected to fail
+    - container:
+        image: collectd/ci:bionic_amd64
+      allow_failures: false
+    - container:
+        image: collectd/ci:focal_amd64
+      allow_failures: false
+      # debian/unstable is expected to fail
     - allow_failures: true
       skip_notifications: true
       only_if: $CIRRUS_BRANCH == 'master'


### PR DESCRIPTION
…hain

Ubuntu 14.04 (Trusty) is out of standard support [1].
``make check`` fails for test_capabilities, as noted in [2].
[3] indicates that the cause is glibc, but that updates are not expected
to the version in trusty.

This PR replaces trusty with Ubuntu 18.04 (Bionic) and 20.04 (Focal).

[1] https://wiki.ubuntu.com/Releases
[2] https://github.com/collectd/collectd/pull/3936
[3] https://github.com/collectd/collectd/pull/3927#issuecomment-953350598

(cherry picked from commit b5d8ad13f4e300a7bfe342d27ad804003fcc9173)