### PR TITLE
[collectd 6] Use real collectd metric functions in gpu_sysman plugin tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1200,7 +1200,7 @@ gpu_sysman_la_LIBADD = $(LEVEL_ZERO_LIBS)
 test_plugin_gpu_sysman_SOURCES = src/gpu_sysman_test.c
 test_plugin_gpu_sysman_CPPFLAGS = $(AM_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(LEVEL_ZERO_CFLAGS)
 test_plugin_gpu_sysman_LDFLAGS = $(PLUGIN_LDFLAGS)
-test_plugin_gpu_sysman_LDADD =
+test_plugin_gpu_sysman_LDADD = libcommon.la
 check_PROGRAMS += test_plugin_gpu_sysman
 TESTS += test_plugin_gpu_sysman
 endif


### PR DESCRIPTION
ChangeLog: Use real collectd metric functions in "gpu_sysman" plugin tests

There have been lot of changes in metric handling code, so it's better to use real metric functions rather than mocked ones.

This allows removing the mock functions, but makes it much easier for unrelated changes to break `gpu_sysman_test.c` compilation (e.g .utf-8 support already broke earlier version of this).