### PR TITLE
[Collectd 6] gpu_sysman: fix initial min memory check value

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3740,8 +3740,9 @@ supporting only single variant ignore this option.
 Counter metric variant (e.g. HW energy usage as Joules counter) is
 preferred by Prometheus as doing rate calculations in Prometheus is
 more flexible. However, because collectd stores counters internally as
-integers, counter metrics cannot using base units (seconds, joules) as
-required by OpenMetrics spec, but microseconds and microjoules.
+integers instead of floating point, counter metrics are given in
+microjoules / microseconds instead of their (joule / second) SI base
+units (required by OpenMetrics spec), for better accuracy.
 
 Rate metric variant is directly human readable, and available for
 metrics where it makes sense (e.g. bytes per second, Watts and RPMs).

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -1,7 +1,7 @@
 /**
  * collectd - src/gpu_sysman.c
  *
- * Copyright(c) 2020-2022 Intel Corporation. All rights reserved.
+ * Copyright(c) 2020-2023 Intel Corporation. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -1163,7 +1163,7 @@ static bool gpu_mems(gpu_device_t *gpu, unsigned int cache_idx) {
       /* find min & max values for memory free from
        * (the configured number of) samples
        */
-      uint64_t free_min = (uint64_t)1024 * 1024 * 1024 * 1024;
+      uint64_t free_min = (uint64_t)0xffffffff;
       uint64_t free_max = 0, mem_free;
       for (uint32_t j = 0; j < config.samples; j++) {
         mem_free = gpu->memory[j][i].free;


### PR DESCRIPTION
ChangeLog: gpu_sysman: fix initial min memory check value

...for GPUs with larger amounts of memory, and clarify in doc why non-standard units are used for counters, although SI units would be desirable.