### PR TITLE
[collectd 6] add reference counting to plugins that register multiple callbacks with the same `user_data_t`.

### DIFF
--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -617,15 +617,14 @@ static void wrr_free(void *p) /* {{{ */
 
   pthread_mutex_lock(&host->lock);
   host->reference_count--;
-  int reference_count = host->reference_count;
-  pthread_mutex_unlock(&host->lock);
-
-  if (reference_count > 0) {
+  if (host->reference_count > 0) {
+    pthread_mutex_unlock(&host->lock);
     return;
   }
 
   wrr_disconnect(host);
 
+  pthread_mutex_unlock(&host->lock);
   pthread_mutex_destroy(&host->lock);
   sfree(host);
 } /* }}} void wrr_free */


### PR DESCRIPTION
This outlines an alternative fix to the problem described in #4117.

The idea is to fix the plugins rather than make the plugin's memory management a problem of the shutdown code in `src/daemon/plugin.c`. By adding a reference count, it doesn't matter in which order the various callbacks are shut down in the daemon code.

I hope that the same approach can be used to fix other affected plugins (write_riemann, write_stackdriver, write_syslog, write_tsdb), but I have not verified that yet.