### PR TITLE
format_influxdb: add config option to write metadata

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -2030,6 +2030,7 @@
 #  Server "localhost"
 #  TimePrecision "ms"
 #  StoreRates true
+#  WriteMetadata false
 #  MaxPacketSize 32768
 #  TimeToLive 128
 #</Plugin>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -11256,6 +11256,7 @@ miliseconds while plugin instance, type and type instance are sent as tags.
    Server "influxdb2.fqdn"
    TimePrecision "ms"
    StoreRates "yes"
+   WriteMetadata "no"
  </Plugin>
 
 =over 4
@@ -11296,6 +11297,11 @@ UDP.
 
 If set to B<true>, convert absolute, counter and derive values to rates. If set
 to B<false> (the default) absolute, counter and derive values are sent as is.
+
+=item B<WriteMetadata> B<true|false>
+
+Defaults to B<false>. If set to B<true>, send aditional tags to influxdb with
+collectd value metadata.
 
 =back
 

--- a/src/utils/format_influxdb/format_influxdb.c
+++ b/src/utils/format_influxdb/format_influxdb.c
@@ -72,9 +72,10 @@ static int format_influxdb_escape_string(char *buffer, size_t buffer_size,
   return dst_pos;
 } /* int format_influxdb_escape_string */
 
-int format_influxdb_value_list(
-    char *buffer, int buffer_len, const data_set_t *ds, const value_list_t *vl,
-    bool store_rates, format_influxdb_time_precision_t time_precision) {
+int format_influxdb_value_list(char *buffer, int buffer_len,
+                               const data_set_t *ds, const value_list_t *vl,
+                               format_influxdb_time_precision_t time_precision,
+                               bool store_rates, bool write_meta) {
   int status;
   int offset = 0;
   gauge_t *rates = NULL;
@@ -116,7 +117,7 @@ int format_influxdb_value_list(
     BUFFER_ADD(",type_instance=");
     BUFFER_ADD_ESCAPE(vl->type_instance);
   }
-  if (vl->meta) {
+  if (write_meta && vl->meta) {
     for (meta_entry_t *it = meta_data_iter(vl->meta); it != NULL;
          it = meta_data_iter_next(it)) {
       const char *key = meta_data_iter_key(it);

--- a/src/utils/format_influxdb/format_influxdb.h
+++ b/src/utils/format_influxdb/format_influxdb.h
@@ -40,7 +40,7 @@ typedef enum {
 
 int format_influxdb_value_list(char *buffer, int buffer_len,
                                const data_set_t *ds, const value_list_t *vl,
-                               bool store_rates,
-                               format_influxdb_time_precision_t time_precision);
+                               format_influxdb_time_precision_t time_precision,
+                               bool store_rates, bool write_meta);
 
 #endif /* UTILS_FORMAT_INFLUXDB_H */

--- a/src/write_http.c
+++ b/src/write_http.c
@@ -605,8 +605,8 @@ static int wh_write_influxdb(const data_set_t *ds,
   }
 
   status = format_influxdb_value_list(cb->send_buffer + cb->send_buffer_fill,
-                                      cb->send_buffer_free, ds, vl,
-                                      cb->store_rates, NS);
+                                      cb->send_buffer_free, ds, vl, NS,
+                                      cb->store_rates, true);
   if (status == -ENOMEM) {
     status = wh_flush_nolock(/* timeout = */ 0, cb);
     if (status != 0) {
@@ -616,8 +616,8 @@ static int wh_write_influxdb(const data_set_t *ds,
     }
 
     status = format_influxdb_value_list(cb->send_buffer + cb->send_buffer_fill,
-                                        cb->send_buffer_free, ds, vl,
-                                        cb->store_rates, NS);
+                                        cb->send_buffer_free, ds, vl, NS,
+                                        cb->store_rates, true);
   }
   if (status < 0) {
     pthread_mutex_unlock(&cb->send_lock);

--- a/src/write_influxdb_udp.c
+++ b/src/write_influxdb_udp.c
@@ -79,6 +79,7 @@ typedef struct sockent {
 static int wifxudp_config_ttl;
 static size_t wifxudp_config_packet_size = NET_DEFAULT_PACKET_SIZE;
 static bool wifxudp_config_store_rates;
+static bool wifxudp_config_write_meta;
 static format_influxdb_time_precision_t wifxudp_config_time_precision = MS;
 
 static sockent_t *sending_sockets;
@@ -354,9 +355,9 @@ write_influxdb_udp_write(const data_set_t *ds, const value_list_t *vl,
                          user_data_t __attribute__((unused)) * user_data) {
   char buffer[NET_DEFAULT_PACKET_SIZE];
 
-  int status = format_influxdb_value_list(buffer, NET_DEFAULT_PACKET_SIZE, ds,
-                                          vl, wifxudp_config_store_rates,
-                                          wifxudp_config_time_precision);
+  int status = format_influxdb_value_list(
+      buffer, NET_DEFAULT_PACKET_SIZE, ds, vl, wifxudp_config_time_precision,
+      wifxudp_config_store_rates, wifxudp_config_write_meta);
 
   if (status < 0) {
     ERROR("write_influxdb_udp plugin: write_influxdb_udp_write failed.");
@@ -509,6 +510,8 @@ static int write_influxdb_udp_config(oconfig_item_t *ci) {
       wifxudp_config_set_time_precision(child);
     else if (strcasecmp("StoreRates", child->key) == 0)
       cf_util_get_boolean(child, &wifxudp_config_store_rates);
+    else if (strcasecmp("WriteMetadata", child->key) == 0)
+      cf_util_get_boolean(child, &wifxudp_config_write_meta);
     else {
       WARNING("write_influxdb_udp plugin: "
               "Option `%s' is not allowed here.",


### PR DESCRIPTION
ChangeLog: format_influxdb: add config option to write metadata

In #3938 the feature to write meta data to influxdb was added. This adds more labels and indexes to influxdb and could not be always desirable. 

This PR adds a configuration option to enable this feature, disabled by default to keep the previous versions of write_influxdb_udp plugin behavior.