### PR TITLE
Increase buffer for OAuth access token.  Another fix for #3897.

### DIFF
--- a/src/utils/oauth/oauth.c
+++ b/src/utils/oauth/oauth.c
@@ -331,7 +331,7 @@ static int new_token(oauth_t *auth) /* {{{ */
   char assertion[1024];
   char post_data[1024];
   memory_t data;
-  char access_token[256];
+  char access_token[GOOGLE_OAUTH_ACCESS_TOKEN_SIZE];
   cdtime_t expires_in;
   cdtime_t now;
   char curl_errbuf[CURL_ERROR_SIZE];


### PR DESCRIPTION
ChangeLog: increase oauth access token buffer size.

Previous PR was insufficient in fixing #3897.  Increase another OAuth access token buffer to 2048 to match the updated spec from Google.

