### PR TITLE
[collectd 6] Sysman plugin improvements

### DIFF
--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -280,6 +280,8 @@ static unsigned int list_gpu_metrics(const gpu_disable_t *disabled) {
     if (!disabled) {
       INFO("- none");
     }
+  }
+  if (config.gpuinfo) {
     INFO("Enabled metrics:");
   }
   unsigned int enabled = 0;
@@ -290,9 +292,9 @@ static unsigned int list_gpu_metrics(const gpu_disable_t *disabled) {
       }
       enabled++;
     }
-    if (config.gpuinfo && !enabled) {
-      INFO("- none");
-    }
+  }
+  if (config.gpuinfo && !enabled) {
+    INFO("- none");
   }
   return enabled;
 }

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -2060,6 +2060,7 @@ static bool gpu_powers(gpu_device_t *gpu) {
   };
   metric_t metric = {0};
 
+  ze_result_t limit_ret = ZE_RESULT_SUCCESS;
   bool reported_ratio = false, reported_power = false, reported_energy = false;
   bool ratio_fail = false;
   bool ok = false;
@@ -2109,8 +2110,8 @@ static bool gpu_powers(gpu_device_t *gpu) {
          * Switch to querying list of limits after Sysman plugin starts
          * requiring that spec version / loader.
          */
-        if (ret = zesPowerGetLimits(powers[i], &sustain, &burst, NULL),
-            ret == ZE_RESULT_SUCCESS) {
+        if (limit_ret = zesPowerGetLimits(powers[i], &sustain, &burst, NULL),
+            limit_ret == ZE_RESULT_SUCCESS) {
           const char *name;
           int32_t limit = 0;
           /* Multiply by 1000, as sustain interval is in ms & power in mJ/s,
@@ -2155,7 +2156,7 @@ static bool gpu_powers(gpu_device_t *gpu) {
     if (ok) {
       WARNING(PLUGIN_NAME ": failed to get power limit(s) "
                           "for any of the %d domain(s), last error = 0x%x",
-              power_count, ret);
+              power_count, limit_ret);
     }
   }
   free(powers);

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -411,6 +411,22 @@ static bool gpu_info(zes_device_handle_t dev, char **pci_bdf, char **pci_dev) {
     WARNING(PLUGIN_NAME ": failed to get GPU device state => 0x%x", ret);
   }
 
+  const char *eccstate = "unavailable";
+  zes_device_ecc_properties_t ecc = {.pNext = NULL};
+  if (zesDeviceGetEccState(dev, &ecc) == ZE_RESULT_SUCCESS) {
+    switch (ecc.currentState) {
+    case ZES_DEVICE_ECC_STATE_ENABLED:
+      eccstate = "enabled";
+      break;
+    case ZES_DEVICE_ECC_STATE_DISABLED:
+      eccstate = "disabled";
+      break;
+    default:
+      break;
+    }
+  }
+  INFO("- ECC state: %s", eccstate);
+
   INFO("HW identification:");
   zes_device_properties_t props = {.pNext = NULL};
   if (ret = zesDeviceGetProperties(dev, &props), ret == ZE_RESULT_SUCCESS) {

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -964,6 +964,24 @@ static ze_result_t set_mem_labels(zes_mem_handle_t mem, metric_t *metric) {
   case ZES_MEM_TYPE_LPDDR5:
     type = "LPDDR5";
     break;
+  case ZES_MEM_TYPE_GDDR4:
+    type = "GDDR4";
+    break;
+  case ZES_MEM_TYPE_GDDR5:
+    type = "GDDR5";
+    break;
+  case ZES_MEM_TYPE_GDDR5X:
+    type = "GDDR5X";
+    break;
+  case ZES_MEM_TYPE_GDDR6:
+    type = "GDDR6";
+    break;
+  case ZES_MEM_TYPE_GDDR6X:
+    type = "GDDR6X";
+    break;
+  case ZES_MEM_TYPE_GDDR7:
+    type = "GDDR7";
+    break;
   case ZES_MEM_TYPE_SRAM:
     type = "SRAM";
     break;

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -250,21 +250,26 @@ ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t dev, uint32_t *count,
 
 /* mock up level-zero sysman device handling API, called during gpu_init() */
 
-#define DEV_GET_ZEROED_STRUCT(callbit, getname, structtype)                    \
+#define DEV_GET_SET_STRUCT(callbit, getname, structtype, setval)               \
   ze_result_t getname(zes_device_handle_t dev, structtype *to_zero) {          \
     ze_result_t ret = dev_args_check(callbit, #getname, dev, to_zero);         \
     if (ret == ZE_RESULT_SUCCESS) {                                            \
       assert(!to_zero->pNext);                                                 \
       memset(to_zero, 0, sizeof(*to_zero));                                    \
+      setval;                                                                  \
     }                                                                          \
     return ret;                                                                \
   }
 
-DEV_GET_ZEROED_STRUCT(5, zesDeviceGetProperties, zes_device_properties_t)
-DEV_GET_ZEROED_STRUCT(6, zesDevicePciGetProperties, zes_pci_properties_t)
-DEV_GET_ZEROED_STRUCT(7, zesDeviceGetState, zes_device_state_t)
+DEV_GET_SET_STRUCT(5, zesDeviceGetProperties, zes_device_properties_t, )
+DEV_GET_SET_STRUCT(6, zesDevicePciGetProperties, zes_pci_properties_t, )
+DEV_GET_SET_STRUCT(7, zesDeviceGetState, zes_device_state_t,
+                   to_zero->reset = (ZES_RESET_REASON_FLAG_WEDGED |
+                                     ZES_RESET_REASON_FLAG_REPAIR))
+DEV_GET_SET_STRUCT(8, zesDeviceGetEccState, zes_device_ecc_properties_t,
+                   to_zero->currentState = ZES_DEVICE_ECC_STATE_ENABLED)
 
-#define INIT_CALL_FUNCS 8
+#define INIT_CALL_FUNCS 9
 #define INIT_CALL_BITS (((uint64_t)1 << INIT_CALL_FUNCS) - 1)
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
ChangeLog: gpu_sysman plugin: Misc improvements

Improvements:
* Much improved logging of enabled/disabled metrics [1]
* Log device (memory) ECC state at start
* Add memory types from L0 v1.3 spec
* Fix error value for power limit failure log message
----

[1] Plugin supports large number of Sysman provided metrics.  It tries each metric, logs failure for each missing one, and disables further queries for that.  However, it could be hard to determine which metrics are actually enabled in the end, especially for older integrated GPUs which provide data only for couple of metrics.

After this change, plugin will log a list of the enabled (and disabled) metrics at end of query round, if the enabled metric set changed (which should happen only few times start startup).