### PR TITLE
use correct path for libgcrypt-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2695,15 +2695,15 @@ AC_ARG_WITH([libgcrypt],
     if test -f "$withval" && test -x "$withval"; then
       with_libgcrypt_config="$withval"
       with_libgcrypt="yes"
-    else if test -f "$withval/bin/gcrypt-config" && test -x "$withval/bin/gcrypt-config"; then
-      with_libgcrypt_config="$withval/bin/gcrypt-config"
+    else if test -f "$withval/bin/libgcrypt-config" && test -x "$withval/bin/libgcrypt-config"; then
+      with_libgcrypt_config="$withval/bin/libgcrypt-config"
       with_libgcrypt="yes"
     else if test -d "$withval"; then
       GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS -I$withval/include"
       GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS -L$withval/lib"
       with_libgcrypt="yes"
     else
-      with_libgcrypt_config="gcrypt-config"
+      with_libgcrypt_config="libgcrypt-config"
       with_libgcrypt="$withval"
     fi; fi; fi
   ],


### PR DESCRIPTION
Changelog: use correct path for libgcrypt-config in configure.ac

```
If you want to compile a source file including the 'gcrypt.h' header
file, you must make sure that the compiler can find it in the directory
hierarchy.  
...
   However, the path to the include file is determined at the time the
source is configured.  To solve this problem, Libgcrypt ships with a
small helper program 'libgcrypt-config' that knows the path to the
include file and other configuration options.
```

Closes #2395