### PR TITLE
Update the format of contrib/snmp-data.conf

### DIFF
--- a/contrib/snmp-data.conf
+++ b/contrib/snmp-data.conf
@@ -6,37 +6,37 @@
     <Data "ifmib_if_octets32">
     	Type "if_octets"
 	Table true
-	Instance "IF-MIB::ifDescr"
+	TypeInstanceOID "IF-MIB::ifDescr"
 	Values "IF-MIB::ifInOctets" "IF-MIB::ifOutOctets"
     </Data>
     <Data "ifmib_if_octets64">
     	Type "if_octets"
 	Table true
-	Instance "IF-MIB::ifName"
+	TypeInstanceOID "IF-MIB::ifName"
 	Values "IF-MIB::ifHCInOctets" "IF-MIB::ifHCOutOctets"
     </Data>
     <Data "ifmib_if_packets32">
     	Type "if_packets"
 	Table true
-	Instance "IF-MIB::ifDescr"
+	TypeInstanceOID "IF-MIB::ifDescr"
 	Values "IF-MIB::ifInUcastPkts" "IF-MIB::ifOutUcastPkts"
     </Data>
     <Data "ifmib_if_packets64">
     	Type "if_packets"
 	Table true
-	Instance "IF-MIB::ifName"
+	TypeInstanceOID "IF-MIB::ifName"
 	Values "IF-MIB::ifHCInUcastPkts" "IF-MIB::ifHCOutUcastPkts"
     </Data>
     <Data "ifmib_if_errors32">
     	Type "if_errors"
 	Table true
-	Instance "IF-MIB::ifDescr"
+	TypeInstanceOID "IF-MIB::ifDescr"
 	Values "IF-MIB::ifInErrors" "IF-MIB::ifOutErrors"
     </Data>
     <Data "ifmib_if_errors64">
     	Type "if_errors"
 	Table true
-	Instance "IF-MIB::ifName"
+	TypeInstanceOID "IF-MIB::ifName"
 	Values "IF-MIB::ifHCInErrors" "IF-MIB::ifHCOutErrors"
     </Data>
 
@@ -48,139 +48,139 @@
     <Data "upsmib_timeleft_battery">
     	Type "timeleft"
 	Table false
-	Instance "battery"
+	TypeInstanceOID "battery"
 	Values ".1.3.6.1.2.1.33.1.2.3.0"
     </Data>
     <Data "upsmib_charge_battery">
     	Type "percent"
 	Table false
-	Instance "charge-battery"
+	TypeInstanceOID "charge-battery"
 	Values ".1.3.6.1.2.1.33.1.2.4.0"
     </Data>
     <Data "upsmib_voltage_battery">
     	Type "voltage"
 	Table false
-	Instance "battery"
+	TypeInstanceOID "battery"
 	Values ".1.3.6.1.2.1.33.1.2.5.0"
 	Scale 0.1
     </Data>
     <Data "upsmib_current_battery">
     	Type "current"
 	Table false
-	Instance "battery"
+	TypeInstanceOID "battery"
 	Values ".1.3.6.1.2.1.33.1.2.6.0"
 	Scale 0.1
     </Data>
     <Data "upsmib_temperature_battery">
     	Type "temperature"
 	Table false
-	Instance "battery"
+	TypeInstanceOID "battery"
 	Values ".1.3.6.1.2.1.33.1.2.7.0"
     </Data>
     # Input branch
     <Data "upsmib_frequency_input">
     	Type "frequency"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.2.1.33.1.3.3.1.2"
 	Scale 0.1
     </Data>
     <Data "upsmib_voltage_input">
     	Type "voltage"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.2.1.33.1.3.3.1.3"
     </Data>
     <Data "upsmib_current_input">
     	Type "current"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.2.1.33.1.3.3.1.4"
 	Scale 0.1
     </Data>
     <Data "upsmib_power_input">
     	Type "power"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.2.1.33.1.3.3.1.5"
     </Data>
     # Output branch
     <Data "upsmib_frequency_output">
     	Type "frequency"
 	Table false
-	Instance "output"
+	TypeInstanceOID "output"
 	Values ".1.3.6.1.2.1.33.1.4.2.0"
 	Scale 0.1
     </Data>
     <Data "upsmib_voltage_output">
     	Type "voltage"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.2.1.33.1.4.4.1.2"
     </Data>
     <Data "upsmib_current_output">
     	Type "current"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.2.1.33.1.4.4.1.3"
 	Scale 0.1
     </Data>
     <Data "upsmib_power_output">
     	Type "power"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.2.1.33.1.4.4.1.4"
     </Data>
     <Data "upsmib_load_output">
     	Type "percent"
 	Table true
