### PR TITLE
cpufreq: dynamically alloc MAX_AVAIL_FREQS according to time_in_state

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -428,7 +428,11 @@
 #  ReportGuestState false
 #  SubtractGuestState true
 #</Plugin>
-#
+
+#<Plugin cpufreq>
+#  MaxAvailableFreqs "20"
+#</Plugin>
+
 #<Plugin csv>
 #	DataDir "@localstatedir@/lib/@PACKAGE_NAME@/csv"
 #	StoreRates false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -429,10 +429,6 @@
 #  SubtractGuestState true
 #</Plugin>
 
-#<Plugin cpufreq>
-#  MaxAvailableFreqs "20"
-#</Plugin>
-
 #<Plugin csv>
 #	DataDir "@localstatedir@/lib/@PACKAGE_NAME@/csv"
 #	StoreRates false

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -31,20 +31,17 @@
 #endif
 #define MAX_AVAIL_FREQS "MaxAvailableFreqs"
 
-static int max_avail_freqs = 20;  // default MAX_AVAIL_FREQS
+static int max_avail_freqs = 20; // default MAX_AVAIL_FREQS
 static const char *config_keys[] = {MAX_AVAIL_FREQS};
 static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
-static int cpufreq_config(char const *key, char const *value)
-{
-  if (strcasecmp(key, "MaxAvailableFreqs") == 0)
-  {
+static int cpufreq_config(char const *key, char const *value) {
+  if (strcasecmp(key, "MaxAvailableFreqs") == 0) {
     int freqs = strtol(value, NULL, 0);
     if (freqs == 0)
       return -1;
     max_avail_freqs = freqs;
-  }
-  else
+  } else
     return -1;
 
   return 0;
@@ -66,7 +63,8 @@ static void cpufreq_stats_init(void) {
   if (cpu_data == NULL)
     return;
   for (int i = 0; i < num_cpu; i++) {
-    cpu_data[i].time_state = calloc(max_avail_freqs, sizeof(value_to_rate_state_t));
+    cpu_data[i].time_state =
+        calloc(max_avail_freqs, sizeof(value_to_rate_state_t));
     if (cpu_data[i].time_state == NULL)
       return;
   }
@@ -273,6 +271,7 @@ static int cpufreq_read(void) {
 
 void module_register(void) {
   plugin_register_init("cpufreq", cpufreq_init);
-  plugin_register_config("cpufreq", cpufreq_config, config_keys, config_keys_num);
+  plugin_register_config("cpufreq", cpufreq_config, config_keys,
+                         config_keys_num);
   plugin_register_read("cpufreq", cpufreq_read);
 }

--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -31,7 +31,7 @@
 #endif
 
 #if KERNEL_LINUX
-static int max_avail_freqs = 20; // default MAX_AVAIL_FREQS
+static int max_avail_freqs = 128; // default MAX_AVAIL_FREQS
 
 static int num_cpu;
 


### PR DESCRIPTION
Hi, there is an error report "cpufreq plugin: Found too many frequency states (21 > 20). Plugin needs to be recompiled. Please open a bug report for this." on our machines. 

We are using Nvidia's ARMv8 processors and Linux kernel based on 4.14.150. We find that there are more than 20 in cpu's freq table:
```
cat /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state | wc -l
23
```

We try to resolve this by making MAX_AVAIL_FREQS a configurable variable in conf file in order to avoid recompiling. And  it is tested on our machines (we make MAX_AVAIL_FREQS to 30 in our conf files).
Please help review if this idea works, if not, should we simply change MAX_AVAIL_FREQS into a bigger one? 
Thanks a lot!

ChangeLog: cpufreq: make MAX_AVAIL_FREQS configurable in conf