### PR TITLE
[Collectd 6] gpu_sysman: add "LogMetrics" option

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3777,6 +3777,18 @@ If enabled, plugin logs at start some information about plugin
 settings, all the GPUs detected through Sysman API, and enables
 "pci_dev" PCI device ID label for the metrics.
 
+=item B<LogMetrics>
+
+If enabled, all metric values are also printed to collectd log
+(standard output by default).  This can be useful for local real-time
+monitoring / debugging of specific GPU metric values, as one does not
+need to enable any write plugins.
+
+Output is most readable when only one metric type + "MetricsOutput"
+variant are enabled, and collectd (container) sees only single GPU.
+Alternatively one could grep the output for the relevant GPU, metric
+type and its output variant, but that adds delay to the output.
+
 =item B<MetricsOutput>
 
 Set of "base", "rate", and "ratio" strings, separated by comma, colon,

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -770,6 +770,24 @@ static int gpu_init(void) {
   return gpu_config_init(count);
 }
 
+static double metric2double(metric_type_t type, value_t value) {
+  switch (type) {
+  case METRIC_TYPE_GAUGE:
+    return value.gauge;
+  case METRIC_TYPE_COUNTER:
+    return value.counter;
+  case METRIC_TYPE_COUNTER_FP:
+    return value.counter_fp;
+  case METRIC_TYPE_UP_DOWN:
+    return value.up_down;
+  case METRIC_TYPE_UP_DOWN_FP:
+    return value.up_down_fp;
+  case METRIC_TYPE_UNTYPED:
+    break;
+  }
+  assert(0);
+}
+
 /* Add device labels to all metrics in given metric family and submit family to
  * collectd, and log the metric if metric logging is enabled.
  * Resets metric family after dispatch */
@@ -806,8 +824,7 @@ static void gpu_submit(gpu_device_t *gpu, metric_family_t *fam) {
       }
       INFO("[%7ld.%03ld] %s: %s / %s [%ld]: %.3f", ts.tv_sec,
            ts.tv_nsec / 1000000, pci_bdf, name, type, i,
-           fam->type == METRIC_TYPE_COUNTER ? m->value.counter
-                                            : m->value.gauge);
+           metric2double(fam->type, m->value));
     }
 
     /* add extra per-metric labels */

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -56,6 +56,7 @@
 #endif
 
 #include "collectd.h"
+/* comment avoiding local clang-format conflict with collectd CI one */
 #include "plugin.h"
 #include "utils/common/common.h"
 

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -809,19 +809,6 @@ static void compose_name(char *buf, size_t bufsize, const char *name,
   assert(len < bufsize);
 }
 
-static double get_value(metric_type_t type, value_t value) {
-  switch (type) {
-  case METRIC_TYPE_COUNTER:
-    return value.counter;
-    break;
-  case METRIC_TYPE_GAUGE:
-    return value.gauge;
-    break;
-  default:
-    assert(0);
-  }
-}
-
 /* matches constructed metric names against validation array ones and
  * updates the values accordingly
  */
@@ -833,7 +820,7 @@ int plugin_dispatch_metric_family(metric_family_t const *fam) {
   metric_t *metric = fam->metric.ptr;
 
   for (size_t m = 0; m < fam->metric.num; m++) {
-    double value = get_value(fam->type, metric[m].value);
+    double value = metric2double(fam->type, metric[m].value);
     compose_name(name, sizeof(name), fam->name, &metric[m]);
     if (globs.verbose & VERBOSE_METRICS) {
       fprintf(stderr, "METRIC: %s: %g\n", name, value);

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -1425,6 +1425,7 @@ int main(int argc, const char **argv) {
 
   assert(registry.config("DisableSeparateErrors", "false") == 0);
   set_verbose(VERBOSE_CALLS_METRICS, VERBOSE_METRICS_NORMAL);
+  assert(registry.config("LogMetrics", "true") == 0);
   assert(registry.init() == 0);
 
   fprintf(stderr, "Query all metrics for the first time, with separate errors "
@@ -1436,6 +1437,7 @@ int main(int argc, const char **argv) {
   assert(globs.warnings == 0);
   /* per-time counters do not report on first round */
   assert(validate_and_reset_saved_metrics(1, 0) > 0);
+  assert(registry.config("LogMetrics", "false") == 0);
   fprintf(stderr, "metrics query round 1: PASS\n\n");
 
   api_calls = globs.api_calls;


### PR DESCRIPTION
ChangeLog: gpu_sysman: add "LogMetrics" option

Adds "LogMetrics" option for real-time monitoring of the GPU metrics:
* Causes each metric value to be written also to collectd log, i.e. by default to console
* Avoids need to setup write plugins and delay caused by their use when investigating GPU behavior
* _Output is much more readable than write plugins' output_ [1]

[1] output looks like this (when only memory metric with just base output variant is enabled):
```
[1058954.410] b3:00.0: memory_used_bytes / device [0]: 26763264.000
[1058957.527] 3c:00.0: memory_used_bytes / device [0]: 26763264.000
[1058957.527] b3:00.0: memory_used_bytes / device [0]: 26763264.000
[1058961.528] 3c:00.0: memory_used_bytes / device [0]: 26763264.000
```

How it differs from the current write plugins' output:
* Single, human readable line per metric
* `dmesg` style "uptime-seconds" timestamp, as it's short and can be correlated with kernel output
* Sub-second timestamp accuracy for debugging which metric(s) cause "read took too long" issues
   - user can then either disable that particular metric type or increase plugin query interval
* Metric info prefixed by (abbreviated) PCI ID of the device generating that metric
  - (after logging, non-abbreviated PCI ID is added as label to metric, so write plugin could get that info too)
* Only values for specific labels are output, and not their names, to avoid line wrapping
   - Some metrics have lot of labels, and some label values can be quite long