### PR TITLE
cirrus: drop CentOS6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,10 +68,6 @@ debian_default_toolchain_task:
 #
 redhat_default_toolchain_task:
   matrix:
-    - allow_failures: false
-      skip_notifications: false
-      container:
-        image: collectd/ci:el6_x86_64
     - allow_failures: true
       skip_notifications: true
       container:


### PR DESCRIPTION
It had been reached EOL at November 30th, 2020.
There is no security updates available anymore.

ref. https://wiki.centos.org/About/Product

Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>
(cherry picked from commit d836b9b20c5ac94ce67f826751d9d717ffabb49c)