### PR TITLE
[collectd 6] Add a `unit` field to the `metric_family_t` struct.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -252,6 +252,8 @@ collectd_SOURCES = \
 	src/daemon/resource.h \
 	src/daemon/types_list.c \
 	src/daemon/types_list.h \
+	src/daemon/unit.c \
+	src/daemon/unit.h \
 	src/daemon/utils_cache.c \
 	src/daemon/utils_cache.h \
 	src/daemon/utils_complain.c \

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -478,6 +478,7 @@ void metric_family_free(metric_family_t *fam) {
 
   free(fam->name);
   free(fam->help);
+  free(fam->unit);
   label_set_reset(&fam->resource);
   metric_list_reset(&fam->metric);
   free(fam);
@@ -497,6 +498,9 @@ metric_family_t *metric_family_clone(metric_family_t const *fam) {
   ret->name = strdup(fam->name);
   if (fam->help != NULL) {
     ret->help = strdup(fam->help);
+  }
+  if (fam->unit != NULL) {
+    ret->unit = strdup(fam->unit);
   }
   ret->type = fam->type;
 

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -166,6 +166,7 @@ typedef struct {
 struct metric_family_s {
   char *name;
   char *help;
+  char *unit;
   metric_type_t type;
 
   label_set_t resource;

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -166,6 +166,9 @@ typedef struct {
 struct metric_family_s {
   char *name;
   char *help;
+  /* unit is a case sensitive "Unified Code for Units of Measure" (UCUM)
+   * denoting the unit of the metric, e.g. "By" for bytes, and "1" for
+   * dimensionless metrics, such as "utilization". */
   char *unit;
   metric_type_t type;
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -36,6 +36,7 @@
 #include "filter_chain.h"
 #include "plugin.h"
 #include "resource.h"
+#include "unit.h"
 #include "utils/avltree/avltree.h"
 #include "utils/common/common.h"
 #include "utils/heap/heap.h"
@@ -2109,6 +2110,7 @@ EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
   }
 
   set_default_resource_attributes(fam_copy);
+  fam_copy->unit = default_unit(fam_copy);
 
   cdtime_t time = cdtime();
   cdtime_t interval = plugin_get_interval();

--- a/src/daemon/unit.c
+++ b/src/daemon/unit.c
@@ -40,6 +40,8 @@ static bool string_has_suffix(char const *s, char const *suffix) {
 }
 
 static char const *default_unit_static(metric_family_t const *fam) {
+  // Determine units for some well-known name suffixes, see:
+  // https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-naming
   if (string_has_suffix(fam->name, ".utilization")) {
     return "1";
   }

--- a/src/daemon/unit.c
+++ b/src/daemon/unit.c
@@ -1,0 +1,70 @@
+/**
+ * collectd - src/daemon/unit.c
+ * Copyright (C) 2023       Florian "octo" Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "collectd.h"
+#include "daemon/unit.h"
+
+static bool string_has_suffix(char const *s, char const *suffix) {
+  size_t s_len = strlen(s);
+  size_t suffix_len = strlen(suffix);
+
+  if (s_len < suffix_len) {
+    return false;
+  }
+
+  s += (s_len - suffix_len);
+  return strcmp(s, suffix) == 0;
+}
+
+static char const *default_unit_static(metric_family_t const *fam) {
+  if (string_has_suffix(fam->name, ".utilization")) {
+    return "1";
+  }
+  if (string_has_suffix(fam->name, ".time")) {
+    return "s";
+  }
+  if (string_has_suffix(fam->name, ".io")) {
+    return "By";
+  }
+  if (string_has_suffix(fam->name, ".operations")) {
+    return "{operation}";
+  }
+
+  return NULL;
+}
+
+char *default_unit(metric_family_t const *fam) {
+  if (fam->unit != NULL) {
+    return fam->unit;
+  }
+
+  char const *unit = default_unit_static(fam);
+  if (unit == NULL) {
+    return NULL;
+  }
+
+  return strdup(unit);
+}

--- a/src/daemon/unit.c
+++ b/src/daemon/unit.c
@@ -26,18 +26,7 @@
 
 #include "collectd.h"
 #include "daemon/unit.h"
-
-static bool string_has_suffix(char const *s, char const *suffix) {
-  size_t s_len = strlen(s);
-  size_t suffix_len = strlen(suffix);
-
-  if (s_len < suffix_len) {
-    return false;
-  }
-
-  s += (s_len - suffix_len);
-  return strcmp(s, suffix) == 0;
-}
+#include "utils/common/common.h"
 
 static char const *default_unit_static(metric_family_t const *fam) {
   // Determine units for some well-known name suffixes, see:

--- a/src/daemon/unit.h
+++ b/src/daemon/unit.h
@@ -32,9 +32,11 @@
 /* default_unit tries to guess a metric family's unit.
  *
  * If fam->unit is not NULL, that pointer is returned. Otherwise, the function
- * tries to heuristically determine a unit for th metric family. If successful,
- * a new string is allocated on the heap and returned. This string must be freed
- * using free(). If unsuccessful, NULL is returned.
+ * tries to heuristically determine a unit for the metric family, based on known
+ * OpenTelemetry metric names:
+ * https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-naming
+ * If successful, a new string is allocated on the heap and returned. This string must
+ * be freed using free(). If unsuccessful, NULL is returned.
  *
  * This is designed to be used like this:
  *   fam->unit = default_unit(fam);

--- a/src/daemon/unit.h
+++ b/src/daemon/unit.h
@@ -1,0 +1,44 @@
+/**
+ * collectd - src/daemon/unit.h
+ * Copyright (C) 2023       Florian "octo" Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#ifndef DAEMON_UNIT_H
+#define DAEMON_UNIT_H 1
+
+#include "daemon/metric.h"
+
+/* default_unit tries to guess a metric family's unit.
+ *
+ * If fam->unit is not NULL, that pointer is returned. Otherwise, the function
+ * tries to heuristically determine a unit for th metric family. If successful,
+ * a new string is allocated on the heap and returned. This string must be freed
+ * using free(). If unsuccessful, NULL is returned.
+ *
+ * This is designed to be used like this:
+ *   fam->unit = default_unit(fam);
+ */
+char *default_unit(metric_family_t const *fam);
+
+#endif

--- a/src/daemon/unit.h
+++ b/src/daemon/unit.h
@@ -35,8 +35,8 @@
  * tries to heuristically determine a unit for the metric family, based on known
  * OpenTelemetry metric names:
  * https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-naming
- * If successful, a new string is allocated on the heap and returned. This string must
- * be freed using free(). If unsuccessful, NULL is returned.
+ * If successful, a new string is allocated on the heap and returned. This
+ * string must be freed using free(). If unsuccessful, NULL is returned.
  *
  * This is designed to be used like this:
  *   fam->unit = default_unit(fam);


### PR DESCRIPTION
Both, OpenMetrics and OpenTelemetry require that metrics specify their unit, such as "bytes per second". See for example OpenTelemetry's [Metrics Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-units).

This adds a `unit` field to the `metric_family_t` field and automatically populates it based on the metric family name, if possible.

ChangeLog: daemon: A unit field has been added to the metric family struct.