### PR TITLE
write_prometheus plugin: Use the `unit` field to create metric names.

### DIFF
--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -263,7 +263,8 @@ void format_metric_family_name(strbuf_t *buf, metric_family_t const *fam) {
   if (unit != NULL) {
     strbuf_printf(buf, "_%s", unit->prometheus);
   } else if (fam->unit != NULL && fam->unit[0] != '{') {
-    strbuf_printf(buf, "_%s", fam->unit);
+    strbuf_print(buf, "_");
+    strbuf_print_restricted(buf, fam->unit, VALID_NAME_CHARS, '_');
   }
 
   if (fam->type == METRIC_TYPE_COUNTER) {

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -126,7 +126,8 @@ static int unit_map_compare(void const *a, void const *b) {
 static unit_map_t const *unit_map_lookup(char const *unit) {
   static bool is_sorted;
   if (!is_sorted) {
-    qsort(unit_map, STATIC_ARRAY_SIZE(unit_map), sizeof(unit_map[0]), unit_map_compare);
+    qsort(unit_map, STATIC_ARRAY_SIZE(unit_map), sizeof(unit_map[0]),
+          unit_map_compare);
     is_sorted = true;
   }
 
@@ -135,9 +136,10 @@ static unit_map_t const *unit_map_lookup(char const *unit) {
   }
 
   unit_map_t key = {
-    .open_telemetry = unit,
+      .open_telemetry = unit,
   };
-  return bsearch(&key, unit_map, STATIC_ARRAY_SIZE(unit_map), sizeof(unit_map[0]), unit_map_compare);
+  return bsearch(&key, unit_map, STATIC_ARRAY_SIZE(unit_map),
+                 sizeof(unit_map[0]), unit_map_compare);
 }
 
 /* Visible for testing */

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -108,14 +108,15 @@ DEF_TEST(format_metric_family_name) {
           .unit = "%",
           .want = "storage_filesystem_utilization_percent",
       },
-      /* Not yet supported:
       {
           .name = "astro.light.speed",
           .type = METRIC_TYPE_GAUGE,
           .unit = "m/s",
+          .want = "astro_light_speed_m_s",
+          /* Not yet supported. Should be:
           .want = "astro_light_speed_meters_per_second",
+          */
       },
-      */
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {

--- a/src/write_prometheus_test.c
+++ b/src/write_prometheus_test.c
@@ -65,12 +65,57 @@ DEF_TEST(format_metric_family_name) {
   struct {
     char *name;
     metric_type_t type;
+    char *unit;
     char *want;
   } cases[] = {
-      {"(lambda).function.executions(#)", METRIC_TYPE_UNTYPED,
-       "lambda_function_executions"},
-      {"system.processes.created", METRIC_TYPE_COUNTER,
-       "system_processes_created_total"},
+      {
+          .name = "(lambda).function.executions(#)",
+          .type = METRIC_TYPE_UNTYPED,
+          .want = "lambda_function_executions",
+      },
+      {
+          .name = "system.processes.created",
+          .type = METRIC_TYPE_COUNTER,
+          .want = "system_processes_created_total",
+      },
+      {
+          .name = "system.filesystem.usage",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "By",
+          .want = "system_filesystem_usage_bytes",
+      },
+      {
+          .name = "system.network.dropped",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "{packets}",
+          .want = "system_network_dropped",
+      },
+      {
+          .name = "system.network.dropped",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "packets",
+          .want = "system_network_dropped_packets",
+      },
+      {
+          .name = "system.memory.utilization",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "1",
+          .want = "system_memory_utilization_ratio",
+      },
+      {
+          .name = "storage.filesystem.utilization",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "%",
+          .want = "storage_filesystem_utilization_percent",
+      },
+      /* Not yet supported:
+      {
+          .name = "astro.light.speed",
+          .type = METRIC_TYPE_GAUGE,
+          .unit = "m/s",
+          .want = "astro_light_speed_meters_per_second",
+      },
+      */
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
@@ -80,6 +125,7 @@ DEF_TEST(format_metric_family_name) {
     metric_family_t fam = {
         .name = cases[i].name,
         .type = cases[i].type,
+        .unit = cases[i].unit,
     };
 
     format_metric_family_name(&got, &fam);


### PR DESCRIPTION
Reference: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1

ChangeLog: Write Prometheus plugin: Units are appended to metric family names if available.