### PR TITLE
[collectd 6] Memory plugin: Add "shared", drop "slab" and "available", report utilization as ratio.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1057,7 +1057,7 @@
 
 #<Plugin memory>
 #	ReportUsage true
-#	ValuesPercentage false
+#	ReportUtilization false
 #</Plugin>
 
 #<Plugin mmc>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1056,7 +1056,7 @@
 #</Plugin>
 
 #<Plugin memory>
-#	ValuesAbsolute true
+#	ReportUsage true
 #	ValuesPercentage false
 #</Plugin>
 

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1057,7 +1057,7 @@
 
 #<Plugin memory>
 #	ReportUsage true
-#	ReportUtilization false
+#	ReportUtilization true
 #</Plugin>
 
 #<Plugin mmc>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1058,6 +1058,7 @@
 #<Plugin memory>
 #	ReportUsage true
 #	ReportUtilization true
+#	ReportLimit false
 #</Plugin>
 
 #<Plugin mmc>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5269,7 +5269,7 @@ The I<memory plugin> provides the following configuration options:
 
 =over 4
 
-=item B<ValuesAbsolute> B<true>|B<false>
+=item B<ReportUsage> B<true>|B<false>
 
 Enables or disables reporting of physical memory usage in absolute numbers,
 i.e. bytes. Defaults to B<true>.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5282,6 +5282,11 @@ memory, e.g. the fraction of physical memory used. Defaults to B<true>.
 This is useful for deploying I<collectd> in a heterogeneous environment in
 which the sizes of physical memory vary.
 
+=item B<ReportLimit> B<false>|B<true>
+
+Controls reporting of the total amount of physical memory available to the
+system. Defaults to B<true>.
+
 =back
 
 =head2 Plugin C<modbus>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5274,10 +5274,10 @@ The I<memory plugin> provides the following configuration options:
 Enables or disables reporting of physical memory usage in absolute numbers,
 i.e. bytes. Defaults to B<true>.
 
-=item B<ValuesPercentage> B<false>|B<true>
+=item B<ReportUtilization> B<false>|B<true>
 
-Enables or disables reporting of physical memory usage in percentages, e.g.
-percent of physical memory used. Defaults to B<false>.
+Enables or disables reporting of physical memory usage as a ratio of total
+memory, e.g. the fraction of physical memory used. Defaults to B<false>.
 
 This is useful for deploying I<collectd> in a heterogeneous environment in
 which the sizes of physical memory vary.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -5274,10 +5274,10 @@ The I<memory plugin> provides the following configuration options:
 Enables or disables reporting of physical memory usage in absolute numbers,
 i.e. bytes. Defaults to B<true>.
 
-=item B<ReportUtilization> B<false>|B<true>
+=item B<ReportUtilization> B<true>|B<false>
 
 Enables or disables reporting of physical memory usage as a ratio of total
-memory, e.g. the fraction of physical memory used. Defaults to B<false>.
+memory, e.g. the fraction of physical memory used. Defaults to B<true>.
 
 This is useful for deploying I<collectd> in a heterogeneous environment in
 which the sizes of physical memory vary.

--- a/src/memory.c
+++ b/src/memory.c
@@ -67,6 +67,7 @@ static char const *const label_state = "system.memory.state";
 typedef enum {
   STATE_USED,
   STATE_FREE,
+  STATE_SHARED,
   STATE_BUFFERS,
   STATE_CACHED,
   STATE_WIRED,
@@ -82,9 +83,9 @@ typedef enum {
 } memory_type_t;
 
 static char const *memory_type_names[STATE_MAX] = {
-    "used",     "free",      "buffers", "cached", "wired",
-    "active",   "inactive",  "kernel",  "locked", "arc",
-    "unusable", "user_wire", "laundry",
+    "used",  "free",     "shared",    "buffers", "cached",
+    "wired", "active",   "inactive",  "kernel",  "locked",
+    "arc",   "unusable", "user_wire", "laundry",
 };
 
 /* vm_statistics_data_t */
@@ -444,6 +445,9 @@ static int memory_read_internal(gauge_t values[STATE_MAX]) {
       mem_not_used += v;
     } else if (strcmp(fields[0], "Cached:") == 0) {
       values[STATE_CACHED] = v;
+      mem_not_used += v;
+    } else if (strcmp(fields[0], "Shmem:") == 0) {
+      values[STATE_SHARED] = v;
       mem_not_used += v;
     }
   }

--- a/src/memory.c
+++ b/src/memory.c
@@ -65,28 +65,41 @@
 static char const *const label_state = "system.memory.state";
 
 typedef enum {
-  STATE_USED,
-  STATE_FREE,
-  STATE_SHARED,
+  STATE_ACTIVE,
+  STATE_ARC,
   STATE_BUFFERS,
   STATE_CACHED,
-  STATE_WIRED,
-  STATE_ACTIVE,
+  STATE_FREE,
   STATE_INACTIVE,
   STATE_KERNEL,
-  STATE_LOCKED,
-  STATE_ARC,
-  STATE_UNUSED,
-  STATE_USER_WIRE,
   STATE_LAUNDRY,
+  STATE_LOCKED,
+  STATE_SHARED,
+  STATE_UNUSED,
+  STATE_USED,
+  STATE_USER_WIRE,
+  STATE_WIRED,
   STATE_MAX, /* #states */
 } memory_type_t;
 
