### PR TITLE
processes: do not post metrics from processes that are not running.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1472,6 +1472,7 @@
 #	CollectMemoryMaps true
 #	CollectDelayAccounting false
 #	CollectSystemContextSwitch false
+#	SkipNonRunningProcess false
 #	Process "name"
 #	ProcessMatch "name" "regex"
 #	<Process "collectd">

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8172,6 +8172,11 @@ Collect ctxt fields from /proc/stat in linux systems.
 Can be configured only outside the B<Process> and B<ProcessMatch>
 blocks.
 
+=item B<SkipNonRunningProcess> I<Boolean>
+
+Skip submitting metrics for Zombie and non running processes.
+Disabled by default.
+
 =back
 
 The B<CollectContextSwitch>, B<CollectDelayAccounting>,


### PR DESCRIPTION
ChangeLog: processes plugin: do not post metrics from processes that are not running.

Currently, processes plugin will emit metrics even if the a process listed in ProcessMatch is not running. This is unnecessary and causes wasteful network/disk activity. 
For process not running all the metrics are 0 but they still submit data. This will lead to a waste of resources.

If a process listed on ProcessMatch runs after collectd is started, those process will start sending metrics.

Please help review. Thanks a lot!
