### PR TITLE
[collectd 6] fix: df plugin: Fix an array out of bounds crash.

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -332,7 +332,7 @@ static int df_read(void) {
       &fam_inode_utilization,
   };
 
-  for (size_t i = 0; STATIC_ARRAY_SIZE(families); i++) {
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(families); i++) {
     if (families[i]->metric.num == 0) {
       continue;
     }


### PR DESCRIPTION
The second argument of the `for` loop always evaluated to true, causing the code to read past the end of the array.

ChangeLog: df plugin: An out of bounds read, causing segmentation faults, has been fixed.