### PR TITLE
[collectd 6] Cirrus CI / GitHub Workers - sync config with main branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,10 +118,6 @@ debian_default_toolchain_task:
 #
 redhat_default_toolchain_task:
   matrix:
-    - allow_failures: false
-      skip_notifications: false
-      container:
-        image: collectd/ci:el6_x86_64
     - allow_failures: true
       skip_notifications: true
       container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -178,6 +178,9 @@ non_standard_toolchains_task:
         - make -j2 -sk
       tests_script:
         - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
+      on_failure:
+        debug_script: cat test-suite.log || true
+
 
     # build against libstatgrab, should always pass
     - env:
@@ -243,6 +246,8 @@ non_standard_toolchains_task:
         - make -j2 -sk
       tests_script:
         - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j2 -sk check
+      on_failure:
+        debug_script: cat test-suite.log || true
 
 ###
 # Build using a range of compilers, available in debian/unstable. NB: might

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate configure script
+      run:
+        ./build.sh
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,55 @@ jobs:
           - fedora35_x86_64
           - fedora34_x86_64
         config_flags: ['']
+
     env:
       MAKEFLAGS: "-j2 -sk"
-      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      CONFIGURE_FLAGS: >-
+        ${{ matrix.config_flags }}
+        --disable-aggregation
+        --disable-amqp
+        --disable-amqp1
+        --disable-barometer
+        --disable-check_uptime
+        --disable-csv
+        --disable-curl_xml
+        --disable-gmond
+        --disable-grpc
+        --disable-java
+        --disable-lua
+        --disable-match_empty_counter
+        --disable-match_hashed
+        --disable-match_regex
+        --disable-match_timediff
+        --disable-match_value
+        --disable-modbus
+        --disable-mqtt
+        --disable-network
+        --disable-openldap
+        --disable-perl
+        --disable-postgresql
+        --disable-python
+        --disable-redis
+        --disable-rrdcached
+        --disable-rrdtool
+        --disable-snmp
+        --disable-snmp_agent
+        --disable-statsd
+        --disable-target_notification
+        --disable-target_replace
+        --disable-target_scale
+        --disable-target_set
+        --disable-target_v5upgrade
+        --disable-threshold
+        --disable-write_graphite
+        --disable-write_kafka
+        --disable-write_mongodb
+        --disable-write_redis
+        --disable-write_riemann
+        --disable-write_sensu
+        --disable-write_syslog
+        --disable-write_tsdb
+
       # this env var picked up by valgrind during make check phase
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
@@ -67,7 +113,7 @@ jobs:
         yum install -y bzip2 || apt install -y bzip2
     - name: Run make distcheck
       run: |
-        make $MAKEFLAG distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+        make $MAKEFLAG distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug $CONFIGURE_FLAGS"
 
   experimental:
     runs-on: ubuntu-20.04
@@ -92,8 +138,53 @@ jobs:
       MAKEFLAGS: "-j2 -sk"
       CFLAGS: ${{ matrix.cflags }}
       CPPFLAGS: ${{ matrix.cppflags }}
-      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
+      CONFIGURE_FLAGS: >-
+        ${{ matrix.config_flags }}
+        --disable-aggregation
+        --disable-amqp
+        --disable-amqp1
+        --disable-barometer
+        --disable-check_uptime
+        --disable-csv
+        --disable-curl_xml
+        --disable-gmond
+        --disable-grpc
+        --disable-java
+        --disable-lua
+        --disable-match_empty_counter
+        --disable-match_hashed
+        --disable-match_regex
+        --disable-match_timediff
+        --disable-match_value
+        --disable-modbus
+        --disable-mqtt
+        --disable-network
+        --disable-openldap
+        --disable-perl
+        --disable-postgresql
+        --disable-python
+        --disable-redis
+        --disable-rrdcached
+        --disable-rrdtool
+        --disable-snmp
+        --disable-snmp_agent
+        --disable-statsd
+        --disable-target_notification
+        --disable-target_replace
+        --disable-target_scale
+        --disable-target_set
+        --disable-target_v5upgrade
+        --disable-threshold
+        --disable-write_graphite
+        --disable-write_kafka
+        --disable-write_mongodb
+        --disable-write_redis
+        --disable-write_riemann
+        --disable-write_sensu
+        --disable-write_syslog
+        --disable-write_tsdb
+
     steps:
     - uses: actions/checkout@v2
     - run: type pkg-config
