### PR TITLE
check_presence plugin: Add new plugin to detect new and missing hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -189,6 +189,9 @@ Florian Eckert
 Gergely Nagy <algernon at madhouse-project.org>
  - Write-Riemann plugin.
 
+Graham Leggett <minfrin at sharp.fm>
+ - check_presence plugin.
+
 Hari TG <hari.tg at intel.com>
  - dcpmm plugin.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -826,6 +826,14 @@ chrony_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 chrony_la_LIBADD = -lm
 endif
 
+if BUILD_PLUGIN_CHECK_PRESENCE
+pkglib_LTLIBRARIES += check_presence.la
+check_presence_la_SOURCES = src/check_presence.c
+check_presence_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBLMDB_CPPFLAGS)
+check_presence_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBLMDB_LDFLAGS)
+check_presence_la_LIBADD = -llmdb
+endif
+
 if BUILD_PLUGIN_CHECK_UPTIME
 pkglib_LTLIBRARIES += check_uptime.la
 check_uptime_la_SOURCES = src/check_uptime.c

--- a/README
+++ b/README
@@ -708,6 +708,11 @@ Features
       Selects multiple value lists based on patterns or regular expressions
       and creates new aggregated values lists from those.
 
+    - check_presence
+      Detects whether a host has been seen for the first time, or whether a
+      host has not been seen for a specified interval, and creates
+      notifications for each case.
+
     - threshold
       Checks values against configured thresholds and creates notifications if
       values are out of bounds. See collectd-threshold(5) for details.

--- a/configure.ac
+++ b/configure.ac
@@ -3193,6 +3193,55 @@ AC_SUBST([BUILD_WITH_LIBLDAP_CPPFLAGS])
 AC_SUBST([BUILD_WITH_LIBLDAP_LDFLAGS])
 # }}}
 
+# --with-liblmdb {{{
+AC_ARG_WITH([liblmdb],
+  [AS_HELP_STRING([--with-liblmdb@<:@=PREFIX@:>@], [Path to liblmdb.])],
+  [
+    if test "x$withval" = "xyes"; then
+      with_liblmdb="yes"
+    else if test "x$withval" = "xno"; then
+      with_liblmdb="no"
+    else
+      with_liblmdb="yes"
+      LIBLMDB_CPPFLAGS="$LIBLMDB_CPPFLAGS -I$withval/include"
+      LIBLMDB_LDFLAGS="$LIBLMDB_LDFLAGS -L$withval/lib"
+    fi; fi
+  ],
+  [with_liblmdb="yes"]
+)
+
+SAVE_CPPFLAGS="$CPPFLAGS"
+SAVE_LDFLAGS="$LDFLAGS"
+
+CPPFLAGS="$CPPFLAGS $LIBLMDB_CPPFLAGS"
+LDFLAGS="$LDFLAGS $LIBLMDB_LDFLAGS"
+
+if test "x$with_liblmdb" = "xyes"; then
+  AC_CHECK_HEADERS([lmdb.h],
+    [with_liblmdb="yes"],
+    [with_liblmdb="no ('lmdb.h' not found)"]
+  )
+fi
+
+if test "x$with_liblmdb" = "xyes"; then
+  AC_CHECK_LIB([lmdb], [mdb_version],
+    [with_liblmdb="yes"],
+    [with_liblmdb="no (symbol 'mdb_version' not found)"]
+  )
+fi
+
+CPPFLAGS="$SAVE_CPPFLAGS"
+LDFLAGS="$SAVE_LDFLAGS"
+
+if test "x$with_liblmdb" = "xyes"
+then
+  BUILD_WITH_LIBLMDB_CPPFLAGS="$LIBLMDB_CPPFLAGS"
+  BUILD_WITH_LIBLMDB_LDFLAGS="$LIBLMDB_LDFLAGS"
+fi
+AC_SUBST([BUILD_WITH_LIBLMDB_CPPFLAGS])
+AC_SUBST([BUILD_WITH_LIBLMDB_LDFLAGS])
+# }}}
+
 # --with-liblua {{{
 AC_ARG_VAR([LIBLUA_PKG_CONFIG_NAME], [Name of liblua used by pkg-config])
 if test "x$LIBLUA_PKG_CONFIG_NAME" != "x"