-	InstancePrefix "load-output"
+	TypeInstancePrefix "load-output"
 	Values ".1.3.6.1.2.1.33.1.4.4.1.5"
     </Data>
     # Bypass branch
     <Data "upsmib_frequency_bypass">
     	Type "frequency"
 	Table false
-	Instance "output"
+	TypeInstanceOID "output"
 	Values ".1.3.6.1.2.1.33.1.5.1.0"
 	Scale 0.1
     </Data>
     <Data "upsmib_voltage_bypass">
     	Type "voltage"
 	Table true
-	InstancePrefix "bypass"
+	TypeInstancePrefix "bypass"
 	Values ".1.3.6.1.2.1.33.1.5.3.1.2"
     </Data>
     <Data "upsmib_current_bypass">
     	Type "current"
 	Table true
-	InstancePrefix "bypass"
+	TypeInstancePrefix "bypass"
 	Values ".1.3.6.1.2.1.33.1.5.3.1.3"
 	Scale 0.1
     </Data>
     <Data "upsmib_power_bypass">
     	Type "power"
 	Table true
-	InstancePrefix "bypass"
+	TypeInstancePrefix "bypass"
 	Values ".1.3.6.1.2.1.33.1.5.3.1.4"
     </Data>
     # Special definitions for broken UPSes
     <Data "upsmib_voltage_battery_unscaled">
     	Type "voltage"
 	Table false
-	Instance "battery"
+	TypeInstanceOID "battery"
 	Values ".1.3.6.1.2.1.33.1.2.5.0"
     </Data>
     <Data "upsmib_current_input_unscaled">
     	Type "current"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.2.1.33.1.3.3.1.4"
     </Data>
     <Data "upsmib_current_output_unscaled">
     	Type "current"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.2.1.33.1.4.4.1.3"
     </Data>
 
@@ -191,19 +191,19 @@
     <Data "riello_temperature_system">
     	Type "temperature"
 	Table false
-	Instance "system"
+	TypeInstanceOID "system"
 	Values ".1.3.6.1.4.1.5491.1.51.1.5.4.0"
     </Data>
     <Data "riello_temperature_rectifier">
     	Type "temperature"
 	Table false
-	Instance "rectifier"
+	TypeInstanceOID "rectifier"
 	Values ".1.3.6.1.4.1.5491.1.51.1.5.5.0"
     </Data>
     <Data "riello_temperature_inverter">
     	Type "temperature"
 	Table false
-	Instance "inverter"
+	TypeInstanceOID "inverter"
 	Values ".1.3.6.1.4.1.5491.1.51.1.5.6.0"
     </Data>
 
@@ -215,97 +215,97 @@
     <Data "powerplus_voltage_input">
     	Type "voltage"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.4.1.6050.5.4.1.1.2"
     </Data>
     <Data "powerplus_current_input">
     	Type "current"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.4.1.6050.5.4.1.1.3"
     </Data>
     <Data "powerplus_power_apparent_input">
     	Type "power"
 	Table true
-	InstancePrefix "apparent-input"
+	TypeInstancePrefix "apparent-input"
 	Values ".1.3.6.1.4.1.6050.5.4.1.1.4"
 	Scale 100.0
     </Data>
     <Data "powerplus_power_active_input">
     	Type "power"
 	Table true
-	InstancePrefix "active-input"
+	TypeInstancePrefix "active-input"
 	Values ".1.3.6.1.4.1.6050.5.4.1.1.5"
 	Scale 100.0
     </Data>
     <Data "powerplus_performance_factor_input">
     	Type "percent"
 	Table true
-	InstancePrefix "performance_factor-input"
+	TypeInstancePrefix "performance_factor-input"
 	Values ".1.3.6.1.4.1.6050.5.4.1.1.6"
     </Data>
     # Global outputs
     <Data "powerplus_voltage_output">
     	Type "voltage"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.2"
     </Data>
     <Data "powerplus_current_output">
     	Type "current"
 	Table true
-	InstancePrefix "output"
+	TypeInstancePrefix "output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.3"
     </Data>
     <Data "powerplus_power_apparent_output">
     	Type "power"
 	Table true
-	InstancePrefix "apparent-output"
+	TypeInstancePrefix "apparent-output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.4"
 	Scale 100.0
     </Data>
     <Data "powerplus_power_active_output">
     	Type "power"
 	Table true
