### PR TITLE
[collectd 6] df plugin: Align metrics with OpenTelemetry recommendations.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -665,11 +665,11 @@
 #	MountPoint "/home"
 #	FSType "ext3"
 #	IgnoreSelected false
+#
 #	LogOnce false
-#	ReportByDevice false
 #	ReportInodes false
-#	ValuesAbsolute true
-#	ValuesPercentage false
+#	ReportUsage true
+#	ReportUtilization false
 #</Plugin>
 
 #<Plugin disk>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2945,14 +2945,14 @@ Enable this option if inodes are a scarce resource for you, usually because
 many small files are stored on the disk. This is a usual scenario for mail
 transfer agents and web caches.
 
-=item B<ValuesAbsolute> B<true>|B<false>
+=item B<ReportUsage> B<true>|B<false>
 
-Enables or disables reporting of free and used disk space in 1K-blocks.
+Enables or disables reporting of free and used disk space in bytes.
 Defaults to B<true>.
 
-=item B<ValuesPercentage> B<false>|B<true>
+=item B<ReportUtilization> B<false>|B<true>
 
-Enables or disables reporting of free and used disk space in percentage.
+Enables or disables reporting of free and used disk space as ratio.
 Defaults to B<false>.
 
 This is useful for deploying I<collectd> on the cloud, where machines with

--- a/src/df.c
+++ b/src/df.c
@@ -46,6 +46,11 @@
 #error "No applicable input method."
 #endif
 
