### PR TITLE
duplicated --datarootdir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -139,7 +139,7 @@ build_cygwin()
       --sysconfdir="${SYSCONFDIR}" \
       --localstatedir="${LOCALSTATEDIR}" \
       --datarootdir="${DATAROOTDIR}" \
-      --datarootdir="${DATADIR}"\
+      --datarootdir="${DATADIR}" \
       --disable-all-plugins \
       --host="mingw32" \
       --enable-logfile \


### PR DESCRIPTION
### With reference to #3980 
ChangeLog: Foo plugin: A specific issue people had has been fixed.
> Created a duplicate root of the directory tree and initialized it to ${DATADIR}\ as mentioned.
