### PR TITLE
[collectd 6] feat: Improve `sstrncpy` semantic.

### DIFF
--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -85,8 +85,10 @@ static pthread_mutex_t strerror_r_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 char *sstrncpy(char *dest, const char *src, size_t n) {
-  strncpy(dest, src, n);
-  dest[n - 1] = '\0';
+  if (n > 0) {
+    strncpy(dest, src, n - 1);
+    dest[n - 1] = 0;
+  }
 
   return dest;
 } /* char *sstrncpy */

--- a/src/utils/common/common.c
+++ b/src/utils/common/common.c
@@ -85,10 +85,12 @@ static pthread_mutex_t strerror_r_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 char *sstrncpy(char *dest, const char *src, size_t n) {
-  if (n > 0) {
-    strncpy(dest, src, n - 1);
-    dest[n - 1] = 0;
+  if (dest == NULL || n == 0) {
+    return NULL;
   }
+
+  strncpy(dest, src != NULL ? src : "", n - 1);
+  dest[n - 1] = 0;
 
   return dest;
 } /* char *sstrncpy */

--- a/src/utils/common/common.h
+++ b/src/utils/common/common.h
@@ -64,6 +64,13 @@ struct value_to_rate_state_s {
 };
 typedef struct value_to_rate_state_s value_to_rate_state_t;
 
+/* sstrncpy is a safe alternative to strncpy(3). It differs from strncpy(3) in
+ * the following ways:
+ * - If dest is NULL or n is zero, NULL is returned and no writes will take
+ *   place.
+ * - If src is NULL it behaves as if an empty string ("") was provided.
+ * - A null byte is written to dest[n-1] unconditionally. That means the return
+ *   value is either NULL or a null terminated string. */
 char *sstrncpy(char *dest, const char *src, size_t n);
 
 __attribute__((format(printf, 3, 4))) int ssnprintf(char *str, size_t size,


### PR DESCRIPTION
While `sstrncpy` guarantees a null terminated string, some compilers don't get the memo and complain about the buffer size being equal to the size provided to *strncpy(3)*. This *is* a potential source of error with *strncpy(3)*, because if the source string is longer than the buffer, the buffer is not null terminated. That is the precise reason `sstrncpy` exists in the first place.

Make these compilers happy by decreasing the size passed to *strncpy(3)* by one.

**Update:** After a discussion with @eero-t I decided to improve the overall `sstrncpy` semantics to handle all inputs gracefully.

ChangeLog: collectd: The `sstrncpy` utility function has been improved to handle all inputs gracefully.