### PR TITLE
Use IOMainPort over deprecated IOMasterPort

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -340,7 +340,7 @@ static int battery_read(void) /* {{{ */
 
   return 0;
 } /* }}} int battery_read */
-  /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
+/* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
 #elif KERNEL_LINUX
 /* Reads a file which contains only a number (and optionally a trailing

--- a/src/battery.c
+++ b/src/battery.c
@@ -61,6 +61,10 @@
 /* No global variables */
 /* #endif HAVE_IOKIT_IOKITLIB_H || HAVE_IOKIT_PS_IOPOWERSOURCES_H */
 
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 #elif KERNEL_LINUX
 #define PROC_PMU_PATH_FORMAT "/proc/pmu/battery_%i"
 #define PROC_ACPI_PATH "/proc/acpi/battery"
@@ -247,7 +251,7 @@ static void get_via_generic_iokit(double *ret_capacity_full, /* {{{ */
   double temp_double;
 
   status = IOServiceGetMatchingServices(
-      kIOMasterPortDefault, IOServiceNameMatching("battery"), &iterator);
+      kIOMainPortDefault, IOServiceNameMatching("battery"), &iterator);
   if (status != kIOReturnSuccess) {
     DEBUG("IOServiceGetMatchingServices failed.");
     return;

--- a/src/disk.c
+++ b/src/disk.c
@@ -75,8 +75,12 @@
 #include <sys/protosw.h>
 #endif
 
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
+#define IOMainPort IOMasterPort
+#endif
+
 #if HAVE_IOKIT_IOKITLIB_H
-static mach_port_t io_master_port = MACH_PORT_NULL;
+static mach_port_t io_main_port = MACH_PORT_NULL;
 /* This defaults to false for backwards compatibility. Please fix in the next
  * major version. */
 static bool use_bsd_name;
@@ -207,15 +211,15 @@ static int disk_init(void) {
 #if HAVE_IOKIT_IOKITLIB_H
   kern_return_t status;
 
-  if (io_master_port != MACH_PORT_NULL) {
-    mach_port_deallocate(mach_task_self(), io_master_port);
-    io_master_port = MACH_PORT_NULL;
+  if (io_main_port != MACH_PORT_NULL) {
+    mach_port_deallocate(mach_task_self(), io_main_port);
+    io_main_port = MACH_PORT_NULL;
   }
 
-  status = IOMasterPort(MACH_PORT_NULL, &io_master_port);
+  status = IOMainPort(MACH_PORT_NULL, &io_main_port);
   if (status != kIOReturnSuccess) {
-    ERROR("IOMasterPort failed: %s", mach_error_string(status));
-    io_master_port = MACH_PORT_NULL;
+    ERROR("IOMainPort failed: %s", mach_error_string(status));
+    io_main_port = MACH_PORT_NULL;
     return -1;
   }
   /* #endif HAVE_IOKIT_IOKITLIB_H */
@@ -466,7 +470,7 @@ static int disk_read(void) {
 
   /* Get the list of all disk objects. */
   if (IOServiceGetMatchingServices(
-          io_master_port, IOServiceMatching(kIOBlockStorageDriverClass),
+          io_main_port, IOServiceMatching(kIOBlockStorageDriverClass),
           &disk_list) != kIOReturnSuccess) {
     ERROR("disk plugin: IOServiceGetMatchingServices failed.");
     return -1;


### PR DESCRIPTION
ChangeLog: Build system: Use IOMainPort over deprecated IOMasterPort

In macOS 12, `IOMasterPort`/`kIOMasterPortDefault` is deprecated in favor of `IOMainPort`/`kIOMainPortDefault`:

```
src/battery.c:250:7: error: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0 [-Werror,-Wdeprecated-declarations]
      kIOMasterPortDefault, IOServiceNameMatching("battery"), &iterator);
      ^~~~~~~~~~~~~~~~~~~~
      kIOMainPortDefault
```