### PR TITLE
gpu_sysman: Add fabric port metrics support

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -799,6 +799,7 @@
 #   MetricsOutput "counter:rate:ratio"
 #   DisableMemory false
 #   DisableMemoryBandwidth false
+#   DisableFabric false
 #   DisableFrequency false
 #   DisableThrottleTime false
 #   DisableTemperature false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3765,6 +3765,10 @@ Disable memory usage metrics collection.
 
 Disable memory bandwidth metrics collection.
 
+=item B<DisableFabric>
+
+Disable fabric port metrics collection.
+
 =item B<DisableFrequency>
 
 Disable actual / requested frequency metrics collection.


### PR DESCRIPTION
ChangeLog: gpu_sysman: Add fabric port metrics support

Fabric port metrics have been supported in L0 Sysman API spec (and frontend) since v1.0, but HW with them and drivers support were not generally available.  Intel Data Center GPU Max Series (supporting XeLink) is now available, along with public driver repositories to support it: https://dgpu-docs.intel.com/installation-guides/index.html#intel-data-center-gpu-max-series

Fabric ports have a lot of properties which means lot of labels.  This required increasing some things in the test code too.

PS. `clang-format` (required by CI) changes to how many columns it formats an array every time new item is added to it.  Is there something that could be done to avoid that, as it increases patch sizes unnecessarily?
