### PR TITLE
.cirrus.yml: statgrab: Print `ldd` of failing plugins. Continue on error.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,7 +153,7 @@ non_standard_toolchains_task:
             if ! $(ldd ".libs/${plugin}.so" 2>/dev/null | grep -q 'libstatgrab.so'); then
               echo "plugin ${plugin} is NOT linked against libstatgrab:"
               ldd ".libs/${plugin}.so" | sed -e 's/^/    /'
-              err=$(($err + 1))
+              err=$((err + 1))
             fi
           done
           exit $err

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,7 +145,7 @@ non_standard_toolchains_task:
           CPPLAGS="$(dpkg-buildflags --get CPPFLAGS)"
           LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"
       build_script:
-        - make -j$(nproc) -sk
+        - make -j$(nproc) -sk V=1
       tests_script:
         - |
           err=0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -147,7 +147,7 @@ non_standard_toolchains_task:
       build_script:
         - make -j$(nproc) -sk
       tests_script:
-        - >
+        - |
           err=0
           for plugin in cpu disk interface load memory swap users; do
             if ! $(ldd ".libs/${plugin}.so" 2>/dev/null | grep -q 'libstatgrab.so'); then

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,10 +110,8 @@ redhat_default_toolchain_task:
 non_standard_toolchains_task:
   container:
     image: collectd/ci:debian12
-  only_if: $CIRRUS_PR == ''
 
   matrix:
-
     # build using clang with default build flags, should always pass
     - env:
         LABEL: clang

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,12 +150,15 @@ non_standard_toolchains_task:
         - make -j$(nproc) -sk
       tests_script:
         - >
-          for i in cpu disk interface load memory swap users; do
-            if ! $(ldd ".libs/${i}.so" 2>/dev/null | grep -q 'libstatgrab.so'); then
-              echo "plugin $i NOT linked against libstatgrab"
-              exit 1
+          err=0
+          for plugin in cpu disk interface load memory swap users; do
+            if ! $(ldd ".libs/${plugin}.so" 2>/dev/null | grep -q 'libstatgrab.so'); then
+              echo "plugin ${plugin} is NOT linked against libstatgrab:"
+              ldd ".libs/${plugin}.so" | sed -e 's/^/    /'
+              err=$(($err + 1))
             fi
           done
+          exit $err
 
     # build using clang with a collection of strict build flags, will most
     # probably always fail


### PR DESCRIPTION
Investigating this error:

```
plugin cpu NOT linked against libstatgrab
```