### PR TITLE
Initial support for gathering metrics from multiple nginx instances.

### DIFF
--- a/contrib/nginx/nginx-multiple-instances.conf
+++ b/contrib/nginx/nginx-multiple-instances.conf
@@ -1,0 +1,14 @@
+# Nginx metrics from /status location for multiple Nginx instances
+LoadPlugin nginx
+<Plugin "nginx">
+    <InstanceName "nginx_1">
+        URL "http://127.0.0.1:80/status"
+    </InstanceName>
+    <InstanceName "nginx_2">
+        URL "http://127.0.0.1:8080/status"
+    </InstanceName>
+    <InstanceName "nginx_3_socket">
+        URL "http://127.0.0.1:80/status"
+        Socket "/var/run/nginx_3.socket"
+    </InstanceName>
+</Plugin>

--- a/src/nginx.c
+++ b/src/nginx.c
@@ -33,25 +33,21 @@
 
 #include <curl/curl.h>
 
-static char *url;
-static char *user;
-static char *pass;
-static char *verify_peer;
-static char *verify_host;
-static char *cacert;
-static char *timeout;
-static char *sock;
+#define MAX_NGINX_INSTANCES 1000     // Max nginx instances that plugin can serve simultaneously
+static int instance_num_counter = 0; // Counts number of configured nginx instances
 
-static CURL *curl;
+/* Stores name and curl options of the nginx instance */
+
+static struct nginx_instance {
+    char name[DATA_MAX_NAME_LEN];
+    CURL *curl;
+} ngx_inst[MAX_NGINX_INSTANCES];
+
+/******************/
 
 static char nginx_buffer[16384];
 static size_t nginx_buffer_len;
 static char nginx_curl_error[CURL_ERROR_SIZE];
-
-static const char *config_keys[] = {"URL",        "User",       "Password",
-                                    "VerifyPeer", "VerifyHost", "CACert",
-                                    "Timeout",    "Socket"};
-static int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
 static size_t nginx_curl_callback(void *buf, size_t size, size_t nmemb,
                                   void __attribute__((unused)) * stream) {
@@ -73,108 +69,223 @@ static size_t nginx_curl_callback(void *buf, size_t size, size_t nmemb,
   return len;
 }
 
-static int config_set(char **var, const char *value) {
-  if (*var != NULL) {
-    free(*var);
-    *var = NULL;
-  }
-
-  if ((*var = strdup(value)) == NULL)
-    return 1;
-  else
-    return 0;
+static int init(void) {
+  return 0;
 }
 
-static int config(const char *key, const char *value) {
-  if (strcasecmp(key, "url") == 0)
-    return config_set(&url, value);
-  else if (strcasecmp(key, "user") == 0)
-    return config_set(&user, value);
-  else if (strcasecmp(key, "password") == 0)
-    return config_set(&pass, value);
-  else if (strcasecmp(key, "verifypeer") == 0)
-    return config_set(&verify_peer, value);
-  else if (strcasecmp(key, "verifyhost") == 0)
-    return config_set(&verify_host, value);
-  else if (strcasecmp(key, "cacert") == 0)
-    return config_set(&cacert, value);
-  else if (strcasecmp(key, "timeout") == 0)
-    return config_set(&timeout, value);
-  else if (strcasecmp(key, "socket") == 0)
-    return config_set(&sock, value);
-  else
+/******* Nginx plugin config parsing. Inspired by ceph plugin config parser implementation ( see ceph.c ) *******/
+static int nginx_handle_str(struct oconfig_item_s *item, char *dest,
+                         int dest_len) {
+  const char *val;
+  if (item->values_num != 1) {
+    return -ENOTSUP;
+  }
+  if (item->values[0].type != OCONFIG_TYPE_STRING) {
+    return -ENOTSUP;
+  }
+  val = item->values[0].value.string;
+  if (snprintf(dest, dest_len, "%s", val) > (dest_len - 1)) {
+    ERROR("nginx plugin: configuration parameter '%s' is too long.\n",
+          item->key);
+    return -ENAMETOOLONG;
+  }
+  return 0;
+}
+
+static int nginx_add_daemon_config(oconfig_item_t *ci) {
+  int ret;
+
+  /* Get instance name first - we need it for building metrics prefix as well */
+
+  if ((ci->values_num != 1) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
+    WARNING("nginx plugin: `InstanceName' block must have only name as an argument.");
     return -1;
-} /* int config */
+  }
 
-static int init(void) {
-  if (curl != NULL)
-    curl_easy_cleanup(curl);
+  ret = nginx_handle_str(ci, ngx_inst[instance_num_counter].name, DATA_MAX_NAME_LEN);
+  if (ret) {
+    return ret;
+  }
 
-  if ((curl = curl_easy_init()) == NULL) {
+  if (ngx_inst[instance_num_counter].name[0] == '\0') {
+    ERROR("nginx plugin: you must configure nginx instance name.\n");
+    return -EINVAL;
+  }
+
+  /*****************************************************************************/
+
+  /* Initialize CURL structure for the conf and set up default options */
+
+  if (ngx_inst[instance_num_counter].curl != NULL)
+    curl_easy_cleanup(ngx_inst[instance_num_counter].curl);
+
+  if ((ngx_inst[instance_num_counter].curl = curl_easy_init()) == NULL) {
     ERROR("nginx plugin: curl_easy_init failed.");
     return -1;
   }
 
-  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, nginx_curl_callback);
-  curl_easy_setopt(curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
-  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, nginx_curl_error);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_WRITEFUNCTION, nginx_curl_callback);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_ERRORBUFFER, nginx_curl_error);
 
-  if (user != NULL) {
-#ifdef HAVE_CURLOPT_USERNAME
-    curl_easy_setopt(curl, CURLOPT_USERNAME, user);
-    curl_easy_setopt(curl, CURLOPT_PASSWORD, (pass == NULL) ? "" : pass);
-#else
-    static char credentials[1024];
-    int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", user,
-                           pass == NULL ? "" : pass);
-    if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
-      ERROR("nginx plugin: Credentials would have been truncated.");
-      return -1;
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_MAXREDIRS, 50L);
+
+  /**********************************************************************/
+
+  /* Local arrays for temporal storing of the parameters available through plugin options */
+
+  char u[DATA_MAX_NAME_LEN] = {'\0'};
+  char p[DATA_MAX_NAME_LEN] = {'\0'};
+  char url[DATA_MAX_NAME_LEN] = {'\0'};
+  char verify_peer[DATA_MAX_NAME_LEN] = {'\0'};
+  char verify_host[DATA_MAX_NAME_LEN] = {'\0'};
+  char cacert[DATA_MAX_NAME_LEN] = {'\0'};
+  char timeout[DATA_MAX_NAME_LEN] = {'\0'};
+  char socket[DATA_MAX_NAME_LEN] = {'\0'};
+
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("user", child->key) == 0) {
+      ret = nginx_handle_str(child, u, sizeof(u));
+      if (ret) {
+        return ret;
+      }
     }
