### PR TITLE
mmc: add more vendor specific and generic data sources

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1491,8 +1491,9 @@ endif
 if BUILD_PLUGIN_MMC
 pkglib_LTLIBRARIES += mmc.la
 mmc_la_SOURCES = src/mmc.c
-mmc_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-mmc_la_LIBADD = libignorelist.la
+mmc_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBUDEV_CPPFLAGS)
+mmc_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBUDEV_LDFLAGS)
+mmc_la_LIBADD = libignorelist.la $(BUILD_WITH_LIBUDEV_LIBS)
 endif
 
 if BUILD_PLUGIN_MULTIMETER

--- a/README
+++ b/README
@@ -266,9 +266,9 @@ Features
       Intel Many Integrated Core (MIC) CPUs.
 
     - mmc
-      Reads the percentage of bad blocks on mmc device. The additional values
-      for block erases and power cycles are also read. This Plugin in does only
-      work for the swissbit mmc Cards. MANFID=0x5D OEMID=0x5342
+      Reads the life time estimates reported by eMMC 5.0+ devices and some more
+      detailed health metrics, like bad block and erase counts or power cycles,
+      for swissbit mmc Cards (MANFID=0x5D OEMID=0x5342).
 
     - modbus
       Reads values from Modbus/TCP enabled devices. Supports reading values

--- a/README
+++ b/README
@@ -268,7 +268,8 @@ Features
     - mmc
       Reads the life time estimates reported by eMMC 5.0+ devices and some more
       detailed health metrics, like bad block and erase counts or power cycles,
-      for micron eMMCs and some swissbit mmc Cards (MANFID=0x5D OEMID=0x5342).
+      for micron and sandisk eMMCs and some swissbit mmc Cards (MANFID=0x5D
+      OEMID=0x5342).
 
     - modbus
       Reads values from Modbus/TCP enabled devices. Supports reading values

--- a/README
+++ b/README
@@ -268,7 +268,7 @@ Features
     - mmc
       Reads the life time estimates reported by eMMC 5.0+ devices and some more
       detailed health metrics, like bad block and erase counts or power cycles,
-      for swissbit mmc Cards (MANFID=0x5D OEMID=0x5342).
+      for micron eMMCs and some swissbit mmc Cards (MANFID=0x5D OEMID=0x5342).
 
     - modbus
       Reads values from Modbus/TCP enabled devices. Supports reading values

--- a/configure.ac
+++ b/configure.ac
@@ -6748,6 +6748,7 @@ if test "x$ac_system" = "xLinux"; then
   plugin_mcelog="yes"
   plugin_mdevents="yes"
   plugin_memory="yes"
+  plugin_mmc="yes"
   plugin_nfs="yes"
   plugin_numa="yes"
   plugin_processes="yes"
@@ -7624,6 +7625,7 @@ AC_MSG_RESULT([    memcachec . . . . . . $enable_memcachec])
 AC_MSG_RESULT([    memcached . . . . . . $enable_memcached])
 AC_MSG_RESULT([    memory  . . . . . . . $enable_memory])
 AC_MSG_RESULT([    mic . . . . . . . . . $enable_mic])
+AC_MSG_RESULT([    mmc . . . . . . . . . $enable_mmc])
 AC_MSG_RESULT([    modbus  . . . . . . . $enable_modbus])
 AC_MSG_RESULT([    mqtt  . . . . . . . . $enable_mqtt])
 AC_MSG_RESULT([    multimeter  . . . . . $enable_multimeter])

--- a/configure.ac
+++ b/configure.ac
@@ -6748,7 +6748,6 @@ if test "x$ac_system" = "xLinux"; then
   plugin_mcelog="yes"
   plugin_mdevents="yes"
   plugin_memory="yes"
-  plugin_mmc="yes"
   plugin_nfs="yes"
   plugin_numa="yes"
   plugin_processes="yes"
@@ -7010,6 +7009,10 @@ if test "x$have_termios_h" = "xyes"; then
     plugin_multimeter="yes"
   fi
   plugin_ted="yes"
