### PR TITLE
Add Valgrind suppression for libvirt memory leak.

### DIFF
--- a/src/valgrind.suppress
+++ b/src/valgrind.suppress
@@ -5,3 +5,12 @@
    obj:*libnl.so.1.*
    ...
 }
+
+{
+  libvirt memory allocated at init
+  Memcheck:Leak
+  fun:calloc
+  fun:g_malloc0
+  ...
+  fun:virOnce
+}


### PR DESCRIPTION
Currently, `make check` fails on some platforms because libvirt is leaking memory:

```
==157492== 61 (48 direct, 13 indirect) bytes in 1 blocks are definitely lost in loss record 316 of 548
==157492==    at 0x484982C: calloc (vg_replace_malloc.c:1554)
==157492==    by 0x50DFB40: g_malloc0 (in /usr/lib64/libglib-2.0.so.0.6800.4)
==157492==    by 0x4983C19: virClassNew (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4B918D9: ??? (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4F20A77: __pthread_once_slow (in /usr/lib64/libc.so.6)
==157492==    by 0x499974A: virOnce (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4B91D7A: virGetConnect (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4B503EF: ??? (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4B51277: virConnectOpen (in /usr/lib64/libvirt.so.0.9003.0)
==157492==    by 0x4043A7: setup (virt_test.c:37)
==157492==    by 0x4037E9: test_get_domain_state_notify (virt_test.c:61)
==157492==    by 0x4037E9: main (virt_test.c:90)
==157492== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   fun:g_malloc0
   fun:virClassNew
   obj:/usr/lib64/libvirt.so.0.9003.0
   fun:__pthread_once_slow
   fun:virOnce
   fun:virGetConnect
   obj:/usr/lib64/libvirt.so.0.9003.0
   fun:virConnectOpen
   fun:setup
   fun:test_get_domain_state_notify
   fun:main
}
```