### PR TITLE
Improve CI workflows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -187,12 +187,10 @@ bleeding_edge_compilers_task:
   skip_notifications: true
   env:
     matrix:
-      CC: gcc-7
-      CC: gcc-8
-      CC: clang-6.0
-      CC: clang-7
-      CC: clang-8
-      CC: clang-9
+      CC: gcc-10
+      CC: clang
+      CC: clang-18
+      CC: clang-17
   configure_script:
     - ./build.sh
     - $CC --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
       run: make -j$(nproc) -sk
     - name: Run make check
       run: |
+        set +e
         make $MAKEFLAGS check
         echo "$?" >make-check.status
       continue-on-error: true
@@ -116,6 +117,7 @@ jobs:
       run: make -j$(nproc) -sk
     - name: Run make check
       run: |
+        set +e
         make $MAKEFLAGS check
         echo "$?" >make-check.status
       continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,14 @@ jobs:
           - el9_x86_64
           - fedora39
           - fedora38_x86_64
-        config_flags: ['']
+        configure_flags: ['']
+        include:
+          - container_tag: bookworm_amd64
+            configure_flags: '--enable-debug'
+          - container_tag: bookworm_amd64
+            configure_flags: 'CC=clang CXX=clang++'
     env:
-      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
       # this env var picked up by valgrind during make check phase
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
@@ -83,15 +88,15 @@ jobs:
         # Add additional per-distro vars here.
         include:
           - container_tag: debian_unstable
-            config_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt"
+            configure_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt"
           - container_tag: fedora_rawhide_x86_64
             cflags: "-fPIE -Wno-deprecated-declarations"
             cppflags: "-fPIE -Wno-deprecated-declarations"
-            config_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt --disable-xmms"
+            configure_flags: "--disable-dpdkstat --disable-dpdkevents --disable-virt --disable-xmms"
     env:
       CFLAGS: ${{ matrix.cflags }}
       CPPFLAGS: ${{ matrix.cppflags }}
-      CONFIGURE_FLAGS: ${{ matrix.config_flags }}
+      CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
           - container_tag: bookworm_amd64
             configure_flags: '--enable-debug'
           - container_tag: bookworm_amd64
-            configure_flags: 'CC=clang CXX=clang++'
+            # By default clang emits DWARF v5, which Valgrind cannot read yet.
+            # https://github.com/llvm/llvm-project/issues/56550
+            configure_flags: 'CC=clang CXX=clang++ CFLAGS=-gdwarf-4'
     env:
       CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
       # this env var picked up by valgrind during make check phase

--- a/src/procevent.c
+++ b/src/procevent.c
@@ -102,6 +102,22 @@
 #define PROCEVENT_VF_STATUS_NORMAL_VALUE "Active"
 
 /*
+ * Disable a clang warning about variable sized types in the middle of a struct.
+ *
+ * The below code uses temporary structs containing a `struct cn_msg` followed
+ * by another field. `struct cn_msg` includes a "flexible array member" and the
+ * struct is an elegant and convenient way of populating this "flexible" element
+ * via the other field in the temporary struct.
+ *
+ * Unfortunately, this is not supported by the C standard. GCC and clang both
+ * can deal with the situation though. Disable the warning to keep the well
+ * readable code.
+ */
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
+#endif
+
+/*
  * Private data types
  */
 


### PR DESCRIPTION
- Update list of compilers used by the "bleeding_edge_compilers_task"
- Add build with `--enable-debug` to GitHub Workflow
- Add build with `CC=clang` to GitHub Workflow.
- Rename `config_flags` to `configure_flags`.