### PR TITLE
Fix md5 compile issue

### DIFF
--- a/contrib/curl_jolokia/curl_jolokia.conf
+++ b/contrib/curl_jolokia/curl_jolokia.conf
@@ -1,4 +1,4 @@
-# This configuration should be taken as an example what the python scrip generates.
+# This configuration should be taken as an example what the python script generates.
 LoadPlugin "curl_jolokia"
 <LoadPlugin curl_jolokia>
      Interval 1

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -677,7 +677,7 @@ static int csnmp_config_add_host_auth_protocol(host_definition_t *hd,
   if (status != 0)
     return status;
 
-#ifdef NETSNMP_USMAUTH_HMACMD5
+#ifndef NETSNMP_DISABLE_MD5
   if (strcasecmp("MD5", buffer) == 0) {
     hd->auth_protocol = usmHMACMD5AuthProtocol;
     hd->auth_protocol_len = sizeof(usmHMACMD5AuthProtocol) / sizeof(oid);


### PR DESCRIPTION
ChangeLog: snmp plugin: Compile issue fixed if net-snmp has NETSNMP_DISABLE_MD5 set
