### PR TITLE
[collectd 6] Fix callback freeing order in plugin_shutdown_all()

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -916,13 +916,6 @@ static void *plugin_write_thread(void *args) /* {{{ */
 
   DEBUG("plugin_write_thread(%s): teardown", this_thread->name);
 
-  /* Cleanup before leaving */
-  free_userdata(&this_thread->ud);
-  this_thread->ud.data = NULL;
-  this_thread->ud.free_func = NULL;
-
-  sfree(this_thread->name);
-
   /* Drop references to all remaining queue elements */
   if (this_thread->head != NULL) {
     write_queue_ref_all(this_thread->head, -1);
@@ -1725,8 +1718,11 @@ EXPORT int plugin_unregister_write(const char *name) {
       status = ret;
     }
 
+    free_userdata(&to_stop->ud);
+    sfree(to_stop->name);
     sfree(to_stop);
-    to_stop = next;
+
+    to_free = next;
   }
 
   return status;


### PR DESCRIPTION
ChangeLog: fix segfaults in plugin_shutdown_all() due to use-after-free

This fixes an issue I've introduced in #4026, which changed the order in which plugin callbacks are freed in `plugin_shutdown_all()`.

Without these changes some plugins will segfault during `plugin_shutdown_all()` e.g. when stopping collectd:

```
[2023-06-02 14:37:34] [debug] plugin_read_thread: Next read of the `flush/write_http/HttpWriter' plugin …
^C
[2023-06-02 14:37:35] [info] Exiting normally.
[2023-06-02 14:37:35] [info] collectd: Stopping 5 read threads.
[2023-06-02 14:37:35] [debug] plugin: stop_read_threads: Signalling `read_cond'
[2023-06-02 14:37:35] [debug] plugin_write_thread(write_prometheus): teardown
[2023-06-02 14:37:35] [debug] plugin_write_thread(write_http/HttpWriter): teardown
fish: “./install/sbin/collectd -f -C /…” terminated by signal SIGSEGV (Address boundary error)
```

This is due to the plugins assuming a specific order in which callbacks (and associated `user_data`) are freed, in accordance with the following comment:

https://github.com/collectd/collectd/blob/8286d53f7cab2457ddb491153345700451603ae3/src/daemon/plugin.c#L1941-L1949

I found at least the following plugins using this trick to prevent double-frees during teardown. Which means they will likely currently produce a SIGSEGV when stopping collectd:

 - `write_http`
 - `write_riemann`
 - `write_stackdriver`
 - `write_syslog`
 - `write_tsdb`

This should fix use-after-frees during teardown of these plugins by restoring the freeing order to what it was before 55efb56.

I've made a previous attempt to fix this issue for `write_http`  (#4104) that I've replaced with this PR.