### PR TITLE
[collectd 6] Write OpenTelemetry: New plugin to export metrics via OTLP over gRPC.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 env:
   LANG: C
   CIRRUS_CLONE_DEPTH: 1
+  CIRRUS_CLONE_SUBMODULES: true
   DEFAULT_CONFIG_OPTS: --enable-debug --without-libstatgrab --disable-dependency-tracking
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,9 @@ jobs:
       # this env var picked up by valgrind during make check phase
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
     - run: type pkg-config
     - run: pkg-config --list-all | sort -u
     - name: Generate configure script
@@ -106,7 +108,9 @@ jobs:
       CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
     - run: type pkg-config
     - run: pkg-config --list-all | sort -u
     - name: Generate configure script

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -22,6 +22,8 @@ jobs:
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Install bzip2
       run: apt install -y bzip2
     - name: Print available packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gnulib"]
 	path = gnulib
 	url = git://git.savannah.gnu.org/gnulib.git
+[submodule "opentelemetry-proto"]
+	path = opentelemetry-proto
+	url = https://github.com/open-telemetry/opentelemetry-proto/

--- a/Makefile.am
+++ b/Makefile.am
@@ -132,6 +132,7 @@ noinst_LTLIBRARIES = \
 	libcommon.la \
 	libformat_graphite.la \
 	libformat_influxdb.la \
+	libformat_open_telemetry.la \
 	libheap.la \
 	libignorelist.la \
 	liblatency.la \
@@ -454,10 +455,6 @@ libplugin_mock_la_SOURCES = \
 libplugin_mock_la_CPPFLAGS = $(AM_CPPFLAGS) -DMOCK_TIME
 libplugin_mock_la_LIBADD = libmetric.la liboconfig.la libcommon.la libignorelist.la $(COMMON_LIBS)
 
-libformat_influxdb_la_SOURCES = \
-	src/utils/format_influxdb/format_influxdb.c \
-	src/utils/format_influxdb/format_influxdb.h
-
 libformat_graphite_la_SOURCES = \
 	src/utils/format_graphite/format_graphite.c \
 	src/utils/format_graphite/format_graphite.h
@@ -471,6 +468,28 @@ test_format_graphite_LDADD = \
 	libplugin_mock.la \
 	libstrbuf.la \
 	-lm
+
+libformat_influxdb_la_SOURCES = \
+	src/utils/format_influxdb/format_influxdb.c \
+	src/utils/format_influxdb/format_influxdb.h
+
+BUILT_SOURCES += \
+	src/opentelemetry/proto/common/v1/common.pb.cc \
+	src/opentelemetry/proto/common/v1/common.pb.h \
+	src/opentelemetry/proto/metrics/v1/metrics.pb.cc \
+	src/opentelemetry/proto/metrics/v1/metrics.pb.h \
+	src/opentelemetry/proto/resource/v1/resource.pb.cc \
+	src/opentelemetry/proto/resource/v1/resource.pb.h
+libformat_open_telemetry_la_SOURCES = \
+	src/utils/format_open_telemetry/format_open_telemetry.cc \
+	src/utils/format_open_telemetry/format_open_telemetry.h \
+	src/opentelemetry/proto/common/v1/common.pb.cc \
+	src/opentelemetry/proto/common/v1/common.pb.h \
+	src/opentelemetry/proto/metrics/v1/metrics.pb.cc \
+	src/opentelemetry/proto/metrics/v1/metrics.pb.h \
+	src/opentelemetry/proto/resource/v1/resource.pb.cc \
+	src/opentelemetry/proto/resource/v1/resource.pb.h
+libformat_open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS)
 
 if BUILD_WITH_LIBYAJL
 noinst_LTLIBRARIES += libformat_json.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -2337,6 +2337,12 @@ write_mongodb_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMONGOC_LDFLAGS)
 write_mongodb_la_LIBADD = $(BUILD_WITH_LIBMONGOC_LIBS)
 endif
 
+# TODO(octo): add configure guards
+pkglib_LTLIBRARIES += write_open_telemetry.la
+write_open_telemetry_la_SOURCES = src/write_open_telemetry.cc
+write_open_telemetry_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+write_open_telemetry_la_LIBADD = libformat_open_telemetry.la
+
 if BUILD_PLUGIN_WRITE_PROMETHEUS
 pkglib_LTLIBRARIES += write_prometheus.la
 write_prometheus_la_SOURCES = src/write_prometheus.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -482,6 +482,8 @@ noinst_LTLIBRARIES += libformat_open_telemetry.la
 libformat_open_telemetry_la_SOURCES = \
 	src/utils/format_open_telemetry/format_open_telemetry.cc \
 	src/utils/format_open_telemetry/format_open_telemetry.h \
+	src/utils/resource_metrics/resource_metrics.c \
+	src/utils/resource_metrics/resource_metrics.h \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h \
 	opentelemetry/proto/common/v1/common.pb.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,11 @@ EXTRA_DIST = \
 	bindings/perl/lib/Collectd/Unixsock.pm \
 	bindings/perl/uninstall_mod.pl \
 	contrib \
+	opentelemetry-proto/LICENSE \
+	opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto \
+	opentelemetry-proto/opentelemetry/proto/common/v1/common.proto \
+	opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto \
+	opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto \
 	proto/collectd.proto \
 	proto/types.proto \
 	src/collectd-email.pod \
@@ -2490,25 +2495,30 @@ endif
 if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
 BUILT_SOURCES += \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h \
 	opentelemetry/proto/common/v1/common.pb.cc \
+	opentelemetry/proto/common/v1/common.pb.h \
 	opentelemetry/proto/metrics/v1/metrics.pb.cc \
-	opentelemetry/proto/resource/v1/resource.pb.cc
+	opentelemetry/proto/metrics/v1/metrics.pb.h \
+	opentelemetry/proto/resource/v1/resource.pb.cc \
+	opentelemetry/proto/resource/v1/resource.pb.h
 
-opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --grpc_out=$(builddir) \
 		--plugin="protoc-gen-grpc=$(GRPC_CPP_PLUGIN)" $<
 
-opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/common/v1/common.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
+opentelemetry/proto/common/v1/common.pb.cc opentelemetry/proto/common/v1/common.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/metrics/v1/metrics.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
+opentelemetry/proto/metrics/v1/metrics.pb.cc opentelemetry/proto/metrics/v1/metrics.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/resource/v1/resource.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
+opentelemetry/proto/resource/v1/resource.pb.cc opentelemetry/proto/resource/v1/resource.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2484,7 +2484,10 @@ collectd.pb.cc: $(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
 types.pb.cc: $(srcdir)/proto/types.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/proto --cpp_out=$(builddir) \
 	$(srcdir)/proto/types.proto
+endif
+endif
 
+if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
 BUILT_SOURCES += \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
@@ -2507,8 +2510,6 @@ opentelemetry/proto/metrics/v1/metrics.pb.cc: $(srcdir)/opentelemetry-proto/open
 
 opentelemetry/proto/resource/v1/resource.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
-
-endif
 endif
 
 install-exec-hook:

--- a/Makefile.am
+++ b/Makefile.am
@@ -132,7 +132,6 @@ noinst_LTLIBRARIES = \
 	libcommon.la \
 	libformat_graphite.la \
 	libformat_influxdb.la \
-	libformat_open_telemetry.la \
 	libheap.la \
 	libignorelist.la \
 	liblatency.la \
@@ -473,23 +472,23 @@ libformat_influxdb_la_SOURCES = \
 	src/utils/format_influxdb/format_influxdb.c \
 	src/utils/format_influxdb/format_influxdb.h
 
-BUILT_SOURCES += \
-	src/opentelemetry/proto/common/v1/common.pb.cc \
-	src/opentelemetry/proto/common/v1/common.pb.h \
-	src/opentelemetry/proto/metrics/v1/metrics.pb.cc \
-	src/opentelemetry/proto/metrics/v1/metrics.pb.h \
-	src/opentelemetry/proto/resource/v1/resource.pb.cc \
-	src/opentelemetry/proto/resource/v1/resource.pb.h
+if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
+noinst_LTLIBRARIES += libformat_open_telemetry.la
 libformat_open_telemetry_la_SOURCES = \
 	src/utils/format_open_telemetry/format_open_telemetry.cc \
 	src/utils/format_open_telemetry/format_open_telemetry.h \
-	src/opentelemetry/proto/common/v1/common.pb.cc \
-	src/opentelemetry/proto/common/v1/common.pb.h \
-	src/opentelemetry/proto/metrics/v1/metrics.pb.cc \
-	src/opentelemetry/proto/metrics/v1/metrics.pb.h \
-	src/opentelemetry/proto/resource/v1/resource.pb.cc \
-	src/opentelemetry/proto/resource/v1/resource.pb.h
-libformat_open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS)
+	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h \
+	opentelemetry/proto/common/v1/common.pb.cc \
+	opentelemetry/proto/common/v1/common.pb.h \
+	opentelemetry/proto/metrics/v1/metrics.pb.cc \
+	opentelemetry/proto/metrics/v1/metrics.pb.h \
+	opentelemetry/proto/resource/v1/resource.pb.cc \
+	opentelemetry/proto/resource/v1/resource.pb.h
+libformat_open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBPROTOBUF_CPPFLAGS)
+libformat_open_telemetry_la_LDFLAGS = $(AM_LDFLAGS) $(BUILD_WITH_LIBPROTOBUF_LDFLAGS)
+libformat_open_telemetry_la_LIBADD = $(BUILD_WITH_LIBPROTOBUF_LIBS)
+endif
 
 if BUILD_WITH_LIBYAJL
 noinst_LTLIBRARIES += libformat_json.la
@@ -2337,11 +2336,15 @@ write_mongodb_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMONGOC_LDFLAGS)
 write_mongodb_la_LIBADD = $(BUILD_WITH_LIBMONGOC_LIBS)
 endif
 
-# TODO(octo): add configure guards
+if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
 pkglib_LTLIBRARIES += write_open_telemetry.la
-write_open_telemetry_la_SOURCES = src/write_open_telemetry.cc
-write_open_telemetry_la_LDFLAGS = $(PLUGIN_LDFLAGS)
-write_open_telemetry_la_LIBADD = libformat_open_telemetry.la
+write_open_telemetry_la_SOURCES = src/write_open_telemetry.cc \
+				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h
+write_open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS)
+write_open_telemetry_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS)
+write_open_telemetry_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS) libformat_open_telemetry.la
+endif
 
 if BUILD_PLUGIN_WRITE_PROMETHEUS
 pkglib_LTLIBRARIES += write_prometheus.la
@@ -2481,6 +2484,31 @@ collectd.pb.cc: $(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
 types.pb.cc: $(srcdir)/proto/types.proto
 	$(V_PROTOC)$(PROTOC) -I$(srcdir)/proto --cpp_out=$(builddir) \
 	$(srcdir)/proto/types.proto
+
+BUILT_SOURCES += \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
+	opentelemetry/proto/common/v1/common.pb.cc \
+	opentelemetry/proto/metrics/v1/metrics.pb.cc \
+	opentelemetry/proto/resource/v1/resource.pb.cc
+
+
+opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --grpc_out=$(builddir) \
+		--plugin="protoc-gen-grpc=$(GRPC_CPP_PLUGIN)" $<
+
+opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+
+opentelemetry/proto/common/v1/common.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
+	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+
+opentelemetry/proto/metrics/v1/metrics.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
+	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+
+opentelemetry/proto/resource/v1/resource.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
+	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2512,13 +2512,13 @@ opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc opentelemetr
 opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/common/v1/common.pb.cc opentelemetry/proto/common/v1/common.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
+opentelemetry/proto/common/v1/common.pb.cc opentelemetry/proto/common/v1/common.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/metrics/v1/metrics.pb.cc opentelemetry/proto/metrics/v1/metrics.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
+opentelemetry/proto/metrics/v1/metrics.pb.cc opentelemetry/proto/metrics/v1/metrics.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
-opentelemetry/proto/resource/v1/resource.pb.cc opentelemetry/proto/resource/v1/resource.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
+opentelemetry/proto/resource/v1/resource.pb.cc opentelemetry/proto/resource/v1/resource.pb.h: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
 	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2473,16 +2473,16 @@ if HAVE_GRPC_CPP
 BUILT_SOURCES += collectd.grpc.pb.cc types.grpc.pb.cc collectd.pb.cc types.pb.cc
 
 collectd.grpc.pb.cc types.grpc.pb.cc: $(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/proto \
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/proto \
 		--grpc_out=$(builddir) --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN) \
 	$(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
 
 collectd.pb.cc: $(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/proto --cpp_out=$(builddir) \
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/proto --cpp_out=$(builddir) \
 	$(srcdir)/proto/collectd.proto $(srcdir)/proto/types.proto
 
 types.pb.cc: $(srcdir)/proto/types.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/proto --cpp_out=$(builddir) \
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/proto --cpp_out=$(builddir) \
 	$(srcdir)/proto/types.proto
 
 BUILT_SOURCES += \
@@ -2492,22 +2492,21 @@ BUILT_SOURCES += \
 	opentelemetry/proto/metrics/v1/metrics.pb.cc \
 	opentelemetry/proto/resource/v1/resource.pb.cc
 
-
 opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --grpc_out=$(builddir) \
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --grpc_out=$(builddir) \
 		--plugin="protoc-gen-grpc=$(GRPC_CPP_PLUGIN)" $<
 
 opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
 opentelemetry/proto/common/v1/common.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
 opentelemetry/proto/metrics/v1/metrics.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
 opentelemetry/proto/resource/v1/resource.pb.cc: $(srcdir)/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
-	$(V_PROTOC)$(PROTOC) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
+	$(V_PROTOC)$(PROTOC) $(PROTOC_FLAGS) -I$(srcdir)/opentelemetry-proto --cpp_out=$(builddir) $<
 
 endif
 endif

--- a/build.sh
+++ b/build.sh
@@ -55,11 +55,6 @@ build()
     && $libtoolize --copy --force \
     && automake --add-missing --copy \
     && autoconf
-
-    for f in common/v1/common.proto metrics/v1/metrics.proto resource/v1/resource.proto collector/metrics/v1/metrics_service.proto; do
-      protoc -Iopentelemetry-proto --cpp_out src/ "opentelemetry-proto/opentelemetry/proto/${f}"
-    done
-    protoc -Iopentelemetry-proto --grpc_out src/ --plugin="protoc-gen-grpc=$(which grpc_cpp_plugin)" "opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto"
 }
 
 build_cygwin()

--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,10 @@ build()
     && $libtoolize --copy --force \
     && automake --add-missing --copy \
     && autoconf
+
+    for f in common/v1/common.proto metrics/v1/metrics.proto resource/v1/resource.proto; do
+      protoc -Iopentelemetry-proto --cpp_out src/ "opentelemetry-proto/opentelemetry/proto/${f}"
+    done
 }
 
 build_cygwin()

--- a/build.sh
+++ b/build.sh
@@ -56,9 +56,10 @@ build()
     && automake --add-missing --copy \
     && autoconf
 
-    for f in common/v1/common.proto metrics/v1/metrics.proto resource/v1/resource.proto; do
+    for f in common/v1/common.proto metrics/v1/metrics.proto resource/v1/resource.proto collector/metrics/v1/metrics_service.proto; do
       protoc -Iopentelemetry-proto --cpp_out src/ "opentelemetry-proto/opentelemetry/proto/${f}"
     done
+    protoc -Iopentelemetry-proto --grpc_out src/ --plugin="protoc-gen-grpc=$(which grpc_cpp_plugin)" "opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto"
 }
 
 build_cygwin()