+static char const *const device_label = "system.device";
+static char const *const mountpoint_label = "system.filesystem.mountpoint";
+static char const *const state_label = "system.filesystem.state";
+static char const *const type_label = "system.filesystem.type";
+
 static const char *config_keys[] = {
     "Device",         "MountPoint",       "FSType",
     "IgnoreSelected", "ReportByDevice",   "ReportInodes",
@@ -230,18 +235,18 @@ static int df_read(void) {
     gauge_t blk_used = (gauge_t)(statbuf.f_blocks - statbuf.f_bfree);
 
     metric_t m = {0};
-    metric_label_set(&m, "device", dev);
-    metric_label_set(&m, "fstype", mnt_ptr->type);
-    metric_label_set(&m, "mountpoint", mnt_ptr->dir);
+    metric_label_set(&m, device_label, dev);
+    metric_label_set(&m, mountpoint_label, mnt_ptr->dir);
+    metric_label_set(&m, type_label, mnt_ptr->type);
 
     if (values_absolute) {
-      metric_family_append(&fam_usage, "state", "used",
+      metric_family_append(&fam_usage, state_label, "used",
                            (value_t){.gauge = blk_used * blocksize}, &m);
 
-      metric_family_append(&fam_usage, "state", "free",
+      metric_family_append(&fam_usage, state_label, "free",
                            (value_t){.gauge = blk_free * blocksize}, &m);
 
-      metric_family_append(&fam_usage, "state", "reserved",
+      metric_family_append(&fam_usage, state_label, "reserved",
                            (value_t){.gauge = blk_reserved * blocksize}, &m);
     }
 
@@ -249,13 +254,13 @@ static int df_read(void) {
       assert(statbuf.f_blocks != 0); // checked above
       gauge_t f = 1.0 / (gauge_t)statbuf.f_blocks;
 
-      metric_family_append(&fam_utilization, "state", "used",
+      metric_family_append(&fam_utilization, state_label, "used",
                            (value_t){.gauge = blk_used * f}, &m);
 
-      metric_family_append(&fam_utilization, "state", "free",
+      metric_family_append(&fam_utilization, state_label, "free",
                            (value_t){.gauge = blk_free * f}, &m);
 
-      metric_family_append(&fam_utilization, "state", "reserved",
+      metric_family_append(&fam_utilization, state_label, "reserved",
                            (value_t){.gauge = blk_reserved * f}, &m);
     }
 
@@ -275,13 +280,13 @@ static int df_read(void) {
         if (statbuf.f_files > 0) {
           gauge_t f = 1.0 / (gauge_t)statbuf.f_files;
 
-          metric_family_append(&fam_inode_utilization, "state", "used",
+          metric_family_append(&fam_inode_utilization, state_label, "used",
                                (value_t){.gauge = inode_used * f}, &m);
 
-          metric_family_append(&fam_inode_utilization, "state", "free",
+          metric_family_append(&fam_inode_utilization, state_label, "free",
                                (value_t){.gauge = inode_free * f}, &m);
 
-          metric_family_append(&fam_inode_utilization, "state", "reserved",
+          metric_family_append(&fam_inode_utilization, state_label, "reserved",
                                (value_t){.gauge = inode_reserved * f}, &m);
         } else {
           metric_reset(&m);
@@ -290,13 +295,13 @@ static int df_read(void) {
         }
       }
       if (values_absolute) {
-        metric_family_append(&fam_inode_usage, "state", "used",
+        metric_family_append(&fam_inode_usage, state_label, "used",
                              (value_t){.gauge = inode_used}, &m);
 
-        metric_family_append(&fam_inode_usage, "state", "free",
+        metric_family_append(&fam_inode_usage, state_label, "free",
                              (value_t){.gauge = inode_free}, &m);
 
-        metric_family_append(&fam_inode_usage, "state", "reserved",
+        metric_family_append(&fam_inode_usage, state_label, "reserved",
                              (value_t){.gauge = inode_reserved}, &m);
       }
     }

--- a/src/df.c
+++ b/src/df.c
@@ -47,9 +47,13 @@
 #endif
 
 static char const *const device_label = "system.device";
+static char const *const mode_label = "system.filesystem.mode";
 static char const *const mountpoint_label = "system.filesystem.mountpoint";
 static char const *const state_label = "system.filesystem.state";
 static char const *const type_label = "system.filesystem.type";
+
+static char const *const mode_ro = "ro";
+static char const *const mode_rw = "rw";
 
 static const char *config_keys[] = {
     "Device",         "MountPoint",       "FSType",
@@ -234,8 +238,11 @@ static int df_read(void) {
     gauge_t blk_reserved = (gauge_t)(statbuf.f_bfree - statbuf.f_bavail);
     gauge_t blk_used = (gauge_t)(statbuf.f_blocks - statbuf.f_bfree);
 
+    bool read_only = (statbuf.f_flag & ST_RDONLY) != 0;
+
     metric_t m = {0};
     metric_label_set(&m, device_label, dev);
+    metric_label_set(&m, mode_label, read_only ? mode_ro : mode_rw);
     metric_label_set(&m, mountpoint_label, mnt_ptr->dir);
     metric_label_set(&m, type_label, mnt_ptr->type);
 

--- a/src/df.c
+++ b/src/df.c
@@ -271,13 +271,13 @@ static int df_read(void) {
         if (statbuf.f_files > 0) {
           gauge_t f = 100.0 / (gauge_t)statbuf.f_files;
 
-          metric_family_append(&fam_inode_usage, "state", "used",
+          metric_family_append(&fam_inode_utilization, "state", "used",
                                (value_t){.gauge = inode_used * f}, &m);
 
-          metric_family_append(&fam_inode_usage, "state", "free",
+          metric_family_append(&fam_inode_utilization, "state", "free",
                                (value_t){.gauge = inode_free * f}, &m);
 
-          metric_family_append(&fam_inode_usage, "state", "reserved",
+          metric_family_append(&fam_inode_utilization, "state", "reserved",
                                (value_t){.gauge = inode_reserved * f}, &m);
         } else {
           metric_reset(&m);

--- a/src/df.c
+++ b/src/df.c
@@ -312,11 +312,13 @@ static int df_read(void) {
   cu_mount_freelist(mnt_list);
 
   metric_family_t *families[] = {
-      &fam_usage, &fam_utilization, &fam_inode_usage, &fam_inode_utilization,
-      NULL,
+      &fam_usage,
+      &fam_utilization,
+      &fam_inode_usage,
+      &fam_inode_utilization,
   };
 
-  for (size_t i = 0; families[i] != NULL; i++) {
+  for (size_t i = 0; STATIC_ARRAY_SIZE(families); i++) {
     if (families[i]->metric.num == 0) {
       continue;
     }

--- a/src/df.c
+++ b/src/df.c
@@ -145,18 +145,22 @@ static int df_read(void) {
 #endif
   metric_family_t fam_usage = {
       .name = "system.filesystem.usage",
+      .unit = "By",
       .type = METRIC_TYPE_GAUGE,
   };
   metric_family_t fam_utilization = {
       .name = "system.filesystem.utilization",
+      .unit = "1",
       .type = METRIC_TYPE_GAUGE,
   };
   metric_family_t fam_inode_usage = {
       .name = "system.filesystem.inodes.usage",
+      .unit = "{inode}",
       .type = METRIC_TYPE_GAUGE,
   };
   metric_family_t fam_inode_utilization = {
       .name = "system.filesystem.inodes.utilization",
+      .unit = "1",
       .type = METRIC_TYPE_GAUGE,
   };
 
@@ -243,7 +247,7 @@ static int df_read(void) {
 
     if (values_percentage) {
       assert(statbuf.f_blocks != 0); // checked above
-      gauge_t f = 100.0 / (gauge_t)statbuf.f_blocks;
+      gauge_t f = 1.0 / (gauge_t)statbuf.f_blocks;
 
       metric_family_append(&fam_utilization, "state", "used",
                            (value_t){.gauge = blk_used * f}, &m);
@@ -269,7 +273,7 @@ static int df_read(void) {
 
       if (values_percentage) {
         if (statbuf.f_files > 0) {
-          gauge_t f = 100.0 / (gauge_t)statbuf.f_files;
+          gauge_t f = 1.0 / (gauge_t)statbuf.f_files;
 
           metric_family_append(&fam_inode_utilization, "state", "used",
                                (value_t){.gauge = inode_used * f}, &m);

--- a/src/df.c
+++ b/src/df.c
@@ -52,6 +52,10 @@ static char const *const mountpoint_label = "system.filesystem.mountpoint";
 static char const *const state_label = "system.filesystem.state";
 static char const *const type_label = "system.filesystem.type";
 
+static char const *const state_free = "free";
+static char const *const state_used = "used";
+static char const *const state_reserved = "reserved";
+
 static char const *const mode_ro = "ro";
 static char const *const mode_rw = "rw";
 
@@ -247,13 +251,13 @@ static int df_read(void) {
     metric_label_set(&m, type_label, mnt_ptr->type);
 
     if (values_absolute) {
-      metric_family_append(&fam_usage, state_label, "used",
+      metric_family_append(&fam_usage, state_label, state_used,
                            (value_t){.gauge = blk_used * blocksize}, &m);
 
-      metric_family_append(&fam_usage, state_label, "free",
+      metric_family_append(&fam_usage, state_label, state_free,
                            (value_t){.gauge = blk_free * blocksize}, &m);
 
-      metric_family_append(&fam_usage, state_label, "reserved",
+      metric_family_append(&fam_usage, state_label, state_reserved,
                            (value_t){.gauge = blk_reserved * blocksize}, &m);
     }
 
@@ -261,13 +265,13 @@ static int df_read(void) {
       assert(statbuf.f_blocks != 0); // checked above
       gauge_t f = 1.0 / (gauge_t)statbuf.f_blocks;
 
-      metric_family_append(&fam_utilization, state_label, "used",
+      metric_family_append(&fam_utilization, state_label, state_used,
                            (value_t){.gauge = blk_used * f}, &m);
 
-      metric_family_append(&fam_utilization, state_label, "free",
+      metric_family_append(&fam_utilization, state_label, state_free,
                            (value_t){.gauge = blk_free * f}, &m);
 
-      metric_family_append(&fam_utilization, state_label, "reserved",
+      metric_family_append(&fam_utilization, state_label, state_reserved,
                            (value_t){.gauge = blk_reserved * f}, &m);
     }
 
@@ -287,13 +291,14 @@ static int df_read(void) {
         if (statbuf.f_files > 0) {
           gauge_t f = 1.0 / (gauge_t)statbuf.f_files;
 
-          metric_family_append(&fam_inode_utilization, state_label, "used",
+          metric_family_append(&fam_inode_utilization, state_label, state_used,
                                (value_t){.gauge = inode_used * f}, &m);
 
-          metric_family_append(&fam_inode_utilization, state_label, "free",
+          metric_family_append(&fam_inode_utilization, state_label, state_free,
                                (value_t){.gauge = inode_free * f}, &m);
 
-          metric_family_append(&fam_inode_utilization, state_label, "reserved",
+          metric_family_append(&fam_inode_utilization, state_label,
+                               state_reserved,
                                (value_t){.gauge = inode_reserved * f}, &m);
         } else {
           metric_reset(&m);
@@ -302,13 +307,13 @@ static int df_read(void) {
         }
       }
       if (values_absolute) {
-        metric_family_append(&fam_inode_usage, state_label, "used",
+        metric_family_append(&fam_inode_usage, state_label, state_used,
                              (value_t){.gauge = inode_used}, &m);
 
-        metric_family_append(&fam_inode_usage, state_label, "free",
+        metric_family_append(&fam_inode_usage, state_label, state_free,
                              (value_t){.gauge = inode_free}, &m);
 
-        metric_family_append(&fam_inode_usage, state_label, "reserved",
+        metric_family_append(&fam_inode_usage, state_label, state_reserved,
                              (value_t){.gauge = inode_reserved}, &m);
       }
     }


### PR DESCRIPTION
* Fixed an error that caused inode utilization (a ratio) to be reported as "usage" (a count).
* Report utilization as "ratio" (i.e. fraction of one) instead of percentage.
* Change label names to match OpenTelemetry semantic conventions. E.g. use `system.filesystem.state` instead of `state`.
* Report the filesystem mode (read-only, read-write).

ChangeLog: DF plugin: The metric schema has been aligned with OpenTelemetry semantic conventions.