-	InstancePrefix "active-output"
+	TypeInstancePrefix "active-output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.5"
 	Scale 100.0
     </Data>
     <Data "powerplus_load_level_output">
     	Type "percent"
 	Table true
-	InstancePrefix "load_level-output"
+	TypeInstancePrefix "load_level-output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.6"
     </Data>
     <Data "powerplus_active_load_level_output">
     	Type "percent"
 	Table true
-	InstancePrefix "active_load_level-output"
+	TypeInstancePrefix "active_load_level-output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.7"
     </Data>
     <Data "powerplus_performance_factor_output">
     	Type "percent"
 	Table true
-	InstancePrefix "performance_factor-output"
+	TypeInstancePrefix "performance_factor-output"
 	Values ".1.3.6.1.4.1.6050.5.5.1.1.8"
     </Data>
     # Global DC
     <Data "powerplus_global_dc_positive">
     	Type "voltage"
 	Table false
-	Instance "dc_positive-global"
+	TypeInstanceOID "dc_positive-global"
 	Values ".1.3.6.1.4.1.6050.5.6.1.0"
     </Data>
     <Data "powerplus_global_dc_negative">
     	Type "voltage"
 	Table false
-	Instance "dc_negative-global"
+	TypeInstanceOID "dc_negative-global"
 	Values ".1.3.6.1.4.1.6050.5.6.2.0"
     </Data>
     <Data "powerplus_global_dc_total">
     	Type "voltage"
 	Table false
-	Instance "dc_total-global"
+	TypeInstanceOID "dc_total-global"
 	Values ".1.3.6.1.4.1.6050.5.6.3.0"
     </Data>
 
@@ -316,19 +316,19 @@
     <Data "netapp_cpu_system">
     	Type "cpu"
 	Table false
-	Instance "system"
+	TypeInstanceOID "system"
 	Values ".1.3.6.1.4.1.789.1.2.1.2.0"
     </Data>
     <Data "netapp_cpu_idle">
     	Type "cpu"
 	Table false
-	Instance "idle"
+	TypeInstanceOID "idle"
 	Values ".1.3.6.1.4.1.789.1.2.1.4.0"
     </Data>
     <Data "netapp_if_octets">
     	Type "if_octets"
 	Table false
-	Instance "net"
+	TypeInstanceOID "net"
 	Values ".1.3.6.1.4.1.789.1.2.2.12.0" ".1.3.6.1.4.1.789.1.2.2.14.0"
     </Data>
 
@@ -339,25 +339,25 @@
     <Data "juniperssl_users_web">
     	Type "users"
 	Table false
-	Instance "web"
+	TypeInstanceOID "web"
 	Values ".1.3.6.1.4.1.12532.2.0"
     </Data>
     <Data "juniperssl_users_mail">
     	Type "users"
 	Table false
-	Instance "mail"
+	TypeInstanceOID "mail"
 	Values ".1.3.6.1.4.1.12532.3.0"
     </Data>
     <Data "juniperssl_percent_logfull">
     	Type "percent"
 	Table false
-	Instance "logfull"
+	TypeInstanceOID "logfull"
 	Values ".1.3.6.1.4.1.12532.1.0"
     </Data>
     <Data "juniperssl_percent_diskfull">
     	Type "percent"
 	Table false
-	Instance "diskfull"
+	TypeInstanceOID "diskfull"
 	Values ".1.3.6.1.4.1.12532.25.0"
     </Data>
 
@@ -370,42 +370,42 @@
     <Data "wut_an8graph">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.6.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.6.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.6.1.4.1.1"
 	Scale 0.1
     </Data>
     <Data "wut_an2graph">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.7.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.7.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.7.1.4.1.1"
 	Scale 0.1
     </Data>
     <Data "wut_an1graph">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.8.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.8.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.8.1.4.1.1"
 	Scale 0.1
     </Data>
     <Data "wut_thermo8">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.1.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.1.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.1.1.4.1.1"
 	Scale 0.1
     </Data>
     <Data "wut_thermo2">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.2.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.2.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.2.1.4.1.1"
 	Scale 0.1
     </Data>
     <Data "wut_thermo1">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.5040.1.2.3.3.2.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.5040.1.2.3.3.2.1.1.2"
 	Values ".1.3.6.1.4.1.5040.1.2.3.1.4.1.1"
 	Scale 0.1
     </Data>