@@ -7226,6 +7275,7 @@ AC_PLUGIN([capabilities],        [$plugin_capabilities],      [Platform static c
 AC_PLUGIN([ceph],                [$plugin_ceph],              [Ceph daemon statistics])
 AC_PLUGIN([cgroups],             [$plugin_cgroups],           [CGroups CPU usage accounting])
 AC_PLUGIN([chrony],              [yes],                       [Chrony statistics])
+AC_PLUGIN([check_presence],      [$with_liblmdb],             [Host presence checking plugin])
 AC_PLUGIN([check_uptime],        [yes],                       [Notify about uptime reset])
 AC_PLUGIN([connectivity],        [$plugin_connectivity],      [Network interface up/down events])
 AC_PLUGIN([conntrack],           [$plugin_conntrack],         [nf_conntrack statistics])
@@ -7602,6 +7652,7 @@ AC_MSG_RESULT([    libjvm  . . . . . . . $with_java])
 AC_MSG_RESULT([    libkstat  . . . . . . $with_kstat])
 AC_MSG_RESULT([    libkvm  . . . . . . . $with_libkvm])
 AC_MSG_RESULT([    libldap . . . . . . . $with_libldap])
+AC_MSG_RESULT([    liblmdb . . . . . . . $with_liblmdb])
 AC_MSG_RESULT([    liblua  . . . . . . . $with_liblua])
 AC_MSG_RESULT([    libmemcached  . . . . $with_libmemcached])
 AC_MSG_RESULT([    libmicrohttpd . . . . $with_libmicrohttpd])
@@ -7675,6 +7726,7 @@ AC_MSG_RESULT([    capabilities  . . . . $enable_capabilities])
 AC_MSG_RESULT([    ceph  . . . . . . . . $enable_ceph])
 AC_MSG_RESULT([    cgroups . . . . . . . $enable_cgroups])
 AC_MSG_RESULT([    chrony. . . . . . . . $enable_chrony])
+AC_MSG_RESULT([    check_presence  . . . $enable_check_presence])
 AC_MSG_RESULT([    check_uptime. . . . . $enable_check_uptime])
 AC_MSG_RESULT([    connectivity. . . . . $enable_connectivity])
 AC_MSG_RESULT([    conntrack . . . . . . $enable_conntrack])

--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -58,7 +58,7 @@
 %define with_bind 0%{!?_without_bind:1}
 %define with_ceph 0%{!?_without_ceph:1}
 %define with_cgroups 0%{!?_without_cgroups:1}
-%define with_check_uptime 0%{!?_without_check_uptime:1}
+%define with_check_presence 0%{!?_without_check_presence:1}
 %define with_chrony 0%{!?_without_chrony:1}
 %define with_connectivity 0%{!?_without_connectivity:1}
 %define with_conntrack 0%{!?_without_conntrack:1}
@@ -527,6 +527,16 @@ Requires:	%{name}%{?_isa} = %{version}-%{release}, hddtemp
 %description hddtemp
 The HDDTemp plugin collects the temperature of hard disks. The temperatures are
 provided via SMART and queried by the external hddtemp daemon.
+%endif
+
+%if %{with_check_presence}
+%package check_presence
+Summary:        Check presence plugin for collectd
+Group:          System Environment/Daemons
+Requires:       %{name}%{?_isa} = %{version}-%{release}, liblmdb
+%description check_presence
+The check_presence plugin sends notifications when a host is seen for the first
+time, and when a host has not been seen for a configurable interval.
 %endif
 
 %if %{with_intel_pmu}
@@ -1244,6 +1254,12 @@ Collectd utilities
 %define _with_ceph --enable-ceph
 %else
 %define _with_ceph --disable-ceph
+%endif
+
+%if %{with_check_presence}
+%define _with_check_presence --enable-check_presence
+%else
+%define _with_check_presence --disable-check_presence
 %endif
 
 %if %{with_curl}
@@ -2116,6 +2132,7 @@ Collectd utilities
 	%{?_with_ceph} \
 	%{?_with_cgroups} \
 	%{?_with_check_uptime} \
+	%{?_with_check_presence} \
 	%{?_with_chrony} \
 	%{?_with_connectivity} \
 	%{?_with_conntrack} \
@@ -2683,6 +2700,11 @@ fi
 %{_libdir}/%{name}/ceph.so
 %endif
 
+%if %{with_check_presence}
+%files check_presence
+%{_libdir}/%{name}/check_presence.so
+%endif
+
 %if %{with_chrony}
 %files chrony
 %{_libdir}/%{name}/chrony.so
@@ -3023,6 +3045,9 @@ fi
 %changelog
 * Thu Sep 08 2022 Laura Hild <lsh@jlab.org> - 5.12.0-2
 - require systemd-devel (libudev.h) to build the SMART plugin
+
+* Thu Oct 25 2021 Graham Leggett <minfrin@sharp.fm> - 5.12.0-1
+- Add new check_presence plugin
 
 * Wed May 05 2021 Fabien Wernli <rpmbuild@faxmodem.org> - 5.12.0-1
 - Update to 5.12.0

--- a/src/check_presence.c
+++ b/src/check_presence.c
@@ -1,0 +1,532 @@
+/**
+ * collectd - src/check_presence.c
+ * Copyright (C) 2019       Graham Leggett
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Graham Leggett <minfrin at sharp.fm>
+ *
+ **/
+
+/*
+ * This plugin keeps track of hosts that have been seen by collectd, and sends
+ * notifications when a new host is seen, and when a host has not been seen.
+ *
+ */
+
+#include "collectd.h"
+
+#include "plugin.h"
+#include "utils/common/common.h"
+
+#include <lmdb.h>
+
+#define PLUGIN_NAME "check_presence"
+
+#define DEFAULT_STATE_DATASTORE "check-presence"
+#define DEFAULT_HOST_TIMEOUT 20
+#define DEFAULT_CHECK_INTERVAL 10
+#define DEFAULT_STARTUP_DELAY 20
+
+static const char *config_keys[] = {"STATEDATASTORE", "HOSTTIMEOUT",
+                                    "STARTUPDELAY", "CHECKINTERVAL"};
+static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
+static char *state_datastore = DEFAULT_STATE_DATASTORE;
+static int host_timeout = DEFAULT_HOST_TIMEOUT;
+static int startup_delay = DEFAULT_STARTUP_DELAY;
+static int check_interval = DEFAULT_CHECK_INTERVAL;
+
+static pthread_mutex_t presence_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t presence_cond = PTHREAD_COND_INITIALIZER;
+static int presence_thread_loop;
+static pthread_t presence_thread_id;
+
+static MDB_env *env;
+
+static void *presence_thread(void *arg) /* {{{ */
+{
+  struct timeval tv_begin = {0};
+
+  if (gettimeofday(&tv_begin, NULL) < 0) {
+    ERROR(PLUGIN_NAME " plugin: gettimeofday failed: %s", STRERRNO);
+    presence_thread_loop = 0;
+    return (void *)0;
+  }
+
+  pthread_mutex_lock(&presence_lock);
+
+  /*
+   * Startup delay - give the hosts a chance to remind us they're
+   * still here.
+   *
+   * When we start up after a reboot or restart, chances are all hosts
+   * on the list will have exceeded the interval through no fault of
+   * their own. To prevent the sending of erroneous failure notifications
+   * we back off for enough time to allow remote hosts to check in and
+   * remind us they're still there.
+   *
+   * Any host that hasn't checked in by this point can be safely assumed
+   * to have vanished, and will accurately trigger a notification.
+   */
+  struct timespec ts_wait = {0};
+
+  ts_wait.tv_sec = tv_begin.tv_sec + startup_delay;
+  ts_wait.tv_nsec = 0;
+
+  pthread_cond_timedwait(&presence_cond, &presence_lock, &ts_wait);
+
+  while (presence_thread_loop > 0) {
+
+    struct timeval tv_now = {0};
+
+    if (gettimeofday(&tv_now, NULL) < 0) {
+      ERROR(PLUGIN_NAME " plugin: gettimeofday failed: %s", STRERRNO);
+      presence_thread_loop = 0;
+      break;
+    }
+
+    pthread_mutex_unlock(&presence_lock);
+
+    /*
+     * Cleanup thread - have any hosts been gone too long?
+     *
+     * We run with a two second delay between each invocation, and walk
+     * the hosts list looking for hosts that we haven't seen for more
+     * than our threshold.
+     *
+     * Hosts that have gone missing are removed from our list, and a
+     * notification is sent.
+     *
+     * When the host returns, the host will be detected by host_write,
+     * and a notification that the host has been seen will be sent.
+     */
+
+    MDB_txn *txn = NULL;
+
+    int rc = mdb_txn_begin(env, NULL, 0, &txn);
+    if (rc) {
+      ERROR(PLUGIN_NAME " plugin: mdb_txn_begin returned: %s (%d)",
+            mdb_strerror(rc), rc);
+      goto skip;
+    }
+
+    MDB_dbi dbi = {0};
+
+    rc = mdb_dbi_open(txn, NULL, MDB_CREATE, &dbi);
+    if (rc) {
+      ERROR(PLUGIN_NAME " plugin: mdb_dbi_open returned: %s (%d)",
+            mdb_strerror(rc), rc);
+      mdb_txn_abort(txn);
+      goto skip;
+    }
+
+    MDB_cursor *cursor = NULL;
+
+    rc = mdb_cursor_open(txn, dbi, &cursor);
+    if (rc) {
+      ERROR(PLUGIN_NAME " plugin: mdb_cursor_open returned: %s (%d)",
+            mdb_strerror(rc), rc);
+      mdb_txn_abort(txn);
+      goto skip;
+    }
+
+    MDB_val key = {0}, data = {0};
+
+    while ((rc = mdb_cursor_get(cursor, &key, &data, MDB_NEXT)) == 0) {
+
+      /* sanity check - remove any entries that have mismatched sizes,
+       * this might happen after an upgrade.
+       */
+
+      notification_t n = {0};
+
+      if (key.mv_size != sizeof(n.host) ||
+          data.mv_size != sizeof(struct timespec)) {
+
+        rc = mdb_cursor_del(cursor, 0);
+        if (rc) {
+          ERROR(PLUGIN_NAME " plugin: mdb_cursor_del returned: %s (%d)",
+                mdb_strerror(rc), rc);
+          mdb_cursor_close(cursor);
+          mdb_txn_abort(txn);
+          goto skip;
+        }
+
+        continue;
+      }
+
+      /* too old? if so, we've lost the host.
+       *
+       * also - stay silent for the first delay_interval after startup so we
+       * don't send a flurry of stale alerts.
+       *
+       */
+
+      const char *host = key.mv_data;
+
+      struct timeval *tv_then = data.mv_data;
+
+      if (tv_now.tv_sec - tv_then->tv_sec >= host_timeout) {
+
+        char message[NOTIF_MAX_MSG_LEN];
+
+        rc = mdb_cursor_del(cursor, 0);
+        if (rc) {
+          ERROR(PLUGIN_NAME " plugin: mdb_cursor_del returned: %s (%d)",
+                mdb_strerror(rc), rc);
+          mdb_cursor_close(cursor);
+          mdb_txn_abort(txn);
+          goto skip;
+        }
+
+        ssnprintf(
+            message, sizeof(message), "Host not seen for %d seconds: %.*s",
+            (int)(tv_now.tv_sec - tv_then->tv_sec), (int)sizeof(n.host), host);
+        notification_init(&n, NOTIF_FAILURE, message, host, PLUGIN_NAME, NULL,
+                          "host", "lost");
+        n.time = cdtime();
+
+        plugin_dispatch_notification(&n);
+      }
+    }
+    mdb_cursor_close(cursor);
+
+    rc = mdb_txn_commit(txn);
+    if (rc) {
+      ERROR(PLUGIN_NAME " plugin: mdb_txn_commit returned: %s (%d)",
+            mdb_strerror(rc), rc);
+      goto skip;
+    }
+
+  skip:
+    pthread_mutex_lock(&presence_lock);
+
+    if (presence_thread_loop <= 0)
+      break;
+
+    ts_wait.tv_sec = tv_now.tv_sec + check_interval;
+    ts_wait.tv_nsec = 0;
+
+    pthread_cond_timedwait(&presence_cond, &presence_lock, &ts_wait);
+    if (presence_thread_loop <= 0)
+      break;
+  } /* while (presence_thread_loop > 0) */
+
+  pthread_mutex_unlock(&presence_lock);
+
+  return (void *)0;
+} /* }}} void *presence_thread */
+
+static int start_thread(void) /* {{{ */
+{
+
+  pthread_mutex_lock(&presence_lock);
+
+  if (presence_thread_loop != 0) {
+    pthread_mutex_unlock(&presence_lock);
+    return 0;
+  }
+
+  presence_thread_loop = 1;
+  int status = plugin_thread_create(&presence_thread_id, presence_thread,
+                                    /* arg = */ (void *)0, PLUGIN_NAME);
+  if (status != 0) {
+    presence_thread_loop = 0;
+    ERROR(PLUGIN_NAME " plugin: starting thread failed.");
+    pthread_mutex_unlock(&presence_lock);
+    return -1;
+  }
+
+  pthread_mutex_unlock(&presence_lock);
+  return 0;
+} /* }}} int start_thread */
+
+static int stop_thread(void) /* {{{ */
+{
+
+  pthread_mutex_lock(&presence_lock);
+
+  if (presence_thread_loop == 0) {
+    pthread_mutex_unlock(&presence_lock);
+    return -1;
+  }
+
+  presence_thread_loop = 0;
+  pthread_cond_broadcast(&presence_cond);
+  pthread_mutex_unlock(&presence_lock);
+
+  int status = pthread_join(presence_thread_id, /* return = */ NULL);
+  if (status != 0) {
+    ERROR(PLUGIN_NAME " plugin: stopping thread failed.");
+    status = -1;
+  }
+
+  pthread_mutex_lock(&presence_lock);
+  memset(&presence_thread_id, 0, sizeof(presence_thread_id));
+  pthread_mutex_unlock(&presence_lock);
+
+  return status;
+} /* }}} int stop_thread */
+
+static int presence_shutdown(void) {
+
+  if (env) {
+
+    INFO(PLUGIN_NAME " plugin: shutting down thread.");
+    if (stop_thread() < 0)
+      return -1;
+
+    mdb_env_close(env);
+  }
+
+  return 0;
+}
+
+static int presence_write(const data_set_t *ds, const value_list_t *vl,
+                          __attribute__((unused)) user_data_t *user_data) {
+
+  struct timeval tv_now = {0};
+
+  int rc = gettimeofday(&tv_now, /* struct timezone = */ NULL);
+  if (rc != 0) {
+    ERROR(PLUGIN_NAME " plugin: gettimeofday failed: %s", STRERRNO);
+    return -1;
+  }
+
+  /*
+   * Fast path - have we seen this host before?
+   *
+   * WHile this step is not strictly necessary, in the vast majority of
+   * cases we will have seen the host before, and we will have seen the
+   * host many times in the same second as each metric is written.
+   *
+   * The LMDB key value store offers very cheap lock free reads, allowing
+   * multiple threads to handle writes without any mutexes.
+   *
+   * This first step discards unnecessary writes as quickly as possible.
+   */
+
+  MDB_val key = {0}, data = {0};
+
+  key.mv_size = sizeof(vl->host);
+  key.mv_data = (void *)vl->host;
+
+  MDB_txn *txn = NULL;
+
+  rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_txn_begin returned: %s (%d)",
+          mdb_strerror(rc), rc);
+    return -1;
+  }
+
+  MDB_dbi dbi = {0};
+
+  rc = mdb_dbi_open(txn, NULL, 0, &dbi);
+  if (MDB_NOTFOUND == rc) {
+
+    /* brand new database, skip the get */
+
+  } else if (rc) {
+
+    /* error happened */
+
+    ERROR(PLUGIN_NAME " plugin: mdb_dbi_open returned: %s (%d)",
+          mdb_strerror(rc), rc);
+    mdb_txn_abort(txn);
+    return -1;
+
+  } else {
+
+    /* existing database, do the get */
+
+    rc = mdb_get(txn, dbi, &key, &data);
+  }
+
+  int add = 0;
+
+  if (MDB_NOTFOUND == rc) {
+
+    /* new host found, send a notification */
+
+    add = 1;
+
+  } else if (rc) {
+
+    /* error happened */
+
+    ERROR(PLUGIN_NAME " plugin: mdb_get returned: %s (%d)", mdb_strerror(rc),
+          rc);
+    mdb_dbi_close(env, dbi);
+    mdb_txn_abort(txn);
+    return -1;
+
+  } else {
+
+    /* have we seen host in the same second as we did our last put? if so
+     * it is good enough, exit cheaply
+     */
+
+    struct timeval *tv_then;
+
+    if (data.mv_size == sizeof(struct timespec) && ((tv_then = data.mv_data)) &&
+        (tv_then->tv_sec == tv_now.tv_sec)) {
+      mdb_dbi_close(env, dbi);
+      mdb_txn_abort(txn);
+      return 0;
+    }
+  }
+
+  mdb_dbi_close(env, dbi);
+  mdb_txn_abort(txn);
+
+  /*
+   * Slow path - we need to update the host's record.
+   *
+   * At this point the host is either brand new, or we have not seen this host
+   * during this second, and we need to perform a write to update the key
+   * value store.
+   *
+   * The LMDB key value store handles locking for us so that writes from
+   * multiple threads are serialised correctly. As soon as the write is
+   * complete, the subsequent reads follow the fast path above, keeping this
+   * as inexpensive as possible.
+   */
+
+  rc = mdb_txn_begin(env, NULL, 0, &txn);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_txn_begin returned: %s (%d)",
+          mdb_strerror(rc), rc);
+    return -1;
+  }
+
+  rc = mdb_dbi_open(txn, NULL, MDB_CREATE, &dbi);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_dbi_open returned: %s (%d)",
+          mdb_strerror(rc), rc);
+    mdb_txn_abort(txn);
+    return -1;
+  }
+
+  data.mv_size = sizeof(tv_now);
+  data.mv_data = &tv_now;
+
+  rc = mdb_put(txn, dbi, &key, &data, add ? MDB_NOOVERWRITE : 0);
+  if (MDB_KEYEXIST == rc) {
+
+    /* another thread beat us to it, do nothing */
+    add = 0;
+
+  } else if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_put returned: %s (%d)", mdb_strerror(rc),
+          rc);
+    mdb_dbi_close(env, dbi);
+    mdb_txn_abort(txn);
+    return -1;
+  }
+
+  rc = mdb_txn_commit(txn);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_txn_commit returned: %s (%d)",
+          mdb_strerror(rc), rc);
+    mdb_dbi_close(env, dbi);
+    return -1;
+  }
+
+  mdb_dbi_close(env, dbi);
+
+  /* finally, handle the notification if needed */
+  if (add) {
+    notification_t n = {0};
+    char message[NOTIF_MAX_MSG_LEN];
+
+    ssnprintf(message, sizeof(message), "Host is found: %.*s",
+              (int)sizeof(vl->host), vl->host);
+    notification_init(&n, NOTIF_OKAY, message, vl->host, PLUGIN_NAME, NULL,
+                      "host", "found");
+    n.time = cdtime();
+
+    plugin_dispatch_notification(&n);
+  }
+
+  return 0;
+}
+
+static int presence_init(void) {
+
+  if (!state_datastore) {
+    INFO(PLUGIN_NAME " plugin: StateDataStore is unset, plugin is disabled.");
+    return 0;
+  }
+
+  int rc = mdb_env_create(&env);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: mdb_env_create failed: %s (%d)",
+          mdb_strerror(rc), rc);
+    return -1;
+  }
+
+  rc = mdb_env_open(env, state_datastore, MDB_NOSUBDIR, 0664);
+  if (rc) {
+    ERROR(PLUGIN_NAME " plugin: opening path '%s' failed: %s (%d)",
+          state_datastore, mdb_strerror(rc), rc);
+    mdb_env_close(env);
+    env = NULL;
+    return -1;
+  }
+
+  plugin_register_write(PLUGIN_NAME, presence_write, NULL);
+  plugin_register_shutdown(PLUGIN_NAME, presence_shutdown);
+
+  return start_thread();
+}
+
+static int presence_config(const char *key, const char *value) {
+  if (strcasecmp(key, "STATEDATASTORE") == 0) {
+    if (value != NULL && strcmp(value, "") != 0) {
+      state_datastore = strdup(value);
+    } else {
+      state_datastore = NULL;
+    }
+    return 0;
+  } else if (strcasecmp(key, "HOSTTIMEOUT") == 0) {
+    if (value != NULL) {
+      host_timeout = atoi(value);
+    }
+    return 0;
+  } else if (strcasecmp(key, "STARTUPDELAY") == 0) {
+    if (value != NULL) {
+      startup_delay = atoi(value);
+    }
+    return 0;
+  } else if (strcasecmp(key, "CHECKINTERVAL") == 0) {
+    if (value != NULL) {
+      check_interval = atoi(value);
+    }
+    return 0;
+  } else
+    return -1;
+} /* int presence_config */
+
+void module_register(void) {
+  plugin_register_init(PLUGIN_NAME, presence_init);
+  plugin_register_config(PLUGIN_NAME, presence_config, config_keys,
+                         config_keys_num);
+}

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -104,6 +104,7 @@
 #@BUILD_PLUGIN_CEPH_TRUE@LoadPlugin ceph
 #@BUILD_PLUGIN_CGROUPS_TRUE@LoadPlugin cgroups
 #@BUILD_PLUGIN_CHRONY_TRUE@LoadPlugin chrony
