### PR TITLE
vmem: add metrics starting with `pgrefill`

### DIFF
--- a/src/vmem.c
+++ b/src/vmem.c
@@ -215,6 +215,9 @@ static int vmem_read(void) {
       char *inst = key + strlen("pgscan_");
       value_t value = {.derive = counter};
       submit_one(inst, "vmpage_action", "scan", value);
+    } else if (strncmp("pgrefill", key, strlen("pgrefill")) == 0) {
+      value_t value = {.derive = counter};
+      submit_one(NULL, "vmpage_action", "refill", value);
     }
 
     /*


### PR DESCRIPTION
Changelog: add metrics starting with `pgrefill`

Same issue as I submit here: https://github.com/collectd/collectd/pull/4093
In newer Linux Kernel, there is only `pgrefill` instead of `pgrefill_*`, so we should add `pgrefill` into consideration. 

But maybe we should discuss if we have to keep the previous `pgrefill_` logic? Since `pgrefill` would also add all `pgrefill_*` into `refill`. 

Please help review, thanks a lot!