### PR TITLE
write_riemann plugin: Terminate `riemann_event_set` arguments with `RIEMANN_EVENT_FIELD_NONE`.

### DIFF
--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -214,7 +214,7 @@ static riemann_message_t *wrr_notification_to_message(notification_t const *n) {
 
 #if RCC_VERSION_NUMBER >= 0x010A00
   riemann_event_set(event, RIEMANN_EVENT_FIELD_TIME_MICROS,
-                    (int64_t)CDTIME_T_TO_US(n->time));
+                    (int64_t)CDTIME_T_TO_US(n->time), RIEMANN_EVENT_FIELD_NONE);
 #endif
 
   if (n->host[0] != 0)
@@ -315,7 +315,8 @@ wrr_value_to_event(struct riemann_host const *host, /* {{{ */
 
 #if RCC_VERSION_NUMBER >= 0x010A00
   riemann_event_set(event, RIEMANN_EVENT_FIELD_TIME_MICROS,
-                    (int64_t)CDTIME_T_TO_US(vl->time));
+                    (int64_t)CDTIME_T_TO_US(vl->time),
+                    RIEMANN_EVENT_FIELD_NONE);
 #endif
 
   if (host->check_thresholds) {


### PR DESCRIPTION
`riemann_event_set` is a variadic function, that means it accepts a variable number of arguments. That means it needs some way to determine – at runtime – how many arguments there are. It appears to be doing so by using `RIEMANN_EVENT_FIELD_NONE` to indicate the last element in the argument list. Unfortunately I was unable to find the library's documentation and code and could not verify this.

That means that the argument list passed to `riemann_event_set` was not always terminated, causing it to read past where it was supposed to and adding random crap into the message it crafted.

ChangeLog: Write Riemann plugin: An out of bounds memory read, resulting in garbled messages, was fixed.
Issue: #4050