+    if (strcasecmp("pass", child->key) == 0) {
+      ret = nginx_handle_str(child, p, sizeof(p));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("url", child->key) == 0) {
+      ret = nginx_handle_str(child, url, sizeof(url));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("verify_peer", child->key) == 0) {
+      ret = nginx_handle_str(child, verify_peer, sizeof(verify_peer));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("verify_host", child->key) == 0) {
+      ret = nginx_handle_str(child, verify_host, sizeof(verify_host));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("cacert", child->key) == 0) {
+      ret = nginx_handle_str(child, cacert, sizeof(cacert));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("timeout", child->key) == 0) {
+      ret = nginx_handle_str(child, timeout, sizeof(timeout));
+      if (ret) {
+        return ret;
+      }
+    }
+    if (strcasecmp("socket", child->key) == 0) {
+      ret = nginx_handle_str(child, socket, sizeof(socket));
+      if (ret) {
+        return ret;
+      }
+    }
+  }
 
-    curl_easy_setopt(curl, CURLOPT_USERPWD, credentials);
+  /****************************************************************************************/
+
+  /* Fill optional curl parameters for instance */
+
+#ifdef HAVE_CURLOPT_USERNAME
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_USERNAME, u);
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_PASSWORD, (p[0] == '\0') ? "" : p);
+#else
+  static char credentials[1024];
+  int status = ssnprintf(credentials, sizeof(credentials), "%s:%s", u, p[0] == '\0' ? "" : p);
+  if ((status < 0) || ((size_t)status >= sizeof(credentials))) {
+    ERROR("nginx plugin: Credentials would have been truncated.");
+    return -1;
+  }
+
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_USERPWD, credentials);
 #endif
-  }
 
-  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
-
-  if ((verify_peer == NULL) || IS_TRUE(verify_peer)) {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+  if ((verify_peer[0] == '\0') || IS_TRUE(verify_peer)) {
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_SSL_VERIFYPEER, 1L);
   } else {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_SSL_VERIFYPEER, 0L);
   }
 
-  if ((verify_host == NULL) || IS_TRUE(verify_host)) {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+  if ((verify_host[0] == '\0') || IS_TRUE(verify_host)) {
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_SSL_VERIFYHOST, 2L);
   } else {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_SSL_VERIFYHOST, 0L);
   }
 
