### PR TITLE
processes: add contextswitches a configurable option & use buffer to read /proc/stat 's content only once

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1458,6 +1458,7 @@
 #	CollectContextSwitch true
 #	CollectMemoryMaps true
 #	CollectDelayAccounting false
+#	CollectSystemContextSwitch false
 #	Process "name"
 #	ProcessMatch "name" "regex"
 #	<Process "collectd">

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8037,6 +8037,7 @@ B<Synopsis:>
    CollectFileDescriptor  true
    CollectContextSwitch   true
    CollectDelayAccounting false
+   CollectSystemContextSwitch false
    Process "name"
    ProcessMatch "name" "regex"
    <Process "collectd">
@@ -8094,6 +8095,13 @@ Disabled by default.
 Collect the number of memory mapped files of the process.
 The limit for this number is configured via F</proc/sys/vm/max_map_count> in
 the Linux kernel.
+
+=item B<CollectSystemContextSwitch> I<Boolean>
+
+Collect the number of context switches at the system level.
+Collect ctxt fields from /proc/stat in linux systems.
+The option can only be configured outside the B<Process> and B<ProcessMatch>
+blocks.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8100,7 +8100,7 @@ the Linux kernel.
 
 Collect the number of context switches at the system level.
 Collect ctxt fields from /proc/stat in linux systems.
-The option can only be configured outside the B<Process> and B<ProcessMatch>
+Can be configured only outside the B<Process> and B<ProcessMatch>
 blocks.
 
 =back

--- a/src/processes.c
+++ b/src/processes.c
@@ -1622,8 +1622,7 @@ static int read_sys_ctxt_switch(const char *buffer) {
   if (status != 0)
     return -1;
 
-  if (report_sys_ctxt_switch)
-    ps_submit_global_stat("contextswitch", value.derive);
+  ps_submit_global_stat("contextswitch", value.derive);
   return 0;
 }
 #endif /*KERNEL_LINUX */
