### PR TITLE
[collectd 6] Add an option to configure resource attributes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -443,6 +443,8 @@ libplugin_mock_la_SOURCES = \
 	src/daemon/plugin_mock.c \
 	src/daemon/configfile.c \
 	src/daemon/configfile.h \
+	src/daemon/resource.c \
+	src/daemon/resource.h \
 	src/daemon/types_list.c \
 	src/daemon/types_list.h \
 	src/daemon/utils_cache_mock.c \

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -17,6 +17,10 @@
 #PluginDir   "@libdir@/@PACKAGE_NAME@"
 #TypesDB     "@prefix@/share/@PACKAGE_NAME@/types.db"
 
+#<Resource "host">
+#	Attribute "custom.key" "custom.value"
+#</Resource>
+
 #----------------------------------------------------------------------------#
 # When enabled, plugins are loaded automatically with the default options    #
 # when an appropriate <Plugin ...> block is encountered.                     #

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -328,6 +328,51 @@ the daemon should try to figure out the "fully qualified domain name", FQDN.
 This is done using a lookup of the name returned by C<gethostname>. This option
 is enabled by default.
 
+=item B<Resource> I<Type>
+
+The B<Resource> block defined the I<Resource Attributes> to use for local
+metrics such as CPU usage, i.e. metrics that were not received from a remote
+system or service.
+
+The recommended way to configure resource attributes is by following the
+OpenTelemetry Semantic Conventions,
+L<https://opentelemetry.io/docs/specs/semconv/resource/>.
+
+The I<Type> argument determines which default attributes are automatically
+populated. B<Attribute> options inside the block can be used to add additional
+attributes or overwrite existing ones.
+
+Valid values for I<Type> are:
+
+=over 4
+
+=item B<Host> (default)
+
+For use with computing instances (e.g. physical and virtual machines). Will
+automatically populate the C<service.name>, C<host.name>, and C<host.id>
+attributes.
+
+For more information, refer to
+L<https://opentelemetry.io/docs/specs/semconv/resource/host/>.
+
+=item B<Generic>
+
+Minimal defaults for maximum flexibility. Only the C<service.name> attribute is
+populated.
+
+=back
+
+Inside the B<Resource> block, the following configuration options are valid:
+
+=over 4
+
+=item B<Attribute> I<Name> I<Value>
+
+Adds a resource attribute or updates an existing one. If I<Value> is the empty
+string, the attribute is deleted.
+
+=back
+
 =item B<PreCacheChain> I<ChainName>
 
 =item B<PostCacheChain> I<ChainName>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -362,6 +362,13 @@ L<https://opentelemetry.io/docs/specs/semconv/resource/host/>.
 Minimal defaults for maximum flexibility. Only the C<service.name> attribute is
 populated.
 
+To also remove the C<service.name> resource attribute, set it to an empty
+string:
+
+  <Resource Generic>
+    Attribute "service.name" ""
+  </Resource>
+
 =back
 
 Inside the B<Resource> block, the following configuration options are valid:

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -330,9 +330,11 @@ is enabled by default.
 
 =item B<Resource> I<Type>
 
-The B<Resource> block defined the I<Resource Attributes> to use for local
+The B<Resource> block defines the I<Resource Attributes> to use for local
 metrics such as CPU usage, i.e. metrics that were not received from a remote
