### PR TITLE
Correct description of FQDNLookup in manpage

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -330,8 +330,8 @@ hostname will be determined using the L<gethostname(2)> system call.
 
 If B<Hostname> is determined automatically this setting controls whether or not
 the daemon should try to figure out the "fully qualified domain name", FQDN.
-This is done using a lookup of the name returned by C<gethostname>. This option
-is enabled by default.
+This is achieved by using C<getaddrinfo()> to look up full web address of the
+first network interface that has one. This option is enabled by default.
 
 =item B<PreCacheChain> I<ChainName>
 


### PR DESCRIPTION
ChangeLog: collectd.conf manpage: Correct description of FQDNLookup option.

 ...of collectd.conf. FQDNLookup uses getaddrinfo() and not gethostname(). 

The `FQDNLookup false` check returns after the hostname was set by using `gethostname()`.