### PR TITLE
Fix anonymous connection_state pointer

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -206,7 +206,8 @@ static MHD_RESULT cap_http_handler(void *cls, struct MHD_Connection *connection,
    * round. The docs are not very specific on the issue. */
   if (*connection_state == NULL) {
     /* set to a random non-NULL pointer. */
-    *connection_state = &(int){44};
+    static int rnd_state = 44;
+    *connection_state = &rnd_state;
     return MHD_YES;
   }
   DEBUG(CAP_PLUGIN ": formatted response: %s", g_cap_json);


### PR DESCRIPTION
Returning an anonymous pointer (which is limited to the scope of the function) causes an error when building with the `-Werror` flag.

Tested with: GCC 12.1.0
Test case:
```sh
echo 'void test(int **r) { *r = &(int){44}; }' | gcc -Werror=dangling-pointer -x c -c -o /dev/null -
```
Error:
```
<stdin>:1:25: error: storing the address of local variable '({anonymous})' in '*r' [-Werror=dangling-pointer=]
```