### PR TITLE
Fix CI failures caused by unsupported distros and updates to dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,7 +61,7 @@ debian_default_toolchain_task:
   build_script:
     - make -j2 -sk
   tests_script:
-    - make -j2 -sk check
+    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
     - /checks/check-built-plugins.sh
 
 ###
@@ -92,7 +92,7 @@ redhat_default_toolchain_task:
   build_script:
     - make -j2 -sk
   tests_script:
-    - make -j2 -sk check
+    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
     - /checks/check-built-plugins.sh
 
 
@@ -124,7 +124,7 @@ non_standard_toolchains_task:
       build_script:
         - make -j2 -sk
       tests_script:
-        - make -j2 -sk check
+        - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
 
     # build against libstatgrab, should always pass
     - env:
@@ -189,7 +189,7 @@ non_standard_toolchains_task:
       build_script:
         - make -j2 -sk
       tests_script:
-        - make -j2 -sk check
+        - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
 
 ###
 # Build using a range of compilers, available in debian/unstable. NB: might
@@ -221,4 +221,4 @@ bleeding_edge_compilers_task:
   build_script:
     - make -j2 -sk
   tests_script:
-    - make -j2 -sk check
+    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,10 @@ jobs:
           - buster_amd64
           - stretch_amd64
           - stretch_i386
-          - trusty_amd64
+          # Ubuntu
           - xenial_amd64
+          - bionic_amd64
+          - focal_amd64
           # RedHat family
           - el8_x86_64
           - el7_x86_64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
     env:
       MAKEFLAGS: "-j 2"
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      # this env var picked up by valgrind during make check phase
+      VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v2
     - run: type pkg-config
@@ -86,6 +88,7 @@ jobs:
       CFLAGS: ${{ matrix.cflags }}
       CPPFLAGS: ${{ matrix.cppflags }}
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v2
     - run: type pkg-config


### PR DESCRIPTION
* Remove Ubuntu/trusty
* Add Ubuntu/Focal and Ubuntu/Bionic
* Let ``make check`` fail on definite memory leaks only 