--- a/configure.ac
+++ b/configure.ac
@@ -6860,6 +6860,7 @@ plugin_write_influxdb_udp="yes"
 plugin_write_kafka="$with_librdkafka"
 plugin_write_log="no"
 plugin_write_mongodb="$with_libmongoc"
+plugin_write_open_telemetry="yes"
 plugin_write_prometheus="no"
 plugin_write_redis="$with_libhiredis"
 plugin_write_riemann="$with_libriemann_client"
@@ -7116,15 +7117,19 @@ fi
 
 if test "x$GRPC_CPP_PLUGIN" = "x"; then
   plugin_grpc="no (grpc_cpp_plugin not found)"
+  plugin_write_open_telemetry="no (grpc_cpp_plugin not found)"
 fi
 if test "x$have_protoc3" != "xyes"; then
   plugin_grpc="no (protoc3 not found)"
+  plugin_write_open_telemetry="no (protoc3 not found)"
 fi
 if test "x$with_libprotobuf" != "xyes"; then
   plugin_grpc="no (libprotobuf not found)"
+  plugin_write_open_telemetry="no (libprotobuf not found)"
 fi
 if test "x$with_libgrpcpp" != "xyes"; then
   plugin_grpc="no (libgrpc++ not found)"
+  plugin_write_open_telemetry="no (libgrpc++ not found)"
 fi
 
 if test "x$have_getifaddrs" = "xyes"; then
