### PR TITLE
[collectd 6] Improve Write Prometheus' handling of resource attributes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,8 +130,8 @@ noinst_LTLIBRARIES = \
 	libavltree.la \
 	libcmds.la \
 	libcommon.la \
-	libformat_influxdb.la \
 	libformat_graphite.la \
+	libformat_influxdb.la \
 	libheap.la \
 	libignorelist.la \
 	liblatency.la \
@@ -141,6 +141,7 @@ noinst_LTLIBRARIES = \
 	libmetric.la \
 	libmount.la \
 	liboconfig.la \
+	libresource_metrics.la \
 	libstrbuf.la
 
 
@@ -386,13 +387,6 @@ test_utils_message_parser_SOURCES = \
 test_utils_message_parser_CPPFLAGS = $(AM_CPPFLAGS)
 test_utils_message_parser_LDADD = libplugin_mock.la -lm
 
-test_utils_resource_metrics_SOURCES = \
-	src/utils/resource_metrics/resource_metrics_test.c \
-	src/utils/resource_metrics/resource_metrics.c \
-	src/utils/resource_metrics/resource_metrics.h \
-	src/testing.h
-test_utils_resource_metrics_LDADD = libplugin_mock.la
-
 test_utils_time_SOURCES = \
 	src/daemon/utils_time_test.c \
 	src/testing.h
@@ -579,6 +573,15 @@ test_utils_mount_LDADD = \
 if BUILD_WITH_LIBKSTAT
 test_utils_mount_LDADD += -lkstat
 endif
