### PR TITLE
modbus: add support for double values

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5179,7 +5179,7 @@ Configures the base register to read from the device. If the option
 B<RegisterType> has been set to B<Uint32> or B<Float>, this and the next
 register will be read (the register number is increased by one).
 
-=item B<RegisterType> B<Int16>|B<Int32>|B<Int64>|B<Uint16>|B<Uint32>|B<UInt64>|B<Float>|B<Int32LE>|B<Uint32LE>|B<FloatLE>
+=item B<RegisterType> B<Int16>|B<Int32>|B<Int64>|B<Uint16>|B<Uint32>|B<UInt64>|B<Float>|B<Int32LE>|B<Uint32LE>|B<FloatLE>|B<Double>
 
 Specifies what kind of data is returned by the device. This defaults to
 B<Uint16>.  If the type is B<Int32>, B<Int32LE>, B<Uint32>, B<Uint32LE>,
@@ -5191,10 +5191,10 @@ significant 16E<nbsp>bits are in the register at B<RegisterBase+1>.
 For B<Int32LE>, B<Uint32LE>, or B<Float32LE>, the high and low order
 registers are swapped with the most significant 16E<nbsp>bits in
 the B<RegisterBase+1> and the least significant 16E<nbsp>bits in
-B<RegisterBase>. If the type is B<Int64> or B<UInt64>, four 16E<nbsp>bit
-registers at B<RegisterBase>, B<RegisterBase+1>, B<RegisterBase+2> and
-B<RegisterBase+3> will be read and the data combined into one
-64E<nbsp>value.
+B<RegisterBase>. If the type is B<Int64>, B<UInt64> or B<Double>, four
+16E<nbsp>bit registers at B<RegisterBase>, B<RegisterBase+1>, B<RegisterBase+2>
+and B<RegisterBase+3> will be read and the data combined into one 64E<nbsp>bit
+value.
 
 =item B<RegisterCmd> B<ReadHolding>|B<ReadInput>
 


### PR DESCRIPTION
ChangeLog: Modbus plugin: support for double values.

Some devices (like the Siemens SENTRON PAC3200), expose some values as double (64-bit IEEE 754 floating point value).

This patch adds support for reading those.