-system or service.
+system or service. The resource attributes describe the resource being
+monitored. A common case for collectd is that the monitored resource is a
+(physical or virtual) I<Host>.
 
 The recommended way to configure resource attributes is by following the
 OpenTelemetry Semantic Conventions,

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -337,13 +337,13 @@ static int format_config_value(strbuf_t *buf, oconfig_value_t v) {
 }
 
 static int dispatch_resource(oconfig_item_t *ci) {
-  char type[128] = {0};
-  int status = cf_util_get_string_buffer(ci, type, sizeof(type));
-  if (status != 0) {
-    return status;
+  if (ci->values_num != 1 || ci->values[0].type != OCONFIG_TYPE_STRING) {
+    ERROR("configfile: The \"%s\" option requires one string argument.",
+          ci->key);
+    return EINVAL;
   }
 
-  status = resource_attributes_init(type);
+  int status = resource_attributes_init(ci->values[0].value.string);
   if (status != 0) {
     return status;
   }

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -29,11 +29,13 @@
 
 #include "liboconfig/oconfig.h"
 
-#include "configfile.h"
-#include "filter_chain.h"
-#include "plugin.h"
-#include "types_list.h"
+#include "daemon/configfile.h"
+#include "daemon/filter_chain.h"
+#include "daemon/plugin.h"
+#include "daemon/resource.h"
+#include "daemon/types_list.h"
 #include "utils/common/common.h"
+#include "utils/strbuf/strbuf.h"
 
 #if HAVE_WORDEXP_H
 #include <wordexp.h>
@@ -87,6 +89,7 @@ static int dispatch_value_typesdb(oconfig_item_t *ci);
 static int dispatch_value_plugindir(oconfig_item_t *ci);
 static int dispatch_loadplugin(oconfig_item_t *ci);
 static int dispatch_block_plugin(oconfig_item_t *ci);
+static int dispatch_resource(oconfig_item_t *ci);
 
 /*
  * Private variables
@@ -94,10 +97,13 @@ static int dispatch_block_plugin(oconfig_item_t *ci);
 static cf_callback_t *first_callback;
 static cf_complex_callback_t *complex_callback_head;
 
-static cf_value_map_t cf_value_map[] = {{"TypesDB", dispatch_value_typesdb},
-                                        {"PluginDir", dispatch_value_plugindir},
-                                        {"LoadPlugin", dispatch_loadplugin},
-                                        {"Plugin", dispatch_block_plugin}};
+static cf_value_map_t cf_value_map[] = {
+    {"TypesDB", dispatch_value_typesdb},
+    {"PluginDir", dispatch_value_plugindir},
+    {"LoadPlugin", dispatch_loadplugin},
+    {"Plugin", dispatch_block_plugin},
+    {"Resource", dispatch_resource},
+};
 static int cf_value_map_num = STATIC_ARRAY_SIZE(cf_value_map);
 
 static cf_global_option_t cf_global_options[] = {
@@ -315,6 +321,74 @@ static int dispatch_loadplugin(oconfig_item_t *ci) {
 
   return ret_val;
 } /* int dispatch_value_loadplugin */
+
+static int format_config_value(strbuf_t *buf, oconfig_value_t v) {
+  switch (v.type) {
+  case OCONFIG_TYPE_STRING:
+    return strbuf_print(buf, v.value.string);
+  case OCONFIG_TYPE_NUMBER:
+    return strbuf_printf(buf, "%g", v.value.number);
+  case OCONFIG_TYPE_BOOLEAN:
+    return strbuf_print(buf, v.value.boolean ? "true" : "false");
+  default:
+    ERROR("configfile: Unexpected value type: %d", v.type);
+    return -1;
+  }
+}
+
+static int dispatch_resource(oconfig_item_t *ci) {
+  char type[128] = {0};
+  int status = cf_util_get_string_buffer(ci, type, sizeof(type));
+  if (status != 0) {
+    return status;
+  }
+
+  status = resource_attributes_init(type);
+  if (status != 0) {
+    return status;
+  }
+
+  for (int i = 0; i < ci->children_num; ++i) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("Attribute", child->key) == 0) {
+      if (child->values_num != 2) {
+        ERROR("configfile: The \"%s\" option requires two values, got %d.",
+              child->key, child->values_num);
+        return EINVAL;
+      }
+      if (child->values[0].type != OCONFIG_TYPE_STRING) {
+        ERROR("configfile: The first value of the \"%s\" option (the attribute "
+              "name) must be a string.",
+              child->key);
+        return EINVAL;
+      }
+      char const *key = child->values[0].value.string;
+
+      strbuf_t value = STRBUF_CREATE;
+      int status = format_config_value(&value, ci->values[1]);
+      if (status != 0) {
+        STRBUF_DESTROY(value);
+        return status;
+      }
+
+      status = resource_attribute_update(key, value.ptr);
+      if (status != 0) {
+        ERROR("configfile: default_resource_attributes_update failed: %s",
+              STRERROR(status));
+        STRBUF_DESTROY(value);
+        return status;
+      }
+
+      STRBUF_DESTROY(value);
+    } else {
+      ERROR("configfile: The option \"%s\" is not valid within \"%s\" blocks.",
+            child->key, ci->key);
+      return EINVAL;
+    }
+  }
+  return 0;
+} /* int dispatch_resource */
 
 static int dispatch_value(oconfig_item_t *ci) {
   int ret = 0;

--- a/src/daemon/resource.c
+++ b/src/daemon/resource.c
@@ -29,6 +29,7 @@
 
 #include "utils/common/common.h"
 
+static bool default_resource_initialized = false;
 static label_set_t default_resource;
 
 static void otel_service_name(void) {
@@ -105,7 +106,7 @@ static int machine_id(void) {
 }
 
 static void resource_host_init(void) {
-  if (default_resource.num != 0) {
+  if (default_resource_initialized) {
     return;
   }
 
@@ -113,15 +114,17 @@ static void resource_host_init(void) {
   otel_resource_attributes();
   host_name();
   machine_id();
+  default_resource_initialized = true;
 }
 
 static void resource_generic_init(void) {
-  if (default_resource.num != 0) {
+  if (default_resource_initialized) {
     return;
   }
 
   otel_service_name();
   otel_resource_attributes();
+  default_resource_initialized = true;
 }
 
 int resource_attributes_init(char const *type) {

--- a/src/daemon/resource.c
+++ b/src/daemon/resource.c
@@ -104,7 +104,7 @@ static int machine_id(void) {
   return ENOENT;
 }
 
-static void init_default_resource(void) {
+static void resource_host_init(void) {
   if (default_resource.num != 0) {
     return;
   }
@@ -115,8 +115,34 @@ static void init_default_resource(void) {
   machine_id();
 }
 
+static void resource_generic_init(void) {
+  if (default_resource.num != 0) {
+    return;
+  }
+
+  otel_service_name();
+  otel_resource_attributes();
+}
+
+int resource_attributes_init(char const *type) {
+  if (strcasecmp("Host", type) == 0) {
+    resource_host_init();
+    return 0;
+  } else if (strcasecmp("Generic", type) == 0) {
+    resource_generic_init();
+    return 0;
+  }
+  ERROR("resource: The resource type \"%s\" is unknown.", type);
+  return ENOENT;
+}
+
+int resource_attribute_update(char const *key, char const *value) {
+  resource_host_init();
+  return label_set_add(&default_resource, key, value);
+}
+
 label_set_t default_resource_attributes(void) {
-  init_default_resource();
+  resource_host_init();
 
   return default_resource;
 }

--- a/src/daemon/resource.h
+++ b/src/daemon/resource.h
@@ -30,6 +30,14 @@
 #include "collectd.h"
 #include "daemon/metric.h"
 
+/* resource_attributes_init sets default resource attributes depending on
+ * "type". Returns ENOENT if type is not known. */
+int resource_attributes_init(char const *type);
+
+/* resource_attribute_update adds a gobal resource attribute. If an
+ * attribute of the same name already exists, it is overwritten. */
+int resource_attribute_update(char const *key, char const *value);
+
 label_set_t default_resource_attributes(void);
 
 #endif


### PR DESCRIPTION
ChangeLog: daemon: The new "Resource" option allows users to configure resource attributes manually if desired.