### PR TITLE
[collectd 6] src/daemon/metric.c: Fix memory corruption in `label_set_delete`.

### DIFF
--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -257,8 +257,8 @@ int metric_reset(metric_t *m) {
   return 0;
 }
 
-static int format_label_set(strbuf_t *buf, label_set_t const *labels,
-                            char const *prefix, bool first_label) {
+static int internal_label_set_format(strbuf_t *buf, label_set_t const *labels,
+                                     char const *prefix, bool first_label) {
   int status = 0;
   for (size_t i = 0; i < labels->num; i++) {
     if (!first_label) {
@@ -276,6 +276,10 @@ static int format_label_set(strbuf_t *buf, label_set_t const *labels,
   return status;
 }
 
+int label_set_format(strbuf_t *buf, label_set_t labels) {
+  return internal_label_set_format(buf, &labels, "", true);
+}
+
 int metric_identity(strbuf_t *buf, metric_t const *m) {
   if ((buf == NULL) || (m == NULL) || (m->family == NULL)) {
     return EINVAL;
@@ -291,11 +295,11 @@ int metric_identity(strbuf_t *buf, metric_t const *m) {
 
   bool first_label = true;
   if (resource->num != 0) {
-    status = status || format_label_set(buf, resource, RESOURCE_LABEL_PREFIX,
-                                        first_label);
+    status = status || internal_label_set_format(
+                           buf, resource, RESOURCE_LABEL_PREFIX, first_label);
     first_label = false;
   }
-  status = status || format_label_set(buf, &m->label, "", first_label);
+  status = status || internal_label_set_format(buf, &m->label, "", first_label);
 
   return status || strbuf_print(buf, "}");
 }

--- a/src/daemon/metric.c
+++ b/src/daemon/metric.c
@@ -151,9 +151,10 @@ static int label_set_delete(label_set_t *labels, label_pair_t *elem) {
   free(elem->name);
   free(elem->value);
 
-  if (index != (labels->num - 1)) {
+  size_t pairs_to_move = labels->num - (index + 1);
+  if (pairs_to_move != 0) {
     memmove(labels->ptr + index, labels->ptr + (index + 1),
-            labels->num - (index + 1));
+            sizeof(*labels->ptr) * pairs_to_move);
   }
   labels->num--;
 

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -92,6 +92,10 @@ void label_set_reset(label_set_t *labels);
  */
 int label_set_compare(label_set_t a, label_set_t b);
 
+/* label_set_format formats a label set as a string, returned in "buf".
+ * Returns zero on success and non-zero on failure. */
+int label_set_format(strbuf_t *buf, label_set_t labels);
+
 /*
  * Metric
  */

--- a/src/daemon/metric_test.c
+++ b/src/daemon/metric_test.c
@@ -29,19 +29,6 @@
 #include "metric.h"
 #include "testing.h"
 
-static void format_label_set(strbuf_t *buf, label_set_t labels) {
-  for (size_t i = 0; i < labels.num; i++) {
-    strbuf_printf(buf, "[i=%zu]", i);
-    if (i != 0) {
-      strbuf_print(buf, ",");
-    }
-    strbuf_print_escaped(buf, labels.ptr[i].name, "\\\"\n\r\t", '\\');
-    strbuf_print(buf, "=\"");
-    strbuf_print_escaped(buf, labels.ptr[i].value, "\\\"\n\r\t", '\\');
-    strbuf_print(buf, "\"");
-  }
-}
-
 DEF_TEST(metric_label_set) {
   struct {
     char const *name;
@@ -186,8 +173,8 @@ DEF_TEST(metric_label_set) {
     strbuf_t got = STRBUF_CREATE;
     strbuf_t want = STRBUF_CREATE;
 
-    format_label_set(&want, cases[i].want);
-    format_label_set(&got, m.label);
+    label_set_format(&want, cases[i].want);
+    label_set_format(&got, m.label);
 
     EXPECT_EQ_STR(want.ptr, got.ptr);
 


### PR DESCRIPTION
The size parameter passed to `memmove` was in number of pairs, not bytes.

ChangeLog: Daemon: Memory corruption in the "label_set_delete" function has been fixed.