### PR TITLE
[collectd 6] Generate better names and labels for legacy metrics.

### DIFF
--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -423,6 +423,21 @@ int strjoin(char *buffer, size_t buffer_size, char **fields, size_t fields_num,
   return (int)buffer_req;
 }
 
+bool string_has_suffix(char const *s, char const *suffix) {
+  if (s == NULL || suffix == NULL) {
+    return false;
+  }
+
+  size_t s_len = strlen(s);
+  size_t suffix_len = strlen(suffix);
+  if (s_len < suffix_len) {
+    return false;
+  }
+
+  s += (s_len - suffix_len);
+  return strcmp(s, suffix) == 0;
+}
+
 int escape_string(char *buffer, size_t buffer_size) {
   char *temp;
   size_t j;

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -179,7 +179,6 @@ int strsplit(char *string, char **fields, size_t size);
 int strjoin(char *dst, size_t dst_len, char **fields, size_t fields_num,
             const char *sep);
 
-
 /* string_has_suffix returns true if s ends with suffix. If either s or suffix
  * are NULL, false is returned. */
 bool string_has_suffix(char const *s, char const *suffix);

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -179,6 +179,11 @@ int strsplit(char *string, char **fields, size_t size);
 int strjoin(char *dst, size_t dst_len, char **fields, size_t fields_num,
             const char *sep);
 
+
+/* string_has_suffix returns true if s ends with suffix. If either s or suffix
+ * are NULL, false is returned. */
+bool string_has_suffix(char const *s, char const *suffix);
+
 /*
  * NAME
  *   escape_slashes

--- a/src/utils/common/common_test.c
+++ b/src/utils/common/common_test.c
@@ -367,16 +367,14 @@ DEF_TEST(string_has_suffix) {
     char const *suffix;
     bool want;
   } cases[] = {
-    {"foo.bar", "bar", true},
-    {"foo.qux", "bar", false},
-    {"foo.Bar", "bar", false},
-    {"foo", "foo", true},
-    {"foo", "foo.bar", false},
-    {"foo", NULL, false},
-    {NULL, "foo", false},
+      {"foo.bar", "bar", true},  {"foo.qux", "bar", false},
+      {"foo.Bar", "bar", false}, {"foo", "foo", true},
+      {"foo", "foo.bar", false}, {"foo", NULL, false},
+      {NULL, "foo", false},
   };
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
-    EXPECT_EQ_INT(cases[i].want, string_has_suffix(cases[i].s, cases[i].suffix));
+    EXPECT_EQ_INT(cases[i].want,
+                  string_has_suffix(cases[i].s, cases[i].suffix));
   }
 
   return 0;

--- a/src/utils/common/common_test.c
+++ b/src/utils/common/common_test.c
@@ -361,6 +361,27 @@ DEF_TEST(format_values) {
   return 0;
 }
 
+DEF_TEST(string_has_suffix) {
+  struct {
+    char const *s;
+    char const *suffix;
+    bool want;
+  } cases[] = {
+    {"foo.bar", "bar", true},
+    {"foo.qux", "bar", false},
+    {"foo.Bar", "bar", false},
+    {"foo", "foo", true},
+    {"foo", "foo.bar", false},
+    {"foo", NULL, false},
+    {NULL, "foo", false},
+  };
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    EXPECT_EQ_INT(cases[i].want, string_has_suffix(cases[i].s, cases[i].suffix));
+  }
+
+  return 0;
+}
+
 int main(void) {
   RUN_TEST(sstrncpy);
   RUN_TEST(sstrdup);
@@ -371,6 +392,7 @@ int main(void) {
   RUN_TEST(strunescape);
   RUN_TEST(value_to_rate);
   RUN_TEST(format_values);
+  RUN_TEST(string_has_suffix);
 
   END_TEST;
 }

--- a/src/utils/value_list/value_list.c
+++ b/src/utils/value_list/value_list.c
@@ -408,6 +408,9 @@ plugin_value_list_to_metric_family(value_list_t const *vl, data_set_t const *ds,
     }
     status = status || metric_label_set(&m, name, vl->type_instance);
   }
+  if (strlen(vl->plugin_instance) == 0 && strlen(vl->type_instance) == 0) {
+    status = status || metric_label_set(&m, "plugin", vl->plugin);
+  }
 
   status = status || metric_family_metric_append(fam, m);
   if (status != 0) {

--- a/src/utils/value_list/value_list.c
+++ b/src/utils/value_list/value_list.c
@@ -420,17 +420,16 @@ plugin_value_list_to_metric_family(value_list_t const *vl, data_set_t const *ds,
     status = status || metric_label_set(&m, "direction", ds->ds[index].name);
   }
 
-  if (strlen(vl->plugin_instance) != 0) {
+  bool have_plugin_instance = strlen(vl->plugin_instance) != 0;
+  bool have_type_instance = strlen(vl->type_instance) != 0;
+  if (have_plugin_instance && have_type_instance) {
     status = status || metric_label_set(&m, vl->plugin, vl->plugin_instance);
-  }
-  if (strlen(vl->type_instance) != 0) {
-    char const *name = "type";
-    if (strlen(vl->plugin_instance) == 0) {
-      name = vl->plugin;
-    }
-    status = status || metric_label_set(&m, name, vl->type_instance);
-  }
-  if (strlen(vl->plugin_instance) == 0 && strlen(vl->type_instance) == 0) {
+    status = status || metric_label_set(&m, "type", vl->type_instance);
+  } else if (have_plugin_instance && !have_type_instance) {
+    status = status || metric_label_set(&m, vl->plugin, vl->plugin_instance);
+  } else if (!have_plugin_instance && have_type_instance) {
+    status = status || metric_label_set(&m, vl->plugin, vl->type_instance);
+  } else if (!have_plugin_instance && !have_type_instance) {
     status = status || metric_label_set(&m, "plugin", vl->plugin);
   }
 

--- a/src/utils/value_list/value_list.c
+++ b/src/utils/value_list/value_list.c
@@ -355,14 +355,14 @@ static bool is_directional_metric(data_set_t const *ds) {
 
 static int metric_family_name(strbuf_t *buf, value_list_t const *vl,
                               data_set_t const *ds, size_t index) {
-  int status = strbuf_print(buf, "collectd.v5");
+  int status = strbuf_print(buf, "collectd.v5.");
   if (strcmp(ds->type, "percent") == 0) {
-    strbuf_printf(buf, ".%s.utilization", vl->plugin);
+    strbuf_printf(buf, "%s.utilization", vl->plugin);
   } else if (is_directional_metric(ds) &&
              string_has_suffix(ds->type, "_octets")) {
-    strbuf_printf(buf, ".%s.io", vl->plugin);
+    strbuf_printf(buf, "%s.io", vl->plugin);
   } else {
-    strbuf_printf(buf, ".%s", vl->type);
+    strbuf_print(buf, vl->type);
   }
 
   if (ds->ds_num > 1 && !is_directional_metric(ds)) {


### PR DESCRIPTION
Legacy metrics, i.e. metrics reported with the `value_list_t` data structure, need to be upgraded to `metric_family_t`.

The new code puts all metrics into the `collectd.v5` namespace. The metric family name is:

* `collectd.v5.${plugin}.utilization` for metrics with `type` "percent".
* `collectd.v5.${plugin}.io` for *directional metrics* ending in `_octets`.
* `collectd.v5.${type}.${data_source}` for metrics with more than one data source (except *directional metrics*).
* `collectd.v5.${type}` for metrics with one data source.

If the `hostname` field is set, it is translated into the `host.name` resource attribute. Otherwise resource attributes are omitted to trigger the default behavior (like an empty `hostname` field does).

The labels depend on whether plugin instance, type instance, or both are set:

* Both: `${plugin}=${plugin_instance}`, `type=${type_instance}`
* Plugin instance: `${plugin}=${plugin_instance}`
* Type instance: `${plugin}=${type_instance}`
* Neither: `plugin=${plugin}`

This does a decent job of mapping metrics to the new schema, but I do wonder if we should simply put those fields into labels 1-to-1: `collectd.v5.plugin=${plugin}`, `collectd.v5.plugin_instance=${plugin_instance}`, `collectd.v5.type_instance=${type_instance}`. What do you think?

**Directional metrics** are metrics with two data sources called "read" and "write", or "rx" and "tx". Despite having more than one data source, the data source name is added to a `direction` label instead of the metric family name.

ChangeLog: The schema with which metrics are translated from v5 to v6 has been improved.