@@ -7457,6 +7462,7 @@ AC_PLUGIN([write_influxdb_udp],  [$plugin_write_influxdb_udp],[Influxdb udp outp
 AC_PLUGIN([write_kafka],         [$plugin_write_kafka],       [Kafka output plugin])
 AC_PLUGIN([write_log],           [$plugin_write_log],         [Log output plugin])
 AC_PLUGIN([write_mongodb],       [$plugin_write_mongodb],     [MongoDB output plugin])
+AC_PLUGIN([write_open_telemetry],[$plugin_write_open_telemetry],[Write OpenTelemetry plugin])
 AC_PLUGIN([write_prometheus],    [$plugin_write_prometheus],  [Prometheus write plugin])
 AC_PLUGIN([write_redis],         [$plugin_write_redis],       [Redis output plugin])
 AC_PLUGIN([write_riemann],       [$plugin_write_riemann],     [Riemann output plugin])
@@ -7903,6 +7909,7 @@ AC_MSG_RESULT([    write_influxdb_udp. . $enable_write_influxdb_udp])
 AC_MSG_RESULT([    write_kafka . . . . . $enable_write_kafka])
 AC_MSG_RESULT([    write_log . . . . . . $enable_write_log])
 AC_MSG_RESULT([    write_mongodb . . . . $enable_write_mongodb])
+AC_MSG_RESULT([    write_open_telemetry  $enable_write_open_telemetry])
 AC_MSG_RESULT([    write_prometheus. . . $enable_write_prometheus])
 AC_MSG_RESULT([    write_redis . . . . . $enable_write_redis])
 AC_MSG_RESULT([    write_riemann . . . . $enable_write_riemann])

--- a/configure.ac
+++ b/configure.ac
@@ -4873,6 +4873,35 @@ if test "x$PROTOC" != "x"; then
 fi
 AM_CONDITIONAL([HAVE_PROTOC3], [test "x$have_protoc3" = "xyes"])
 
+protoc3_optional="no"
+if test "x$have_protoc3" = "xyes"; then
+  AC_MSG_CHECKING([whether protoc supports optional fields])
+  testfile=`mktemp`
+  cat <<EOF >"$testfile"
+syntax = "proto3";
+message Test {
+  optional bool support_optional = 1;
+}
+EOF
+  cpp_out=`mktemp -d`
+
+  protoc3_optional="no"
+  PROTOC_FLAGS=""
+  if $PROTOC -I`dirname $testfile` --cpp_out="$cpp_out" "$testfile"; then
+    protoc3_optional="yes"
+  elif $PROTOC -I`dirname $testfile` --cpp_out="$cpp_out" --experimental_allow_proto3_optional "$testfile"; then
+    protoc3_optional="yes (with --experimental_allow_proto3_optional)"
+    PROTOC_FLAGS="--experimental_allow_proto3_optional"
+  fi
+
+  # Clean up
+  rm "$testfile" "$cpp_out/`basename $testfile`.pb.cc" "$cpp_out/`basename $testfile`.pb.h"
+  rmdir "$cpp_out"
+
+  AC_MSG_RESULT([$protoc3_optional])
+  AC_SUBST(PROTOC_FLAGS)
+fi
+
 # --with-libprotobuf-c {{{
 AC_ARG_WITH([libprotobuf-c],
   [AS_HELP_STRING([--with-libprotobuf-c@<:@=PREFIX@:>@], [Path to libprotobuf-c.])],
@@ -7130,6 +7159,9 @@ fi
 if test "x$with_libgrpcpp" != "xyes"; then
   plugin_grpc="no (libgrpc++ not found)"
   plugin_write_open_telemetry="no (libgrpc++ not found)"
+fi
+if test "x$protoc3_optional" = "xno"; then
+  plugin_write_open_telemetry="no (protoc does not support optional fields)"
 fi
 
 if test "x$have_getifaddrs" = "xyes"; then

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -236,6 +236,7 @@
 #@BUILD_PLUGIN_WRITE_KAFKA_TRUE@LoadPlugin write_kafka
 #@BUILD_PLUGIN_WRITE_LOG_TRUE@LoadPlugin write_log
 #@BUILD_PLUGIN_WRITE_MONGODB_TRUE@LoadPlugin write_mongodb
+#@BUILD_PLUGIN_WRITE_OPEN_TELEMETRY_TRUE@LoadPlugin write_open_telemetry
 #@BUILD_PLUGIN_WRITE_PROMETHEUS_TRUE@LoadPlugin write_prometheus
 #@BUILD_PLUGIN_WRITE_REDIS_TRUE@LoadPlugin write_redis
 #@BUILD_PLUGIN_WRITE_RIEMANN_TRUE@LoadPlugin write_riemann

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -2067,6 +2067,13 @@
 #	</Node>
 #</Plugin>
 
+#<Plugin write_open_telemetry>
+#  <Node "example">
+#    Host "localhost"
+#    Port "4317"
+#  </Node>
+#</Plugin>
+
 #<Plugin write_prometheus>
 #	Port "9103"
 #</Plugin>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -11138,6 +11138,35 @@ want to use authentication all three fields must be set.
 
 =back
 
+=head2 Plugin C<write_open_telemetry>
+
+The I<write_open_telemetry plugin> will export metrics to an I<OpenTelemetry
+collector> using the gRPC based OTLP protocol.
+
+B<Synopsis:>
+
+ <Plugin "write_open_telemetry">
+   <Node "default">
+     Host "localhost"
+     Port "4317"
+   </Node>
+ </Plugin>
+
+The plugin can export metrics to multiple collectord by specifying multiple
+B<Node> blocks. Within the B<Node> blocks, the following options are available:
+
+=over 4
+
+=item B<Host> I<Address>
+
+Hostname or address to connect to. Defaults to C<localhost>.
+
+=item B<Port> I<Service>
+
+Service name or port number to connect to. Defaults to C<4317>.
+
+=back
+
 =head2 Plugin C<write_prometheus>
 
 The I<write_prometheus plugin> implements a tiny webserver that can be scraped

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -11152,7 +11152,7 @@ B<Synopsis:>
    </Node>
  </Plugin>
 
-The plugin can export metrics to multiple collectord by specifying multiple
+The plugin can export metrics to multiple collectors by specifying multiple
 B<Node> blocks. Within the B<Node> blocks, the following options are available:
 
 =over 4

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -563,11 +563,6 @@ metric_family_t *metric_family_clone_shallow(metric_family_t const *fam) {
 }
 
 metric_family_t *metric_family_clone(metric_family_t const *fam) {
-  if (fam == NULL) {
-    errno = EINVAL;
-    return NULL;
-  }
-
   metric_family_t *ret = metric_family_clone_shallow(fam);
   if (ret == NULL) {
     return NULL;

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -254,6 +254,28 @@ int label_set_clone(label_set_t *dest, label_set_t src) {
   return 0;
 }
 
+static int metric_clone_into(metric_t *dest, metric_t src) {
+  *dest = (metric_t){
+      .family = src.family,
+      .value = src.value,
+      .time = src.time,
+      .interval = src.interval,
+      .meta = meta_data_clone(src.meta),
+  };
+  if ((src.meta != NULL) && (dest->meta == NULL)) {
+    return ENOMEM;
+  }
+
+  int status = label_set_clone(&dest->label, src.label);
+  if (status != 0) {
+    label_set_reset(&dest->label);
+    meta_data_destroy(dest->meta);
+    return status;
+  }
+
+  return 0;
+}
+
 int metric_reset(metric_t *m) {
   if (m == NULL) {
     return EINVAL;
@@ -353,22 +375,34 @@ static int metric_list_add(metric_list_t *metrics, metric_t m) {
   }
   metrics->ptr = tmp;
 
-  metric_t copy = {
-      .family = m.family,
-      .value = m.value,
-      .time = m.time,
-      .interval = m.interval,
-      .meta = meta_data_clone(m.meta),
-  };
-  int status = label_set_clone(&copy.label, m.label);
-  if (((m.meta != NULL) && (copy.meta == NULL)) || (status != 0)) {
-    label_set_reset(&copy.label);
-    meta_data_destroy(copy.meta);
+  int status = metric_clone_into(&metrics->ptr[metrics->num], m);
+  if (status != 0) {
     return status;
   }
 
-  metrics->ptr[metrics->num] = copy;
   metrics->num++;
+  return 0;
+}
+
+static int metric_list_append_list(metric_list_t *dest, metric_list_t src) {
+  if (dest == NULL) {
+    return EINVAL;
+  }
+
+  metric_t *tmp =
+      realloc(dest->ptr, sizeof(*dest->ptr) * (dest->num + src.num));
+  if (tmp == NULL) {
+    return errno;
+  }
+  dest->ptr = tmp;
+
+  for (size_t i = 0; i < src.num; i++) {
+    int status = metric_clone_into(&dest->ptr[dest->num], src.ptr[i]);
+    if (status != 0) {
+      return status;
+    }
+    dest->num++;
+  }
 
   return 0;
 }
@@ -417,6 +451,20 @@ static int metric_list_clone(metric_list_t *dest, metric_list_t src,
   }
 
   *dest = ret;
+  return 0;
+}
+
+int metric_family_append_list(metric_family_t *fam, metric_list_t list) {
+  size_t offset = fam->metric.num;
+  int status = metric_list_append_list(&fam->metric, list);
+  if (status != 0) {
+    return status;
+  }
+
+  for (size_t i = offset; i < fam->metric.num; i++) {
+    fam->metric.ptr[i].family = fam;
+  }
+
   return 0;
 }
 
@@ -484,7 +532,7 @@ void metric_family_free(metric_family_t *fam) {
   free(fam);
 }
 
-metric_family_t *metric_family_clone(metric_family_t const *fam) {
+metric_family_t *metric_family_clone_shallow(metric_family_t const *fam) {
   if (fam == NULL) {
     errno = EINVAL;
     return NULL;
@@ -511,7 +559,21 @@ metric_family_t *metric_family_clone(metric_family_t const *fam) {
     return NULL;
   }
 
-  status = metric_list_clone(&ret->metric, fam->metric, ret);
+  return ret;
+}
+
+metric_family_t *metric_family_clone(metric_family_t const *fam) {
+  if (fam == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  metric_family_t *ret = metric_family_clone_shallow(fam);
+  if (ret == NULL) {
+    return NULL;
+  }
+
+  int status = metric_list_clone(&ret->metric, fam->metric, ret);
   if (status != 0) {
     metric_family_free(ret);
     errno = status;

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -176,6 +176,9 @@ struct metric_family_s {
   metric_list_t metric;
 };
 
+/* metric_family_append_list appends a metric_list_t to the metric family. */
+int metric_family_append_list(metric_family_t *fam, metric_list_t list);
+
 /* metric_family_metric_append appends a new metric to the metric family. This
  * allocates memory which must be freed using metric_family_metric_reset. */
 int metric_family_metric_append(metric_family_t *fam, metric_t m);
@@ -215,6 +218,11 @@ void metric_family_free(metric_family_t *fam);
  * errno is set and NULL is returned. The returned pointer must be freed with
  * metric_family_free(). */
 metric_family_t *metric_family_clone(metric_family_t const *fam);
+
+/* metric_family_clone_shallow returns a copy of the provided metric family
+ * without any metrics. On error, errno is set and NULL is returned. The
+ * returned pointer must be freed with metric_family_free(). */
+metric_family_t *metric_family_clone_shallow(metric_family_t const *fam);
 
 /* metric_family_compare compares two metric families, taking into account the
  * metric family name and any resource attributes. It returns an integer

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -132,6 +132,7 @@ static void add_metric(ScopeMetrics *sm, metric_family_t const *fam) {
     return;
   case METRIC_TYPE_UNTYPED:
     // never reached, only here to make the compiler happy
+    return;
   }
 }
 

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -94,8 +94,11 @@ static void set_sum(Metric *m, metric_family_t const *fam) {
 static void set_gauge(Metric *m, metric_family_t const *fam) {
   Gauge *g = m->mutable_gauge();
   for (size_t i = 0; i < fam->metric.num; i++) {
+    metric_t const *m = fam->metric.ptr + i;
+    assert(m->family == fam);
+
     NumberDataPoint *dp = g->add_data_points();
-    metric_to_number_data_point(dp, fam->metric.ptr + i);
+    metric_to_number_data_point(dp, m);
   }
 }
 

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -84,7 +84,7 @@ static void set_sum(Metric *m, metric_family_t const *fam) {
     assert(m->family == fam);
 
     NumberDataPoint *dp = s->add_data_points();
-    metric_to_number_data_point(dp, fam->metric.ptr + i);
+    metric_to_number_data_point(dp, m);
   }
 
   s->set_aggregation_temporality(AGGREGATION_TEMPORALITY_CUMULATIVE);

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -1,5 +1,5 @@
 /**
- * collectd - src/utils_format_open_telemetry.c
+ * collectd - src/utils/format_open_telemetry/format_open_telemetry.cc
  * Copyright (C) 2023       Florian octo Forster
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -47,6 +47,7 @@ using opentelemetry::proto::metrics::v1::NumberDataPoint;
 using opentelemetry::proto::metrics::v1::ResourceMetrics;
 using opentelemetry::proto::metrics::v1::ScopeMetrics;
 using opentelemetry::proto::metrics::v1::Sum;
+using opentelemetry::proto::resource::v1::Resource;
 
 static void metric_to_number_data_point(NumberDataPoint *dp,
                                         metric_t const *m) {
@@ -134,7 +135,7 @@ static void add_scope_metrics(ResourceMetrics *rm, metric_family_t const *fam) {
 
 static void init_resource_metrics(ResourceMetrics *rm,
                                   metric_family_t const *fam) {
-  Resource *res = rm->resource();
+  Resource *res = rm->mutable_resource();
   for (size_t i = 0; i < fam->resource.num; i++) {
     label_pair_t *l = fam->resource.ptr + i;
 

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -106,6 +106,9 @@ static void add_metric(ScopeMetrics *sm, metric_family_t const *fam) {
   if (fam->help != NULL) {
     m->set_description(fam->help);
   }
+  if (fam->unit != NULL) {
+    m->set_unit(fam->unit);
+  }
 
   switch (fam->type) {
   case METRIC_TYPE_COUNTER:

--- a/src/utils/format_open_telemetry/format_open_telemetry.cc
+++ b/src/utils/format_open_telemetry/format_open_telemetry.cc
@@ -1,0 +1,142 @@
+/**
+ * collectd - src/utils_format_open_telemetry.c
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+extern "C" {
+#include "collectd.h"
+#include "metric.h"
+
+#include "utils/format_open_telemetry/format_open_telemetry.h"
+}
+
+#include "opentelemetry/proto/common/v1/common.pb.h"
+#include "opentelemetry/proto/metrics/v1/metrics.pb.h"
+#include "opentelemetry/proto/resource/v1/resource.pb.h"
+
+using opentelemetry::proto::common::v1::AnyValue;
+using opentelemetry::proto::common::v1::InstrumentationScope;
+using opentelemetry::proto::common::v1::KeyValue;
+using opentelemetry::proto::metrics::v1::AGGREGATION_TEMPORALITY_CUMULATIVE;
+using opentelemetry::proto::metrics::v1::Gauge;
+using opentelemetry::proto::metrics::v1::Metric;
+using opentelemetry::proto::metrics::v1::NumberDataPoint;
+using opentelemetry::proto::metrics::v1::ResourceMetrics;
+using opentelemetry::proto::metrics::v1::ScopeMetrics;
+using opentelemetry::proto::metrics::v1::Sum;
+
+static void metric_to_number_data_point(NumberDataPoint *dp, metric_t const *m) {
+  for (size_t i = 0; i < m->label.num; i++) {
+    label_pair_t *l = m->label.ptr + i;
+
+    KeyValue *kv = dp->add_attributes();
+    kv->set_key(l->name);
+    AnyValue *v = kv->mutable_value();
+    v->set_string_value(l->value);
+  }
+
+  dp->set_time_unix_nano(CDTIME_T_TO_NS(m->time));
+  // TODO(): also set "start time". We may need to use the cache to determine
+  // when we've seen a metric for the first time.
+
+  switch (m->family->type) {
+    case METRIC_TYPE_COUNTER:
+      dp->set_as_int(m->value.derive);
+    case METRIC_TYPE_GAUGE:
+      dp->set_as_double(m->value.gauge);
+    case METRIC_TYPE_UNTYPED:
+      // TODO
+      assert(0);
+  }
+}
+
+static void set_sum(Metric *m, metric_family_t const *fam) {
+  Sum *s = m->mutable_sum();
+  for (size_t i = 0; i < fam->metric.num; i++) {
+    NumberDataPoint *dp = s->add_data_points();
+    metric_to_number_data_point(dp, fam->metric.ptr + i);
+  }
+
+  s->set_aggregation_temporality(AGGREGATION_TEMPORALITY_CUMULATIVE);
+  s->set_is_monotonic(true);
+}
+
+static void set_gauge(Metric *m, metric_family_t const *fam) {
+  Gauge *g = m->mutable_gauge();
+  for (size_t i = 0; i < fam->metric.num; i++) {
+    NumberDataPoint *dp = g->add_data_points();
+    metric_to_number_data_point(dp, fam->metric.ptr + i);
+  }
+}
+
+static void add_metric(ScopeMetrics *sm, metric_family_t const *fam) {
+  Metric *m = sm->add_metrics();
+
+  m->set_name(fam->name);
+  if (fam->help != NULL) {
+    m->set_description(fam->help);
+  }
+
+  switch (fam->type) {
+    case METRIC_TYPE_COUNTER:
+      set_sum(m, fam);
+      return;
+    case METRIC_TYPE_GAUGE:
+      set_gauge(m, fam);
+      return;
+    case METRIC_TYPE_UNTYPED:
+      // TODO
+      assert(0);
+  }
+}
+
+static void set_instrumentation_scope(ScopeMetrics *sm) {
+  InstrumentationScope *is = sm->mutable_scope();
+  is->set_name(PACKAGE_NAME);
+  is->set_version(PACKAGE_VERSION);
+}
+
+static void set_scope_metrics(ResourceMetrics *rm, metric_family_t const *fam) {
+  ScopeMetrics *sm = rm->add_scope_metrics();
+
+  set_instrumentation_scope(sm);
+
+  add_metric(sm, fam);
+}
+
+int format_open_telemetry(strbuf_t *sb, metric_family_t const *fam) {
+  ResourceMetrics rm;
+
+  set_scope_metrics(&rm, fam);
+
+  std::string serialization;
+  bool ok = rm.SerializeToString(&serialization);
+  if (!ok) {
+    return -1;
+  }
+
+  strbuf_print(sb, serialization.c_str());
+  return 0;
+}
+

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -1,0 +1,35 @@
+/**
+ * collectd - src/utils_format_open_telemetry.h
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#ifndef UTILS_FORMAT_OPEN_TELEMETRY_H
+#define UTILS_FORMAT_OPEN_TELEMETRY_H 1
+
+#include "collectd.h"
+#include "metric.h"
+
+int format_open_telemetry(strbuf_t *sb, metric_family_t const *fam); // TODO: lacks return value
+
+#endif /* UTILS_FORMAT_OPEN_TELEMETRY_H */

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -1,5 +1,5 @@
 /**
- * collectd - src/utils_format_open_telemetry.h
+ * collectd - src/utils/format_open_telemetry/format_open_telemetry.h
  * Copyright (C) 2023       Florian octo Forster
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -32,7 +32,8 @@ extern "C" {
 #endif
 
 #include "collectd.h"
-#include "metric.h"
+#include "daemon/metric.h"
+#include "utils/resource_metrics/resource_metrics.h"
 
 #ifdef __cplusplus
 }
@@ -42,7 +43,7 @@ extern "C" {
 
 opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest *
 format_open_telemetry_export_metrics_service_request(
-    metric_family_t const **fam, size_t fam_num);
+    resource_metrics_set_t set);
 #endif
 
 #endif /* UTILS_FORMAT_OPEN_TELEMETRY_H */

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -27,9 +27,29 @@
 #ifndef UTILS_FORMAT_OPEN_TELEMETRY_H
 #define UTILS_FORMAT_OPEN_TELEMETRY_H 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "collectd.h"
 #include "metric.h"
 
-int format_open_telemetry(strbuf_t *sb, metric_family_t const *fam); // TODO: lacks return value
+int format_open_telemetry_resource_metrics_serialized(
+    strbuf_t *sb, metric_family_t const **fam, size_t fam_num);
+
+#ifdef __cplusplus
+}
+
+#include "opentelemetry/proto/metrics/v1/metrics.pb.h"
+#include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
+
+opentelemetry::proto::metrics::v1::ResourceMetrics *
+format_open_telemetry_resource_metrics_serialized(metric_family_t const **fam,
+                                                  size_t fam_num);
+
+opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest *
+format_open_telemetry_export_metrics_service_request(
+    metric_family_t const **fam, size_t fam_num);
+#endif
 
 #endif /* UTILS_FORMAT_OPEN_TELEMETRY_H */

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -34,18 +34,11 @@ extern "C" {
 #include "collectd.h"
 #include "metric.h"
 
-int format_open_telemetry_resource_metrics_serialized(
-    strbuf_t *sb, metric_family_t const **fam, size_t fam_num);
-
 #ifdef __cplusplus
 }
 
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
-
-opentelemetry::proto::metrics::v1::ResourceMetrics *
-format_open_telemetry_resource_metrics_serialized(metric_family_t const **fam,
-                                                  size_t fam_num);
 
 opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest *
 format_open_telemetry_export_metrics_service_request(

--- a/src/utils/format_open_telemetry/format_open_telemetry.h
+++ b/src/utils/format_open_telemetry/format_open_telemetry.h
@@ -37,8 +37,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 
-#include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
+#include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 
 opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest *
 format_open_telemetry_export_metrics_service_request(

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -234,6 +234,11 @@ static int ot_config_node(oconfig_item_t *ci) {
       .free_func = ot_callback_decref,
   };
 
+  /* Call ot_flush periodically. */
+  plugin_ctx_t ctx = plugin_get_ctx();
+  ctx.flush_interval = plugin_get_interval();
+  plugin_set_ctx(ctx);
+
   cb->reference_count++;
   plugin_register_write(callback_name.ptr, ot_write, &user_data);
 

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -35,6 +35,7 @@
  * </Plugin>
  */
 
+extern "C" {
 #include "collectd.h"
 
 #include "plugin.h"
@@ -46,6 +47,7 @@
 #include "utils_complain.h"
 
 #include <netdb.h>
+}
 
 #ifndef OT_DEFAULT_HOST
 #define OT_DEFAULT_HOST "localhost"

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -1,0 +1,380 @@
+/**
+ * collectd - src/write_open_telemetry.c
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+/* write_open_telemetry plugin configuration example
+ *
+ * <Plugin write_open_telemetry>
+ *   <Node "name">
+ *     Host "localhost"
+ *     Port "8080"
+ *     Path "/v1/metrics"
+ *   </Node>
+ * </Plugin>
+ */
+
+#include "collectd.h"
+
+#include "plugin.h"
+#include "utils/common/common.h"
+
+#include "utils/avltree/avltree.h"
+#include "utils/format_open_telemetry/format_open_telemetry.h"
+#include "utils/strbuf/strbuf.h"
+#include "utils_complain.h"
+
+#include <netdb.h>
+
+#ifndef OT_DEFAULT_HOST
+#define OT_DEFAULT_HOST "localhost"
+#endif
+
+#ifndef OT_DEFAULT_PORT
+#define OT_DEFAULT_PORT "8080"
+#endif
+
+#ifndef OT_DEFAULT_PATH
+#define OT_DEFAULT_PATH "/v1/metrics"
+#endif
+
+#ifndef OT_DEFAULT_LOG_SEND_ERRORS
+#define OT_DEFAULT_LOG_SEND_ERRORS true
+#endif
+
+#ifndef OT_DEFAULT_ESCAPE
+#define OT_DEFAULT_ESCAPE '_'
+#endif
+
+/* Ethernet - (IPv6 + TCP) = 1500 - (40 + 32) = 1428 */
+#ifndef OT_SEND_BUF_SIZE
+#define OT_SEND_BUF_SIZE 1428
+#endif
+
+#ifndef OT_MIN_RECONNECT_INTERVAL
+#define OT_MIN_RECONNECT_INTERVAL TIME_T_TO_CDTIME_T(1)
+#endif
+
+/*
+ * Private variables
+ */
+typedef struct {
+  char *name;
+  int reference_count;
+
+  char *host;
+  char *port;
+  char *path;
+
+  c_avl_tree_t *cached_metrics;         // char* metric_identity() -> NULL
+  c_avl_tree_t *cached_metric_families; // char* fam->name -> metric_family_t*
+
+  pthread_mutex_t mu;
+} ot_callback_t;
+
+static int ot_send_buffer(ot_callback_t *cb) {
+  size_t families_num = (size_t)c_avl_size(cb->cached_metric_families);
+  metric_family_t *families[families_num];
+
+  memset(families, 0, sizeof(families));
+
+  c_avl_iterator_t *iter = c_avl_get_iterator(cb->cached_metric_families);
+  for (size_t i = 0; i < families_num; i++) {
+    metric_family_t *fam = NULL;
+    int status = c_avl_iterator_next(iter, /* key = */ NULL, (void **)&fam);
+    if (status != 0) {
+      ERROR("write_open_telemetry plugin: found %zu metric families, want %zu",
+            i, families_num);
+      return -1;
+    }
+
+    families[i] = fam;
+  }
+
+  DEBUG("write_open_telemetry plugin: TODO(octo): send %zu metric families",
+        families_num);
+  return 0;
+}
+
+static void ot_reset_buffer(ot_callback_t *cb) {
+  void *dummy = NULL;
+  metric_family_t *fam = NULL;
+  while (c_avl_pick(cb->cached_metric_families, &dummy, (void **)&fam) == 0) {
+    metric_family_free(fam);
+  }
+
+  char *id = NULL;
+  while (c_avl_pick(cb->cached_metrics, (void **)&id, NULL) == 0) {
+    sfree(id);
+  }
+}
+
+/* NOTE: You must hold cb->send_lock when calling this function! */
+static int ot_flush_nolock(cdtime_t timeout, ot_callback_t *cb) {
+  DEBUG("write_open_telemetry plugin: ot_flush_nolock: timeout = %.3f; "
+        "send_buf_fill = %" PRIsz ";",
+        (double)timeout, cb->send_buf_fill);
+
+#if 0
+  /* timeout == 0  => flush unconditionally */
+  if (timeout > 0) {
+    cdtime_t now;
+
+    now = cdtime();
+    if ((cb->send_buf_init_time + timeout) > now)
+      return 0;
+  }
+
+  if (cb->send_buf_fill == 0) {
+    cb->send_buf_init_time = cdtime();
+    return 0;
+  }
+#endif
+
+  int status = ot_send_buffer(cb);
+  ot_reset_buffer(cb);
+
+  return status;
+}
+
+static void ot_callback_decref(void *data) {
+  ot_callback_t *cb = (ot_callback_t *)data;
+  if (cb == NULL)
+    return;
+
+  pthread_mutex_lock(&cb->mu);
+  cb->reference_count--;
+  if (cb->reference_count > 0) {
+    pthread_mutex_unlock(&cb->mu);
+    return;
+  }
+
+  ot_flush_nolock(/* timeout = */ 0, cb);
+
+  c_avl_destroy(cb->cached_metrics);
+  c_avl_destroy(cb->cached_metric_families);
+
+  sfree(cb->host);
+  sfree(cb->port);
+  sfree(cb->path);
+
+  pthread_mutex_unlock(&cb->mu);
+  pthread_mutex_destroy(&cb->mu);
+
+  sfree(cb);
+}
+
+static int ot_flush(cdtime_t timeout,
+                    const char *identifier __attribute__((unused)),
+                    user_data_t *user_data) {
+  if (user_data == NULL)
+    return -EINVAL;
+
+  ot_callback_t *cb = (ot_callback_t *)user_data->data;
+
+  pthread_mutex_lock(&cb->mu);
+  int status = ot_flush_nolock(timeout, cb);
+  pthread_mutex_unlock(&cb->mu);
+
+  return status;
+}
+
+static bool ot_metric_is_cached(ot_callback_t *cb, metric_t const *m) {
+  strbuf_t id = STRBUF_CREATE;
+  metric_identity(&id, m);
+
+  int status = c_avl_get(cb->cached_metrics, id.ptr, NULL);
+  STRBUF_DESTROY(id);
+  return status == 0;
+}
+
+static bool ot_need_flush(ot_callback_t *cb, metric_family_t const *fam) {
+  int status = c_avl_get(cb->cached_metric_families, fam->name, NULL);
+  if (status != 0) {
+    return false;
+  }
+
+  /* if any of the metrics are already cached, we should flush before adding
+   * this metric family. */
+  for (size_t i = 0; i < fam->metric.num; i++) {
+    bool ok = ot_metric_is_cached(cb, fam->metric.ptr + i);
+    if (ok) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static int ot_mark_metric_cached(ot_callback_t *cb, metric_t const *m) {
+  strbuf_t buf = STRBUF_CREATE;
+  int status = metric_identity(&buf, m);
+  if (status != 0) {
+    ERROR("write_open_telemetry plugin: metric_identity failed: %d", status);
+    STRBUF_DESTROY(buf);
+    return status;
+  }
+
+  char *id = strdup(buf.ptr);
+  if (id == NULL) {
+    STRBUF_DESTROY(buf);
+    return errno;
+  }
+
+  status = c_avl_insert(cb->cached_metrics, id, /* value = */ NULL);
+  if (status != 0) {
+    ERROR("write_open_telemetry plugin: c_avl_insert(\"%s\") failed: %d",
+          buf.ptr, status);
+    STRBUF_DESTROY(buf);
+    return status;
+  }
+
+  STRBUF_DESTROY(buf);
+  return 0;
+}
+
+static metric_family_t *ot_cached_metric_family(ot_callback_t *cb,
+                                                metric_family_t const *fam) {
+  metric_family_t *ret = NULL;
+  int status = c_avl_get(cb->cached_metric_families, fam->name, (void **)&ret);
+  if (status == 0) {
+    return ret;
+  }
+
+  ret = metric_family_clone_shallow(fam);
+  c_avl_insert(cb->cached_metric_families, ret->name, ret);
+  return ret;
+}
+
+static int ot_write(metric_family_t const *fam, user_data_t *user_data) {
+  if ((fam == NULL) || (user_data == NULL)) {
+    return EINVAL;
+  }
+
+  ot_callback_t *cb = (ot_callback_t *)user_data->data;
+  pthread_mutex_lock(&cb->mu);
+
+  if (ot_need_flush(cb, fam)) {
+    cdtime_t timeout = 0;
+    ot_flush_nolock(timeout, cb);
+  }
+
+  metric_family_t *cache = ot_cached_metric_family(cb, fam);
+  size_t offset = cache->metric.num;
+
+  int status = metric_family_append_list(cache, fam->metric);
+  if (status != 0) {
+    ERROR("write_open_telemetry plugin: metric_list_append_list failed: %d",
+          status);
+    return status;
+  }
+
+  for (size_t i = offset; i < cache->metric.num; i++) {
+    ot_mark_metric_cached(cb, &cache->metric.ptr[i]);
+  }
+
+  return 0;
+}
+
+static int ot_config_node(oconfig_item_t *ci) {
+  ot_callback_t *cb = (ot_callback_t *)calloc(1, sizeof(*cb));
+  if (cb == NULL) {
+    ERROR("write_open_telemetry plugin: calloc failed.");
+    return -1;
+  }
+
+  cb->reference_count = 1;
+  cf_util_get_string(ci, &cb->name);
+  cb->host = strdup(OT_DEFAULT_HOST);
+  cb->port = strdup(OT_DEFAULT_PORT);
+  cb->path = strdup(OT_DEFAULT_PATH);
+
+  cb->cached_metrics =
+      c_avl_create((int (*)(const void *, const void *))strcmp);
+  cb->cached_metric_families =
+      c_avl_create((int (*)(const void *, const void *))strcmp);
+
+  pthread_mutex_init(&cb->mu, /* attr = */ NULL);
+
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    int status = 0;
+    if (strcasecmp("Host", child->key) == 0)
+      status = cf_util_get_string(child, &cb->host);
+    else if (strcasecmp("Port", child->key) == 0)
+      status = cf_util_get_service(child, &cb->port);
+    else if (strcasecmp("Protocol", child->key) == 0)
+      status = cf_util_get_string(child, &cb->path);
+    else {
+      ERROR("write_open_telemetry plugin: Invalid configuration "
+            "option: %s.",
+            child->key);
+      status = -1;
+    }
+
+    if (status != 0) {
+      ot_callback_decref(cb);
+      return status;
+    }
+  }
+
+  char callback_name[DATA_MAX_NAME_LEN];
+  ssnprintf(callback_name, sizeof(callback_name), "write_open_telemetry/%s",
+            cb->name);
+
+  user_data_t user_data = {
+      .data = cb,
+      .free_func = ot_callback_decref,
+  };
+
+  cb->reference_count++;
+  plugin_register_write(callback_name, ot_write, &user_data);
+
+  cb->reference_count++;
+  plugin_register_flush(callback_name, ot_flush, &user_data);
+
+  ot_callback_decref(cb);
+  return 0;
+}
+
+static int ot_config(oconfig_item_t *ci) {
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("Node", child->key) == 0)
+      ot_config_node(child);
+    else {
+      ERROR("write_open_telemetry plugin: Invalid configuration "
+            "option: %s.",
+            child->key);
+    }
+  }
+
+  return 0;
+}
+
+void module_register(void) {
+  plugin_register_complex_config("write_open_telemetry", ot_config);
+}

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -156,6 +156,7 @@ static void ot_callback_decref(void *data) {
 
   cb->stub.reset();
 
+  sfree(cb->name);
   sfree(cb->host);
   sfree(cb->port);
 

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -1,5 +1,5 @@
 /**
- * collectd - src/write_open_telemetry.c
+ * collectd - src/write_open_telemetry.cc
  * Copyright (C) 2023       Florian octo Forster
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -234,7 +234,7 @@ static bool ot_metric_is_staged(ot_callback_t *cb, metric_t const *m) {
 }
 
 static bool ot_need_flush(ot_callback_t *cb, metric_family_t const *fam) {
-  int status = c_avl_get(cb->staged_metric_families, fam->name, NULL);
+  int status = c_avl_get(cb->staged_metric_families, fam, NULL);
   if (status != 0) {
     return false;
   }
@@ -288,7 +288,7 @@ static int ot_mark_metric_staged(ot_callback_t *cb, metric_t const *m) {
 static metric_family_t *ot_staged_metric_family(ot_callback_t *cb,
                                                 metric_family_t const *fam) {
   metric_family_t *ret = NULL;
-  int status = c_avl_get(cb->staged_metric_families, fam->name, (void **)&ret);
+  int status = c_avl_get(cb->staged_metric_families, fam, (void **)&ret);
   if (status == 0) {
     DEBUG("write_open_telemetry plugin: Found staged metric family \"%s\"",
           ret->name);
@@ -296,7 +296,7 @@ static metric_family_t *ot_staged_metric_family(ot_callback_t *cb,
   }
 
   ret = metric_family_clone_shallow(fam);
-  c_avl_insert(cb->staged_metric_families, ret->name, ret);
+  c_avl_insert(cb->staged_metric_families, ret, ret);
   DEBUG("write_open_telemetry plugin: Successfully staged metric family \"%s\"",
         ret->name);
   return ret;
@@ -349,7 +349,7 @@ static int ot_config_node(oconfig_item_t *ci) {
   cb->staged_metrics =
       c_avl_create((int (*)(const void *, const void *))strcmp);
   cb->staged_metric_families =
-      c_avl_create((int (*)(const void *, const void *))strcmp);
+      c_avl_create((int (*)(const void *, const void *))metric_family_compare);
 
   pthread_mutex_init(&cb->mu, /* attr = */ NULL);
 

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -61,10 +61,6 @@ extern "C" {
 #define OT_DEFAULT_PORT "4317"
 #endif
 
-#ifndef OT_DEFAULT_PATH
-#define OT_DEFAULT_PATH "/v1/metrics"
-#endif
-
 using opentelemetry::proto::collector::metrics::v1::
     ExportMetricsServiceResponse;
 using opentelemetry::proto::collector::metrics::v1::MetricsService;
@@ -78,7 +74,6 @@ typedef struct {
 
   char *host;
   char *port;
-  char *path;
 
   cdtime_t staged_time;
   c_avl_tree_t *staged_metrics;         // char* metric_identity() -> NULL
@@ -207,7 +202,6 @@ static void ot_callback_decref(void *data) {
 
   sfree(cb->host);
   sfree(cb->port);
-  sfree(cb->path);
 
   pthread_mutex_unlock(&cb->mu);
   pthread_mutex_destroy(&cb->mu);
@@ -351,7 +345,6 @@ static int ot_config_node(oconfig_item_t *ci) {
   cf_util_get_string(ci, &cb->name);
   cb->host = strdup(OT_DEFAULT_HOST);
   cb->port = strdup(OT_DEFAULT_PORT);
-  cb->path = strdup(OT_DEFAULT_PATH);
 
   cb->staged_metrics =
       c_avl_create((int (*)(const void *, const void *))strcmp);
@@ -368,8 +361,6 @@ static int ot_config_node(oconfig_item_t *ci) {
       status = cf_util_get_string(child, &cb->host);
     else if (strcasecmp("Port", child->key) == 0)
       status = cf_util_get_service(child, &cb->port);
-    else if (strcasecmp("Protocol", child->key) == 0)
-      status = cf_util_get_string(child, &cb->path);
     else {
       ERROR("write_open_telemetry plugin: Invalid configuration "
             "option: %s.",

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -130,7 +130,7 @@ static int ot_flush_nolock(cdtime_t timeout, ot_callback_t *cb) {
   /* timeout == 0  => flush unconditionally */
   if (timeout > 0) {
     cdtime_t now = cdtime();
-    if ((cb->staged_time + timeout) > now)
+    if (now < (cb->staged_time + timeout))
       return 0;
   }
 

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -95,7 +95,8 @@ static int export_metrics(ot_callback_t *cb) {
     STRBUF_DESTROY(buf);
   }
 
-  auto req = format_open_telemetry_export_metrics_service_request(cb->resource_metrics);
+  auto req = format_open_telemetry_export_metrics_service_request(
+      cb->resource_metrics);
 
   grpc::ClientContext context;
   ExportMetricsServiceResponse resp;

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -188,7 +188,10 @@ static int ot_write(metric_family_t const *fam, user_data_t *user_data) {
   int status = resource_metrics_add(&cb->resource_metrics, fam);
   pthread_mutex_unlock(&cb->mu);
 
-  return status;
+  if (status < 0) {
+    return status;
+  }
+  return 0;
 }
 
 static int ot_config_node(oconfig_item_t *ci) {

--- a/src/write_open_telemetry.cc
+++ b/src/write_open_telemetry.cc
@@ -163,7 +163,7 @@ static int ot_flush_nolock(cdtime_t timeout, ot_callback_t *cb) {
         "send_buf_fill = %d;",
         CDTIME_T_TO_DOUBLE(timeout), staged_num);
 
-  if (c_avl_size(cb->staged_metrics) == 0) {
+  if (staged_num == 0) {
     cb->staged_time = cdtime();
     return 0;
   }


### PR DESCRIPTION
This adds a new plugin that exports metrics to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) using the *OpenTelemetry Protocol* (OTLP) over gRPC.

This is intended as an MVP and comes with many limitations, e.g.:

* Communication is synchronous and blocks the write thread
* TLS is not yet supported
* ~The [Resource field](https://opentelemetry.io/docs/concepts/resources/) is unset (→ see #4187)~

ChangeLog: Write OpenTelemetry: A new plugin for exporting metrics using the OpenTelemetry Protocol over gRPC has been added.