### PR TITLE
[collectd 6] fix: Handle metric families with zero metrics gracefully.

### DIFF
--- a/src/chrony.c
+++ b/src/chrony.c
@@ -1105,14 +1105,12 @@ static int chrony_read(void) {
   }
 
   for (size_t i = 0; i < FAM_CHRONY_MAX; i++) {
-    if (fams[i].metric.num > 0) {
-      int status = plugin_dispatch_metric_family(&fams[i]);
-      if (status != 0) {
-        ERROR("chrony plugin: plugin_dispatch_metric_family failed: %s",
-              STRERROR(status));
-      }
-      metric_family_metric_reset(&fams[i]);
+    int status = plugin_dispatch_metric_family(&fams[i]);
+    if (status != 0) {
+      ERROR("chrony plugin: plugin_dispatch_metric_family failed: %s",
+            STRERROR(status));
     }
+    metric_family_metric_reset(&fams[i]);
   }
 
   return CHRONY_RC_OK;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2105,6 +2105,9 @@ EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
     return EINVAL;
   }
   if (fam->metric.num == 0) {
+    DEBUG("plugin_dispatch_metric_family: Metric family \"%s\" contains zero "
+          "metrics.",
+          fam->name);
     return 0;
   }
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -2100,8 +2100,12 @@ static void set_default_resource_attributes(metric_family_t *fam) {
 }
 
 EXPORT int plugin_dispatch_metric_family(metric_family_t const *fam) {
-  if ((fam == NULL) || (fam->metric.num == 0)) {
+  if (fam == NULL) {
+    ERROR("plugin_dispatch_metric_family: fam == NULL");
     return EINVAL;
+  }
+  if (fam->metric.num == 0) {
+    return 0;
   }
 
   /* Create a copy of the metric_family_t so we can modify the time and

--- a/src/df.c
+++ b/src/df.c
@@ -333,10 +333,6 @@ static int df_read(void) {
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(families); i++) {
-    if (families[i]->metric.num == 0) {
-      continue;
-    }
-
     int status = plugin_dispatch_metric_family(families[i]);
     if (status != 0) {
       ERROR("df: plugin_dispatch_metric_family failed: %s", STRERROR(status));

--- a/src/disk.c
+++ b/src/disk.c
@@ -1179,10 +1179,6 @@ static int disk_read(void) {
 #endif /* HAVE_SYSCTL && KERNEL_NETBSD */
 
   for (size_t i = 0; fams[i] != NULL; i++) {
-    if (fams[i]->metric.num == 0) {
-      continue;
-    }
-
     int status = plugin_dispatch_metric_family(fams[i]);
     if (status != 0) {
       ERROR("disk: plugin_dispatch_metric_family failed: %s", STRERROR(status));

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -396,14 +396,12 @@ static int ipc_read(void) /* {{{ */
   status |= ipc_read_msg(fams);
 
   for (size_t i = 0; i < FAM_IPC_MAX; i++) {
-    if (fams[i].metric.num > 0) {
-      int status = plugin_dispatch_metric_family(&fams[i]);
-      if (status != 0) {
-        ERROR("ipc plugin: plugin_dispatch_metric_family failed: %s",
-              STRERROR(status));
-      }
-      metric_family_metric_reset(&fams[i]);
+    int status = plugin_dispatch_metric_family(&fams[i]);
+    if (status != 0) {
+      ERROR("ipc plugin: plugin_dispatch_metric_family failed: %s",
+            STRERROR(status));
     }
+    metric_family_metric_reset(&fams[i]);
   }
 
   return status;

--- a/src/irq.c
+++ b/src/irq.c
@@ -243,15 +243,13 @@ static int irq_read(void) {
 
   int ret = irq_read_data(&fam);
 
-  if (fam.metric.num > 0) {
-    int status = plugin_dispatch_metric_family(&fam);
-    if (status != 0) {
-      ERROR("irq plugin: plugin_dispatch_metric_family failed: %s",
-            STRERROR(status));
-      ret = -1;
-    }
-    metric_family_metric_reset(&fam);
+  int status = plugin_dispatch_metric_family(&fam);
+  if (status != 0) {
+    ERROR("irq plugin: plugin_dispatch_metric_family failed: %s",
+          STRERROR(status));
+    ret = -1;
   }
+  metric_family_metric_reset(&fam);
 
   return ret;
 }

--- a/src/ping.c
+++ b/src/ping.c
@@ -668,14 +668,12 @@ static int ping_read(void) /* {{{ */
   } /* }}} for (hl = hostlist_head; hl != NULL; hl = hl->next) */
 
   for (size_t i = 0; fams[i] != NULL; i++) {
-    if (fams[i]->metric.num > 0) {
-      int status = plugin_dispatch_metric_family(fams[i]);
-      if (status != 0) {
-        ERROR("ping plugin: plugin_dispatch_metric_family failed: %s",
-              STRERROR(status));
-      }
-      metric_family_metric_reset(fams[i]);
+    int status = plugin_dispatch_metric_family(fams[i]);
+    if (status != 0) {
+      ERROR("ping plugin: plugin_dispatch_metric_family failed: %s",
+            STRERROR(status));
     }
+    metric_family_metric_reset(fams[i]);
   }
 
   return 0;

--- a/src/utils/format_json/format_json_test.c
+++ b/src/utils/format_json/format_json_test.c
@@ -136,7 +136,7 @@ static int expect_json_labels(char *json, label_pair_t *labels,
 
 DEF_TEST(notification) {
   label_pair_t labels[] = {
-      {"summary", "this is a message"},
+      {"summary", "this is a \"message\""},
       {"alertname", "collectd_unit_test"},
       {"instance", "example.com"},
       {"service", "collectd"},
@@ -144,19 +144,21 @@ DEF_TEST(notification) {
   };
 
   /* 1448284606.125 ^= 1555083754651779072 */
-  notification_t n = {NOTIF_WARNING,
-                      1555083754651779072ULL,
-                      "this is a message",
-                      "example.com",
-                      "unit",
-                      "",
-                      "test",
-                      "case",
-                      NULL};
+  notification_t n = {
+      .severity = NOTIF_WARNING,
+      .time = 1555083754651779072ULL,
+      .message = "this is a \"message\"",
+      .host = "example.com",
+      .plugin = "unit",
+      .plugin_instance = "",
+      .type = "test",
+      .type_instance = "case",
+      .meta = NULL,
+  };
 
   char got[1024];
   CHECK_ZERO(format_json_notification(got, sizeof(got), &n));
-  // printf ("got = \"%s\";\n", got);
+  printf("got = \"%s\";\n", got);
 
   return expect_json_labels(got, labels, STATIC_ARRAY_SIZE(labels));
 }


### PR DESCRIPTION
This allows plugins to call `plugin_dispatch_metric_family()` unconditionally.

ChangeLog: Daemon: The `plugin_dispatch_metric_family()` function has been changed to handle metric families with zero metrics gracefully.