+#@BUILD_PLUGIN_CHECK_PRESENCE_TRUE@LoadPlugin check_presence
 #@BUILD_PLUGIN_CHECK_UPTIME_TRUE@LoadPlugin check_uptime
 #@BUILD_PLUGIN_CONNECTIVITY_TRUE@LoadPlugin connectivity
 #@BUILD_PLUGIN_CONNTRACK_TRUE@LoadPlugin conntrack
@@ -403,6 +404,13 @@
 #  <Daemon "mds.a">
 #    SocketPath "/var/run/ceph/ceph-mds.ceph1.asok"
 #  </Daemon>
+#</Plugin>
+
+#<Plugin check_presence>
+#    StateDatastore "check-presence"
+#    HostTimeout 20
+#    StartupDelay 20
+#    CheckInterval 10
 #</Plugin>
 
 #<Plugin chrony>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1650,6 +1650,46 @@ at all, B<all> cgroups are selected.
 
 =back
 
+=head2 Plugin C<check_presence>
+
+The B<check_presence> plugin keeps track of hosts that have been recently seen,
+and sends notifications when a host is seen for the first time, and subsequently
+when a host has gone missing after not being seen for a period of time. The
+duration after which a host is considered missing is controlled with the
+B<HostTimeout> option.
+
+To ensure that no notifications are missed or duplicated, the hosts are
+persisted in an LMDB key/value store, which is kept across collectd restarts.
+The check_presence plugin provides a grace period after starting up for hosts to
+tell us they are still present, catching hosts that have gone missing during our
+restart. The grace period is controlled with the B<StartupDelay> option.
+
+Note: Both the B<HostTimeout> and B<StartupDelay> values must be greater than
+the Interval, otherwise hosts will be marked missing and then newly rediscovered.
+
+=over 4
+
+=item B<StateDatastore> I<path/to/database>
+
+Path and filename of the LMDB hosts key/value store. Defaults to B<check-presence>.
+
+=item B<HostTimeout> I<Seconds>
+
+Number of seconds after a host has last been seen before the host is considered
+missing. Defaults to B<20>.
+
+=item B<StartupDelay> I<Seconds>
+
+Number of seconds after startup to suppress missing notifications. Defaults to B<20>.
+
+=item B<CheckInterval> I<Seconds>
+
+Interval in seconds between checking that hosts are present. Defaults to B<10>,
+which is half the value of B<HostTimeout>. The lower this value, the sooner a
+missing host is detected, but at the cost of more CPU usage.
+
+=back
+
 =head2 Plugin C<check_uptime>
 
 The I<check_uptime plugin> designed to check and notify about host or service


### PR DESCRIPTION
ChangeLog: check_presence plugin: Add new plugin to detect new and missing hosts.

This PR adds a new plugin that keeps track of hosts that have been seen by collectd, and sends notifications when a new host is seen, or an existing is no longer seen for a period of time, respectively.

It depends on liblmdb to provide the underlying index, chosen for low cost.

Example notification when a host is seen:

Notification: severity = OKAY, host = little-net.local, plugin = host, type = host, type_instance = found, message = Host is found: little-net.local

Example notification when a host goes missing:

Notification: severity = FAILURE, host = little-net.local, plugin = host, type = host, type_instance = lost, message = Host not seen for 45 seconds: little-net.local