### PR TITLE
[collectd 6, draft] Add the `VALUE_T()` generic macro.

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -366,8 +366,7 @@ static cpu_state_t *get_cpu_state(size_t cpu_num, size_t state) /* {{{ */
 static int total_rate(gauge_t *sum_by_state, size_t state, derive_t d,
                       value_to_rate_state_t *conv, cdtime_t now) {
   gauge_t rate = NAN;
-  int status =
-      value_to_rate(&rate, (value_t){.derive = d}, DS_TYPE_DERIVE, now, conv);
+  int status = value_to_rate(&rate, VALUE_T(d), DS_TYPE_DERIVE, now, conv);
   if (status != 0)
     return status;
 
@@ -593,7 +592,6 @@ static int cpu_stage(size_t cpu_num, size_t state, derive_t d,
   int status;
   cpu_state_t *s;
   gauge_t rate = NAN;
-  value_t val = {.derive = d};
 
   if (state >= COLLECTD_CPU_STATE_ACTIVE)
     return EINVAL;
@@ -607,7 +605,7 @@ static int cpu_stage(size_t cpu_num, size_t state, derive_t d,
 
   s = get_cpu_state(cpu_num, state);
 
-  status = value_to_rate(&rate, val, DS_TYPE_DERIVE, now, &s->conv);
+  status = value_to_rate(&rate, VALUE_T(d), DS_TYPE_DERIVE, now, &s->conv);
   if (status != 0)
     return status;
 

--- a/src/daemon/metric.h
+++ b/src/daemon/metric.h
@@ -52,6 +52,12 @@ union value_u {
 };
 typedef union value_u value_t;
 
+#define VALUE_T(x)                                                             \
+  _Generic((x),                                                                \
+      counter_t: (value_t){.counter = (x)},                                    \
+      gauge_t: (value_t){.gauge = (x)},                                        \
+      derive_t: (value_t){.derive = (x)})
+
 /* value_marshal_text prints a text representation of v to buf. */
 int value_marshal_text(strbuf_t *buf, value_t v, metric_type_t type);
 

--- a/src/df.c
+++ b/src/df.c
@@ -232,13 +232,13 @@ static int df_read(void) {
 
     if (values_absolute) {
       metric_family_append(&fam_usage, "state", "used",
-                           (value_t){.gauge = blk_used * blocksize}, &m);
+                           VALUE_T(blk_used * blocksize), &m);
 
       metric_family_append(&fam_usage, "state", "free",
-                           (value_t){.gauge = blk_free * blocksize}, &m);
+                           VALUE_T(blk_free * blocksize), &m);
 
       metric_family_append(&fam_usage, "state", "reserved",
-                           (value_t){.gauge = blk_reserved * blocksize}, &m);
+                           VALUE_T(blk_reserved * blocksize), &m);
     }
 
     if (values_percentage) {
@@ -246,13 +246,13 @@ static int df_read(void) {
       gauge_t f = 100.0 / (gauge_t)statbuf.f_blocks;
 
       metric_family_append(&fam_utilization, "state", "used",
-                           (value_t){.gauge = blk_used * f}, &m);
+                           VALUE_T(blk_used * f), &m);
 
       metric_family_append(&fam_utilization, "state", "free",
-                           (value_t){.gauge = blk_free * f}, &m);
+                           VALUE_T(blk_free * f), &m);
 
       metric_family_append(&fam_utilization, "state", "reserved",
-                           (value_t){.gauge = blk_reserved * f}, &m);
+                           VALUE_T(blk_reserved * f), &m);
     }
 
     /* inode handling */
@@ -272,13 +272,13 @@ static int df_read(void) {
           gauge_t f = 100.0 / (gauge_t)statbuf.f_files;
 
           metric_family_append(&fam_inode_usage, "state", "used",
-                               (value_t){.gauge = inode_used * f}, &m);
+                               VALUE_T(inode_used * f), &m);
 
           metric_family_append(&fam_inode_usage, "state", "free",
-                               (value_t){.gauge = inode_free * f}, &m);
+                               VALUE_T(inode_free * f), &m);
 
           metric_family_append(&fam_inode_usage, "state", "reserved",
-                               (value_t){.gauge = inode_reserved * f}, &m);
+                               VALUE_T(inode_reserved * f), &m);
         } else {
           metric_reset(&m);
           retval = -1;
@@ -287,13 +287,13 @@ static int df_read(void) {
       }
       if (values_absolute) {
         metric_family_append(&fam_inode_usage, "state", "used",
-                             (value_t){.gauge = inode_used}, &m);
+                             VALUE_T(inode_used), &m);
 
         metric_family_append(&fam_inode_usage, "state", "free",
-                             (value_t){.gauge = inode_free}, &m);
+                             VALUE_T(inode_free), &m);
 
         metric_family_append(&fam_inode_usage, "state", "reserved",
-                             (value_t){.gauge = inode_reserved}, &m);
+                             VALUE_T(inode_reserved), &m);
       }
     }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -185,7 +185,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
 
     if (values_absolute) {
       metric_family_append(&fam_absolute, label_state, memory_type_names[i],
-                           (value_t){.gauge = values[i]}, NULL);
+                           VALUE_T(values[i]), NULL);
     }
   }
 
@@ -220,7 +220,7 @@ static int memory_dispatch(gauge_t values[COLLECTD_MEMORY_TYPE_MAX]) {
     }
 
     metric_family_append(&fam_percent, label_state, memory_type_names[i],
-                         (value_t){.gauge = 100.0 * values[i] / total}, NULL);
+                         VALUE_T(100.0 * values[i] / total), NULL);
   }
 
   int status = plugin_dispatch_metric_family(&fam_percent);


### PR DESCRIPTION
`VALUE_T(x)` is a generic macro that initializes and returns a `value_t`. Depending on the type of the argument `x`, it will either initialize the `value_t` as a `counter_t`, `derive_t`, or `gauge_t`.

This means that the previous expression:

```c
value_t x = (value_t){.derive = y};
```

can now be written as:

```c
value_t x = VALUE_T(y);
```

Passing in an incompatible type, such as an `int`, will cause a compile time error:

```
src/cpu.c: In function 'module_register':
./src/daemon/metric.h:56:12: error: '_Generic' selector of type 'int' is not compatible with any association
   56 |   _Generic((x),                                                                \
      |            ^
src/cpu.c:929:17: note: in expansion of macro 'VALUE_T'
  929 |   value_t foo = VALUE_T((int){42});
      |                 ^~~~~~~
```

**Draft:** I want to gauge how widely supported this C11 feature is.