### PR TITLE
Intel RDT: fix compilation with libpqos < 4.4.

### DIFF
--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -44,10 +44,15 @@
 
 #define RDT_PLUGIN "intel_rdt"
 
+#if PQOS_VERSION >= 40400
 #define RDT_EVENTS                                                             \
   (PQOS_MON_EVENT_L3_OCCUP | PQOS_PERF_EVENT_IPC | PQOS_MON_EVENT_LMEM_BW |    \
    PQOS_MON_EVENT_TMEM_BW | PQOS_MON_EVENT_RMEM_BW | PQOS_PERF_EVENT_LLC_REF)
-
+#else
+#define RDT_EVENTS                                                             \
+  (PQOS_MON_EVENT_L3_OCCUP | PQOS_PERF_EVENT_IPC | PQOS_MON_EVENT_LMEM_BW |    \
+   PQOS_MON_EVENT_TMEM_BW | PQOS_MON_EVENT_RMEM_BW)
+#endif
 
 #define RDT_MAX_SOCKETS 8
 #define RDT_MAX_SOCKET_CORES 64


### PR DESCRIPTION
Currently the compilation fails on a number of systems with the following error:

```
  CC       src/intel_rdt_la-intel_rdt.lo
../../src/intel_rdt.c: In function 'rdt_config_events':
../../src/intel_rdt.c:49:54: error: 'PQOS_PERF_EVENT_LLC_REF' undeclared (first use in this function); did you mean 'PQOS_PERF_EVENT_LLC_MISS'?
    PQOS_MON_EVENT_TMEM_BW | PQOS_MON_EVENT_RMEM_BW | PQOS_PERF_EVENT_LLC_REF)
                                                      ^~~~~~~~~~~~~~~~~~~~~~~
../../src/intel_rdt.c:568:13: note: in expansion of macro 'RDT_EVENTS'
   events &= RDT_EVENTS;
             ^~~~~~~~~~
../../src/intel_rdt.c:49:54: note: each undeclared identifier is reported only once for each function it appears in
    PQOS_MON_EVENT_TMEM_BW | PQOS_MON_EVENT_RMEM_BW | PQOS_PERF_EVENT_LLC_REF)
                                                      ^~~~~~~~~~~~~~~~~~~~~~~
../../src/intel_rdt.c:568:13: note: in expansion of macro 'RDT_EVENTS'
   events &= RDT_EVENTS;
             ^~~~~~~~~~
make[2]: *** [Makefile:8133: src/intel_rdt_la-intel_rdt.lo] Error 1
```

ChangeLog: Intel RDT plugin: A compatibility issue with pqos < 4.4 has been fixed.