### PR TITLE
Fix the virt plugin for Openstack wallaby and later use

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -865,6 +865,7 @@ before attempting to reconnect. Defaults to 1, which implies attempt
 to reconnect at 1 second intervals.
 
 =item B<SendQueueLimit> I<SendQueueLimit>
+
 If there is no AMQP1 connection, the plugin will continue to queue
 messages to send, which could result in unbounded memory consumption. This
 parameter is used to limit the number of messages in the outbound queue to

--- a/src/virt.c
+++ b/src/virt.c
@@ -736,7 +736,7 @@ static void set_field_from_metadata(value_list_t *vl, virDomainPtr dom,
 
   const char *namespace = NULL;
   if (hm_ns == NULL) {
-    namespace = "http://openstack.org/xmlns/libvirt/nova/1.0";
+    namespace = "http://openstack.org/xmlns/libvirt/nova/1.1";
   } // namespace =hm_ns;
   else {
     namespace = hm_ns;


### PR DESCRIPTION
ChangeLog: Plugin virt: update the XML namespace for Nova