### PR TITLE
[collectd 6] Allow arbitrary UTF-8 strings as label names.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,7 +141,8 @@ noinst_LTLIBRARIES = \
 	libmetric.la \
 	libmount.la \
 	liboconfig.la \
-	libstrbuf.la
+	libstrbuf.la \
+	libutf8.la
 
 
 check_LTLIBRARIES = \
@@ -634,6 +635,8 @@ liboconfig_la_SOURCES = \
 	src/liboconfig/parser.y
 liboconfig_la_CPPFLAGS = -I$(srcdir)/src/liboconfig $(AM_CPPFLAGS)
 liboconfig_la_LDFLAGS = -avoid-version $(LEXLIB)
+
+libutf8_la_SOURCES = src/utils/utf8/utf8.c
 
 if BUILD_WITH_LIBCURL
 if BUILD_WITH_LIBSSL

--- a/Makefile.am
+++ b/Makefile.am
@@ -636,7 +636,7 @@ liboconfig_la_SOURCES = \
 liboconfig_la_CPPFLAGS = -I$(srcdir)/src/liboconfig $(AM_CPPFLAGS)
 liboconfig_la_LDFLAGS = -avoid-version $(LEXLIB)
 
-libutf8_la_SOURCES = src/utils/utf8/utf8.c
+libutf8_la_SOURCES = src/utils/utf8/utf8.c src/utils/utf8/utf8.h
 
 if BUILD_WITH_LIBCURL
 if BUILD_WITH_LIBSSL

--- a/Makefile.am
+++ b/Makefile.am
@@ -438,7 +438,7 @@ libmetadata_la_SOURCES = \
 libmetric_la_SOURCES = \
 		       src/daemon/metric.c \
 		       src/daemon/metric.h
-libmetric_la_LIBADD = libmetadata.la $(COMMON_LIBS)
+libmetric_la_LIBADD = libmetadata.la libutf8.la $(COMMON_LIBS)
 
 libplugin_mock_la_SOURCES = \
 	src/daemon/plugin_mock.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -637,6 +637,10 @@ liboconfig_la_CPPFLAGS = -I$(srcdir)/src/liboconfig $(AM_CPPFLAGS)
 liboconfig_la_LDFLAGS = -avoid-version $(LEXLIB)
 
 libutf8_la_SOURCES = src/utils/utf8/utf8.c src/utils/utf8/utf8.h
+check_PROGRAMS += test_utils_utf8
+TESTS += test_utils_utf8
+test_utils_utf8_SOURCES = src/utils/utf8/utf8_test.c
+test_utils_utf8_LDADD = libutf8.la
 
 if BUILD_WITH_LIBCURL
 if BUILD_WITH_LIBSSL

--- a/Makefile.am
+++ b/Makefile.am
@@ -142,7 +142,7 @@ noinst_LTLIBRARIES = \
 	libmount.la \
 	liboconfig.la \
 	libresource_metrics.la \
-  libstrbuf.la \
+	libstrbuf.la \
 	libutf8.la
 
 

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -29,20 +29,23 @@
 
 #include "metric.h"
 #include "plugin.h"
+#include "utils/utf8/utf8.h"
 
-/* Label names must match the regex `[a-zA-Z_][a-zA-Z0-9_]*`. Label names
- * beginning with __ are reserved for internal use.
- *
- * Source:
- * https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels */
-#define VALID_LABEL_CHARS                                                      \
+/* If these characters are used in resource attribute names or metric label
+ * names, they will not cause quotes to be printed when formatting the metric
+ * name. Resource attribute values and metric label values are always printed in
+ * quotes. */
+#define UNQUOTED_LABEL_CHARS                                                   \
   "abcdefghijklmnopqrstuvwxyz"                                                 \
   "ABCDEFGHIJKLMNOPQRSTUVWXYZ"                                                 \
-  "0123456789_.-"
+  "0123456789_.-:"
 
 /* Metric names must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*` */
 // instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
-#define VALID_NAME_CHARS VALID_LABEL_CHARS "/"
+#define VALID_NAME_CHARS                                                       \
+  "abcdefghijklmnopqrstuvwxyz"                                                 \
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"                                                 \
+  "0123456789_.-/"
 
 #define RESOURCE_LABEL_PREFIX "resource:"
 
