### PR TITLE
intel_pmu plugin: Fix format string for printing `counter_t`.

### DIFF
--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -292,9 +292,8 @@ static void pmu_submit_counters(const char *cgroup, const char *event,
   sstrncpy(vl.type, "pmu_counter", sizeof(vl.type));
   sstrncpy(vl.type_instance, event, sizeof(vl.type_instance));
 
-  DEBUG(PMU_PLUGIN ": %s/%s = %" PRIu64 " (%" PRIu64 " * %" PRIu64 " / %" PRIu64
-                   ")",
-        vl.type_instance, vl.plugin_instance, scaled, raw, enabled, running);
+  DEBUG(PMU_PLUGIN ": %s/%s = %llu (%llu * %llu / %llu)", vl.type_instance,
+        vl.plugin_instance, scaled, raw, enabled, running);
 
   plugin_dispatch_values(&vl);
 }

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -292,8 +292,9 @@ static void pmu_submit_counters(const char *cgroup, const char *event,
   sstrncpy(vl.type, "pmu_counter", sizeof(vl.type));
   sstrncpy(vl.type_instance, event, sizeof(vl.type_instance));
 
-  DEBUG(PMU_PLUGIN ": %s/%s = %llu (%llu * %llu / %llu)", vl.type_instance,
-        vl.plugin_instance, scaled, raw, enabled, running);
+  DEBUG(PMU_PLUGIN ": %s/%s = %" PRIu64 " (%" PRIu64 " * %" PRIu64 " / %" PRIu64
+                   ")",
+        vl.type_instance, vl.plugin_instance, scaled, raw, enabled, running);
 
   plugin_dispatch_values(&vl);
 }

--- a/src/utils/config_cores/config_cores.h
+++ b/src/utils/config_cores/config_cores.h
@@ -28,11 +28,7 @@
 #ifndef UTILS_CONFIG_CORES_H
 #define UTILS_CONFIG_CORES_H 1
 
-#include "configfile.h"
-
-#ifndef PRIsz
-#define PRIsz "zu"
-#endif /* PRIsz */
+#include "daemon/configfile.h"
 
 struct core_group_s {
   char *desc;


### PR DESCRIPTION
`uint64_t` may be defined as `unsigned long` on 64-bit architectures, causing some compilers to complain about this:

```
src/intel_pmu.c: In function 'pmu_submit_counters':
src/intel_pmu.c:37:20: error: format '%llu' expects argument of type 'long long unsigned int', but argument 5 has type 'counter_t' {aka 'long unsigned int'} [-Werror=format=]
```