### PR TITLE
[CI] Update Fedora versions used in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
           # RedHat family
           - el8_x86_64
           - el7_x86_64
+          - fedora36_x86_64
+          - fedora35_x86_64
           - fedora34_x86_64
-          - fedora28_x86_64
         config_flags: ['']
     env:
       MAKEFLAGS: "-j2 -sk"


### PR DESCRIPTION
Fedora 28 is really old, and we now have containers for f35 and f36