### PR TITLE
disk: add /proc/diskstats fields 15 to 20 in KERNEL_LINUX

### DIFF
--- a/src/types.db
+++ b/src/types.db
@@ -57,7 +57,13 @@ df_inodes               value:GAUGE:0:U
 dilution_of_precision   value:GAUGE:0:U
 disk_allocation         value:GAUGE:0:U
 disk_capacity           value:GAUGE:0:U
+disk_discard_ops        value:DERIVE:0:U
+disk_discard_merged     value:DERIVE:0:U
+disk_discard_sectors    value:DERIVE:0:U
+disk_discard_time       value:DERIVE:0:U
 disk_error              value:GAUGE:0:U
+disk_flush_ops          value:DERIVE:0:U
+disk_flush_time         value:DERIVE:0:U
 disk_io_time            io_time:DERIVE:0:U, weighted_io_time:DERIVE:0:U
 disk_latency            read:GAUGE:0:U, write:GAUGE:0:U
 disk_merged             read:DERIVE:0:U, write:DERIVE:0:U


### PR DESCRIPTION
Kernel 4.18+ appends four more fields for discard tracking putting the total at 18.
Kernel 5.5+ appends two more fields for flush requests. 
Details see: https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats

This patch makes collectd available for those fields.

Tested on kernel 5.15* (Ubuntu 22.04), e, g, 'write_log' writes things like:
"[{"values":[9993,5746],"dstypes":["derive","derive"],"dsnames":["complete","time"],"time":1705653958.743,"interval":10.000,"host":"7643","plugin":"disk","plugin_instance":"nvme0n1","type":"disk_flush","type_instance":""}]"


ChangeLog: disk plugin: supports /proc/diskstats fields 15 to 20 in Linux