@@ -98,8 +101,7 @@ int label_set_add(label_set_t *labels, char const *name, char const *value) {
     return EINVAL;
   }
 
-  size_t valid_len = strspn(name, VALID_LABEL_CHARS);
-  if ((valid_len != name_len) || isdigit((int)name[0])) {
+  if (!utf8_valid(name) || !utf8_valid(value)) {
     return EINVAL;
   }
 
@@ -265,8 +267,18 @@ static int internal_label_set_format(strbuf_t *buf, label_set_t const *labels,
       status = status || strbuf_print(buf, ",");
     }
 
-    status = status || strbuf_print(buf, prefix);
-    status = status || strbuf_print(buf, labels->ptr[i].name);
+    bool needs_quotes = strlen(labels->ptr[i].name) !=
+                        strspn(labels->ptr[i].name, UNQUOTED_LABEL_CHARS);
+    if (needs_quotes) {
+      status = status || strbuf_print(buf, "\"");
+      status = status || strbuf_print(buf, prefix);
+      status = status || strbuf_print_escaped(buf, labels->ptr[i].name,
+                                              "\\\"\n\r\t", '\\');
+      status = status || strbuf_print(buf, "\"");
+    } else {
+      status = status || strbuf_print(buf, prefix);
+      status = status || strbuf_print(buf, labels->ptr[i].name);
+    }
     status = status || strbuf_print(buf, "=\"");
     status = status || strbuf_print_escaped(buf, labels->ptr[i].value,
                                             "\\\"\n\r\t", '\\');
@@ -502,11 +514,11 @@ metric_family_t *metric_family_clone(metric_family_t const *fam) {
   return ret;
 }
 
-/* parse_label_value reads a label value, unescapes it and prints it to buf. On
- * success, inout is updated to point to the character just *after* the label
- * value, i.e. the character *following* the ending quotes - either a comma or
- * closing curlies. */
-static int parse_label_value(strbuf_t *buf, char const **inout) {
+/* parse_quoted_string reads a label value, unescapes it and prints it to buf.
+ * On success, inout is updated to point to the character just *after* the
+ * string value, i.e. the character *following* the ending quotes - either an
+ * equal sign, a comma, or closing curlies. */
+static int parse_quoted_string(strbuf_t *buf, char const **inout) {
   char const *ptr = *inout;
 
   if (ptr[0] != '"') {
@@ -602,21 +614,19 @@ static int metric_family_unmarshal_identity(metric_family_t *fam,
   while ((ptr[0] == '{') || (ptr[0] == ',')) {
     ptr++;
 
-    bool is_resource_label =
-        strncmp(ptr, RESOURCE_LABEL_PREFIX, strlen(RESOURCE_LABEL_PREFIX)) == 0;
-    if (is_resource_label) {
-      ptr += strlen(RESOURCE_LABEL_PREFIX);
+    strbuf_t key = STRBUF_CREATE;
+    if (ptr[0] == '"') {
+      int status = parse_quoted_string(&key, &ptr);
+      if (status != 0) {
+        ret = status;
+        STRBUF_DESTROY(key);
+        break;
+      }
+    } else {
+      size_t key_len = strspn(ptr, UNQUOTED_LABEL_CHARS);
+      strbuf_printn(&key, ptr, key_len);
+      ptr += key_len;
     }
-
-    size_t key_len = strspn(ptr, VALID_LABEL_CHARS);
-    if (key_len == 0) {
-      ret = EINVAL;
-      break;
-    }
-    char key[key_len + 1];
-    strncpy(key, ptr, key_len);
-    key[key_len] = 0;
-    ptr += key_len;
 
     if (ptr[0] != '=') {
       ret = EINVAL;
@@ -625,9 +635,10 @@ static int metric_family_unmarshal_identity(metric_family_t *fam,
     ptr++;
 
     strbuf_t value = STRBUF_CREATE;
-    int status = parse_label_value(&value, &ptr);
+    int status = parse_quoted_string(&value, &ptr);
     if (status != 0) {
       ret = status;
+      STRBUF_DESTROY(key);
       STRBUF_DESTROY(value);
       break;
     }
@@ -635,11 +646,15 @@ static int metric_family_unmarshal_identity(metric_family_t *fam,
     /* one metric is added to the family by metric_family_unmarshal_text. */
     assert(fam->metric.num >= 1);
 
+    bool is_resource_label = strncmp(key.ptr, RESOURCE_LABEL_PREFIX,
+                                     strlen(RESOURCE_LABEL_PREFIX)) == 0;
     if (is_resource_label) {
-      status = metric_family_resource_attribute_update(fam, key, value.ptr);
+      status = metric_family_resource_attribute_update(
+          fam, key.ptr + strlen(RESOURCE_LABEL_PREFIX), value.ptr);
     } else {
-      status = metric_label_set(m, key, value.ptr);
+      status = metric_label_set(m, key.ptr, value.ptr);
     }
+    STRBUF_DESTROY(key);
     STRBUF_DESTROY(value);
     if (status != 0) {
       ret = status;

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -253,6 +253,23 @@ DEF_TEST(metric_identity) {
               "metric_with_resource_and_labels{resource:alpha=\"resources\","
               "resource:omega=\"always\",beta=\"come\",gamma=\"first\"}",
       },
+      {
+          .name = "complex_names.are.quoted",
+          .rattr =
+              (label_pair_t[]){
+                  {"with space", "gets quotes"},
+              },
+          .rattr_num = 1,
+          .labels =
+              (label_pair_t[]){
+                  {"and \"quotes\" are", "escaped"},
+              },
+          .labels_num = 1,
+          .want = "complex_names.are.quoted{"
+                  "\"resource:with space\"=\"gets quotes\","
+                  "\"and \\\"quotes\\\" are\"=\"escaped\""
+                  "}",
+      },
   };
 
   for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
@@ -368,6 +385,34 @@ DEF_TEST(metric_parse_identity) {
                                   .ptr =
                                       (label_pair_t[]){
                                           {"host.name", "example.com"},
+                                      },
+                                  .num = 1,
+                              },
+                      },
+              },
+      },
+      {
+          .name = "complex names are quoted",
+          .input = "complex_names.are.quoted{\"resource:with space\"=\"gets "
+                   "quotes\",\"and \\\"quotes\\\" are\"=\"escaped\"}",
+          .want =
+              {
+                  .label =
+                      {
+                          .ptr =
+                              (label_pair_t[]){
+                                  {"and \"quotes\" are", "escaped"},
+                              },
+                          .num = 1,
+                      },
+                  .family =
+                      &(metric_family_t){
+                          .name = "complex_names.are.quoted",
+                          .resource =
+                              {
+                                  .ptr =
+                                      (label_pair_t[]){
+                                          {"with space", "gets quotes"},
                                       },
                                   .num = 1,
                               },

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -419,6 +419,21 @@ DEF_TEST(metric_parse_identity) {
                       },
               },
       },
+      {
+          .name = "invalid character in metric name",
+          .input = "example@metric{label=\"value\"}",
+          .want_err = EINVAL,
+      },
+      {
+          .name = "curly not closed",
+          .input = "example_metric{label=\"value\"",
+          .want_err = EINVAL,
+      },
+      {
+          .name = "trailing curly",
+          .input = "example_metric{label=\"value\"}}",
+          .want_err = EINVAL,
+      },
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -26,8 +26,9 @@
 
 #include "collectd.h"
 
-#include "metric.h"
+#include "daemon/metric.h"
 #include "testing.h"
+#include "utils/common/common.h"
 
 DEF_TEST(metric_label_set) {
   struct {
@@ -287,6 +288,113 @@ DEF_TEST(metric_identity) {
   return 0;
 }
 
+static int metric_compare(metric_t const *got, metric_t const *want) {
+  EXPECT_EQ_INT(0, metric_family_compare(got->family, want->family));
+  EXPECT_EQ_INT(0, label_set_compare(got->label, want->label));
+  return 0;
+}
+
+DEF_TEST(metric_parse_identity) {
+  struct {
+    char const *name;
+    char const *input;
+    metric_t want;
+    int want_err;
+  } cases[] = {
+      {
+          .name = "metric without labels",
+          .input = "metric_without_labels",
+          .want =
+              {
+                  .family =
+                      &(metric_family_t){
+                          .name = "metric_without_labels",
+                      },
+              },
+      },
+      {
+          .name = "metric with labels",
+          .input = "metric_with_labels{alphabetically=\"true\",sorted=\"yes\"}",
+          .want =
+              {
+                  .label =
+                      {
+                          .ptr =
+                              (label_pair_t[]){
+                                  {"alphabetically", "true"},
+                                  {"sorted", "yes"},
+                              },
+                          .num = 2,
+                      },
+                  .family =
+                      &(metric_family_t){
+                          .name = "metric_with_labels",
+                      },
+              },
+      },
+      {
+          .name = "escape sequences",
+          .input = "escape_sequences{cardridge_return=\"\\r\",newline=\"\\n\","
+                   "quote=\"\\\"\",tab=\"\\t\"}",
+          .want =
+              {
+                  .label =
+                      {
+                          .ptr =
+                              (label_pair_t[]){
+                                  {"cardridge_return", "\r"},
+                                  {"newline", "\n"},
+                                  {"quote", "\""},
+                                  {"tab", "\t"},
+                              },
+                          .num = 4,
+                      },
+                  .family =
+                      &(metric_family_t){
+                          .name = "escape_sequences",
+                      },
+              },
+      },
+      {
+          .name = "metric with resource",
+          .input = "metric_with_resource{resource:host.name=\"example.com\"}",
+          .want =
+              {
+                  .family =
+                      &(metric_family_t){
+                          .name = "metric_with_resource",
+                          .resource =
+                              {
+                                  .ptr =
+                                      (label_pair_t[]){
+                                          {"host.name", "example.com"},
+                                      },
+                                  .num = 1,
+                              },
+                      },
+              },
+      },
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    printf("## Case %zu: %s\n", i, cases[i].name);
+
+    errno = 0;
+    metric_t *got = metric_parse_identity(cases[i].input);
+    OK1((got == NULL) == (errno != 0), "iff \"got\" is NULL, \"errno\" is set");
+    EXPECT_EQ_INT(cases[i].want_err, errno);
+    if (cases[i].want_err != 0) {
+      continue;
+    }
+
+    EXPECT_EQ_INT(0, metric_compare(got, &cases[i].want));
+
+    metric_family_free(got->family);
+  }
+
+  return 0;
+}
+
 DEF_TEST(metric_family_append) {
   struct {
     char const *lname;
@@ -391,6 +499,7 @@ DEF_TEST(metric_family_append) {
 int main(void) {
   RUN_TEST(metric_label_set);
   RUN_TEST(metric_identity);
+  RUN_TEST(metric_parse_identity);
   RUN_TEST(metric_family_append);
 
   END_TEST;

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -25,6 +25,7 @@
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 1
 
+// clang-format off
 static const uint8_t utf8d[] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
@@ -41,21 +42,19 @@ static const uint8_t utf8d[] = {
   1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
   1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
 };
+// clang-format on
 
-uint32_t inline
-decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
+uint32_t inline decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   uint32_t type = utf8d[byte];
 
-  *codep = (*state != UTF8_ACCEPT) ?
-    (byte & 0x3fu) | (*codep << 6) :
-    (0xff >> type) & (byte);
+  *codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6)
+                                   : (0xff >> type) & (byte);
 
-  *state = utf8d[256 + *state*16 + type];
+  *state = utf8d[256 + *state * 16 + type];
   return *state;
 }
 
-int
-IsUTF8(uint8_t* s) {
+int IsUTF8(uint8_t *s) {
   uint32_t codepoint, state = 0;
 
   while (*s)

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -56,7 +56,7 @@ static uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   return *state;
 }
 
-int utf8_valid(char const *s) {
+bool utf8_valid(char const *s) {
   uint32_t codepoint, state = 0;
 
   while (*s)

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -46,17 +46,15 @@ static const uint8_t utf8d[] = {
 };
 // clang-format on
 
-static void decode(uint32_t *state, uint32_t byte) {
+static uint32_t decode(uint32_t state, uint32_t byte) {
   uint32_t type = utf8d[byte];
-
-  *state = utf8d[256 + (*state) * 16 + type];
+  return utf8d[256 + state * 16 + type];
 }
 
 bool utf8_valid(char const *s) {
   uint32_t state = 0;
-
   for (size_t i = 0; s[i] != 0; i++) {
-    decode(&state, (uint8_t)s[i]);
+    state = decode(state, (uint8_t)s[i]);
   }
 
   return state == UTF8_ACCEPT;

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -56,11 +56,11 @@ static uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   return *state;
 }
 
-int utf8_valid(uint8_t *s) {
+int utf8_valid(char const *s) {
   uint32_t codepoint, state = 0;
 
   while (*s)
-    decode(&state, &codepoint, *s++);
+    decode(&state, &codepoint, (uint8_t)*s++);
 
   return state == UTF8_ACCEPT;
 }

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -46,20 +46,17 @@ static const uint8_t utf8d[] = {
 };
 // clang-format on
 
-static void decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
+static void decode(uint32_t *state, uint32_t byte) {
   uint32_t type = utf8d[byte];
-
-  *codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6)
-                                   : (0xff >> type) & (byte);
 
   *state = utf8d[256 + (*state) * 16 + type];
 }
 
 bool utf8_valid(char const *s) {
-  uint32_t codepoint, state = 0;
+  uint32_t state = 0;
 
   for (size_t i = 0; s[i] != 0; i++) {
-    decode(&state, &codepoint, (uint8_t)s[i]);
+    decode(&state, (uint8_t)s[i]);
   }
 
   return state == UTF8_ACCEPT;

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -58,8 +58,9 @@ static void decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
 bool utf8_valid(char const *s) {
   uint32_t codepoint, state = 0;
 
-  while (*s)
-    decode(&state, &codepoint, (uint8_t)*s++);
+  for (size_t i = 0; s[i] != 0; i++) {
+    decode(&state, &codepoint, (uint8_t)s[i]);
+  }
 
   return state == UTF8_ACCEPT;
 }

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -46,14 +46,13 @@ static const uint8_t utf8d[] = {
 };
 // clang-format on
 
-static uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
+static void decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   uint32_t type = utf8d[byte];
 
   *codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6)
                                    : (0xff >> type) & (byte);
 
-  *state = utf8d[256 + *state * 16 + type];
-  return *state;
+  *state = utf8d[256 + (*state) * 16 + type];
 }
 
 bool utf8_valid(char const *s) {

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -22,6 +22,8 @@
 
 // See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
 
+#include "collectd.h"
+
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 1
 
@@ -44,7 +46,7 @@ static const uint8_t utf8d[] = {
 };
 // clang-format on
 
-uint32_t inline decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
+static uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   uint32_t type = utf8d[byte];
 
   *codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6)

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -56,7 +56,7 @@ static uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte) {
   return *state;
 }
 
-int IsUTF8(uint8_t *s) {
+int utf8_valid(uint8_t *s) {
   uint32_t codepoint, state = 0;
 
   while (*s)

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT 1
+
+static const uint8_t utf8d[] = {
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+  8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+  0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+  0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+  0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+  1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+  1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+  1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+};
+
+uint32_t inline
+decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
+  uint32_t type = utf8d[byte];
+
+  *codep = (*state != UTF8_ACCEPT) ?
+    (byte & 0x3fu) | (*codep << 6) :
+    (0xff >> type) & (byte);
+
+  *state = utf8d[256 + *state*16 + type];
+  return *state;
+}
+
+int
+IsUTF8(uint8_t* s) {
+  uint32_t codepoint, state = 0;
+
+  while (*s)
+    decode(&state, &codepoint, *s++);
+
+  return state == UTF8_ACCEPT;
+}

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -22,7 +22,7 @@
 
 // See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
 
-#include "collectd.h"
+#include "utils/utf8/utf8.h"
 
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 1

--- a/src/utils/utf8/utf8.c
+++ b/src/utils/utf8/utf8.c
@@ -52,6 +52,10 @@ static uint32_t decode(uint32_t state, uint32_t byte) {
 }
 
 bool utf8_valid(char const *s) {
+  if (s == NULL) {
+    return false;
+  }
+
   uint32_t state = 0;
   for (size_t i = 0; s[i] != 0; i++) {
     state = decode(state, (uint8_t)s[i]);

--- a/src/utils/utf8/utf8.h
+++ b/src/utils/utf8/utf8.h
@@ -25,6 +25,6 @@
 
 #include "collectd.h"
 
-int IsUTF8(uint8_t *s);
+int utf8_valid(uint8_t *s);
 
 #endif

--- a/src/utils/utf8/utf8.h
+++ b/src/utils/utf8/utf8.h
@@ -25,6 +25,6 @@
 
 #include "collectd.h"
 
-int utf8_valid(uint8_t *s);
+int utf8_valid(char const *s);
 
 #endif

--- a/src/utils/utf8/utf8.h
+++ b/src/utils/utf8/utf8.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023      Florian "octo" Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef UTILS_UTF8_H
+#define UTILS_UTF8_H 1
+
+#include "collectd.h"
+
+int IsUTF8(uint8_t *s);
+
+#endif

--- a/src/utils/utf8/utf8.h
+++ b/src/utils/utf8/utf8.h
@@ -25,6 +25,6 @@
 
 #include "collectd.h"
 
-int utf8_valid(char const *s);
+bool utf8_valid(char const *s);
 
 #endif

--- a/src/utils/utf8/utf8_test.c
+++ b/src/utils/utf8/utf8_test.c
@@ -25,80 +25,80 @@
 #include "utils/common/common.h"
 #include "utils/utf8/utf8.h"
 
-DEF_TEST(IsUTF8) {
+DEF_TEST(utf8_valid) {
   struct {
     char const *name;
     char *input;
     bool want;
   } cases[] = {
-    {
-        .name = "simple string",
-        .input = "Hello, World!",
-        .want = true,
-    },
-    {
-        .name = "empty string",
-        .input = "",
-        .want = true,
-    },
-    {
-        .name = "The greek work \"kosme\"",
-        .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc,
-                          0xce, 0xb5, 0},
-        .want = true,
-    },
-    {
-        .name = "First possible sequence of three bytes",
-        .input = (char[]){0xe0, 0xa0, 0x80, 0},
-        .want = true,
-    },
-    {
-        .name = "First possible sequence of four bytes",
-        .input = (char[]){0xf0, 0x90, 0x80, 0x80, 0},
-        .want = true,
-    },
-    {
-        .name = "U-0000D7F",
-        .input = (char[]){0xed, 0x9f, 0xbf, 0},
-        .want = true,
-    },
-    {
-        .name = "0xFE (invalid byte)",
-        .input = (char[]){'H', 0xfe, 'l', 'l', 'o', 0},
-        .want = false,
-    },
-    {
-        .name = "0xFF (invalid byte)",
-        .input = (char[]){'C', 'o', 0xff, 'e', 'e', 0},
-        .want = false,
-    },
-    {
-        .name = "Continuation byte at end of string",
-        .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc,
-                          0xce, 0},
-        .want = false,
-    },
-    {
-        .name = "U+002F (overlong ASCII character, 2 bytes)",
-        .input = (char[]){0xc0, 0xaf, 0},
-        .want = false,
-    },
-    {
-        .name = "U+002F (overlong ASCII character, 3 bytes)",
-        .input = (char[]){0xe0, 0x80, 0xaf, 0},
-        .want = false,
-    },
+      {
+          .name = "simple string",
+          .input = "Hello, World!",
+          .want = true,
+      },
+      {
+          .name = "empty string",
+          .input = "",
+          .want = true,
+      },
+      {
+          .name = "The greek work \"kosme\"",
+          .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
+                            0xbc, 0xce, 0xb5, 0},
+          .want = true,
+      },
+      {
+          .name = "First possible sequence of three bytes",
+          .input = (char[]){0xe0, 0xa0, 0x80, 0},
+          .want = true,
+      },
+      {
+          .name = "First possible sequence of four bytes",
+          .input = (char[]){0xf0, 0x90, 0x80, 0x80, 0},
+          .want = true,
+      },
+      {
+          .name = "U-0000D7F",
+          .input = (char[]){0xed, 0x9f, 0xbf, 0},
+          .want = true,
+      },
+      {
+          .name = "0xFE (invalid byte)",
+          .input = (char[]){'H', 0xfe, 'l', 'l', 'o', 0},
+          .want = false,
+      },
+      {
+          .name = "0xFF (invalid byte)",
+          .input = (char[]){'C', 'o', 0xff, 'e', 'e', 0},
+          .want = false,
+      },
+      {
+          .name = "Continuation byte at end of string",
+          .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
+                            0xbc, 0xce, 0},
+          .want = false,
+      },
+      {
+          .name = "U+002F (overlong ASCII character, 2 bytes)",
+          .input = (char[]){0xc0, 0xaf, 0},
+          .want = false,
+      },
+      {
+          .name = "U+002F (overlong ASCII character, 3 bytes)",
+          .input = (char[]){0xe0, 0x80, 0xaf, 0},
+          .want = false,
+      },
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
     printf("Case #%zu: %s\n", i, cases[i].name);
-    EXPECT_EQ_INT(cases[i].want, IsUTF8((uint8_t *)cases[i].input));
+    EXPECT_EQ_INT(cases[i].want, utf8_valid((uint8_t *)cases[i].input));
   }
   return 0;
 }
 
 int main(void) {
-  RUN_TEST(IsUTF8);
+  RUN_TEST(utf8_valid);
 
   END_TEST;
 }

--- a/src/utils/utf8/utf8_test.c
+++ b/src/utils/utf8/utf8_test.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023      Florian "octo" Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "collectd.h"
+#include "testing.h"
+#include "utils/common/common.h"
+#include "utils/utf8/utf8.h"
+
+DEF_TEST(IsUTF8) {
+  struct {
+    char const *name;
+    char *input;
+    bool want;
+  } cases[] = {
+    {
+        .name = "simple string",
+        .input = "Hello, World!",
+        .want = true,
+    },
+    {
+        .name = "empty string",
+        .input = "",
+        .want = true,
+    },
+    {
+        .name = "The greek work \"kosme\"",
+        .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc,
+                          0xce, 0xb5, 0},
+        .want = true,
+    },
+    {
+        .name = "First possible sequence of three bytes",
+        .input = (char[]){0xe0, 0xa0, 0x80, 0},
+        .want = true,
+    },
+    {
+        .name = "First possible sequence of four bytes",
+        .input = (char[]){0xf0, 0x90, 0x80, 0x80, 0},
+        .want = true,
+    },
+    {
+        .name = "U-0000D7F",
+        .input = (char[]){0xed, 0x9f, 0xbf, 0},
+        .want = true,
+    },
+    {
+        .name = "0xFE (invalid byte)",
+        .input = (char[]){'H', 0xfe, 'l', 'l', 'o', 0},
+        .want = false,
+    },
+    {
+        .name = "0xFF (invalid byte)",
+        .input = (char[]){'C', 'o', 0xff, 'e', 'e', 0},
+        .want = false,
+    },
+    {
+        .name = "Continuation byte at end of string",
+        .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc,
+                          0xce, 0},
+        .want = false,
+    },
+    {
+        .name = "U+002F (overlong ASCII character, 2 bytes)",
+        .input = (char[]){0xc0, 0xaf, 0},
+        .want = false,
+    },
+    {
+        .name = "U+002F (overlong ASCII character, 3 bytes)",
+        .input = (char[]){0xe0, 0x80, 0xaf, 0},
+        .want = false,
+    },
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    printf("Case #%zu: %s\n", i, cases[i].name);
+    EXPECT_EQ_INT(cases[i].want, IsUTF8((uint8_t *)cases[i].input));
+  }
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(IsUTF8);
+
+  END_TEST;
+}

--- a/src/utils/utf8/utf8_test.c
+++ b/src/utils/utf8/utf8_test.c
@@ -42,6 +42,11 @@ DEF_TEST(utf8_valid) {
           .want = true,
       },
       {
+          .name = "null string",
+          .input = NULL,
+          .want = false,
+      },
+      {
           .name = "The greek work \"kosme\"",
           .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
                             0xbc, 0xce, 0xb5, 0},

--- a/src/utils/utf8/utf8_test.c
+++ b/src/utils/utf8/utf8_test.c
@@ -92,7 +92,7 @@ DEF_TEST(utf8_valid) {
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
     printf("Case #%zu: %s\n", i, cases[i].name);
-    EXPECT_EQ_INT(cases[i].want, utf8_valid((uint8_t *)cases[i].input));
+    EXPECT_EQ_INT(cases[i].want, utf8_valid(cases[i].input));
   }
   return 0;
 }


### PR DESCRIPTION
Source: https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/

ChangeLog: Daemon: All valid UTF-8 strings are now accepted as resource attribute name and metric label name.