### PR TITLE
cpython: fix build with Python 3.11

### DIFF
--- a/src/cpython.h
+++ b/src/cpython.h
@@ -24,9 +24,15 @@
  *   Sven Trenkel <collectd at semidefinite.de>
  **/
 
+#include <Python.h>
 /* Some python versions don't include this by default. */
-
+#if PY_VERSION_HEX < 0x030B0000
+/*
+ * Python 3.11 move longintrepr.h to cpython/longintrepr.h
+ * And it's always included
+ */
 #include <longintrepr.h>
+#endif /* PY_VERSION_HEX < 0x030B0000 */
 
 /* These two macros are basically Py_BEGIN_ALLOW_THREADS and
  * Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
Python 3.11 moves longintrepr.h into cpython sub-directory. However, in this version, longintrepr.h is always included.

ChangeLog: cpython: fix build with Python 3.11