### PR TITLE
vmem: add metrics start with "pgscan_" in Kernel Linux

### DIFF
--- a/src/vmem.c
+++ b/src/vmem.c
@@ -211,10 +211,6 @@ static int vmem_read(void) {
       char *inst = key + strlen("pgsteal_");
       value_t value = {.derive = counter};
       submit_one(inst, "vmpage_action", "steal", value);
-    } else if (strncmp("pgscan_", key, strlen("pgscan_")) == 0) {
-      char *inst = key + strlen("pgscan_");
-      value_t value = {.derive = counter};
-      submit_one(inst, "vmpage_action", "scan", value);
     } else if (strncmp("pgscan_kswapd_", key, strlen("pgscan_kswapd_")) == 0) {
       char *inst = key + strlen("pgscan_kswapd_");
       value_t value = {.derive = counter};
@@ -223,6 +219,10 @@ static int vmem_read(void) {
       char *inst = key + strlen("pgscan_direct_");
       value_t value = {.derive = counter};
       submit_one(inst, "vmpage_action", "scan_direct", value);
+    } else if (strncmp("pgscan_", key, strlen("pgscan_")) == 0) {
+      char *inst = key + strlen("pgscan_");
+      value_t value = {.derive = counter};
+      submit_one(inst, "vmpage_action", "scan", value);
     }
 
     /*

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -211,6 +211,10 @@ static int vmem_read(void) {
       char *inst = key + strlen("pgsteal_");
       value_t value = {.derive = counter};
       submit_one(inst, "vmpage_action", "steal", value);
+    } else if (strncmp("pgscan_", key, strlen("pgscan_")) == 0) {
+      char *inst = key + strlen("pgscan_");
+      value_t value = {.derive = counter};
+      submit_one(inst, "vmpage_action", "scan", value);
     } else if (strncmp("pgscan_kswapd_", key, strlen("pgscan_kswapd_")) == 0) {
       char *inst = key + strlen("pgscan_kswapd_");
       value_t value = {.derive = counter};

--- a/src/vmem.c
+++ b/src/vmem.c
@@ -211,14 +211,6 @@ static int vmem_read(void) {
       char *inst = key + strlen("pgsteal_");
       value_t value = {.derive = counter};
       submit_one(inst, "vmpage_action", "steal", value);
-    } else if (strncmp("pgscan_kswapd_", key, strlen("pgscan_kswapd_")) == 0) {
-      char *inst = key + strlen("pgscan_kswapd_");
-      value_t value = {.derive = counter};
-      submit_one(inst, "vmpage_action", "scan_kswapd", value);
-    } else if (strncmp("pgscan_direct_", key, strlen("pgscan_direct_")) == 0) {
-      char *inst = key + strlen("pgscan_direct_");
-      value_t value = {.derive = counter};
-      submit_one(inst, "vmpage_action", "scan_direct", value);
     } else if (strncmp("pgscan_", key, strlen("pgscan_")) == 0) {
       char *inst = key + strlen("pgscan_");
       value_t value = {.derive = counter};


### PR DESCRIPTION
ChangeLog: Vmem plugin: A feature  supporting metrics start with "pgscan_" in Kernel Linux was added.

Some Linux Kernel versions have metrics start with "pgscan_" in /proc/vmstat, for instance:
```
cat /proc/vmstat | grep pgscan
pgscan_kswapd 0
pgscan_direct 0
pgscan_direct_throttle 0
```