### PR TITLE
Fix: use nsid 0 when sending NVME_ADMIN_IDENTIFY command

### DIFF
--- a/src/smart.c
+++ b/src/smart.c
@@ -287,7 +287,7 @@ static int get_vendor_id(const char *dev, char const *name) {
 
   err = ioctl(fd, NVME_IOCTL_ADMIN_CMD,
               &(struct nvme_admin_cmd){.opcode = NVME_ADMIN_IDENTIFY,
-                                       .nsid = NVME_NSID_ALL,
+                                       .nsid = 0,
                                        .addr = (unsigned long)&vid,
                                        .data_len = sizeof(vid),
                                        .cdw10 = 1,


### PR DESCRIPTION
ChangeLog: smart plugin: using NSID 0 when issuing the Identify Admin command, otherwise FireCuda 530 ssd logs an error.

I managed to narrow down the problem to the smart.c file using NSID 0xFFFFFFFF when sending the Identify Admin command.

Far from being an expert in NVME, I found this code [https://www.smartmontools.org/static/doxygen/nvmecmds_8cpp_source.html#l00134](https://www.smartmontools.org/static/doxygen/nvmecmds_8cpp_source.html#l00134) which sends the command using NSID argument with value 0.
This indeed causes no more problems with the FireCuda 530 hard disk adding errors when queried.

Fixes: #4127