### PR TITLE
MQTT: fix off-by-one error in published message length

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -532,7 +532,7 @@ static int mqtt_write(const data_set_t *ds, const value_list_t *vl,
     return status;
   }
 
-  status = publish(conf, topic, payload, strlen(payload) + 1);
+  status = publish(conf, topic, payload, strlen(payload));
   if (status != 0) {
     ERROR("mqtt plugin: publish failed: %s", mosquitto_strerror(status));
     return status;


### PR DESCRIPTION
The mqtt plugin publishes messages including the trailing '\0'-Byte, as can be verified using e.g. the `mosquitto_sub` command with a HEX message formatter:

```
  $ mosquitto_sub -t "#" -F "%t: %X"
  metrics/loragw1/users/users: 313635323334303737392E3938353A3000
                                                               ^^
```
While the the MQTT PUBLISH payload is, according to the specification, application specific and most (C-Based) consumers will not notice the trailing '\0'-Byte, it is rather uncommon to publish messages like this.

We stumbled upon this error while using Telegraf to ingest metrics via MQTT, as it is Go-Based and does not use '\0'-terminated strings, leading to issues parsing these '\0'-Terminated strings into numbers.

Fix the off-by-one error by using the result of strlen() as-is.

ChangeLog: mqtt plugin: Fix off-by-one error/trailing '\0'-Byte in published messages 

Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>


(edit mrunge: add the ChangeLog line)