### PR TITLE
[collectd 6] RFC: Add resource attributes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -243,6 +243,8 @@ collectd_SOURCES = \
 	src/daemon/globals.h \
 	src/daemon/plugin.c \
 	src/daemon/plugin.h \
+	src/daemon/resource.c \
+	src/daemon/resource.h \
 	src/daemon/types_list.c \
 	src/daemon/types_list.h \
 	src/daemon/utils_cache.c \

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -214,6 +214,10 @@ void label_set_reset(label_set_t *labels) {
 }
 
 int label_set_clone(label_set_t *dest, label_set_t src) {
+  if (dest == NULL || dest->num != 0) {
+    return EINVAL;
+  }
+
   if (src.num == 0) {
     return 0;
   }

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -285,10 +285,11 @@ int metric_identity(strbuf_t *buf, metric_t const *m) {
   status = status || strbuf_print(buf, "{");
 
   bool first_label = true;
-  status = status || format_label_set(buf, &m->resource, RESOURCE_LABEL_PREFIX,
-                                      first_label);
-
-  first_label = (m->resource.num == 0);
+  if (m->resource.num == 0) {
+    status = status || format_label_set(buf, &m->resource,
+                                        RESOURCE_LABEL_PREFIX, first_label);
+    first_label = false;
+  }
   status = status || format_label_set(buf, &m->label, "", first_label);
 
   return status || strbuf_print(buf, "}");

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -70,7 +70,7 @@ typedef struct {
   size_t num;
 } label_set_t;
 
-/* label_set_clone copies all the laels in src into dest. If dest contains
+/* label_set_clone copies all the labels in src into dest. If dest contains
  * any labels prior to calling label_set_clone, the associated memory is
  * leaked. */
 int label_set_clone(label_set_t *dest, label_set_t src);

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -96,7 +96,6 @@ typedef struct {
   metric_family_t *family; /* backreference for family->name and family->type */
 
   label_set_t label;
-  label_set_t resource;
 
   value_t value;
   cdtime_t time; /* TODO(octo): use ms or µs instead? */
@@ -121,12 +120,6 @@ metric_t *metric_parse_identity(char const *s);
  * If "value" is NULL or the empty string, the label is removed. Removing a
  * label that does not exist is *not* an error. */
 int metric_label_set(metric_t *m, char const *name, char const *value);
-
-/* metric_resource_attribute_update adds, updates, or deletes a resource
- * attribute. If "value" is NULL or an empty string, the attribute is removed.
- * Removing an attribute that does not exist is *not* an error. */
-int metric_resource_attribute_update(metric_t *m, char const *name,
-                                     char const *value);
 
 /* metric_label_get efficiently looks up and returns the value of the "name"
  * label. If a label does not exist, NULL is returned and errno is set to
@@ -153,12 +146,21 @@ struct metric_family_s {
   char *help;
   metric_type_t type;
 
+  label_set_t resource;
   metric_list_t metric;
 };
 
 /* metric_family_metric_append appends a new metric to the metric family. This
  * allocates memory which must be freed using metric_family_metric_reset. */
 int metric_family_metric_append(metric_family_t *fam, metric_t m);
+
+/* metric_family_resource_attribute_update adds, updates, or deletes a
+ * resource attribute. If "value" is NULL or an empty string, the attribute
+ * is removed.
+ * Removing an attribute that does not exist is *not* an error. */
+int metric_family_resource_attribute_update(metric_family_t *fam,
+                                            char const *name,
+                                            char const *value);
 
 /* metric_family_append constructs a new metric_t and appends it to fam. It is
  * a convenience function that is funcitonally approximately equivalent to the

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -122,8 +122,8 @@ metric_t *metric_parse_identity(char const *s);
  * label that does not exist is *not* an error. */
 int metric_label_set(metric_t *m, char const *name, char const *value);
 
-/* metric_resource_attribute_update adds, updates, or deleted a resource
- * attribute. If "value" is NULL or the empty string, the attribute is removed.
+/* metric_resource_attribute_update adds, updates, or deletes a resource
+ * attribute. If "value" is NULL or an empty string, the attribute is removed.
  * Removing an attribute that does not exist is *not* an error. */
 int metric_resource_attribute_update(metric_t *m, char const *name,
                                      char const *value);

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -70,6 +70,19 @@ typedef struct {
   size_t num;
 } label_set_t;
 
+/* label_set_clone copies all the laels in src into dest. If dest contains
+ * any labels prior to calling label_set_clone, the associated memory is
+ * leaked. */
+int label_set_clone(label_set_t *dest, label_set_t src);
+
+/* label_set_add adds a label to the label set. If a label with name already
+ * exists, EEXIST is returned. The set of labels is sorted by label name. */
+int label_set_add(label_set_t *labels, char const *name, char const *value);
+
+/* label_set_reset frees all the memory referenced by the label set and
+ * initializes the label set to zero. */
+void label_set_reset(label_set_t *labels);
+
 /*
  * Metric
  */
@@ -83,10 +96,11 @@ typedef struct {
   metric_family_t *family; /* backreference for family->name and family->type */
 
   label_set_t label;
+  label_set_t resource;
+
   value_t value;
   cdtime_t time; /* TODO(octo): use ms or µs instead? */
   cdtime_t interval;
-  /* TODO(octo): target labels */
   meta_data_t *meta;
 } metric_t;
 
@@ -107,6 +121,12 @@ metric_t *metric_parse_identity(char const *s);
  * If "value" is NULL or the empty string, the label is removed. Removing a
  * label that does not exist is *not* an error. */
 int metric_label_set(metric_t *m, char const *name, char const *value);
+
+/* metric_resource_attribute_update adds, updates, or deleted a resource
+ * attribute. If "value" is NULL or the empty string, the attribute is removed.
+ * Removing an attribute that does not exist is *not* an error. */
+int metric_resource_attribute_update(metric_t *m, char const *name,
+                                     char const *value);
 
 /* metric_label_get efficiently looks up and returns the value of the "name"
  * label. If a label does not exist, NULL is returned and errno is set to

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -70,9 +70,9 @@ typedef struct {
   size_t num;
 } label_set_t;
 
-/* label_set_clone copies all the labels in src into dest. If dest contains
- * any labels prior to calling label_set_clone, the associated memory is
- * leaked. */
+/* label_set_clone copies all the labels in src into dest. dest must be an empty
+ * label set, i.e. it must not contain any prior labels, otherwise EINVAL is
+ * returned. */
 int label_set_clone(label_set_t *dest, label_set_t src);
 
 /* label_set_add adds a label to the label set. If a label with name already

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -175,8 +175,8 @@ DEF_TEST(metric_identity) {
                                   cases[i].labels[j].value));
     }
     for (size_t j = 0; j < cases[i].rattr_num; j++) {
-      CHECK_ZERO(metric_resource_attribute_update(&m, cases[i].rattr[j].name,
-                                                  cases[i].rattr[j].value));
+      CHECK_ZERO(metric_family_resource_attribute_update(
+          &fam, cases[i].rattr[j].name, cases[i].rattr[j].value));
     }
 
     strbuf_t buf = STRBUF_CREATE;
@@ -186,6 +186,7 @@ DEF_TEST(metric_identity) {
 
     STRBUF_DESTROY(buf);
     metric_family_metric_reset(&fam);
+    label_set_reset(&fam.resource);
     metric_reset(&m);
   }
 

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -100,6 +100,8 @@ DEF_TEST(metric_identity) {
     char *name;
     label_pair_t *labels;
     size_t labels_num;
+    label_pair_t *rattr;
+    size_t rattr_num;
     char const *want;
   } cases[] = {
       {
@@ -129,6 +131,33 @@ DEF_TEST(metric_identity) {
           .want = "escape_sequences{cardridge_return=\"\\r\",newline=\"\\n\","
                   "quote=\"\\\"\",tab=\"\\t\"}",
       },
+      {
+          .name = "metric_with_resource",
+          .rattr =
+              (label_pair_t[]){
+                  {"host.name", "example.com"},
+              },
+          .rattr_num = 1,
+          .want = "metric_with_resource{resource:host.name=\"example.com\"}",
+      },
+      {
+          .name = "metric_with_resource_and_labels",
+          .rattr =
+              (label_pair_t[]){
+                  {"omega", "always"},
+                  {"alpha", "resources"},
+              },
+          .rattr_num = 2,
+          .labels =
+              (label_pair_t[]){
+                  {"gamma", "first"},
+                  {"beta", "come"},
+              },
+          .labels_num = 2,
+          .want =
+              "metric_with_resource_and_labels{resource:alpha=\"resources\","
+              "resource:omega=\"always\",beta=\"come\",gamma=\"first\"}",
+      },
   };
 
   for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
@@ -144,6 +173,10 @@ DEF_TEST(metric_identity) {
     for (size_t j = 0; j < cases[i].labels_num; j++) {
       CHECK_ZERO(metric_label_set(&m, cases[i].labels[j].name,
                                   cases[i].labels[j].value));
+    }
+    for (size_t j = 0; j < cases[i].rattr_num; j++) {
+      CHECK_ZERO(metric_resource_attribute_update(&m, cases[i].rattr[j].name,
+                                                  cases[i].rattr[j].value));
     }
 
     strbuf_t buf = STRBUF_CREATE;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2198,12 +2198,12 @@ static int plugin_dispatch_metric_internal(metric_family_t const *fam) {
   return 0;
 } /* int plugin_dispatch_values_internal */
 
-static void set_default_resource_attributes(metric_t *m) {
-  if (m->resource.num > 0) {
+static void set_default_resource_attributes(metric_family_t *fam) {
+  if (fam->resource.num > 0) {
     return;
   }
 
-  label_set_clone(&m->resource, default_resource_attributes());
+  label_set_clone(&fam->resource, default_resource_attributes());
 }
 
 EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
@@ -2222,6 +2222,8 @@ EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
     return status;
   }
 
+  set_default_resource_attributes(fam_copy);
+
   cdtime_t time = cdtime();
   cdtime_t interval = plugin_get_interval();
 
@@ -2233,8 +2235,6 @@ EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
     if (m->interval == 0) {
       m->interval = interval;
     }
-
-    set_default_resource_attributes(m);
   }
 
   int status = plugin_dispatch_metric_internal(fam_copy);

--- a/src/daemon/resource.c
+++ b/src/daemon/resource.c
@@ -1,0 +1,122 @@
+/**
+ * collectd - src/daemon/resource.c
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "collectd.h"
+#include "daemon/resource.h"
+
+#include "utils/common/common.h"
+
+static label_set_t default_resource;
+
+static void otel_service_name(void) {
+  char *sn = getenv("OTEL_SERVICE_NAME");
+  if (sn != NULL) {
+    label_set_add(&default_resource, "service.name", sn);
+    return;
+  }
+
+  strbuf_t buf = STRBUF_CREATE;
+  strbuf_print(&buf, "unknown_service:" PACKAGE_NAME);
+  label_set_add(&default_resource, "service.name", buf.ptr);
+  STRBUF_DESTROY(buf);
+}
+
+static void otel_resource_attributes(void) {
+  char *ra = getenv("OTEL_RESOURCE_ATTRIBUTES");
+  if (ra == NULL) {
+    return;
+  }
+
+  size_t tmp_sz = strlen(ra) + 1;
+  char tmp[tmp_sz];
+  sstrncpy(tmp, ra, sizeof(tmp));
+
+  char *str = &tmp[0];
+  char *saveptr = NULL;
+  char *key;
+  while ((key = strtok_r(str, ",", &saveptr)) != NULL) {
+    str = NULL;
+    char *value = strchr(key, '=');
+    if (value == NULL) {
+      continue;
+    }
+    *value = 0;
+    value++;
+
+    label_set_add(&default_resource, key, value);
+  }
+}
+
+static void host_name(void) {
+  if (strlen(hostname_g) > 0) {
+    label_set_add(&default_resource, "host.name", hostname_g);
+  }
+}
+
+static int machine_id(void) {
+  char *files[] = {
+      "/etc/machine-id",
+      "/etc/hostid",
+      "/var/lib/dbus/machine-id",
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(files); i++) {
+    char *f = files[i];
+    if (access(f, R_OK) != 0) {
+      continue;
+    }
+
+    char buf[1024] = {0};
+    ssize_t status = read_text_file_contents(f, buf, sizeof(buf));
+    if (status <= 0) {
+      NOTICE("machine_id: reading \"%s\" failed: %zd", f, status);
+      continue;
+    }
+    strstripnewline(buf);
+
+    label_set_add(&default_resource, "host.id", buf);
+    return 0;
+  }
+
+  return ENOENT;
+}
+
+static void init_default_resource(void) {
+  if (default_resource.num != 0) {
+    return;
+  }
+
+  otel_service_name();
+  otel_resource_attributes();
+  host_name();
+  machine_id();
+}
+
+label_set_t default_resource_attributes(void) {
+  init_default_resource();
+
+  return default_resource;
+}

--- a/src/daemon/resource.h
+++ b/src/daemon/resource.h
@@ -1,0 +1,35 @@
+/**
+ * collectd - src/daemon/resource.c
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#ifndef DAEMON_RESOURCE_H
+#define DAEMON_RESOURCE_H 1
+
+#include "collectd.h"
+#include "daemon/metric.h"
+
+label_set_t default_resource_attributes(void);
+
+#endif

--- a/src/utils/format_graphite/format_graphite.c
+++ b/src/utils/format_graphite/format_graphite.c
@@ -96,7 +96,8 @@ static int graphite_print_escaped(strbuf_t *buf, char const *s,
   return 0;
 }
 
-static void gr_format_label_set(strbuf_t *buf, label_set_t const *labels, char const escape_char, unsigned int flags) {
+static void gr_format_label_set(strbuf_t *buf, label_set_t const *labels,
+                                char const escape_char, unsigned int flags) {
   for (size_t i = 0; i < labels->num; i++) {
     label_pair_t *l = labels->ptr + i;
     strbuf_print(buf, ".");
@@ -107,8 +108,8 @@ static void gr_format_label_set(strbuf_t *buf, label_set_t const *labels, char c
 }
 
 static void gr_format_name(strbuf_t *buf, metric_t const *m, char const *prefix,
-                          char const *suffix, char const escape_char,
-                          unsigned int flags) {
+                           char const *suffix, char const escape_char,
+                           unsigned int flags) {
   if (prefix != NULL) {
     strbuf_print(buf, prefix);
   }
@@ -117,7 +118,7 @@ static void gr_format_name(strbuf_t *buf, metric_t const *m, char const *prefix,
     strbuf_print(buf, suffix);
   }
 
-  gr_format_label_set(buf, &m->resource, escape_char, flags);
+  gr_format_label_set(buf, &m->family->resource, escape_char, flags);
   gr_format_label_set(buf, &m->label, escape_char, flags);
 }
 


### PR DESCRIPTION
The internal data structure in collectd 6 is closely modeled after [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md). This is, for example, where the term "metric family" originates.

In the mean time, [OpenTelemetry](https://opentelemetry.io/) has emerged as the de-facto industry standard for metrics, in particular in "cloud native" environments. I think it is prudent to ensure collectd 6 is compatible with OpenTelemetry and integrates well into this ecosystem.

Most concepts translate well and don't require changes to our internal data structures. However, there is one important differentiation:

OpenTelemetry specifies two sets of "attributes" (aka. labels): "metric attributes" and "resource attributes". For former is equivalent to the existing `label` field in `metric_t`. [Resource attributes](https://opentelemetry.io/docs/specs/semconv/resource/) describe which resource is being monitored and currently lacks an equivalent in collectd 6. In collectd 5, the `host` field played a comparable role. I believe other systems use this information for sharding, i.e. ensure data locality for metrics originating from the same "resource".

I propose the following changes:

* Associate a new "resource attributes" `label_set_t` with metrics, either directly or indirectly. I see a few ways we could implement this:
    1. Create a `resource_metrics_t` struct, wrapping one or more `metric_family_t`.
        * :+1: Pro: closely follows the OpenTelemetry data structures, avoiding future incompatibilities.
        * :-1: Con: requires lots of code changes because `metric_family_t` is used as *the* metric exchange struct throughout the existing code.
    2. Create a `resource_metrics_t` struct and add a pointer to it to `metric_family_t`.
        * :+1: Pro: conceptually this is similar to how a `metric_t` refers back to its `metric_family_t`. In other words, we'd be kind of "wrapping" the metric family without changing which struct we're passing around (→ fewer code changes).
        * :-1: Con: metrics from different "resources" have to go into separate metric families.
    3. Add a `label_set_t resource` field to `metric_t`.
        * :+1: Pro: most information identifying a metric is concentrated in one place (the metric name is in the metric family though). Schema is relatively simple to understand.
        * :-1: Con: resource attributes have to be stored with each metric, consuming a lot of memory, particularly when one resource is exporting a large number of metrics.

    I have initially implemented the last option (iii.). A later commit changes this to store the resource attributes in `metric_family_t` (similar to option ii.).
* Write infrastructure that auto-populates the "resource attributes" with reasonable defaults. I think following the [Host](https://opentelemetry.io/docs/specs/semconv/resource/host/) semantics for compute instances would be a good MVP. More attributes for specific cloud environments could be added at a later time and the infrastructure should be able to accommodate these extensions.
* Allow users to overwrite the resource attributes, either partially or in full.

ChangeLog: Resource attributes have been added to the core data structures.