### PR TITLE
Add scalloc() and use it in src/processes.c

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1658,15 +1658,15 @@ static int ps_read_process(long pid, process_entry_t *ps, char *state) {
   snprintf(f_psinfo, sizeof(f_psinfo), "/proc/%li/psinfo", pid);
   snprintf(f_usage, sizeof(f_usage), "/proc/%li/usage", pid);
 
-  buffer = calloc(1, sizeof(pstatus_t));
+  buffer = scalloc(1, sizeof(pstatus_t));
   read_file_contents(filename, buffer, sizeof(pstatus_t));
   myStatus = (pstatus_t *)buffer;
 
-  buffer = calloc(1, sizeof(psinfo_t));
+  buffer = scalloc(1, sizeof(psinfo_t));
   read_file_contents(f_psinfo, buffer, sizeof(psinfo_t));
   myInfo = (psinfo_t *)buffer;
 
-  buffer = calloc(1, sizeof(prusage_t));
+  buffer = scalloc(1, sizeof(prusage_t));
   read_file_contents(f_usage, buffer, sizeof(prusage_t));
   myUsage = (prusage_t *)buffer;
 

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -235,6 +235,17 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
   return buf;
 } /* char *sstrerror */
 
+void *scalloc(size_t nmemb, size_t size) {
+  void *r;
+
+  if ((r = calloc(nmemb, size)) == NULL) {
+    ERROR("Not enough memory.");
+    exit(3);
+  }
+
+  return r;
+} /* void *scalloc */
+
 void *smalloc(size_t size) {
   void *r;
 

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -205,7 +205,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
 
     pthread_mutex_unlock(&strerror_r_lock);
   }
-    /* #endif !HAVE_STRERROR_R */
+  /* #endif !HAVE_STRERROR_R */
 
 #elif STRERROR_R_CHAR_P
   {
@@ -221,7 +221,7 @@ char *sstrerror(int errnum, char *buf, size_t buflen) {
                  buflen);
     }
   }
-    /* #endif STRERROR_R_CHAR_P */
+  /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {
@@ -804,8 +804,8 @@ unsigned long long htonll(unsigned long long n) {
 #endif /* HAVE_HTONLL */
 
 #if FP_LAYOUT_NEED_NOTHING
-  /* Well, we need nothing.. */
-  /* #endif FP_LAYOUT_NEED_NOTHING */
+/* Well, we need nothing.. */
+/* #endif FP_LAYOUT_NEED_NOTHING */
 
 #elif FP_LAYOUT_NEED_ENDIANFLIP || FP_LAYOUT_NEED_INTSWAP
 #if FP_LAYOUT_NEED_ENDIANFLIP

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -75,6 +75,7 @@ __attribute__((format(printf, 1, 2))) char *ssnprintf_alloc(char const *format,
 char *sstrdup(const char *s);
 size_t sstrnlen(const char *s, size_t n);
 char *sstrndup(const char *s, size_t n);
+void *scalloc(size_t nmemb, size_t size);
 void *smalloc(size_t size);
 char *sstrerror(int errnum, char *buf, size_t buflen);
 


### PR DESCRIPTION
ChangeLog: add scalloc() calloc wrapper + use it in "processes" plugin

scalloc() calloc wrapper complements already existing smalloc() malloc wrapper, already added to the v6 branch.

In v6 branch, scalloc() is used by the new "gpu_sysman" plugin.

To have user for scalloc() also in v5 branch... I changed calloc() calls which return values were no checked (for Solaris-only ps_read_process() function) in "processes" plugin, to use scalloc() instead.  Unlike the other places in processes.c which gracefully handle calloc() failures [1], scalloc() will just exit collectd with error message.  If this is unwanted, I can drop the processes.c patch.

[1] All other plugins seem to handle calloc failures gracefully.  Some of the test code uses asserts instead.  src/processes.c::ps_read_process() was the only place I noticed not to handle calloc failures at all.