### PR TITLE
ChangeLog: Renamed README to README.md and added TOC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ About
   and provides mechanisms to store and monitor the values in a variety of
   ways.
 
+- [collectd - System information collection daemon](#collectd---system-information-collection-daemon)
+  - [About](#about)
+  - [Features](#features)
+  - [Operation](#operation)
+  - [collectd and chkrootkit](#collectd-and-chkrootkit)
+  - [Prerequisites](#prerequisites)
+  - [Configuring / Compiling / Installing](#configuring--compiling--installing)
+  - [Generating the configure script](#generating-the-configure-script)
+  - [Building on Windows](#building-on-windows)
+  - [Crosscompiling](#crosscompiling)
+  - [Contact](#contact)
+  - [Author](#author)
+
 
 Features
 --------


### PR DESCRIPTION
ChangeLog: Renamed README to markdown and added TOC
Making a start on #3052 to improve readability of the README.
I have only changed the file-name and added a TOC for this PR.