### PR TITLE
Update standard system metric names in accordance with OpenTelemetry.

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -442,7 +442,7 @@ static void aggregate(gauge_t *sum_by_state) /* {{{ */
 static void cpu_commit_one(int cpu_num, /* {{{ */
                            gauge_t rates[static COLLECTD_CPU_STATE_MAX]) {
   metric_family_t fam = {
-      .name = "cpu_usage_percent",
+      .name = "system.cpu.utilization",
       .type = METRIC_TYPE_GAUGE,
   };
 
@@ -450,8 +450,8 @@ static void cpu_commit_one(int cpu_num, /* {{{ */
   if (cpu_num == -1) {
     metric_label_set(&m, "cpu", "total");
   } else {
-    char cpu_num_str[16];
-    snprintf(cpu_num_str, sizeof(cpu_num_str), "%d", cpu_num);
+    char cpu_num_str[32];
+    ssnprintf(cpu_num_str, sizeof(cpu_num_str), "%d", cpu_num);
     metric_label_set(&m, "cpu", cpu_num_str);
   }
 
@@ -515,7 +515,7 @@ static void cpu_reset(void) /* {{{ */
 static void cpu_commit_without_aggregation(void) /* {{{ */
 {
   metric_family_t fam = {
-      .name = "cpu_usage_total",
+      .name = "system.cpu.time",
       .type = METRIC_TYPE_COUNTER,
   };
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -167,7 +167,7 @@ static int memory_config(oconfig_item_t *ci) /* {{{ */
 
 static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
   metric_family_t fam_absolute = {
-      .name = "memory_usage",
+      .name = "system.memory.usage",
       .type = METRIC_TYPE_GAUGE,
   };
   gauge_t total = 0;
@@ -180,7 +180,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
     total += values[i];
 
     if (values_absolute) {
-      metric_family_append(&fam_absolute, "type", memory_type_names[i],
+      metric_family_append(&fam_absolute, "state", memory_type_names[i],
                            (value_t){.gauge = values[i]}, NULL);
     }
   }
@@ -205,7 +205,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
   }
 
   metric_family_t fam_percent = {
-      .name = "memory_usage_percent",
+      .name = "system.memory.utilization",
       .type = METRIC_TYPE_GAUGE,
   };
   for (size_t i = 0; i < COLLECTD_MEMORY_TYPE_MAX; i++) {
@@ -213,7 +213,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
       continue;
     }
 
-    metric_family_append(&fam_percent, "type", memory_type_names[i],
+    metric_family_append(&fam_percent, "state", memory_type_names[i],
                          (value_t){.gauge = 100.0 * values[i] / total}, NULL);
   }
 


### PR DESCRIPTION
[OpenTelemetry Enhancement Proposal \#119](https://github.com/open-telemetry/oteps/blob/main/text/0119-standard-system-metrics.md) outlines names for a few commonly tracked system metrics, such as CPU, disk, and memory usage. This change intends to change the emitted metrics of the appropriate plugins to match this naming schema.

This includes merging metric families in the disk and df plugins, which have previously used separate metric families for the read and write "direction".

ChangeLog: CPU, DF, Disk, and Memory plugins: Metric names have been updates to conform to OTEP 119.