### PR TITLE
gmond plugin: Import `<ganglia.h>`.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2639,9 +2639,9 @@ CPPFLAGS="$CPPFLAGS $GANGLIA_CPPFLAGS"
 LDFLAGS="$LDFLAGS $GANGLIA_LDFLAGS"
 
 if test "x$with_libganglia" = "xyes"; then
-  AC_CHECK_HEADERS([gm_protocol.h],
+  AC_CHECK_HEADERS([ganglia.h],
     [with_libganglia="yes"],
-    [with_libganglia="no (gm_protocol.h not found)"]
+    [with_libganglia="no (ganglia.h not found)"]
   )
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2633,6 +2633,25 @@ if test "x$with_libganglia" = "xyes"; then
   fi
 fi
 
+AC_CHECK_HEADERS([rpc/types.h],
+  [have_rpc_types_h="yes"],
+  [have_rpc_types_h="no"]
+)
+AS_UNSET([ac_cv_header_rpc_types_h])
+if test "x$have_rpc_types_h" = "xno"; then
+  # SunRPC has been removed from glibc.
+  # Replacement headers are in the "tirpc" subdirectory.
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
+
+  AC_CHECK_HEADERS([rpc/types.h],
+    [GANGLIA_CPPFLAGS="$GANGLIA_CPPFLAGS -I/usr/include/tirpc"],
+    [with_libganglia="no (rpc/types.h not found)"]
+  )
+
+  CPPFLAGS="$SAVE_CPPFLAGS"
+fi
+
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS $GANGLIA_CPPFLAGS"

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -43,7 +43,7 @@
 #include <poll.h>
 #endif
 
-#include <gm_protocol.h>
+#include <ganglia.h>
 
 #ifndef IPV6_ADD_MEMBERSHIP
 #ifdef IPV6_JOIN_GROUP

--- a/src/gmond.c
+++ b/src/gmond.c
@@ -616,50 +616,42 @@ static int mc_handle_value_msg(Ganglia_value_msg *msg) /* {{{ */
 
 static int mc_handle_metadata_msg(Ganglia_metadata_msg *msg) /* {{{ */
 {
-  switch (msg->id) {
-  case gmetadata_full: {
-    Ganglia_metadatadef msg_meta;
-    staging_entry_t *se;
-    const data_set_t *ds;
-    metric_map_t *map;
-
-    msg_meta = msg->Ganglia_metadata_msg_u.gfull;
-
-    if (msg_meta.metric.tmax == 0)
-      return -1;
-
-    map = metric_lookup(msg_meta.metric_id.name);
-    if (map == NULL) {
-      DEBUG("gmond plugin: Not handling meta data %s.",
-            msg_meta.metric_id.name);
-      return 0;
-    }
-
-    ds = plugin_get_ds(map->type);
-    if (ds == NULL) {
-      WARNING("gmond plugin: Could not find data set %s.", map->type);
-      return -1;
-    }
-
-    DEBUG("gmond plugin: Received meta data for %s/%s.",
-          msg_meta.metric_id.host, msg_meta.metric_id.name);
-
-    pthread_mutex_lock(&staging_lock);
-    se = staging_entry_get(msg_meta.metric_id.host, msg_meta.metric_id.name,
-                           map->type, map->type_instance, ds->ds_num);
-    if (se != NULL)
-      se->vl.interval = TIME_T_TO_CDTIME_T(msg_meta.metric.tmax);
-    pthread_mutex_unlock(&staging_lock);
-
-    if (se == NULL) {
-      ERROR("gmond plugin: staging_entry_get failed.");
-      return -1;
-    }
-
-    break;
+  if (msg->id != gmetadata_full) {
+    return -1;
   }
 
-  default: { return -1; }
+  Ganglia_metadatadef msg_meta = msg->Ganglia_metadata_msg_u.gfull;
+  if (msg_meta.metric.tmax == 0) {
+    return -1;
+  }
+
+  metric_map_t *map = metric_lookup(msg_meta.metric_id.name);
+  if (map == NULL) {
+    DEBUG("gmond plugin: Not handling meta data %s.", msg_meta.metric_id.name);
+    return 0;
+  }
+
+  data_set_t const *ds = plugin_get_ds(map->type);
+  if (ds == NULL) {
+    WARNING("gmond plugin: Could not find data set %s.", map->type);
+    return -1;
+  }
+
+  DEBUG("gmond plugin: Received meta data for %s/%s.", msg_meta.metric_id.host,
+        msg_meta.metric_id.name);
+
+  pthread_mutex_lock(&staging_lock);
+  staging_entry_t *se =
+      staging_entry_get(msg_meta.metric_id.host, msg_meta.metric_id.name,
+                        map->type, map->type_instance, ds->ds_num);
+  if (se != NULL) {
+    se->vl.interval = TIME_T_TO_CDTIME_T(msg_meta.metric.tmax);
+  }
+  pthread_mutex_unlock(&staging_lock);
+
+  if (se == NULL) {
+    ERROR("gmond plugin: staging_entry_get failed.");
+    return -1;
   }
 
   return 0;


### PR DESCRIPTION
`<gm_protocol.h>` has been removed in new versions of *libganglia*.

Additionally, `<rpc/types.h>` has been removed from glibc and is not in the `/usr/include/tirpc` subdirectory instead.

This fixes the gmond plugin on Debian 12 ("Bookworm") and later.

ChangeLog: gmond plugin: Compatibility fixes for new versions of libganglia have been applied.