+fi
+
+if test "x$with_libudev" = "xyes"; then
+  plugin_mmc="yes"
 fi
 
 if test "x$have_thread_info" = "xyes"; then

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -41,12 +41,6 @@ static const char *config_keys[] = {
 };
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
-#define MMC_MANUFACTOR "manfid"
-#define MMC_OEM_ID "oemid"
-#define MMC_SSR "ssr"
-#define MMC_LIFE_TIME "life_time"
-#define MMC_PRE_EOL_INFO "pre_eol_info"
-
 static ignorelist_t *ignorelist = NULL;
 
 static int mmc_config(const char *key, const char *value) {
@@ -121,10 +115,10 @@ static int mmc_read_dev_attr(const char *dev_name, const char *file_name,
 static int mmc_read_manfid(const char *dev_name, int *value) {
   char buffer[4096];
 
-  if (mmc_read_dev_attr(dev_name, MMC_MANUFACTOR, buffer, sizeof(buffer)) ==
+  if (mmc_read_dev_attr(dev_name, "manfid", buffer, sizeof(buffer)) ==
       0) {
     *value = (int)strtol(buffer, NULL, 0);
-    DEBUG(PLUGIN_NAME "(%s): [%s]=%s (%d)", dev_name, MMC_MANUFACTOR, buffer,
+    DEBUG(PLUGIN_NAME "(%s): [%s]=%s (%d)", dev_name, "manfid", buffer,
           *value);
     return 0;
   }
@@ -137,9 +131,9 @@ static int mmc_read_manfid(const char *dev_name, int *value) {
 static int mmc_read_oemid(const char *dev_name, int *value) {
   char buffer[4096];
 
-  if (mmc_read_dev_attr(dev_name, MMC_OEM_ID, buffer, sizeof(buffer)) == 0) {
+  if (mmc_read_dev_attr(dev_name, "oemid", buffer, sizeof(buffer)) == 0) {
     *value = (int)strtol(buffer, NULL, 0);
-    DEBUG(PLUGIN_NAME "(%s): [%s]=%s (%d)", dev_name, MMC_OEM_ID, buffer,
+    DEBUG(PLUGIN_NAME "(%s): [%s]=%s (%d)", dev_name, "oemid", buffer,
           *value);
     return 0;
   }
@@ -158,7 +152,7 @@ static int mmc_read_emmc_generic(const char *dev_name) {
   int res = EXIT_FAILURE;
 
   /* write generic eMMC 5.0 lifetime estimates / health reports */
-  if (mmc_read_dev_attr(dev_name, MMC_LIFE_TIME, buffer, sizeof(buffer)) == 0) {
+  if (mmc_read_dev_attr(dev_name, "life_time", buffer, sizeof(buffer)) == 0) {
     if (sscanf(buffer, "%hhx %hhx", &life_time_a, &life_time_b) == 2) {
       mmc_submit(dev_name, "mmc_life_time_est_typ_a", (gauge_t)life_time_a);
       mmc_submit(dev_name, "mmc_life_time_est_typ_b", (gauge_t)life_time_b);
@@ -166,7 +160,7 @@ static int mmc_read_emmc_generic(const char *dev_name) {
     }
   }
 
-  if (mmc_read_dev_attr(dev_name, MMC_PRE_EOL_INFO, buffer, sizeof(buffer)) ==
+  if (mmc_read_dev_attr(dev_name, "pre_eol_info", buffer, sizeof(buffer)) ==
       0) {
     if (sscanf(buffer, "%hhx", &pre_eol) == 1) {
       mmc_submit(dev_name, "mmc_pre_eol_info", (gauge_t)pre_eol);
@@ -214,7 +208,7 @@ static int mmc_read_ssr_swissbit(const char *dev_name) {
     return EXIT_FAILURE;
   }
 
-  if (mmc_read_dev_attr(dev_name, MMC_SSR, buffer, sizeof(buffer)) != 0) {
+  if (mmc_read_dev_attr(dev_name, "ssr", buffer, sizeof(buffer)) != 0) {
     return EXIT_FAILURE;
   }
 
@@ -229,7 +223,7 @@ static int mmc_read_ssr_swissbit(const char *dev_name) {
     INFO(PLUGIN_NAME "(%s): The SSR register is not 128 byte long", dev_name);
     return EXIT_FAILURE;
   }
-  DEBUG(PLUGIN_NAME "(%s): [%s]=%s", dev_name, MMC_SSR, buffer);
+  DEBUG(PLUGIN_NAME "(%s): [%s]=%s", dev_name, "ssr", buffer);
 
   /* write mmc_bad_blocks */
   sstrncpy(bad_blocks, &buffer[SWISSBIT_SSR_START_SPARE_BLOCKS],

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -151,13 +151,6 @@ static int mmc_read_oemid(const char *dev_name, int *value) {
   return EXIT_FAILURE;
 }
 
-#define MMC_POWER_CYCLES "mmc_power_cycles"
-#define MMC_BLOCK_ERASES "mmc_block_erases"
-#define MMC_BAD_BLOCKS "mmc_bad_blocks"
-#define MMC_LTE_A "mmc_life_time_est_typ_a"
-#define MMC_LTE_B "mmc_life_time_est_typ_b"
-#define MMC_EOL_INFO "mmc_pre_eol_info"
-
 static int mmc_read_emmc_generic(const char *dev_name) {
   char buffer[4096];
   uint8_t life_time_a, life_time_b;
@@ -167,8 +160,8 @@ static int mmc_read_emmc_generic(const char *dev_name) {
   /* write generic eMMC 5.0 lifetime estimates / health reports */
   if (mmc_read_dev_attr(dev_name, MMC_LIFE_TIME, buffer, sizeof(buffer)) == 0) {
     if (sscanf(buffer, "%hhx %hhx", &life_time_a, &life_time_b) == 2) {
-      mmc_submit(dev_name, MMC_LTE_A, (gauge_t)life_time_a);
-      mmc_submit(dev_name, MMC_LTE_B, (gauge_t)life_time_b);
+      mmc_submit(dev_name, "mmc_life_time_est_typ_a", (gauge_t)life_time_a);
+      mmc_submit(dev_name, "mmc_life_time_est_typ_b", (gauge_t)life_time_b);
       res = EXIT_SUCCESS;
     }
   }
@@ -176,7 +169,7 @@ static int mmc_read_emmc_generic(const char *dev_name) {
   if (mmc_read_dev_attr(dev_name, MMC_PRE_EOL_INFO, buffer, sizeof(buffer)) ==
       0) {
     if (sscanf(buffer, "%hhx", &pre_eol) == 1) {
-      mmc_submit(dev_name, MMC_EOL_INFO, (gauge_t)pre_eol);
+      mmc_submit(dev_name, "mmc_pre_eol_info", (gauge_t)pre_eol);
       res = EXIT_SUCCESS;
     }
   }
@@ -238,7 +231,7 @@ static int mmc_read_ssr_swissbit(const char *dev_name) {
   }
   DEBUG(PLUGIN_NAME "(%s): [%s]=%s", dev_name, MMC_SSR, buffer);
 
-  /* write MMC_BAD_BLOCKS */
+  /* write mmc_bad_blocks */
   sstrncpy(bad_blocks, &buffer[SWISSBIT_SSR_START_SPARE_BLOCKS],
            sizeof(bad_blocks) - 1);
   bad_blocks[sizeof(bad_blocks) - 1] = '\0';
@@ -247,25 +240,25 @@ static int mmc_read_ssr_swissbit(const char *dev_name) {
   value = abs(value - 100);
   DEBUG(PLUGIN_NAME "(%s): [bad_blocks] str=%s int=%d", dev_name, bad_blocks,
         value);
-  mmc_submit(dev_name, MMC_BAD_BLOCKS, (gauge_t)value);
+  mmc_submit(dev_name, "mmc_bad_blocks", (gauge_t)value);
 
-  /* write MMC_BLOCK_ERASES */
+  /* write mmc_block_erases */
   sstrncpy(block_erases, &buffer[SWISSBIT_SSR_START_BLOCK_ERASES],
            sizeof(block_erases) - 1);
   block_erases[sizeof(block_erases) - 1] = '\0';
   value = (int)strtol(block_erases, NULL, 16);
   DEBUG(PLUGIN_NAME "(%s): [block_erases] str=%s int=%d", dev_name,
         block_erases, value);
-  mmc_submit(dev_name, MMC_BLOCK_ERASES, (gauge_t)value);
+  mmc_submit(dev_name, "mmc_block_erases", (gauge_t)value);
 
-  /* write MMC_POWER_CYCLES */
+  /* write mmc_power_cycles  */
   sstrncpy(power_on, &buffer[SWISSBIT_SSR_START_POWER_ON],
            sizeof(power_on) - 1);
   power_on[sizeof(power_on) - 1] = '\0';
   value = (int)strtol(power_on, NULL, 16);
   DEBUG(PLUGIN_NAME "(%s): [power_on] str=%s int=%d", dev_name, power_on,
         value);
-  mmc_submit(dev_name, MMC_POWER_CYCLES, (gauge_t)value);
+  mmc_submit(dev_name, "mmc_power_cycles", (gauge_t)value);
 
   return 0;
 }

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -250,6 +250,9 @@ static int mmc_read(void) {
   }
 
   while ((dirent = readdir(dir)) != NULL) {
+    if (dirent->d_name[0] == '.')
+      continue;
+
     if (ignorelist_match(ignorelist, dirent->d_name))
       continue;
 

--- a/src/types.db
+++ b/src/types.db
@@ -168,7 +168,14 @@ memory_lua              value:GAUGE:0:281474976710656
 memory_throttle_count   value:DERIVE:0:U
 mmc_power_cycles        value:GAUGE:0:U
 mmc_block_erases        value:GAUGE:0:U
-mmc_bad_blocks          value:GAUGE:0:255
+mmc_erases_mlc_avg      value:GAUGE:0:U
+mmc_erases_mlc_max      value:GAUGE:0:U
+mmc_erases_mlc_min      value:GAUGE:0:U
+mmc_erases_slc_avg      value:GAUGE:0:U
+mmc_erases_slc_max      value:GAUGE:0:U
+mmc_erases_slc_min      value:GAUGE:0:U
+mmc_bad_blocks          value:GAUGE:0:U
+mmc_spare_blocks        value:GAUGE:0:U
 mmc_life_time_est_typ_a value:GAUGE:1:11
 mmc_life_time_est_typ_b value:GAUGE:1:11
 mmc_pre_eol_info        value:GAUGE:0:4

--- a/src/types.db
+++ b/src/types.db
@@ -174,6 +174,9 @@ mmc_erases_mlc_min      value:GAUGE:0:U
 mmc_erases_slc_avg      value:GAUGE:0:U
 mmc_erases_slc_max      value:GAUGE:0:U
 mmc_erases_slc_min      value:GAUGE:0:U
+mmc_erases_sys_avg      value:GAUGE:0:U
+mmc_erases_sys_max      value:GAUGE:0:U
+mmc_erases_sys_min      value:GAUGE:0:U
 mmc_bad_blocks          value:GAUGE:0:U
 mmc_spare_blocks        value:GAUGE:0:U
 mmc_life_time_est_typ_a value:GAUGE:1:11

--- a/src/types.db
+++ b/src/types.db
@@ -169,6 +169,9 @@ memory_throttle_count   value:DERIVE:0:U
 mmc_power_cycles        value:GAUGE:0:U
 mmc_block_erases        value:GAUGE:0:U
 mmc_bad_blocks          value:GAUGE:0:255
+mmc_life_time_est_typ_a value:GAUGE:1:11
+mmc_life_time_est_typ_b value:GAUGE:1:11
+mmc_pre_eol_info        value:GAUGE:0:4
 multimeter              value:GAUGE:U:U
 mutex_operations        value:DERIVE:0:U
 mysql_bpool_bytes       value:GAUGE:0:U


### PR DESCRIPTION
ChangeLog: mmc plugin: add support for generic and sandisk/micron health info

This PR extends the mmc plugin introduced by @feckert in #3887 with the following features:

- Support for the generic health metrics included in the eMMC 5.0 (and later) specification.
- Support for vendor-specific health metrics for micron and sandisk eMMCs.

The new vendor-specific health metrics are read out via `ioctl`s on the `/dev/mmcblk?` devices, while all other metrics are read out from the sysfs. Getting the respective device node for a path in sysfs is a non-trivial task that is solved quite nicely by `libudev`, which is why this PR also ports the plugin to use `libudev`.

I've tested the patch with sandisk and micon eMMCs, but did not have any swissbit devices at hand, so it would be nice if @feckert could tune in and check if everything still works there.