### PR TITLE
[collectd 6] Fix most -Wpedantic warnings in collectd core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,7 @@ Makefile.in
 /install-sh
 /libltdl/
 /ltmain.sh
-/m4/libtool.m4
-/m4/ltargz.m4
-/m4/ltdl.m4
-/m4/lt~obsolete.m4
-/m4/ltoptions.m4
-/m4/ltsugar.m4
-/m4/ltversion.m4
+/m4/
 /missing
 /src/config.h.in
 
@@ -40,6 +34,7 @@ src/stamp-h1
 .dirstamp
 .libs/
 .deps/
+/collectd
 /collectd-nagios
 /collectd-tg
 /collectdctl
@@ -87,12 +82,13 @@ bindings/perl/pm_to_blib
 *.pyc
 
 # backup stuff
+*.bak
 *~
 
 # lint stuff
 *.ln
 
-#ide stuff
+# IDE stuff
 .vscode
 
 # cscope stuff
@@ -103,5 +99,6 @@ test-suite.log
 src/tests/
 test_*
 
-# src/daemon/...
-/collectd
+# coverage data
+*.gcov
+*.gcno

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -909,7 +909,7 @@ static meta_data_t *uc_get_meta(metric_t const *m) /* {{{ */
 /* Sorry about this preprocessor magic, but it really makes this file much
  * shorter.. */
 #define UC_WRAP(wrap_function)                                                 \
-  {                                                                            \
+  do {                                                                         \
     pthread_mutex_lock(&cache_lock);                                           \
     errno = 0;                                                                 \
     meta_data_t *meta = uc_get_meta(m);                                        \
@@ -920,23 +920,23 @@ static meta_data_t *uc_get_meta(metric_t const *m) /* {{{ */
     int ret = wrap_function(meta, key);                                        \
     pthread_mutex_unlock(&cache_lock);                                         \
     return ret;                                                                \
-  }
+  } while (0)
 
-int uc_meta_data_exists(metric_t const *m, const char *key)
-    UC_WRAP(meta_data_exists);
-
-int uc_meta_data_delete(metric_t const *m, const char *key)
-    UC_WRAP(meta_data_delete);
-
+int uc_meta_data_exists(metric_t const *m, const char *key) {
+  UC_WRAP(meta_data_exists);
+}
+int uc_meta_data_delete(metric_t const *m, const char *key) {
+  UC_WRAP(meta_data_delete);
+}
 /* The second argument is called `toc` in the API, but the macro expects
  * `key`. */
-int uc_meta_data_toc(metric_t const *m, char ***key) UC_WRAP(meta_data_toc);
+int uc_meta_data_toc(metric_t const *m, char ***key) { UC_WRAP(meta_data_toc); }
 #undef UC_WRAP
 
 /* We need a new version of this macro because the following functions take
- * two argumetns. gratituous semicolons added for formatting sanity*/
+ * two arguments. Gratuitous semicolons added for formatting sanity. */
 #define UC_WRAP(wrap_function)                                                 \