+// clang-format off
 static char const *memory_type_names[STATE_MAX] = {
-    "used",  "free",     "shared",    "buffers", "cached",
-    "wired", "active",   "inactive",  "kernel",  "locked",
-    "arc",   "unusable", "user_wire", "laundry",
+  [STATE_ACTIVE]    = "active",
+  [STATE_ARC]       = "arc",
+  [STATE_BUFFERS]   = "buffers",
+  [STATE_CACHED]    = "cached",
+  [STATE_FREE]      = "free",
+  [STATE_INACTIVE]  = "inactive",
+  [STATE_KERNEL]    = "kernel",
+  [STATE_LAUNDRY]   = "laundry",
+  [STATE_LOCKED]    = "locked",
+  [STATE_SHARED]    = "shared",
+  [STATE_UNUSED]    = "unusable",
+  [STATE_USED]      = "used",
+  [STATE_USER_WIRE] = "user_wire",
+  [STATE_WIRED]     = "wired",
 };
+// clang-format on
 
 /* vm_statistics_data_t */
 #if HAVE_HOST_STATISTICS

--- a/src/memory.c
+++ b/src/memory.c
@@ -250,10 +250,10 @@ static int memory_dispatch(gauge_t values[STATE_MAX]) {
   if (status != 0) {
     ERROR("memory plugin: plugin_dispatch_metric_family failed: %s",
           STRERROR(status));
-    ret = ret ? ret : status;
   }
-  metric_family_metric_reset(&fam_util);
+  ret = ret ? ret : status;
 
+  metric_family_metric_reset(&fam_util);
   return ret;
 }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -150,7 +150,7 @@ static int pagesize;
 #endif
 
 static bool report_usage = true;
-static bool values_percentage;
+static bool report_utilization;
 
 static int memory_config(oconfig_item_t *ci) /* {{{ */
 {
@@ -159,8 +159,9 @@ static int memory_config(oconfig_item_t *ci) /* {{{ */
     if (strcasecmp("ReportUsage", child->key) == 0 ||
         strcasecmp("ValuesAbsolute", child->key) == 0)
       cf_util_get_boolean(child, &report_usage);
-    else if (strcasecmp("ValuesPercentage", child->key) == 0)
-      cf_util_get_boolean(child, &values_percentage);
+    else if (strcasecmp("ReportUtilization", child->key) == 0 ||
+             strcasecmp("ValuesPercentage", child->key) == 0)
+      cf_util_get_boolean(child, &report_utilization);
     else
       ERROR("memory plugin: Invalid configuration option: \"%s\".", child->key);
   }
@@ -201,7 +202,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
   }
   metric_family_metric_reset(&fam_usage);
 
-  if (!values_percentage) {
+  if (!report_utilization) {
     return ret;
   }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -208,7 +208,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
     return EINVAL;
   }
 
-  metric_family_t fam_percent = {
+  metric_family_t fam_util = {
       .name = "system.memory.utilization",
       .help = "Reports memory in use by state",
       .unit = "1",
@@ -219,17 +219,17 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
       continue;
     }
 
-    metric_family_append(&fam_percent, label_state, memory_type_names[i],
-                         (value_t){.gauge = 100.0 * values[i] / total}, NULL);
+    metric_family_append(&fam_util, label_state, memory_type_names[i],
+                         (value_t){.gauge = values[i] / total}, NULL);
   }
 
-  int status = plugin_dispatch_metric_family(&fam_percent);
+  int status = plugin_dispatch_metric_family(&fam_util);
   if (status != 0) {
     ERROR("memory plugin: plugin_dispatch_metric_family failed: %s",
           STRERROR(status));
     ret = ret ? ret : status;
   }
-  metric_family_metric_reset(&fam_percent);
+  metric_family_metric_reset(&fam_util);
 
   return ret;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -140,6 +140,8 @@ static int memory_config(oconfig_item_t *ci) /* {{{ */
 {
   for (int i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
+    /* "ValuesAbsolute" & "ValuesPercentage" are for compatibility with the v5
+     * version */
     if (strcasecmp("ReportUsage", child->key) == 0 ||
         strcasecmp("ValuesAbsolute", child->key) == 0)
       cf_util_get_boolean(child, &report_usage);

--- a/src/memory.c
+++ b/src/memory.c
@@ -150,7 +150,7 @@ static int pagesize;
 #endif
 
 static bool report_usage = true;
-static bool report_utilization;
+static bool report_utilization = true;
 
 static int memory_config(oconfig_item_t *ci) /* {{{ */
 {


### PR DESCRIPTION
Another round of improvements for the *memory plugin*:

* Report the `system.memory.utilization` metric as a fraction. Previously, the metric family's unit was `1` but the reported values were `%`. This fixes the discrepancy by changing how values are reported.

    Side note: We could report a percentage, but there is no "official" OpenTelemetry guidance for it. If we want to do this (I'm not convinced that we should), we need to add a config option (allowing users to explicitly opt-in to this behavior) and create a new metric family, maybe `system.memory.utilization_percent`.
* Create two new config options, `ReportUsage` and `ReportUtilization`. The previous config options have been kept for compatibility.
* Utilization reporting has been enabled by default, following the OT semantic convention.
* The `system.memory.limit` metric has been added. As per semantic convention, reporting of this metric is guarded by a config option and disabled by default.
* The "slab" and "available" states have been removed from the Linux implementation. The reported values are already contained in other states, resulting in double reporting of some bytes. This leads to the memory total fluctuating over time.
* The "shared" state has been added for Linux. This is in line with the OT semantic conventions and the *free(1)* command line utility.

ChangeLog: Memory plugin: The `system.memory.limit` metric has been added. The "slab" and "available" states have been removed, the "shared" state was added (Linux only). Utilization reporting has been changed to report a ratio (fraction of 1) rather than a percentage.