### PR TITLE
[collectd 6.0] gpu_sysman: Add more metric output variants and better control for them

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -796,7 +796,7 @@
 #<Plugin gpu_sysman>
 #   Samples 1
 #   LogGpuInfo false
-#   MetricsOutput both
+#   MetricsOutput "counter:rate:ratio"
 #   DisableMemory false
 #   DisableMemoryBandwidth false
 #   DisableFrequency false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3736,10 +3736,10 @@ Several of the metric types support multiple variants for their
 values. This option specifies which ones of them are to be reported.
 
 Default is to report all variants ("counter:rate:ratio"). To reduce
-amount of data, it is better to configure just the relevant one for
-given use. Note that some of the metric types support only two of
-these variants, whereas metrics supporting only single variant ignore
-this option.
+amount of data, it is better to configure just the relevant ones for
+given use (e.g. "counter:ratio" or "rate:ratio"). Note that some of
+the metric types support only two of these variants, whereas metrics
+supporting only single variant ignore this option.
 
 Counter metric variant (e.g. HW energy usage as Joules counter) is
 preferred by Prometheus as doing rate calculations in Prometheus is

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3717,9 +3717,10 @@ per second. When Samples is larger than 1, min + max are calculated
 for the sampled values and submitted instead of the read values
 themselves.
 
-Other metrics values are either counters, or change much slower, and
-are read only at submit intervals.  If collecting of the sampled
-values is disabled, it is better to set Samples to 1 (default).
+Most of other metrics values are either counters, or change much
+slower, and are read only at submit intervals.  If collecting of the
+sampled values is disabled, it is better to set Samples to 1
+(default).
 
 =item B<LogGpuInfo>
 
@@ -3728,13 +3729,32 @@ settings and all the GPUs detected through Sysman API.
 
 =item B<MetricsOutput>
 
-Either "raw", "derived" or "both".
+Set of "counter", "rate", and "ratio" values, separated by comma,
+colon, slash or space.
 
