### PR TITLE
Change AMQP queue drops from DEBUG to WARNING

### DIFF
--- a/src/amqp1.c
+++ b/src/amqp1.c
@@ -346,7 +346,7 @@ static int encqueue(cd_message_t *cdm,
       DEQ_SIZE(out_messages) >= transport->sendq_limit) {
     cd_message_t *evict;
 
-    DEBUG("amqp1 plugin: dropping oldest message because sendq is full");
+    WARNING("amqp1 plugin: dropping oldest message because sendq is full");
     evict = DEQ_HEAD(out_messages);
     DEQ_REMOVE_HEAD(out_messages);
     cd_message_free(evict);


### PR DESCRIPTION
Debug messages are only available if collectd is compiled with debug enabled, making it hard to troubleshoot the situation where the amqp queue is being overrun.

I think dropping metrics merits a "warning", but could be negotiated down to pretty much any level above debug :)