### PR TITLE
write_prometheus: don't use AI_ADDRCONFIG for resolving bind address

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -757,7 +757,7 @@ static int prom_open_socket(int addrfamily) {
   struct addrinfo *res;
   int status = getaddrinfo(httpd_host, service,
                            &(struct addrinfo){
-                               .ai_flags = AI_PASSIVE | AI_ADDRCONFIG,
+                               .ai_flags = AI_PASSIVE,
                                .ai_family = addrfamily,
                                .ai_socktype = SOCK_STREAM,
                            },


### PR DESCRIPTION
Fixes #4150

write_prometheus uses getaddrinfo to resolve the bind address. The AI_ADDRCONFIG flag causes getaddrinfo to refuse to resolve 0.0.0.0 when the system has no non-loopback IPv4 addresses configured and refuse to resolve :: when the system has no non-loopback IPv6 configured.

We want binding to a wildcard address (0.0.0.0 or ::) to always work, even if the network is down.

To achieve that, don't pass the AI_ADDRCONFIG flag when resolving a bind address.

Changelog: write_prometheus: fixed failing to listen on wildcard address before network is up