### PR TITLE
Build workflow: remove old distros.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,10 @@ jobs:
           # Ubuntu
           - focal_amd64
           - bionic_amd64
-          - xenial_amd64
           # RedHat family
           - el9_x86_64
           - el8_x86_64
-          - el7_x86_64
           - fedora36_x86_64
-          - fedora35_x86_64
-          - fedora34_x86_64
         config_flags: ['']
     env:
       MAKEFLAGS: "-j2 -sk"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
           - bionic_amd64
           # RedHat family
           - el9_x86_64
-          - el8_x86_64
           - fedora36_x86_64
         config_flags: ['']
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
           - bullseye_amd64
           - buster_amd64
           # Ubuntu
+          - mantic_amd64
+          - jammy_amd64
           - focal_amd64
           - bionic_amd64
           # RedHat family


### PR DESCRIPTION
This removes old and unsupported Linux distros:

*   Ubuntu 16 ("Xenial", support ended April 2021)
*   Ubuntu 18 ("Bionic Beaver", support ended June 2023)
*   Enterprise Linux 7 (technically still supported, but nine years old
    at this point)
*   Fedora 34 (support ended June 2022)
*   Fedora 35 (support ended December 2022)

Fedora 36 is also unsupported. We will keep the builder until we have never versions of Fedora available (or at least Rawhide builds again).