### PR TITLE
[collectd 6] src/memory.c: bring to feature parity with main branch

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -78,6 +78,8 @@ typedef enum {
   COLLECTD_MEMORY_TYPE_ARC,
   COLLECTD_MEMORY_TYPE_UNUSED,
   COLLECTD_MEMORY_TYPE_AVAILABLE,
+  COLLECTD_MEMORY_TYPE_USER_WIRE,
+  COLLECTD_MEMORY_TYPE_LAUNDRY,
   COLLECTD_MEMORY_TYPE_MAX, /* #states */
 } memory_type_t;
 
@@ -97,6 +99,8 @@ static char const *memory_type_names[COLLECTD_MEMORY_TYPE_MAX] = {
     "arc",
     "unusable",
     "available",
+    "user_wire",
+    "laundry",
 };
 
 /* vm_statistics_data_t */
@@ -356,6 +360,8 @@ static int memory_read_internal(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
    * vm.stats.vm.v_active_count: 55239
    * vm.stats.vm.v_inactive_count: 113730
    * vm.stats.vm.v_cache_count: 10809
+   * vm.stats.vm.v_user_wire_count: 0
+   * vm.stats.vm.v_laundry_count: 40394
    */
   struct {
     char const *sysctl_key;
@@ -367,6 +373,8 @@ static int memory_read_internal(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
       {"vm.stats.vm.v_active_count", COLLECTD_MEMORY_TYPE_ACTIVE},
       {"vm.stats.vm.v_inactive_count", COLLECTD_MEMORY_TYPE_INACTIVE},
       {"vm.stats.vm.v_cache_count", COLLECTD_MEMORY_TYPE_CACHED},
+      {"vm.stats.vm.v_user_wire_count", COLLECTD_MEMORY_TYPE_USER_WIRE},
+      {"vm.stats.vm.v_laundry_count", COLLECTD_MEMORY_TYPE_LAUNDRY},
   };
 
   gauge_t pagesize = 0;

--- a/src/memory.c
+++ b/src/memory.c
@@ -77,6 +77,7 @@ typedef enum {
   COLLECTD_MEMORY_TYPE_LOCKED,
   COLLECTD_MEMORY_TYPE_ARC,
   COLLECTD_MEMORY_TYPE_UNUSED,
+  COLLECTD_MEMORY_TYPE_AVAILABLE,
   COLLECTD_MEMORY_TYPE_MAX, /* #states */
 } memory_type_t;
 
@@ -95,6 +96,7 @@ static char const *memory_type_names[COLLECTD_MEMORY_TYPE_MAX] = {
     "locked",
     "arc",
     "unusable",
+    "available",
 };
 
 /* vm_statistics_data_t */
@@ -432,6 +434,8 @@ static int memory_read_internal(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
       values[COLLECTD_MEMORY_TYPE_SLAB_RECL] = v;
     } else if (strcmp(fields[0], "SUnreclaim:") == 0) {
       values[COLLECTD_MEMORY_TYPE_SLAB_UNRECL] = v;
+    } else if (strcmp(fields[0], "MemAvailable:") == 0) {
+      values[COLLECTD_MEMORY_TYPE_AVAILABLE] = v;
     }
   }
 


### PR DESCRIPTION
ChangeLog: memory plugin: bring to feature parity with main branch

The `memory` plugin is already ported to the v6 API but some new features have been added in the `main` branch in the meantime.

This PR should bring the `memory` plugin in the collectd-6 branch to feature parity with the `main` branch by:

  - Replicating the feature introduced in #3916 (Report MemAvailable when present in meminfo)
  - Cherry-Picking #3880 (do not account reclaimable slab as used)
  - Cherry-Picking #3962 (add laundry and user wired pages)