-Specifies whether metrics should be reported as raw values provided
-by Sysman (e.g. HW energy usage counter value in Joules) which is
-preferred for use in Prometheus, as more human-readable and easier
-to debug derived values (e.g. power usage gauge value in Watts), or
-whether to increase number of produced metrics by reporting both.
+Several of the metric types support multiple variants for their
+values. This option specifies which ones of them are to be reported.
+
+Default is to report all variants ("counter:rate:ratio"). To reduce
+amount of data, it is better to configure just the relevant one for
+given use. Note that some of the metric types support only two of
+these variants, whereas metrics supporting only single variant ignore
+this option.
+
+Counter metric variant (e.g. HW energy usage as Joules counter) is
+preferred by Prometheus as doing rate calculations in Prometheus is
+more flexible. However, because collectd stores counters internally as
+integers, counter metrics cannot using base units (seconds, joules) as
+required by OpenMetrics spec, but microseconds and microjoules.
+
+Rate metric variant is directly human readable, and available for
+metrics where it makes sense (e.g. bytes per second, Watts and RPMs).
+
+Ratio variant is a utilization metric. It can be reported only for
+metric types which are either based on time (e.g. GPU engine use
+time), or for which Sysman provides a limit / maximum value. Some
+metrics may give over 100% ratios if their limit applies over longer
+time than the query inteval (could happen e.g. with power limits).
 
 =item B<DisableMemory>
 

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -2023,7 +2023,7 @@ static int gpu_config_parse(const char *key, const char *value) {
   } else if (strcasecmp(key, KEY_METRICS_OUTPUT) == 0) {
     config.output = 0;
     static const char delim[] = ",:/ ";
-    char *save, *flag, *flags = strdup(value);
+    char *save, *flag, *flags = sstrdup(value);
     for (flag = strtok_r(flags, delim, &save); flag;
          flag = strtok_r(NULL, delim, &save)) {
       unsigned i;

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -1019,8 +1019,10 @@ static bool gpu_mems(gpu_device_t *gpu, unsigned int cache_idx) {
       mem_used = mem_size - mem_free;
       metric.value.gauge = mem_used;
       metric_family_metric_append(&fam_bytes, metric);
-      metric.value.gauge = mem_used / mem_size;
-      metric_family_metric_append(&fam_ratio, metric);
+      if (config.output & OUTPUT_RATIO) {
+        metric.value.gauge = mem_used / mem_size;
+        metric_family_metric_append(&fam_ratio, metric);
+      }
     } else {
       /* find min & max values for memory free from
        * (the configured number of) samples
@@ -1041,16 +1043,19 @@ static bool gpu_mems(gpu_device_t *gpu, unsigned int cache_idx) {
       metric.value.gauge = mem_used;
       metric_label_set(&metric, "function", "min");
       metric_family_metric_append(&fam_bytes, metric);
-      metric.value.gauge = mem_used / mem_size;
-      metric_family_metric_append(&fam_ratio, metric);
-
+      if (config.output & OUTPUT_RATIO) {
+        metric.value.gauge = mem_used / mem_size;
+        metric_family_metric_append(&fam_ratio, metric);
+      }
       /* smallest used amount of memory */
       mem_used = mem_size - free_min;
       metric.value.gauge = mem_used;
       metric_label_set(&metric, "function", "max");
       metric_family_metric_append(&fam_bytes, metric);
-      metric.value.gauge = mem_used / mem_size;
-      metric_family_metric_append(&fam_ratio, metric);
+      if (config.output & OUTPUT_RATIO) {
+        metric.value.gauge = mem_used / mem_size;
+        metric_family_metric_append(&fam_ratio, metric);
+      }
     }
   }
   if (ok && cache_idx == 0) {

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -120,10 +120,10 @@ typedef struct {
 } gpu_device_t;
 
 typedef enum {
-  OUTPUT_COUNTER = 1,
-  OUTPUT_RATE = 2,
-  OUTPUT_RATIO = 4,
-  OUTPUT_ALL = 7
+  OUTPUT_COUNTER = (1 << 0),
+  OUTPUT_RATE = (1 << 1),
+  OUTPUT_RATIO = (1 << 2),
+  OUTPUT_ALL = (OUTPUT_COUNTER | OUTPUT_RATE | OUTPUT_RATIO)
 } output_t;
 
 static const struct {
@@ -2026,15 +2026,17 @@ static int gpu_config_parse(const char *key, const char *value) {
     char *save, *flag, *flags = sstrdup(value);
     for (flag = strtok_r(flags, delim, &save); flag;
          flag = strtok_r(NULL, delim, &save)) {
-      unsigned i;
-      for (i = 0; i < STATIC_ARRAY_SIZE(metrics_output); i++) {
+      bool found = false;
+      for (unsigned i = 0; i < STATIC_ARRAY_SIZE(metrics_output); i++) {
         if (strcasecmp(flag, metrics_output[i].name) == 0) {
           config.output |= metrics_output[i].value;
+          found = true;
           break;
         }
       }
-      if (i >= STATIC_ARRAY_SIZE(metrics_output)) {
+      if (!found) {
         free(flags);
+        ERROR(PLUGIN_NAME ": Invalid '%s' config key value '%s'", key, value);
         return RET_INVALID_CONFIG;
       }
     }

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -1380,6 +1380,11 @@ static bool gpu_freqs_throttle(gpu_device_t *gpu) {
     gpu->throttle = scalloc(freq_count, sizeof(*gpu->throttle));
     gpu->throttle_count = freq_count;
   }
+  if (!(config.output & (OUTPUT_COUNTER | OUTPUT_RATIO))) {
+    ERROR(PLUGIN_NAME ": no throttle-time output variants selected");
+    free(freqs);
+    return false;
+  }
 
   metric_family_t fam_ratio = {
       .help =
@@ -1555,6 +1560,11 @@ static bool gpu_powers(gpu_device_t *gpu) {
     gpu->power = scalloc(power_count, sizeof(*gpu->power));
     gpu->power_count = power_count;
   }
+  if (!(config.output & (OUTPUT_COUNTER | OUTPUT_RATE))) {
+    ERROR(PLUGIN_NAME ": no power output variants selected");
+    free(powers);
+    return false;
+  }
 
   metric_family_t fam_power = {
       .help = "Average power usage (in Watts) over query interval",
@@ -1638,6 +1648,11 @@ static bool gpu_engines(gpu_device_t *gpu) {
     }
     gpu->engine = scalloc(engine_count, sizeof(*gpu->engine));
     gpu->engine_count = engine_count;
+  }
+  if (!(config.output & (OUTPUT_COUNTER | OUTPUT_RATIO))) {
+    ERROR(PLUGIN_NAME ": no engine output variants selected");
+    free(engines);
+    return false;
   }
 
   metric_family_t fam_ratio = {

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -725,8 +725,8 @@ static double get_value(metric_type_t type, value_t value) {
 int plugin_dispatch_metric_family(metric_family_t const *fam) {
   assert(fam && fam->name && fam->metric.num && fam->metric.ptr);
 
-  char name[128];
   bool found = false;
+  char name[128] = "\0";
   metric_t *metric = fam->metric.ptr;
 
   for (size_t m = 0; m < fam->metric.num; m++) {
@@ -749,7 +749,11 @@ int plugin_dispatch_metric_family(metric_family_t const *fam) {
       }
     }
   }
-  assert(found);
+  if (!found) {
+    fprintf(stderr, "ERROR: found no '%s' metrics\n(e.g '%s')\n", fam->name,
+            name);
+    exit(1);
+  }
   return 0;
 }
 

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -936,16 +936,17 @@ static int test_config_keys(bool check_nonbool, bool enable_metrics,
     const char *value;
     bool success;
   } test[] = {
-      {"MetricsOutput", "derived", true},
-      {"MetricsOutput", "raW", true},
-      {"MetricsOutput", "Foobar", false},
+      {"MetricsOutput", "counter", true},
+      {"MetricsOutput", "rate", true},
+      {"MetricsOutput", "RatiO", true},
+      {"MetricsOutput", "RatiO/fooBAR", false},
       {"MetricsOutput", "1", false},
       {"Foobar", "Foobar", false},
       {"Samples", "999", false},
       {"Samples", "-1", false},
       {"Samples", "8", true},
       /* set back to default */
-      {"MetricsOutput", "Both", true},
+      {"MetricsOutput", "counter:rate:ratio", true},
       {"Samples", "1", true},
   };
   unsigned int i, j;

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -304,6 +304,7 @@ static ze_result_t metric_args_check(int callbit, const char *name,
 #define RAS_INIT 0
 #define RAS_INC 1
 
+#define TEMP_LIMIT 95
 #define TEMP_INIT 10
 #define TEMP_INC 5
 
@@ -393,7 +394,7 @@ ADD_METRIC(9, zesDeviceEnumPowerDomains, zes_pwr_handle_t,
            power_counter.energy += COUNTER_INC,
            power_counter.timestamp += TIME_INC)
 
-static zes_temp_properties_t temp_props;
+static zes_temp_properties_t temp_props = {.maxTemperature = TEMP_LIMIT};
 static double temperature = TEMP_INIT;
 static int dummy;
 
@@ -480,6 +481,9 @@ typedef struct {
   double last;
 } metrics_validation_t;
 
+#define TEMP_RATIO_INIT ((double)(TEMP_INIT) / (TEMP_LIMIT))
+#define TEMP_RATIO_INC ((double)(TEMP_INC) / (TEMP_LIMIT))
+
 #define MEM_RATIO_INIT ((double)MEMORY_INIT / MEMORY_SIZE)
 #define MEM_RATIO_INC ((double)MEMORY_INC / MEMORY_SIZE)
 
@@ -508,6 +512,7 @@ static metrics_validation_t valid_metrics[] = {
     {"memory_usage_ratio/HBM/system", false, false, MEM_RATIO_INIT,
      MEM_RATIO_INC, 0, 0.0},
     {"temperature_celsius", true, false, TEMP_INIT, TEMP_INC, 0, 0.0},
+    {"temperature_ratio", true, false, TEMP_RATIO_INIT, TEMP_RATIO_INC, 0, 0.0},
 
     /* while counters increase, per-time incremented value should stay same */
     {"energy_ujoules_total", true, false, COUNTER_START, COUNTER_INC, 0, 0.0},

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -464,10 +464,11 @@ typedef struct {
   double last;
 } metrics_validation_t;
 
-#define RATIO_INIT ((double)MEMORY_INIT / MEMORY_SIZE)
-#define RATIO_INC ((double)MEMORY_INC / MEMORY_SIZE)
+#define MEM_RATIO_INIT ((double)MEMORY_INIT / MEMORY_SIZE)
+#define MEM_RATIO_INC ((double)MEMORY_INC / MEMORY_SIZE)
 
 static metrics_validation_t valid_metrics[] = {
+    /* gauge value changes */
     {"all_errors_total", true, false, RAS_INIT, RAS_INC, 0, 0.0},
     {"frequency_mhz/actual/gpu/min", true, true, FREQ_INIT, FREQ_INC, 0, 0.0},
     {"frequency_mhz/actual/gpu/max", true, true, FREQ_INIT, FREQ_INC, 0, 0.0},
@@ -478,27 +479,25 @@ static metrics_validation_t valid_metrics[] = {
      0.0},
     {"frequency_mhz/request/gpu", false, false, FREQ_INIT, 2 * FREQ_INC, 0,
      0.0},
-    {"memory_used_bytes/HBM/system/min", true, true, MEMORY_INIT, +MEMORY_INC,
-     0, 0.0},
-    {"memory_used_bytes/HBM/system/max", true, true, MEMORY_INIT, +MEMORY_INC,
-     0, 0.0},
-    {"memory_used_bytes/HBM/system", false, false, MEMORY_INIT, +MEMORY_INC, 0,
+    {"memory_used_bytes/HBM/system/min", true, true, MEMORY_INIT, MEMORY_INC, 0,
      0.0},
-    {"memory_usage_ratio/HBM/system/min", true, true, RATIO_INIT, +RATIO_INC, 0,
+    {"memory_used_bytes/HBM/system/max", true, true, MEMORY_INIT, MEMORY_INC, 0,
      0.0},
-    {"memory_usage_ratio/HBM/system/max", true, true, RATIO_INIT, +RATIO_INC, 0,
+    {"memory_used_bytes/HBM/system", false, false, MEMORY_INIT, MEMORY_INC, 0,
      0.0},
-    {"memory_usage_ratio/HBM/system", false, false, RATIO_INIT, +RATIO_INC, 0,
-     0.0},
+    {"memory_usage_ratio/HBM/system/min", true, true, MEM_RATIO_INIT,
+     MEM_RATIO_INC, 0, 0.0},
+    {"memory_usage_ratio/HBM/system/max", true, true, MEM_RATIO_INIT,
+     MEM_RATIO_INC, 0, 0.0},
+    {"memory_usage_ratio/HBM/system", false, false, MEM_RATIO_INIT,
+     MEM_RATIO_INC, 0, 0.0},
     {"temperature_celsius", true, false, TEMP_INIT, TEMP_INC, 0, 0.0},
 
     /* while counters increase, per-time incremented value should stay same */
+    {"energy_ujoules_total", true, false, COUNTER_START, COUNTER_INC, 0, 0.0},
+    {"engine_ratio/all", true, false, COUNTER_RATIO, 0, 0, 0.0},
     {"engine_use_usecs_total/all", true, false, COUNTER_START, COUNTER_INC, 0,
      0.0},
-    {"engine_ratio/all", true, false, COUNTER_RATIO, 0, 0, 0.0},
-    {"throttled_usecs_total/gpu", true, false, COUNTER_START, COUNTER_INC, 0,
-     0.0},
-    {"throttled_ratio/gpu", true, false, COUNTER_RATIO, 0, 0, 0.0},
     {"memory_bw_bytes_total/HBM/system/read", true, false, 2 * COUNTER_START,
      2 * COUNTER_INC, 0, 0.0},
     {"memory_bw_bytes_total/HBM/system/write", true, false, COUNTER_START,
@@ -506,8 +505,10 @@ static metrics_validation_t valid_metrics[] = {
     {"memory_bw_ratio/HBM/system/read", true, false, 2 * COUNTER_RATIO, 0, 0,
      0.0},
     {"memory_bw_ratio/HBM/system/write", true, false, COUNTER_RATIO, 0, 0, 0.0},
-    {"energy_ujoules_total", true, false, COUNTER_START, COUNTER_INC, 0, 0.0},
     {"power_watts", true, false, COUNTER_RATIO, 0, 0, 0.0},
+    {"throttled_usecs_total/gpu", true, false, COUNTER_START, COUNTER_INC, 0,
+     0.0},
+    {"throttled_ratio/gpu", true, false, COUNTER_RATIO, 0, 0, 0.0},
 };
 
 /* VALIDATE: reset tracked metrics values and return count of how many

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -294,6 +294,7 @@ static ze_result_t metric_args_check(int callbit, const char *name,
 #define COUNTER_MAX_RATIO                                                      \
   (1.0e6 * COUNTER_INC / ((double)COUNTER_MAX * TIME_INC))
 
+#define FREQ_LIMIT 1600
 #define FREQ_INIT 300
 #define FREQ_INC 50
 
@@ -366,7 +367,7 @@ ADD_METRIC(0, zesDeviceEnumEngineGroups, zes_engine_handle_t,
            engine_stats.activeTime += COUNTER_INC,
            engine_stats.timestamp += TIME_INC)
 
-static zes_freq_properties_t freq_props;
+static zes_freq_properties_t freq_props = {.max = FREQ_LIMIT};
 static zes_freq_state_t freq_state = {.request = FREQ_INIT,
                                       .actual = FREQ_INIT};
 
@@ -481,6 +482,9 @@ typedef struct {
   double last;
 } metrics_validation_t;
 
+#define FREQ_RATIO_INIT ((double)(FREQ_INIT) / (FREQ_LIMIT))
+#define FREQ_RATIO_INC ((double)(FREQ_INC) / (FREQ_LIMIT))
+
 #define TEMP_RATIO_INIT ((double)(TEMP_INIT) / (TEMP_LIMIT))
 #define TEMP_RATIO_INC ((double)(TEMP_INC) / (TEMP_LIMIT))
 
@@ -499,6 +503,18 @@ static metrics_validation_t valid_metrics[] = {
      0.0},
     {"frequency_mhz/request/gpu", false, false, FREQ_INIT, 2 * FREQ_INC, 0,
      0.0},
+    {"frequency_ratio/actual/gpu/min", true, true, FREQ_RATIO_INIT,
+     FREQ_RATIO_INC, 0, 0.0},
+    {"frequency_ratio/actual/gpu/max", true, true, FREQ_RATIO_INIT,
+     FREQ_RATIO_INC, 0, 0.0},
+    {"frequency_ratio/actual/gpu", false, false, FREQ_RATIO_INIT,
+     FREQ_RATIO_INC, 0, 0.0},
+    {"frequency_ratio/request/gpu/min", true, true, FREQ_RATIO_INIT,
+     2 * FREQ_RATIO_INC, 0, 0.0},
+    {"frequency_ratio/request/gpu/max", true, true, FREQ_RATIO_INIT,
+     2 * FREQ_RATIO_INC, 0, 0.0},
+    {"frequency_ratio/request/gpu", false, false, FREQ_RATIO_INIT,
+     2 * FREQ_RATIO_INC, 0, 0.0},
     {"memory_used_bytes/HBM/system/min", true, true, MEMORY_INIT, MEMORY_INC, 0,
      0.0},
     {"memory_used_bytes/HBM/system/max", true, true, MEMORY_INIT, MEMORY_INC, 0,

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -285,11 +285,14 @@ static ze_result_t metric_args_check(int callbit, const char *name,
 #define COUNTER_START 100000 // 100ms
 #define COUNTER_INC 20000    // 20ms
 #define TIME_START 5000000   // 5s in us
-#define TIME_INC 1000000     // 1s in us
+#define TIME_INC 2000000     // 2s in us
 #define COUNTER_MAX TIME_INC
 
 /* what should get reported as result of above */
 #define COUNTER_RATIO ((double)COUNTER_INC / TIME_INC)
+#define COUNTER_RATE (1.0e6 * COUNTER_INC / TIME_INC)
+#define COUNTER_MAX_RATIO                                                      \
+  (1.0e6 * COUNTER_INC / ((double)COUNTER_MAX * TIME_INC))
 
 #define FREQ_INIT 300
 #define FREQ_INC 50
@@ -502,9 +505,14 @@ static metrics_validation_t valid_metrics[] = {
      2 * COUNTER_INC, 0, 0.0},
     {"memory_bw_bytes_total/HBM/system/write", true, false, COUNTER_START,
      COUNTER_INC, 0, 0.0},
-    {"memory_bw_ratio/HBM/system/read", true, false, 2 * COUNTER_RATIO, 0, 0,
+    {"memory_bw_bytes_per_second/HBM/system/read", true, false,
+     2 * COUNTER_RATE, 0, 0, 0.0},
+    {"memory_bw_bytes_per_second/HBM/system/write", true, false, COUNTER_RATE,
+     0, 0, 0.0},
+    {"memory_bw_ratio/HBM/system/read", true, false, 2 * COUNTER_MAX_RATIO, 0,
+     0, 0.0},
+    {"memory_bw_ratio/HBM/system/write", true, false, COUNTER_MAX_RATIO, 0, 0,
      0.0},
-    {"memory_bw_ratio/HBM/system/write", true, false, COUNTER_RATIO, 0, 0, 0.0},
     {"power_watts", true, false, COUNTER_RATIO, 0, 0, 0.0},
     {"throttled_usecs_total/gpu", true, false, COUNTER_START, COUNTER_INC, 0,
      0.0},


### PR DESCRIPTION
ChangeLog: gpu_sysman: Add more metric output variants and better control for them

Changes:
* Add "rate" variant flag (3rd one) for MetricsOutput option, and change that option to a bitmask
* Rename MetricsOutput "raw" + "derived" flag names to "counter" + "ratio" ones matching metric names [1]
* Add "ratio" variant to all metric types where L0 API provides limit / max value for the metric (frequency, power, temperature)
* Add "rate" variant for memory BW metric type, in addition to already existing "counter" and "ratio" variants
* All metric types that submit multiple variants, check now these flags, and if metric type is enabled, but none of its output variants are enabled, warning is logged
* Tests for the new metrics + related improvements to the generic sysman plugin test code

Because this adds quite a bit of code to the plugin (231 added, 71 removed lines), main question is whether providing multiple variants for same metric is fine (e.g. for memory bandwidth: increasing counter, bytes per second value, and a ratio for how much that is from max BW)?

(Things like Prometheus can provide rate data based on counter data only, but if one is consuming metric data directly, providing rate directly from collectd would be preferred.)

[1] As there has been no release with this plugin, this API change should be fine.