### PR TITLE
write_redis plugin: Clean up allocated fields in `wr_config_free()`.

### DIFF
--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -170,7 +170,9 @@ static void wr_config_free(void *ptr) /* {{{ */
     node->conn = NULL;
   }
 
+  pthread_mutex_destroy(&node->lock);
   sfree(node->host);
+  sfree(node->prefix);
   sfree(node);
 } /* }}} void wr_config_free */
 


### PR DESCRIPTION
Technically these fields leak. Because they're allocated during start-up only, there is no runtime or user-observable impact, i.e. this is a cleanup.