### PR TITLE
disk.c: add config options to support diskstats 15-20 in KERNEL_LINUX

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -683,6 +683,8 @@
 #	IgnoreSelected false
 #	UseBSDName false
 #	UdevNameAttr "DEVNAME"
+#	ReportDiscard false
+#	ReportFlush false
 #</Plugin>
 
 #<Plugin dns>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3027,6 +3027,16 @@ data about the whole disk and each partition being mixed together incorrectly.
 In this case, you can use B<ID_COLLECTD> attribute that is provided by
 I<contrib/99-storage-collectd.rules> udev rule file instead.
 
+=item B<ReportDiscard> B<true>|B<false>
+
+Whether to submit discard metrics (/proc/diskstats 15-18), on Linux only.
+Requires Linux Kernel version > 4.18+.
+
+=item B<ReportFlush> B<true>|B<false>
+
+Whether to submit flush metrics (/proc/diskstats 19-20), on Linux only.
+Requires Linux Kernel version > 5.5+.
+
 =back
 
 =head2 Plugin C<dns>


### PR DESCRIPTION
According to feedback by
#4242
This PR lets discard and flush metrics to be disabled by default and able to enabled by config options.

ChangeLog: disk plugin: options to control discard and flush metrics