### PR TITLE
Write MongoDB plugin: fix format trunction errors.

### DIFF
--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -94,9 +94,9 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
 
   BSON_APPEND_ARRAY_BEGIN(ret, "values", &subarray); /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
-    char key[16];
+    char key[32] = {0};
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (ds->ds[i].type == DS_TYPE_GAUGE)
       BSON_APPEND_DOUBLE(&subarray, key, vl->values[i].gauge);
@@ -119,9 +119,9 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
 
   BSON_APPEND_ARRAY_BEGIN(ret, "dstypes", &subarray); /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
-    char key[16];
+    char key[32] = {0};
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
 
     if (store_rates)
       BSON_APPEND_UTF8(&subarray, key, "gauge");
@@ -132,9 +132,9 @@ static bson_t *wm_create_bson(const data_set_t *ds, /* {{{ */
 
   BSON_APPEND_ARRAY_BEGIN(ret, "dsnames", &subarray); /* {{{ */
   for (size_t i = 0; i < ds->ds_num; i++) {
-    char key[16];
+    char key[32] = {0};
 
-    snprintf(key, sizeof(key), "%" PRIsz, i);
+    ssnprintf(key, sizeof(key), "%" PRIsz, i);
     BSON_APPEND_UTF8(&subarray, key, ds->ds[i].name);
   }
   bson_append_array_end(ret, &subarray); /* }}} dsnames */


### PR DESCRIPTION
When a `size_t` is a 64bit integer, the 16 byte buffer could potentially overflow. Fix this by using a larger buffer and also collectd's own `ssnprintf()` function which guarantees to result in a null terminated string.

```
In function 'wm_create_bson',
    inlined from 'wm_write' at src/write_mongodb.c:229:17:
src/write_mongodb.c:99:32: error: '%zu' directive output may be truncated writing between 1 and 20 bytes into a region of size 16 [-Werror=format-truncation=]
   99 |     snprintf(key, sizeof(key), "%" PRIsz, i);
      |                                ^~~
src/write_mongodb.c: In function 'wm_write':
src/write_mongodb.c:99:33: note: format string is defined here
   99 |     snprintf(key, sizeof(key), "%" PRIsz, i);
```