-  {                                                                            \
+  do {                                                                         \
     pthread_mutex_lock(&cache_lock);                                           \
     errno = 0;                                                                 \
     meta_data_t *meta = uc_get_meta(m);                                        \
@@ -947,37 +947,41 @@ int uc_meta_data_toc(metric_t const *m, char ***key) UC_WRAP(meta_data_toc);
     int ret = wrap_function(meta, key, value);                                 \
     pthread_mutex_unlock(&cache_lock);                                         \
     return ret;                                                                \
-  }
+  } while (0)
+
 int uc_meta_data_add_string(metric_t const *m, const char *key,
-                            const char *value) UC_WRAP(meta_data_add_string);
-
+                            const char *value) {
+  UC_WRAP(meta_data_add_string);
+}
 int uc_meta_data_add_signed_int(metric_t const *m, const char *key,
-                                int64_t value)
-    UC_WRAP(meta_data_add_signed_int);
-
+                                int64_t value) {
+  UC_WRAP(meta_data_add_signed_int);
+}
 int uc_meta_data_add_unsigned_int(metric_t const *m, const char *key,
-                                  uint64_t value)
-    UC_WRAP(meta_data_add_unsigned_int);
-
-int uc_meta_data_add_double(metric_t const *m, const char *key, double value)
-    UC_WRAP(meta_data_add_double);
-int uc_meta_data_add_boolean(metric_t const *m, const char *key, bool value)
-    UC_WRAP(meta_data_add_boolean);
-
-int uc_meta_data_get_string(metric_t const *m, const char *key, char **value)
-    UC_WRAP(meta_data_get_string);
-
+                                  uint64_t value) {
+  UC_WRAP(meta_data_add_unsigned_int);
+}
+int uc_meta_data_add_double(metric_t const *m, const char *key, double value) {
+  UC_WRAP(meta_data_add_double);
+}
+int uc_meta_data_add_boolean(metric_t const *m, const char *key, bool value) {
+  UC_WRAP(meta_data_add_boolean);
+}
+int uc_meta_data_get_string(metric_t const *m, const char *key, char **value) {
+  UC_WRAP(meta_data_get_string);
+}
 int uc_meta_data_get_signed_int(metric_t const *m, const char *key,
-                                int64_t *value)
-    UC_WRAP(meta_data_get_signed_int);
-
+                                int64_t *value) {
+  UC_WRAP(meta_data_get_signed_int);
+}
 int uc_meta_data_get_unsigned_int(metric_t const *m, const char *key,
-                                  uint64_t *value)
-    UC_WRAP(meta_data_get_unsigned_int);
-
-int uc_meta_data_get_double(metric_t const *m, const char *key, double *value)
-    UC_WRAP(meta_data_get_double);
-
-int uc_meta_data_get_boolean(metric_t const *m, const char *key, bool *value)
-    UC_WRAP(meta_data_get_boolean);
+                                  uint64_t *value) {
+  UC_WRAP(meta_data_get_unsigned_int);
+}
+int uc_meta_data_get_double(metric_t const *m, const char *key, double *value) {
+  UC_WRAP(meta_data_get_double);
+}
+int uc_meta_data_get_boolean(metric_t const *m, const char *key, bool *value) {
+  UC_WRAP(meta_data_get_boolean);
+}
 #undef UC_WRAP

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -275,7 +275,7 @@ static int redfish_preconfig(void) {
     goto error;
 
   /* Creating placeholder for queries */
-  ctx.queries = c_avl_create((void *)strcmp);
+  ctx.queries = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (ctx.services == NULL)
     goto free_services;
 

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -492,13 +492,14 @@ sd_output_t *sd_output_create(sd_resource_t *res) /* {{{ */
     return NULL;
   }
 
-  out->staged = c_avl_create((void *)strcmp);
+  out->staged = c_avl_create((int (*)(const void *, const void *))strcmp);
   if (out->staged == NULL) {
     sd_output_destroy(out);
     return NULL;
   }
 
-  out->metric_descriptors = c_avl_create((void *)strcmp);
+  out->metric_descriptors =
+      c_avl_create((int (*)(const void *, const void *))strcmp);
   if (out->metric_descriptors == NULL) {
     sd_output_destroy(out);
     return NULL;

--- a/src/utils/lookup/vl_lookup_test.c
+++ b/src/utils/lookup/vl_lookup_test.c
@@ -129,7 +129,8 @@ static int checked_lookup_search(lookup_t *obj, char const *host,
 DEF_TEST(group_by_specific_host) {
   lookup_t *obj;
   CHECK_NOT_NULL(obj = lookup_create(lookup_class_callback, lookup_obj_callback,
-                                     (void *)free, (void *)free));
+                                     (lookup_free_class_callback_t)free,
+                                     (lookup_free_obj_callback_t)free));
 
   checked_lookup_add(obj, "/.*/", "test", "", "test", "/.*/", LU_GROUP_BY_HOST);
   checked_lookup_search(obj, "host0", "test", "", "test", "0",
@@ -148,7 +149,8 @@ DEF_TEST(group_by_specific_host) {
 DEF_TEST(group_by_any_host) {
   lookup_t *obj;
   CHECK_NOT_NULL(obj = lookup_create(lookup_class_callback, lookup_obj_callback,
-                                     (void *)free, (void *)free));
+                                     (lookup_free_class_callback_t)free,
+                                     (lookup_free_obj_callback_t)free));
 
   checked_lookup_add(obj, "/.*/", "/.*/", "/.*/", "test", "/.*/",
                      LU_GROUP_BY_HOST);
@@ -178,7 +180,8 @@ DEF_TEST(multiple_lookups) {
   int status;
 
   CHECK_NOT_NULL(obj = lookup_create(lookup_class_callback, lookup_obj_callback,
-                                     (void *)free, (void *)free));
+                                     (lookup_free_class_callback_t)free,
+                                     (lookup_free_obj_callback_t)free));
 
   checked_lookup_add(obj, "/.*/", "plugin0", "", "test", "/.*/",
                      LU_GROUP_BY_HOST);
@@ -204,7 +207,8 @@ DEF_TEST(multiple_lookups) {
 DEF_TEST(regex) {
   lookup_t *obj;
   CHECK_NOT_NULL(obj = lookup_create(lookup_class_callback, lookup_obj_callback,
-                                     (void *)free, (void *)free));
+                                     (lookup_free_class_callback_t)free,
+                                     (lookup_free_obj_callback_t)free));
 
   checked_lookup_add(obj, "/^db[0-9]\\./", "cpu", "/.*/", "cpu", "/.*/",
                      LU_GROUP_BY_TYPE_INSTANCE);

--- a/src/utils/resource_metrics/resource_metrics.c
+++ b/src/utils/resource_metrics/resource_metrics.c
@@ -28,10 +28,9 @@
 #include "utils/common/common.h"
 #include "utils/resource_metrics/resource_metrics.h"
 
-typedef int (*compare_fn_t)(const void *, const void *);
-
-static int resource_metrics_compare(resource_metrics_t const *a,
-                                    resource_metrics_t const *b) {
+static int resource_metrics_compare(void const *ra, void const *rb) {
+  resource_metrics_t const *a = (resource_metrics_t const *)ra;
+  resource_metrics_t const *b = (resource_metrics_t const *)rb;
   return label_set_compare(a->resource, b->resource);
 }
 
@@ -42,7 +41,7 @@ static resource_metrics_t *lookup_resource(resource_metrics_set_t *set,
   };
 
   return bsearch(&key, set->ptr, set->num, sizeof(*set->ptr),
-                 (compare_fn_t)resource_metrics_compare);
+                 resource_metrics_compare);
 }
 
 static int insert_resource(resource_metrics_set_t *set, label_set_t resource) {
@@ -62,8 +61,7 @@ static int insert_resource(resource_metrics_set_t *set, label_set_t resource) {
   }
   set->num++;
 
-  qsort(set->ptr, set->num, sizeof(*set->ptr),
-        (compare_fn_t)resource_metrics_compare);
+  qsort(set->ptr, set->num, sizeof(*set->ptr), resource_metrics_compare);
   return 0;
 }
 