@@ -2176,8 +2175,9 @@ static int ps_read(void) {
     ps_submit_proc_list(ps_ptr);
 
   read_fork_rate(buffer);
-  read_sys_ctxt_switch(buffer);
-  /* #endif KERNEL_LINUX */
+  if (report_sys_ctxt_switch)
+    read_sys_ctxt_switch(buffer);
+    /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKVM_GETPROCS && HAVE_STRUCT_KINFO_PROC_FREEBSD
   int running = 0;

--- a/src/processes.c
+++ b/src/processes.c
@@ -977,10 +977,7 @@ static void ps_submit_proc_list(procstat_t *ps) {
 } /* void ps_submit_proc_list */
 
 #if KERNEL_LINUX || KERNEL_SOLARIS
-static void ps_submit_global_stat(
-    const char *type_name,
-    derive_t value) { // change: ps_submit_fork_rate -> ps_submit_global_stat.
-                      // In addtion, add a argument: char* type_name.
+static void ps_submit_global_stat(const char *type_name, derive_t value) {
   value_list_t vl = VALUE_LIST_INIT;
 
   vl.values = &(value_t){.derive = value};
@@ -1469,7 +1466,7 @@ static int procs_running(const char *buffer) {
    */
   running = strstr(buffer, id);
   if (!running) {
-    WARNING("'processes ' not found in /proc/stat");
+    WARNING("'procs_running ' not found in /proc/stat");
     return -1;
   }
   running += strlen(id);

--- a/src/processes.c
+++ b/src/processes.c
@@ -1587,8 +1587,9 @@ static int read_fork_rate(const char *buffer) {
     return -1;
   }
 
-  fields_num = strsplit(processes, fields, STATIC_ARRAY_SIZE(fields));
-  if (fields_num != 2)
+  const int expected = STATIC_ARRAY_SIZE(fields);
+  fields_num = strsplit(processes, fields, expected);
+  if (fields_num != expected)
     return -1;
 
   status = parse_value(fields[1], &value, DS_TYPE_DERIVE);
@@ -1614,8 +1615,9 @@ static int read_sys_ctxt_switch(const char *buffer) {
     return -1;
   }
 
-  fields_num = strsplit(ctxt, fields, STATIC_ARRAY_SIZE(fields));
-  if (fields_num != 2)
+  const int expected = STATIC_ARRAY_SIZE(fields);
+  fields_num = strsplit(ctxt, fields, expected);
+  if (fields_num != expected)
     return -1;
 
   status = parse_value(fields[1], &value, DS_TYPE_DERIVE);

--- a/src/processes.c
+++ b/src/processes.c
@@ -1469,7 +1469,7 @@ static int procs_running(const char *buffer) {
    */
   running = strstr(buffer, id);
   if (!running) {
-    WARNING("procs_running not found");
+    WARNING("'processes ' not found in /proc/stat");
     return -1;
   }
   running += strlen(id);
@@ -1583,7 +1583,7 @@ static int read_fork_rate(const char *buffer) {
 
   processes = strstr(buffer, id);
   if (!processes) {
-    WARNING("processes not found");
+    WARNING("'processes ' not found in /proc/stat");
     return -1;
   }
 
@@ -1610,7 +1610,7 @@ static int read_sys_ctxt_switch(const char *buffer) {
 
   ctxt = strstr(buffer, id);
   if (!ctxt) {
-    WARNING("ctxt not found");
+    WARNING("'ctxt ' not found in /proc/stat");
     return -1;
   }
 
@@ -2152,7 +2152,7 @@ static int ps_read(void) {
   closedir(proc);
 
   if (read_file_contents("/proc/stat", buffer, sizeof(buffer) - 1) <= 0) {
-    ERROR("Cannot open `/proc/stat`");
+    ERROR("Cannot read `/proc/stat`");
     return -1;
   }
   /* get procs_running from /proc/stat

--- a/src/processes.c
+++ b/src/processes.c
@@ -1577,6 +1577,7 @@ static int read_fork_rate(const char *buffer) {
   int status;
   char *fields[2];
   int fields_num;
+  const int expected = STATIC_ARRAY_SIZE(fields);
 
   processes = strstr(buffer, id);
   if (!processes) {
@@ -1584,7 +1585,6 @@ static int read_fork_rate(const char *buffer) {
     return -1;
   }
 
-  const int expected = STATIC_ARRAY_SIZE(fields);
   fields_num = strsplit(processes, fields, expected);
   if (fields_num != expected)
     return -1;
@@ -1605,6 +1605,7 @@ static int read_sys_ctxt_switch(const char *buffer) {
   int status;
   char *fields[2];
   int fields_num;
+  const int expected = STATIC_ARRAY_SIZE(fields);
 
   ctxt = strstr(buffer, id);
   if (!ctxt) {
@@ -1612,7 +1613,6 @@ static int read_sys_ctxt_switch(const char *buffer) {
     return -1;
   }
 
-  const int expected = STATIC_ARRAY_SIZE(fields);
   fields_num = strsplit(ctxt, fields, expected);
   if (fields_num != expected)
     return -1;

--- a/src/processes.c
+++ b/src/processes.c
@@ -2119,9 +2119,6 @@ static int ps_read(void) {
     }
 
     switch (state) {
-    case 'R':
-      running++;
-      break;
     case 'S':
       sleeping++;
       break;


### PR DESCRIPTION
Changelog: add contextswitches a configurable option & use buffer to read /proc/stat 's content only once

We already have a plugin "contextswitch" to collect "ctxt" in "/proc/stat" in Linux. But since we also read from "/proc/stat" from plugin "processes". We add an option to enable "contextswitch" in plugin "processes", default disabled. For this feature, please see 58a1e09e88f2cce1640a4072f7527c54832901d6 

Also, we find that we open and read "/proc/stat" repeatedly when we read "procs_running" and "fork_rate", so we also patch this by only reading "/proc/stat" once into a buffer and making "procs_running", "fork_rate" and "contextswitch" read from this buffer. For this feature, please see de2d033ba5ccd1531caab2e3772d471c219671eb

Tested on my local Linux machines; please help review. Thanks a lot!