### PR TITLE
plugin mysql: translate a column name to a column index in mysql_read…

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -523,6 +523,7 @@ static int mysql_read_replica_stats(mysql_database_t *db, MYSQL *con) {
         io = row[metrics[i].field_index];
       }
     }
+
     set_host(db, n.host, sizeof(n.host));
 
     /* Assured by "mysql_config_database" */


### PR DESCRIPTION
plugin mysql: translate a column name to a column index in mysql_read_replica_stats
ChangeLog: plugin mysql: translate a column name to a column index in mysql_read_replica_stats

prepare for commit add support mariadb multisource replication