### PR TITLE
[collectd 6] ci: Remove the "statgrab" task from CirrusCI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,33 +131,6 @@ non_standard_toolchains_task:
       tests_script:
         - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j$(nproc) -sk check || (cat ./test-suite.log && false)
 
-    # build against libstatgrab, should always pass
-    - env:
-        LABEL: statgrab
-      allow_failures: false
-      skip_notifications: false
-      configure_script:
-        - ./build.sh
-        - gcc --version
-        - >
-          ./configure --with-libstatgrab --enable-debug
-          CFLAGS="$(dpkg-buildflags --get CFLAGS)"
-          CPPLAGS="$(dpkg-buildflags --get CPPFLAGS)"
-          LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"
-      build_script:
-        - make -j$(nproc) -sk V=1
-      tests_script:
-        - |
-          err=0
-          for plugin in cpu disk interface load memory swap users; do
-            if ! $(ldd ".libs/${plugin}.so" 2>/dev/null | grep -q 'libstatgrab.so'); then
-              echo "plugin ${plugin} is NOT linked against libstatgrab:"
-              ldd ".libs/${plugin}.so" | sed -e 's/^/    /'
-              err=$((err + 1))
-            fi
-          done
-          exit $err
-
     # build using clang with a collection of strict build flags, will most
     # probably always fail
     - env:


### PR DESCRIPTION
The "statgrab" job builds collectd with the "statgrab" library and then expects certain plugins to be linked against it. However, since the build runs on Linux, the plugins are actually using the "native" implementation. The linker, noticing that the plugin is not referring to any symbol in the statgrab library, does not actually produce a link, causing the test to fail.

The native implementations provide much richer metrics than the libstatgrab based implementations, so we'll drop the test.