### PR TITLE
Fix-configure.ac: define PREFIX in config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,10 @@ if test "x$ac_system" = "xAIX"; then
   AC_DEFINE([_THREAD_SAFE_ERRNO], [1], [Define to use the thread-safe version of errno under AIX.])
 fi
 
+if test "x${prefix}" != xNONE; then
+  AC_DEFINE_UNQUOTED([PREFIX], ["${prefix}"], [Define the install prefix.])
+fi
+
 # Where to install .pc files.
 pkgconfigdir="${libdir}/pkgconfig"
 AC_SUBST([pkgconfigdir])


### PR DESCRIPTION
ChangeLog: build: define PREFIX for later use.

ChangeLog: PREFIX was never defined and therefore set to the
default value `/opt/collectd`. collectd searched in
this path for desired files e.g. typesdb, plugins, etc
no matter if it was configured with `--prefix`.

Replaced `&(int){44}` with `(void *)((size_t)-1)` so
GCC-12 won't complain anymore.

Signed-off-by: lns <matzeton@googlemail.com>


Edit: @mrunge adjust ChangeLog (only one line and a limited number of characters allowed).