### PR TITLE
plugin.c: fix drop probability

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2235,7 +2235,7 @@ static bool check_drop_value(void) /* {{{ */
     return true;
 
   q = cdrand_d();
-  if (q > p)
+  if (p > q)
     return true;
   else
     return false;


### PR DESCRIPTION
ChangeLog: plugin.c: fix drop probability

The higher is the position p in the window between min and max thresholds the higher must be the probability to drop. (ie, p=0, returns false and p=1 returns true).

