### PR TITLE
[collectd 6] .github/workflows/build.yml: Remove Ubuntu Bionic.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
           - mantic_amd64
           - jammy_amd64
           - focal_amd64
-          - bionic_amd64
           # RedHat family
           - el9_x86_64
           - fedora39


### PR DESCRIPTION
It is too old to work with `actions/checkout@v4`.

This is a prerequisite for #4180 