@@ -117,5 +208,5 @@ jobs:
         yum install -y bzip2 || apt install -y bzip2
     - name: Run make distcheck
       run: |
-        make $MAKEFLAGS distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+        make $MAKEFLAGS distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug $CONFIGURE_FLAGS"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           - bionic_amd64
           - focal_amd64
           # RedHat family
+          - el9_x86_64
           - el8_x86_64
           - el7_x86_64
           - fedora36_x86_64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,21 +6,105 @@ on:
   pull_request:
     branches: [ main ]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    container: collectd/ci:${{ matrix.container_tag }}
+    continue-on-error: ${{ matrix.allow_failures }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # for tasks that are optional, use the continue-on-error option, to prevent a workflow from failing when the task fails
+        allow_failures: [ false ]
+        container_tag:
+          # debian family
+          - bullseye_amd64
+          - buster_amd64
+          - stretch_amd64
+          - stretch_i386
+          - trusty_amd64
+          - xenial_amd64
+          # RedHat family
+          - el8_x86_64
+          - el7_x86_64
+          - fedora34_x86_64
+          - fedora28_x86_64
+        config_flags: ['']
+    env:
+      MAKEFLAGS: "-j 2"
+      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
     steps:
     - uses: actions/checkout@v2
+    - run: type pkg-config
+    - run: pkg-config --list-all | sort -u
     - name: Generate configure script
       run:
         ./build.sh
     - name: configure
-      run: ./configure
-    - name: make
+      run: ./configure $CONFIGURE_FLAGS
+    - name: Make
       run: make
     - name: make check
+      continue-on-error: true
       run: make check
+    - name: install bzip2
+      continue-on-error: true
+      run: |
+        yum install -y bzip2 || apt install -y bzip2
+    - name: make
+      continue-on-error: true
+      run: |
+        make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+
+  experimental:
+    runs-on: ubuntu-20.04
+    container: collectd/ci:${{ matrix.container_tag }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # for tasks that are optional, use the continue-on-error option, to prevent a workflow from failing when the task fails
+        container_tag:
+          - sid_amd64
+          - fedora_rawhide_x86_64
+        # Add additional per-distro vars here.
+        include:
+          - container_tag: sid_amd64
+            config_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt"
+          - container_tag: fedora_rawhide_x86_64
+            cflags: "-fPIE -Wno-deprecated-declarations"
+            cppflags: "-fPIE -Wno-deprecated-declarations"
+            config_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt --disable-xmms"
+    env:
+      MAKEFLAGS: "-j 2"
+      CFLAGS: ${{ matrix.cflags }}
+      CPPFLAGS: ${{ matrix.cppflags }}
+      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: type pkg-config
+    - run: pkg-config --list-all | sort -u
+    - name: Generate configure script
+      run:
+        ./build.sh
+    - name: configure
+      run: ./configure $CONFIGURE_FLAGS
+    - name: Make
+      run: make
+    - name: make check
+      # Make check is failing on a few newer distros, temporarily mark it as optional until that is resolved 
+      continue-on-error: true
+      run: make check
+    - name: install bzip2
+      continue-on-error: true
+      run: |
+        yum install -y bzip2 || apt install -y bzip2
     - name: make distcheck
-      run: make distcheck
+      continue-on-error: true
+      run: |
+        make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
           # RedHat family
           - el8_x86_64
           - el7_x86_64
+          - fedora36_x86_64
+          - fedora35_x86_64
           - fedora34_x86_64
-          - fedora28_x86_64
         config_flags: ['']
     env:
       MAKEFLAGS: "-j2 -sk"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,10 @@ jobs:
           - buster_amd64
           - stretch_amd64
           - stretch_i386
-          - trusty_amd64
+          # Ubuntu
           - xenial_amd64
+          - bionic_amd64
+          - focal_amd64
           # RedHat family
           - el8_x86_64
           - el7_x86_64
@@ -37,6 +39,8 @@ jobs:
     env:
       MAKEFLAGS: "-j 2"
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      # this env var picked up by valgrind during make check phase
+      VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v2
     - run: type pkg-config
@@ -84,6 +88,7 @@ jobs:
       CFLAGS: ${{ matrix.cflags }}
       CPPFLAGS: ${{ matrix.cppflags }}
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v2
     - run: type pkg-config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           - fedora28_x86_64
         config_flags: ['']
     env:
-      MAKEFLAGS: "-j 2"
+      MAKEFLAGS: "-j2 -sk"
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
       # this env var picked up by valgrind during make check phase
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
@@ -48,24 +48,21 @@ jobs:
     - name: Generate configure script
       run:
         ./build.sh
-    - name: configure
+    - name: Run configure script
       run: ./configure $CONFIGURE_FLAGS
-    - name: Make
-      run: make
-    - name: make check
-      continue-on-error: true
-      run: make check
+    - name: Build collectd
+      run: make $MAKEFLAGS
+    - name: Run make check
+      run: make $MAKEFLAGS check
     - name: Dump test logs
       run: |
           cat ./test-suite.log || true
-    - name: install bzip2
-      continue-on-error: true
+    - name: Install bzip2
       run: |
         yum install -y bzip2 || apt install -y bzip2
-    - name: make
-      continue-on-error: true
+    - name: Run make distcheck
       run: |
-        make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+        make $MAKEFLAG distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
 
   experimental:
     runs-on: ubuntu-20.04
@@ -87,7 +84,7 @@ jobs:
             cppflags: "-fPIE -Wno-deprecated-declarations"
             config_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt --disable-xmms"
     env:
-      MAKEFLAGS: "-j 2"
+      MAKEFLAGS: "-j2 -sk"
       CFLAGS: ${{ matrix.cflags }}
       CPPFLAGS: ${{ matrix.cppflags }}
       CONFIGURE_FLAGS: ${{ matrix.config_flags }}
@@ -99,23 +96,21 @@ jobs:
     - name: Generate configure script
       run:
         ./build.sh
-    - name: configure
+    - name: Run configure script
       run: ./configure $CONFIGURE_FLAGS
-    - name: Make
-      run: make
-    - name: make check
+    - name: Build collectd
+      run: make $MAKEFLAGS
+    - name: Run make check
       # Make check is failing on a few newer distros, temporarily mark it as optional until that is resolved 
       continue-on-error: true
-      run: make check
+      run: make $MAKEFLAGS check
     - name: Dump test logs
       run: |
           cat ./test-suite.log || true
-    - name: install bzip2
-      continue-on-error: true
+    - name: Install bzip2
       run: |
         yum install -y bzip2 || apt install -y bzip2
-    - name: make distcheck
-      continue-on-error: true
+    - name: Run make distcheck
       run: |
-        make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
+        make $MAKEFLAGS distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-dependency-tracking --enable-debug"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ collectd-6.0 ]
   pull_request:
-    branches: [ main ]
+    branches: [ collectd-6.0 ]
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
     - name: make check
       continue-on-error: true
       run: make check
+    - name: Dump test logs
+      run: |
+          cat ./test-suite.log || true
     - name: install bzip2
       continue-on-error: true
       run: |
@@ -104,6 +107,9 @@ jobs:
       # Make check is failing on a few newer distros, temporarily mark it as optional until that is resolved 
       continue-on-error: true
       run: make check
+    - name: Dump test logs
+      run: |
+          cat ./test-suite.log || true
     - name: install bzip2
       continue-on-error: true
       run: |


### PR DESCRIPTION
Hi,

we've found some differences in the way the CI behaves between the `main` and the `collect-6.0` branches in #4077.
This PR cherry-picks all changes to `.cirrus.yml` and `.github/workflows/build.yml` from `main` on top of `collectd-6.0`.

Changes introduced here that were not in `main`/`collectd-6.0` are:

- Usage of `on_failure:` instead of `|| cat … || false` in the `.cirrus.yml` to print a log on failure. This matches the what 1b040d7cd0a8d8fcabdd8952a48e97045de9d508 already did in the `collectd-6.0` branch and is imho prettier.
- Trigger on changes to the `collectd-6.0` branch in the GitHub action config instead of `main`.

My only experience with these CI runners is them flagging my pull requests as bad, so feel free to comment if something looks wrong.

The GitHub worker config will likely need to be extended to disable plugins that are not yet buildable.

ChangeLog: CI: Update collectd-6.0 branch to match main

