### PR TITLE
[collectd 6] Write Prometheus plugin: Ensure metric and label names are properly formatted.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2307,6 +2307,15 @@ write_prometheus_la_SOURCES = src/write_prometheus.c
 write_prometheus_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBMICROHTTPD_CPPFLAGS)
 write_prometheus_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMICROHTTPD_LDFLAGS)
 write_prometheus_la_LIBADD = $(BUILD_WITH_LIBMICROHTTPD_LIBS)
+
+test_plugin_write_prometheus_SOURCES = src/write_prometheus_test.c \
+				       src/write_prometheus.c
+test_plugin_write_prometheus_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBMICROHTTPD_CPPFLAGS)
+test_plugin_write_prometheus_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMICROHTTPD_LDFLAGS)
+test_plugin_write_prometheus_LDADD = libplugin_mock.la libavltree.la \
+				     $(BUILD_WITH_LIBMICROHTTPD_LIBS)
+check_PROGRAMS += test_plugin_write_prometheus
+TESTS += test_plugin_write_prometheus
 endif
 
 if BUILD_PLUGIN_WRITE_REDIS

--- a/configure.ac
+++ b/configure.ac
@@ -7145,6 +7145,8 @@ fi
 
 if test "x$with_libmicrohttpd" = "xyes"; then
   plugin_write_prometheus="yes"
+else
+  plugin_write_prometheus="no (libmicrohttpd not found)"
 fi
 
 # Mac OS X memory interface

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -290,7 +290,7 @@ int strbuf_print_escaped(strbuf_t *buf, char const *s, char const *need_escape,
   return 0;
 }
 
-static void bitmap_set(uint64_t b[static 4] , uint8_t v) {
+static void bitmap_set(uint64_t b[static 4], uint8_t v) {
   uint8_t index = v / 64;
   uint8_t bit = v % 64;
   b[index] |= 1 << bit;

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -292,7 +292,8 @@ int strbuf_print_escaped(strbuf_t *buf, char const *s, char const *need_escape,
 
 int strbuf_print_restricted(strbuf_t *buf, char const *s, char const *accept,
                             char replace_char) {
-  if (buf == NULL || s == NULL || accept == NULL || accept[0] == 0 || replace_char == 0) {
+  if (buf == NULL || s == NULL || accept == NULL || accept[0] == 0 ||
+      replace_char == 0) {
     return EINVAL;
   }
   if (strchr(accept, replace_char) == NULL) {

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -326,10 +326,6 @@ int strbuf_print_restricted(strbuf_t *buf, char const *s, char const *accept,
     return status;
   }
 
-  size_t s_len = strlen(s);
-  char conv[s_len + 1];
-  memcpy(conv, s, sizeof(conv));
-
   for (size_t i = start_pos; buf->ptr[i] != 0; i++) {
     if (!bitmap_lookup(bitmap, (uint8_t)buf->ptr[i])) {
       buf->ptr[i] = replace_char;

--- a/src/utils/strbuf/strbuf.h
+++ b/src/utils/strbuf/strbuf.h
@@ -104,4 +104,10 @@ int strbuf_printn(strbuf_t *buf, char const *s, size_t n);
 int strbuf_print_escaped(strbuf_t *buf, char const *s, char const *need_escape,
                          char escape_char);
 
+/* strbuf_print_restricted adds a copy of "s" to the buffer, that only consists
+ * of characters in "accept". All other characters are replaced with
+ * "replace_char". "replace_char" has to be in "accept". */
+int strbuf_print_restricted(strbuf_t *buf, char const *s, char const *accept,
+                            char replace_char);
+
 #endif

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -1,0 +1,52 @@
+/**
+ * collectd - src/write_prometheus_test.c
+ * Copyright (C) 2023       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ */
+
+#include "collectd.h"
+
+#include "testing.h"
+#include "daemon/metric.h"
+
+void format_metric_family(strbuf_t *buf, metric_family_t const *prom_fam);
+
+DEF_TEST(format_metric_family) {
+  strbuf_t got = STRBUF_CREATE;
+
+  metric_family_t fam = {
+    .name = "unit.test",
+  };
+
+  format_metric_family(&got, &fam);
+  EXPECT_EQ_INT(0, got.pos);
+
+  STRBUF_DESTROY(got);
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(format_metric_family);
+
+  END_TEST;
+}

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -50,22 +50,23 @@ DEF_TEST(format_metric_family) {
           .name = "metric without labels",
           .fam =
               {
-                  .name = "unittest",
+                  .name = "unit.test",
                   .type = METRIC_TYPE_COUNTER,
                   .metric =
                       {
                           .ptr =
                               &(metric_t){
-                                  .value = (value_t){
-                                    .counter = 42,
-                                  },
+                                  .value =
+                                      (value_t){
+                                          .counter = 42,
+                                      },
                               },
                           .num = 1,
                       },
               },
-          .want = "# HELP unittest\n"
-              "# TYPE unittest counter\n"
-              "unittest 42\n",
+          .want = "# HELP unit_test\n"
+                  "# TYPE unit_test counter\n"
+                  "unit_test 42\n",
       },
       {
           .name = "metric with one label",
@@ -86,16 +87,48 @@ DEF_TEST(format_metric_family) {
                                               },
                                           .num = 1,
                                       },
-                                  .value = (value_t){
-                                    .counter = 42,
-                                  },
+                                  .value =
+                                      (value_t){
+                                          .counter = 42,
+                                      },
                               },
                           .num = 1,
                       },
               },
           .want = "# HELP unittest\n"
-              "# TYPE unittest counter\n"
-              "unittest{foo=\"bar\"} 42\n",
+                  "# TYPE unittest counter\n"
+                  "unittest{foo=\"bar\"} 42\n",
+      },
+      {
+          .name = "invalid characters are replaced",
+          .fam =
+              {
+                  .name = "unit.test",
+                  .type = METRIC_TYPE_COUNTER,
+                  .metric =
+                      {
+                          .ptr =
+                              &(metric_t){
+                                  .label =
+                                      {
+                                          .ptr =
+                                              &(label_pair_t){
+                                                  .name = "metric.name",
+                                                  .value = "unit.test",
+                                              },
+                                          .num = 1,
+                                      },
+                                  .value =
+                                      (value_t){
+                                          .counter = 42,
+                                      },
+                              },
+                          .num = 1,
+                      },
+              },
+          .want = "# HELP unit_test\n"
+                  "# TYPE unit_test counter\n"
+                  "unit_test{metric_name=\"unit.test\"} 42\n",
       },
   };
 


### PR DESCRIPTION
ChangeLog: Write Prometheus plugin: Escaping for metric and label names has been added. Test coverage has been improved.
Fixes: #4204 