### PR TITLE
Fix for smart plugin crashing on Intel NVMe drives

### DIFF
--- a/src/intel-nvme.h
+++ b/src/intel-nvme.h
@@ -71,4 +71,5 @@ struct nvme_additional_smart_log {
   struct nvme_additional_smart_log_item pll_lock_loss_cnt;
   struct nvme_additional_smart_log_item nand_bytes_written;
   struct nvme_additional_smart_log_item host_bytes_written;
+  char padding[321];
 };


### PR DESCRIPTION
I have a server with an Intel NVMe, model SSDPE2MX450G7. The smart plugin crashes and takes down whole collectd with it. The error message I get is

```
*** stack smashing detected ***: terminated
Aborted (core dumped)
```

It looks like there is inadequate data allocated for the return values of an ioctl. This patch adds padding to the data, padding even one byte less will result in the crash mentioned above.

ChangeLog: Smart plugin: Fix crash on Intel NVMe