@@ -85,7 +83,9 @@ lookup_or_insert_resource(resource_metrics_set_t *set, label_set_t resource) {
   return ret;
 }
 
-static int compare_family_by_name(metric_family_t **a, metric_family_t **b) {
+static int compare_family_by_name(void const *ma, void const *mb) {
+  metric_family_t **a = (metric_family_t **)ma;
+  metric_family_t **b = (metric_family_t **)mb;
   return strcmp((*a)->name, (*b)->name);
 }
 
@@ -93,7 +93,7 @@ static metric_family_t *lookup_family(resource_metrics_t *rm,
                                       metric_family_t const *fam) {
   metric_family_t **ret =
       bsearch(&fam, rm->families, rm->families_num, sizeof(*rm->families),
-              (compare_fn_t)compare_family_by_name);
+              compare_family_by_name);
   if (ret == NULL) {
     return NULL;
   }
@@ -124,7 +124,7 @@ static int insert_family(resource_metrics_t *rm, metric_family_t const *fam) {
   rm->families_num++;
 
   qsort(rm->families, rm->families_num, sizeof(*rm->families),
-        (compare_fn_t)compare_family_by_name);
+        compare_family_by_name);
   return 0;
 }
 
@@ -146,7 +146,9 @@ static metric_family_t *lookup_or_insert_family(resource_metrics_t *rm,
   return ret;
 }
 
