### PR TITLE
Allow date setting in files generated by the CSV plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -432,6 +432,7 @@
 #<Plugin csv>
 #	DataDir "@localstatedir@/lib/@PACKAGE_NAME@/csv"
 #	StoreRates false
+#	FileDate true
 #</Plugin>
 
 #<Plugin curl>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1875,6 +1875,11 @@ If set to B<true>, convert counter values to rates. If set to B<false> (the
 default) counter values are stored as is, i.E<nbsp>e. as an increasing integer
 number.
 
+=item B<FileDate> B<true|false>
+
+If set to B<true> (the default value), the generated files will include the date.
+If set to B<false> the date will not be included in the generated files.
+
 =back
 
 =head2 cURL Statistics

--- a/src/csv.c
+++ b/src/csv.c
@@ -30,12 +30,13 @@
 /*
  * Private variables
  */
-static const char *config_keys[] = {"DataDir", "StoreRates"};
+static const char *config_keys[] = {"DataDir", "StoreRates", "FileDate"};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static char *datadir;
 static int store_rates;
 static int use_stdio;
+static int file_date = 1;
 
 static int value_list_to_string(char *buffer, int buffer_len,
                                 const data_set_t *ds, const value_list_t *vl) {
@@ -126,6 +127,9 @@ static int value_list_to_filename(char *buffer, size_t buffer_size,
   if (use_stdio)
     return 0;
 
+  if (!file_date)
+    return 0;
+
   ptr_size -= strlen(ptr);
   ptr += strlen(ptr);
 
@@ -205,6 +209,11 @@ static int csv_config(const char *key, const char *value) {
       store_rates = 1;
     else
       store_rates = 0;
+  } else if (strcasecmp("FileDate", key) == 0) {
+    if (IS_TRUE(value))
+      file_date = 1;
+    else
+      file_date = 0;
   } else {
     return -1;
   }


### PR DESCRIPTION
ChangeLog: CSV plugin: Allow date setting in files generated by the CSV plugin.