-  if (cacert != NULL) {
-    curl_easy_setopt(curl, CURLOPT_CAINFO, cacert);
+  if (cacert[0] != '\0') {
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_CAINFO, cacert);
   }
 
 #ifdef HAVE_CURLOPT_TIMEOUT_MS
-  if (timeout != NULL) {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, atol(timeout));
+  if (timeout[0] != '\0') {
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_TIMEOUT_MS, atol(timeout));
   } else {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS,
-                     (long)CDTIME_T_TO_MS(plugin_get_interval()));
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_TIMEOUT_MS, (long)CDTIME_T_TO_MS(plugin_get_interval()));
   }
 #endif
 
 #ifdef HAVE_CURLOPT_UNIX_SOCKET_PATH
-  if (sock != NULL) {
-    curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, sock);
+  if (socket[0] != '\0') {
+    curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_UNIX_SOCKET_PATH, socket);
   }
 #endif
 
-  return 0;
-} /* void init */
+  curl_easy_setopt(ngx_inst[instance_num_counter].curl, CURLOPT_URL, url);
 
-static void submit(const char *type, const char *inst, long long value) {
+  /*************************************************************************/
+
+  instance_num_counter++; // Increase counter of configured nginx instances.
+
+  return 0;
+}
+
+static int nginx_config(oconfig_item_t *ci) {
+  int ret;
+
+  for(int i = 0 ; i < MAX_NGINX_INSTANCES ; i++) {
+    for( int j = 0 ; j < DATA_MAX_NAME_LEN ; j++) {
+      ngx_inst[i].name[j] = '\0';
+    }
+    ngx_inst[i].curl = NULL;
+  }
+
+  for (int i = 0; i < ci->children_num; ++i) {
+    if(instance_num_counter > MAX_NGINX_INSTANCES -1 ) {
+      WARNING("nginx plugin: number of configured nginx instances execeeded. Limit is %d.", MAX_NGINX_INSTANCES);
+      break;
+    } else {
+      oconfig_item_t *child = ci->children + i;
+      if (strcasecmp("instancename", child->key) == 0) {
+        ret = nginx_add_daemon_config(child);
+        if (ret) {
+          // process other instances and ignore this one
+          continue;
+        }
+      } else {
+        WARNING("nginx plugin: ignoring unknown option %s", child->key);
+      }
+    }
+  }
+  return 0;
+}
+
+static void submit(const char *instance_name, const char *type, const char *inst, long long value) {
   value_t values[1];
   value_list_t vl = VALUE_LIST_INIT;
 
@@ -189,7 +300,7 @@ static void submit(const char *type, const char *inst, long long value) {
 
   vl.values = values;
   vl.values_len = STATIC_ARRAY_SIZE(values);
-  sstrncpy(vl.plugin, "nginx", sizeof(vl.plugin));
+  sstrncpy(vl.plugin, instance_name, sizeof(vl.plugin));
   sstrncpy(vl.type, type, sizeof(vl.type));
 
   if (inst != NULL)
@@ -201,78 +312,72 @@ static void submit(const char *type, const char *inst, long long value) {
 static int nginx_read(void) {
   char *ptr;
   char *lines[16];
-  int lines_num = 0;
+  int lines_num;
   char *saveptr;
 
   char *fields[16];
   int fields_num;
 
-  if (curl == NULL)
-    return -1;
-  if (url == NULL)
-    return -1;
+  for(int n = 0 ; n < instance_num_counter ; n++)  {
+    lines_num = 0;
+    nginx_buffer_len = 0;
+    if (curl_easy_perform(ngx_inst[n].curl) != CURLE_OK) {
+      WARNING("nginx plugin: curl_easy_perform failed: %s", nginx_curl_error);
+      return -1;
+    }
 
-  nginx_buffer_len = 0;
+    ptr = nginx_buffer;
+    saveptr = NULL;
+    while ((lines[lines_num] = strtok_r(ptr, "\n\r", &saveptr)) != NULL) {
+      ptr = NULL;
+      lines_num++;
 
-  curl_easy_setopt(curl, CURLOPT_URL, url);
+      if (lines_num >= 16)
+        break;
+    }
 
-  if (curl_easy_perform(curl) != CURLE_OK) {
-    WARNING("nginx plugin: curl_easy_perform failed: %s", nginx_curl_error);
-    return -1;
-  }
+    /*
+     * Active connections: 291
+     * server accepts handled requests
+     *  101059015 100422216 347910649
+     * Reading: 6 Writing: 179 Waiting: 106
+     */
+    for (int i = 0; i < lines_num; i++) {
+      fields_num =
+          strsplit(lines[i], fields, (sizeof(fields) / sizeof(fields[0])));
 
-  ptr = nginx_buffer;
-  saveptr = NULL;
-  while ((lines[lines_num] = strtok_r(ptr, "\n\r", &saveptr)) != NULL) {
-    ptr = NULL;
-    lines_num++;
-
-    if (lines_num >= 16)
-      break;
-  }
-
-  /*
-   * Active connections: 291
-   * server accepts handled requests
-   *  101059015 100422216 347910649
-   * Reading: 6 Writing: 179 Waiting: 106
-   */
-  for (int i = 0; i < lines_num; i++) {
-    fields_num =
-        strsplit(lines[i], fields, (sizeof(fields) / sizeof(fields[0])));
-
-    if (fields_num == 3) {
-      if ((strcmp(fields[0], "Active") == 0) &&
-          (strcmp(fields[1], "connections:") == 0)) {
-        submit("nginx_connections", "active", atoll(fields[2]));
-      } else if ((atoll(fields[0]) != 0) && (atoll(fields[1]) != 0) &&
-                 (atoll(fields[2]) != 0)) {
-        submit("connections", "accepted", atoll(fields[0]));
-        /* TODO: The legacy metric "handled", which is the sum of "accepted" and
-         * "failed", is reported for backwards compatibility only. Remove in the
-         * next major version. */
-        submit("connections", "handled", atoll(fields[1]));
-        submit("connections", "failed", (atoll(fields[0]) - atoll(fields[1])));
-        submit("nginx_requests", NULL, atoll(fields[2]));
-      }
-    } else if (fields_num == 6) {
-      if ((strcmp(fields[0], "Reading:") == 0) &&
-          (strcmp(fields[2], "Writing:") == 0) &&
-          (strcmp(fields[4], "Waiting:") == 0)) {
-        submit("nginx_connections", "reading", atoll(fields[1]));
-        submit("nginx_connections", "writing", atoll(fields[3]));
-        submit("nginx_connections", "waiting", atoll(fields[5]));
+      if (fields_num == 3) {
+        if ((strcmp(fields[0], "Active") == 0) &&
+            (strcmp(fields[1], "connections:") == 0)) {
+          submit(ngx_inst[n].name, "nginx_connections", "active", atoll(fields[2]));
+        } else if ((atoll(fields[0]) != 0) && (atoll(fields[1]) != 0) &&
+                   (atoll(fields[2]) != 0)) {
+          submit(ngx_inst[n].name, "connections", "accepted", atoll(fields[0]));
+          /* TODO: The legacy metric "handled", which is the sum of "accepted" and
+           * "failed", is reported for backwards compatibility only. Remove in the
+           * next major version. */
+          submit(ngx_inst[n].name, "connections", "handled", atoll(fields[1]));
+          submit(ngx_inst[n].name, "connections", "failed", (atoll(fields[0]) - atoll(fields[1])));
+          submit(ngx_inst[n].name, "nginx_requests", NULL, atoll(fields[2]));
+        }
+      } else if (fields_num == 6) {
+        if ((strcmp(fields[0], "Reading:") == 0) &&
+            (strcmp(fields[2], "Writing:") == 0) &&
+            (strcmp(fields[4], "Waiting:") == 0)) {
+          submit(ngx_inst[n].name,"nginx_connections", "reading", atoll(fields[1]));
+          submit(ngx_inst[n].name,"nginx_connections", "writing", atoll(fields[3]));
+          submit(ngx_inst[n].name,"nginx_connections", "waiting", atoll(fields[5]));
+        }
       }
     }
   }
-
-  nginx_buffer_len = 0;
 
   return 0;
 } /* int nginx_read */
 
 void module_register(void) {
-  plugin_register_config("nginx", config, config_keys, config_keys_num);
   plugin_register_init("nginx", init);
+  plugin_register_complex_config("nginx", nginx_config);
   plugin_register_read("nginx", nginx_read);
 } /* void module_register */
+


### PR DESCRIPTION
Several days ago I faced with a case in which I needed to gather /status metrics from multiple nginx instances with a single collectd instance, something like https://github.com/collectd/collectd/issues/780.

I created a patch to the current nginx plugin implementation that covers this above mentioned case. The main idea of the patch is to create a number of structures that store configured "InstanceName" and a CURL object containing options for curl-ing of each nginx instance separately. The config parser implementation was inspired by the one for ceph plugin. The only difference between them is a static limitation on a total number of nginx instances which can be served by plugin simultaneously. It's defined with a constant value:
```c
#define MAX_NGINX_INSTANCES 1000     // Max nginx instances that plugin can serve simultaneously
```  