### PR TITLE
NUT plugin: improve support for faulty versions of libupsclient.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5836,6 +5836,7 @@ if test "x$with_libupsclient" = "xyes"; then
     [[
       #include <stdlib.h>
       #include <stdio.h>
+      #include <time.h>
       #include <upsclient.h>
     ]]
   )
@@ -5878,6 +5879,7 @@ if test "x$with_libupsclient" = "xyes"; then
      for port_arg in 'uint16_t' 'int' ; do
         AC_COMPILE_IFELSE([
             AC_LANG_PROGRAM([
+#include <time.h>
 #include <upsclient.h>
 /* int upscli_splitname(const char *buf, char **upsname, char **hostname, <port_arg> *port); */
             ],[
@@ -5909,6 +5911,7 @@ return(res);
      for size_arg in 'size_t' 'unsigned int' 'int' ; do
         AC_COMPILE_IFELSE([
             AC_LANG_PROGRAM([
+#include <time.h>
 #include <upsclient.h>
 /* int upscli_list_next(UPSCONN_t *ups, <size_arg> numq, const char **query, <size_arg> *numa, char ***answer); */
 


### PR DESCRIPTION
Deal with versions of libupsclient where `<upsclient.h>` is not self contained (it needs `<time.h>`), see networkupstools/nut#1638. This has been fixed upstream in networkupstools/nut#1641 but Debian Bookworm contains the faulty version.

ChangeLog: NUT plugin: Compatibility with new versions of libupsclient has been improved.