### PR TITLE
write_log plugin: remove the "write_log values:" line when logging metrics.

### DIFF
--- a/src/write_log.c
+++ b/src/write_log.c
@@ -56,7 +56,7 @@ static int wl_write_graphite(metric_family_t const *fam) {
     if (status != 0) {
       ERROR("write_log plugin: format_graphite failed: %d", status);
     } else {
-      INFO("write_log values:\n%s", buf.ptr);
+      INFO("%s", buf.ptr);
     }
 
     strbuf_reset(&buf);
@@ -73,7 +73,7 @@ static int wl_write_json(metric_family_t const *fam) {
   if (status != 0) {
     ERROR("write_log plugin: format_json_metric_family failed: %d", status);
   } else {
-    INFO("write_log values:\n%s", buf.ptr);
+    INFO("%s", buf.ptr);
   }
 
   STRBUF_DESTROY(buf);


### PR DESCRIPTION
These lines use up vertical screen real estate and don't provide utility.

See discussion in  #4173