### PR TITLE
Fix a memory leak in the `write_stackdriver` plugin

### DIFF
--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -343,6 +343,7 @@ static int wg_flush_nolock(cdtime_t timeout, wg_callback_t *cb) /* {{{ */
   char *payload = sd_output_reset(cb->formatter);
   int status = wg_call_timeseries_write(cb, payload);
   wg_reset_buffer(cb);
+  sfree(payload);
   return status;
 } /* }}} wg_flush_nolock */
 


### PR DESCRIPTION
ChangeLog: write_stackdriver plugin: A memory leak has been fixed

The `payload` was never freed. This was affecting potentially every call to both the "write" and "flush" callbacks.