+
+libresource_metrics_la_SOURCES = src/utils/resource_metrics/resource_metrics.c \
+				 src/utils/resource_metrics/resource_metrics.h
+libresource_metrics_la_LIBADD = libcommon.la
+
+test_utils_resource_metrics_SOURCES = \
+	src/utils/resource_metrics/resource_metrics_test.c \
+	src/testing.h
+test_utils_resource_metrics_LDADD = libresource_metrics.la libplugin_mock.la
 
 libstrbuf_la_SOURCES = \
 		       src/utils/strbuf/strbuf.c \

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -75,9 +75,18 @@ typedef struct {
  * returned. */
 int label_set_clone(label_set_t *dest, label_set_t src);
 
+/* label_set_get looks up the label pair by name, and returns the associated
+ * value. Returns NULL and sets errno to ENOENT if the label doesn't exist. */
+char const *label_set_get(label_set_t labels, char const *name);
+
 /* label_set_add adds a label to the label set. If a label with name already
  * exists, EEXIST is returned. The set of labels is sorted by label name. */
 int label_set_add(label_set_t *labels, char const *name, char const *value);
+
+/* label_set_update adds, updates, or deletes a label pair. If "value" is NULL
+ * or an empty string, the label is removed.
+ * Removing a label that does not exist is *not* an error. */
+int label_set_update(label_set_t *labels, char const *name, char const *value);
 
 /* label_set_reset frees all the memory referenced by the label set and
  * initializes the label set to zero. */

--- a/src/utils/resource_metrics/resource_metrics.c
+++ b/src/utils/resource_metrics/resource_metrics.c
@@ -160,9 +160,8 @@ static int compare_metrics(metric_t const *a, metric_t const *b) {
 }
 
 static bool metric_exists(metric_family_t const *fam, metric_t const *m) {
-  metric_family_t *found =
-      bsearch(m, fam->metric.ptr, fam->metric.num, sizeof(*fam->metric.ptr),
-              (void *)compare_metrics);
+  metric_t *found = bsearch(m, fam->metric.ptr, fam->metric.num,
+                            sizeof(*fam->metric.ptr), (void *)compare_metrics);
   return found != NULL;
 }
 
@@ -170,7 +169,6 @@ static int insert_metrics(metric_family_t *fam, metric_list_t metrics) {
   int skipped = 0;
   for (size_t i = 0; i < metrics.num; i++) {
     metric_t const *m = metrics.ptr + i;
-
     if (metric_exists(fam, m)) {
 #if COLLECT_DEBUG
       strbuf_t buf = STRBUF_CREATE;

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -271,8 +271,13 @@ void target_info(strbuf_t *buf, label_set_t resource) {
   label_set_update(&rattr, "service.name", NULL);
   label_set_update(&rattr, "service.instance.id", NULL);
 
+#ifdef EXPOSE_OPEN_METRICS
   strbuf_print(buf, "# TYPE target info\n");
   strbuf_print(buf, "# HELP target Target metadata\n");
+#else
+  strbuf_print(buf, "# HELP target_info Target metadata\n");
+  strbuf_print(buf, "# TYPE target_info gauge\n");
+#endif
 
   strbuf_print(buf, "target_info{");
   format_label_set(buf, rattr, job, instance);

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -248,8 +248,9 @@ void format_metric_family(strbuf_t *buf, metric_family_t const *prom_fam) {
       strbuf_printf(buf, "\n");
     }
   }
-
   STRBUF_DESTROY(family_name);
+
+  strbuf_printf(buf, "\n");
 }
 
 /* target_info prints a special "info" metric that contains all the "target
@@ -301,8 +302,8 @@ static void format_text(strbuf_t *buf) {
   }
   c_avl_iterator_destroy(iter);
 
-  strbuf_printf(buf, "\n# collectd/write_prometheus %s at %s\n",
-                PACKAGE_VERSION, hostname_g);
+  strbuf_printf(buf, "# collectd/write_prometheus %s at %s\n", PACKAGE_VERSION,
+                hostname_g);
 
   pthread_mutex_unlock(&prom_metrics_lock);
 }

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -111,19 +111,20 @@ static int format_metric(strbuf_t *buf, metric_t const *m) {
   if ((buf == NULL) || (m == NULL) || (m->family == NULL)) {
     return EINVAL;
   }
-  label_set_t const *resource = &m->family->resource;
+  label_set_t resource = m->family->resource;
 
   int status =
       strbuf_print_restricted(buf, m->family->name, VALID_NAME_CHARS, '_');
-  if (resource->num == 0 && m->label.num == 0) {
+  if (resource.num == 0 && m->label.num == 0) {
     return status;
   }
 
   status = status || strbuf_print(buf, "{");
 
   bool first_label = true;
-  if (resource->num != 0) {
-    status = status || format_label_set(buf, resource, RESOURCE_LABEL_PREFIX,
+  if (resource.num != 0 &&
+      label_set_compare(resource, default_resource_attributes()) != 0) {
+    status = status || format_label_set(buf, &resource, RESOURCE_LABEL_PREFIX,
                                         true, first_label);
     first_label = false;
   }

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -150,8 +150,43 @@ DEF_TEST(format_metric_family) {
   return 0;
 }
 
+void target_info(strbuf_t *buf, label_set_t resource);
+
+DEF_TEST(target_info) {
+  struct {
+    char const *name;
+    label_set_t resource;
+    char const *want;
+  } cases[] = {
+      {
+          .name = "single resource attribute",
+          .resource =
+              {
+                  .ptr = &(label_pair_t){"foo", "bar"},
+                  .num = 1,
+              },
+          .want = "# TYPE target info\n"
+                  "# HELP target Target metadata\n"
+                  "target_info{foo=\"bar\"} 1\n",
+      },
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    printf("# Case %zu: %s\n", i, cases[i].name);
+    strbuf_t got = STRBUF_CREATE;
+
+    target_info(&got, cases[i].resource);
+    EXPECT_EQ_STR(cases[i].want, got.ptr);
+
+    STRBUF_DESTROY(got);
+  }
+
+  return 0;
+}
+
 int main(void) {
   RUN_TEST(format_metric_family);
+  RUN_TEST(target_info);
 
   END_TEST;
 }

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -268,8 +268,8 @@ DEF_TEST(target_info) {
                   .ptr = &(label_pair_t){"foo", "bar"},
                   .num = 1,
               },
-          .want = "# TYPE target info\n"
-                  "# HELP target Target metadata\n"
+          .want = "# HELP target_info Target metadata\n"
+                  "# TYPE target_info gauge\n"
                   "target_info{foo=\"bar\"} 1\n",
       },
       {
@@ -279,8 +279,8 @@ DEF_TEST(target_info) {
                   .ptr = &(label_pair_t){"service.name", "unittest"},
                   .num = 1,
               },
-          .want = "# TYPE target info\n"
-                  "# HELP target Target metadata\n"
+          .want = "# HELP target_info Target metadata\n"
+                  "# TYPE target_info gauge\n"
                   "target_info{job=\"unittest\"} 1\n",
       },
       {
@@ -290,8 +290,8 @@ DEF_TEST(target_info) {
                   .ptr = &(label_pair_t){"service.instance.id", "42"},
                   .num = 1,
               },
-          .want = "# TYPE target info\n"
-                  "# HELP target Target metadata\n"
+          .want = "# HELP target_info Target metadata\n"
+                  "# TYPE target_info gauge\n"
                   "target_info{instance=\"42\"} 1\n",
       },
   };

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -169,6 +169,28 @@ DEF_TEST(target_info) {
                   "# HELP target Target metadata\n"
                   "target_info{foo=\"bar\"} 1\n",
       },
+      {
+          .name = "service.name gets translated to job",
+          .resource =
+              {
+                  .ptr = &(label_pair_t){"service.name", "unittest"},
+                  .num = 1,
+              },
+          .want = "# TYPE target info\n"
+                  "# HELP target Target metadata\n"
+                  "target_info{job=\"unittest\"} 1\n",
+      },
+      {
+          .name = "service.instance.id gets translated to instance",
+          .resource =
+              {
+                  .ptr = &(label_pair_t){"service.instance.id", "42"},
+                  .num = 1,
+              },
+          .want = "# TYPE target info\n"
+                  "# HELP target Target metadata\n"
+                  "target_info{instance=\"42\"} 1\n",
+      },
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -127,7 +127,8 @@ DEF_TEST(format_metric_family) {
               },
           .want = "# HELP unit_test_total\n"
                   "# TYPE unit_test_total counter\n"
-                  "unit_test_total 42\n",
+                  "unit_test_total 42\n"
+                  "\n",
       },
       {
           .name = "metric with one label",
@@ -158,7 +159,8 @@ DEF_TEST(format_metric_family) {
               },
           .want = "# HELP unittest\n"
                   "# TYPE unittest gauge\n"
-                  "unittest{foo=\"bar\"} 42\n",
+                  "unittest{foo=\"bar\"} 42\n"
+                  "\n",
       },
       {
           .name = "invalid characters are replaced",
@@ -189,7 +191,8 @@ DEF_TEST(format_metric_family) {
               },
           .want = "# HELP unit_test\n"
                   "# TYPE unit_test untyped\n"
-                  "unit_test{metric_name=\"unit.test\"} 42\n",
+                  "unit_test{metric_name=\"unit.test\"} 42\n"
+                  "\n",
       },
       {
           .name = "most resource attributes are ignored",
@@ -231,7 +234,8 @@ DEF_TEST(format_metric_family) {
           .want = "# HELP unit_test\n"
                   "# TYPE unit_test untyped\n"
                   "unit_test{job=\"service name\",instance=\"service instance "
-                  "id\",metric_name=\"unit.test\"} 42\n",
+                  "id\",metric_name=\"unit.test\"} 42\n"
+                  "\n",
       },
   };
 


### PR DESCRIPTION
This PR aims to implement the "target info" metrics described in the [guidance on push based systems from the OpenMetrics spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#supporting-target-metadata-in-both-push-based-and-pull-based-systems). It also heavily relies on guidance provided in https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/.

* Calculate a set of all resources, called `target_info_t`.
* Emit a `target_info` gauge metric family.
* Emit one `target_info` metric for each "resource" in the set. The resource attributes `service.name` and `service.instance.id` are mapped to the special Prometheus labels `job` and `instance` respectively. Resource attributes are only emitted once, in the special "target info metric". Other metrics are exported with `job` and `instance` labels (if available) but no other resource attributes.
* Re-implement the logic for sanitizing metric names and label names based on the OpenTelemetry integration.

ChangeLog: Write Prometheus plugin: Resource attributes have been integrated into the plugin. "service.name" and "service.instance.id" are exported as "job" and "instance" labels. All other resource attributes are exported once in the `target_info` metric family.