-static int compare_metrics(metric_t const *a, metric_t const *b) {
+static int compare_metrics(void const *ma, void const *mb) {
+  metric_t const *a = (metric_t const *)ma;
+  metric_t const *b = (metric_t const *)mb;
   int cmp = label_set_compare(a->label, b->label);
   if (cmp != 0) {
     return cmp;
@@ -162,9 +164,8 @@ static int compare_metrics(metric_t const *a, metric_t const *b) {
 }
 
 static bool metric_exists(metric_family_t const *fam, metric_t const *m) {
-  metric_t *found =
-      bsearch(m, fam->metric.ptr, fam->metric.num, sizeof(*fam->metric.ptr),
-              (compare_fn_t)compare_metrics);
+  metric_t *found = bsearch(m, fam->metric.ptr, fam->metric.num,
+                            sizeof(*fam->metric.ptr), compare_metrics);
   return found != NULL;
 }
 
@@ -194,7 +195,7 @@ static int insert_metrics(metric_family_t *fam, metric_list_t metrics) {
 
   if (((size_t)skipped) != metrics.num) {
     qsort(fam->metric.ptr, fam->metric.num, sizeof(*fam->metric.ptr),
-          (compare_fn_t)compare_metrics);
+          compare_metrics);
   }
 
   return skipped;

--- a/src/utils/utf8/utf8_test.c
+++ b/src/utils/utf8/utf8_test.c
@@ -28,17 +28,17 @@
 DEF_TEST(utf8_valid) {
   struct {
     char const *name;
-    char *input;
+    uint8_t *input;
     bool want;
   } cases[] = {
       {
           .name = "simple string",
-          .input = "Hello, World!",
+          .input = (uint8_t *)"Hello, World!",
           .want = true,
       },
       {
           .name = "empty string",
-          .input = "",
+          .input = (uint8_t *)"",
           .want = true,
       },
       {
@@ -48,56 +48,56 @@ DEF_TEST(utf8_valid) {
       },
       {
           .name = "The greek work \"kosme\"",
-          .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
-                            0xbc, 0xce, 0xb5, 0},
+          .input = (uint8_t[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
+                               0xbc, 0xce, 0xb5, 0},
           .want = true,
       },
       {
           .name = "First possible sequence of three bytes",
-          .input = (char[]){0xe0, 0xa0, 0x80, 0},
+          .input = (uint8_t[]){0xe0, 0xa0, 0x80, 0},
           .want = true,
       },
       {
           .name = "First possible sequence of four bytes",
-          .input = (char[]){0xf0, 0x90, 0x80, 0x80, 0},
+          .input = (uint8_t[]){0xf0, 0x90, 0x80, 0x80, 0},
           .want = true,
       },
       {
           .name = "U-0000D7F",
-          .input = (char[]){0xed, 0x9f, 0xbf, 0},
+          .input = (uint8_t[]){0xed, 0x9f, 0xbf, 0},
           .want = true,
       },
       {
           .name = "0xFE (invalid byte)",
-          .input = (char[]){'H', 0xfe, 'l', 'l', 'o', 0},
+          .input = (uint8_t[]){'H', 0xfe, 'l', 'l', 'o', 0},
           .want = false,
       },
       {
           .name = "0xFF (invalid byte)",
-          .input = (char[]){'C', 'o', 0xff, 'e', 'e', 0},
+          .input = (uint8_t[]){'C', 'o', 0xff, 'e', 'e', 0},
           .want = false,
       },
       {
           .name = "Continuation byte at end of string",
-          .input = (char[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
-                            0xbc, 0xce, 0},
+          .input = (uint8_t[]){0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce,
+                               0xbc, 0xce, 0},
           .want = false,
       },
       {
           .name = "U+002F (overlong ASCII character, 2 bytes)",
-          .input = (char[]){0xc0, 0xaf, 0},
+          .input = (uint8_t[]){0xc0, 0xaf, 0},
           .want = false,
       },
       {
           .name = "U+002F (overlong ASCII character, 3 bytes)",
-          .input = (char[]){0xe0, 0x80, 0xaf, 0},
+          .input = (uint8_t[]){0xe0, 0x80, 0xaf, 0},
           .want = false,
       },
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
     printf("Case #%zu: %s\n", i, cases[i].name);
-    EXPECT_EQ_INT(cases[i].want, utf8_valid(cases[i].input));
+    EXPECT_EQ_INT(cases[i].want, utf8_valid((const char *)cases[i].input));
   }
   return 0;
 }

--- a/src/utils/value_list/value_list_test.c
+++ b/src/utils/value_list/value_list_test.c
@@ -25,6 +25,7 @@
  */
 
 #include "testing.h"
+#include "utils/common/common.h"
 #include "utils/value_list/value_list.h"
 
 DEF_TEST(parse_values) {

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -732,7 +732,7 @@ static int prom_config(oconfig_item_t *ci) {
 
 static int prom_init() {
   if (prom_metrics == NULL) {
-    prom_metrics = c_avl_create((void *)strcmp);
+    prom_metrics = c_avl_create((int (*)(const void *, const void *))strcmp);
     if (prom_metrics == NULL) {
       ERROR("write_prometheus plugin: c_avl_create() failed.");
       return -1;


### PR DESCRIPTION
ChangeLog: Fix most `-Wpedantic` warnings in collectd core

I think first commit makes code more readable (and fixes comment typo).

Second commit should probably be dropped, as I do not see any reliable way to detect compilers that do not support C99 (`__func__` is variable in GCC, so one cannot use `#ifdef` check for it). It's included in case C89 compiler support is something that we do not actually care about (then few plugins could have similar change too)?