@@ -418,38 +418,38 @@
     <Data "infratec_h2_17_temperature">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.4519.10.4.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.4519.10.4.1.1.2"
 	Values ".1.3.6.1.4.1.4519.10.4.1.1.3"
     </Data>
     <Data "infratec_h2_17_humidity">
     	Type "humidity"
 	Table true
-	Instance ".1.3.6.1.4.1.4519.10.5.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.4519.10.5.1.1.2"
 	Values ".1.3.6.1.4.1.4519.10.5.1.1.3"
     </Data>
     <Data "infratec_h2_17_voltage">
     	Type "voltage"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.4.1.4519.10.6.1.1.3"
     </Data>
     # Model H2-30
     <Data "infratec_h2_30_temperature">
     	Type "temperature"
 	Table true
-	Instance ".1.3.6.1.4.1.1909.10.4.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.1909.10.4.1.1.2"
 	Values ".1.3.6.1.4.1.1909.10.4.1.1.3"
     </Data>
     <Data "infratec_h2_30_humidity">
     	Type "humidity"
 	Table true
-	Instance ".1.3.6.1.4.1.1909.10.5.1.1.2"
+	TypeInstanceOID ".1.3.6.1.4.1.1909.10.5.1.1.2"
 	Values ".1.3.6.1.4.1.1909.10.5.1.1.3"
     </Data>
     <Data "infratec_h2_30_voltage">
     	Type "voltage"
 	Table true
-	InstancePrefix "input"
+	TypeInstancePrefix "input"
 	Values ".1.3.6.1.4.1.1909.10.6.1.1.3"
     </Data>
 
@@ -460,24 +460,24 @@
     <Data "mikrotik_wl_sta_bitrate_tx">
         tYPE "Bitrate"
         Table true
-        InstancePrefix "st-tx-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
+        TypeInstancePrefix "st-tx-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
         Values ".1.3.6.1.4.1.14988.1.1.1.1.1.2"
     </Data>
 
     <Data "mikrotik_wl_sta_bitrate_rx">
         Type "bitrate"
         Table true
-        InstancePrefix "st-rx-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
+        TypeInstancePrefix "st-rx-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
         Values ".1.3.6.1.4.1.14988.1.1.1.1.1.3"
     </Data>
 
     <Data "mikrotik_wl_sta_signal">
         Type "signal_power"
         Table true
-        InstancePrefix "st-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
+        TypeInstancePrefix "st-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.1.1.5"
         Values ".1.3.6.1.4.1.14988.1.1.1.1.1.4"
     </Data>
 
@@ -485,40 +485,40 @@
     <Data "mikrotik_wl_reg_signal">
         Type "signal_power"
         Table true
-        InstancePrefix "ap-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
+        TypeInstancePrefix "ap-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
         Values ".1.3.6.1.4.1.14988.1.1.1.2.1.3"
     </Data>
 
     <Data "mikrotik_wl_reg_octets">
         Type "if_octets"
         Table true
-        InstancePrefix "ap-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
+        TypeInstancePrefix "ap-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
         Values ".1.3.6.1.4.1.14988.1.1.1.2.1.5" ".1.3.6.1.4.1.14988.1.1.1.2.1.4"
     </Data>
 
     <Data "mikrotik_wl_reg_packets">
         Type "if_packets"
         Table true
-        InstancePrefix "ap-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
+        TypeInstancePrefix "ap-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
         Values ".1.3.6.1.4.1.14988.1.1.1.2.1.7" ".1.3.6.1.4.1.14988.1.1.1.2.1.6"
     </Data>
 
     <Data "mikrotik_wl_reg_bitrate_tx">
         Type "bitrate"
         Table true
-        InstancePrefix "ap-tx-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
+        TypeInstancePrefix "ap-tx-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
         Values ".1.3.6.1.4.1.14988.1.1.1.2.1.8"
     </Data>
 
     <Data "mikrotik_wl_reg_bitrate_rx">
         Type "bitrate"
         Table true
-        InstancePrefix "ap-rx-"
-        Instance ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
+        TypeInstancePrefix "ap-rx-"
+        TypeInstanceOID ".1.3.6.1.4.1.14988.1.1.1.2.1.1"
         Values ".1.3.6.1.4.1.14988.1.1.1.2.1.9"
     </Data>
 </Plugin>


### PR DESCRIPTION
ChangeLog: Update the format of snmp-data.conf file to not issue deprecation warning on startup.

s/InstancePrefix/TypeInstancePrefix/g
s/Instance/TypeInstanceOID/g

Signed-off-by: Vit Kabele <vit@kabele.me>