### PR TITLE
[collectd 6] gpu_sysman plugin: Fix double reporting of metric.

### DIFF
--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -1553,7 +1553,6 @@ static bool gpu_freqs(gpu_device_t *gpu, unsigned int cache_idx) {
           metric_family_metric_append(&fam_freq, metric);
           reported_base = true;
         }
-        metric_family_metric_append(&fam_freq, metric);
         if ((config.output & OUTPUT_RATIO) && maxfreq > 0) {
           metric.value.gauge = req_max / maxfreq;
           metric_family_metric_append(&fam_ratio, metric);


### PR DESCRIPTION
This metric is already added to the metric family in line 1553. Adding it twice leads to `uc_update` errors.

Fixes: #4200