### PR TITLE
[collectd 6, WIP] Fix more GCC "-Wpedantic" warnings

### DIFF
--- a/src/dcpmm.c
+++ b/src/dcpmm.c
@@ -90,7 +90,7 @@ static void add_metric(const char *plugin_inst, const char *type,
 } /* void add_metric  */
 
 static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   int i, ret = 0;
   char dimm_num[16];
@@ -167,12 +167,12 @@ static int dcpmm_read(__attribute__((unused)) user_data_t *ud) {
 } /* int dcpmm_read */
 
 static int dcpmm_stop(void) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   int ret = 0;
 
   if (skip_stop) {
-    DEBUG(PLUGIN_NAME ": %s:%d skipping stop function", __FUNCTION__, __LINE__);
+    DEBUG(PLUGIN_NAME ": %s:%d skipping stop function", __func__, __LINE__);
 
     return ret;
   }
@@ -186,7 +186,7 @@ static int dcpmm_stop(void) {
 } /* int dcpmm_stop */
 
 static int dcpmm_shutdown(void) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   int ret = 0;
 
@@ -198,7 +198,7 @@ static int dcpmm_shutdown(void) {
 } /* int dcpmm_shutdown */
 
 static int dcpmm_init(void) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   int ret = 0;
 
@@ -239,7 +239,7 @@ static int dcpmm_init(void) {
 } /* int dcpmm_init */
 
 static int dcpmm_config(oconfig_item_t *ci) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   int ret = 0;
 

--- a/src/dpdk_telemetry.c
+++ b/src/dpdk_telemetry.c
@@ -67,7 +67,7 @@ static char g_dpdk_path[BUF_SIZE];
 static int dpdk_telemetry_config(oconfig_item_t *ci) {
   int ret, i;
 
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   for (i = 0; i < ci->children_num; i++) {
     oconfig_item_t *child = ci->children + i;
@@ -85,7 +85,7 @@ static int dpdk_telemetry_config(oconfig_item_t *ci) {
     }
 
     if (ret < 0) {
-      INFO(PLUGIN_NAME ": %s:%d ret =%d", __FUNCTION__, __LINE__, ret);
+      INFO(PLUGIN_NAME ": %s:%d ret =%d", __func__, __LINE__, ret);
       return ret;
     }
   }
@@ -248,7 +248,7 @@ static int dpdk_telemetry_cleanup(void) {
 }
 
 static int dpdk_telemetry_socket_init(void) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
   char message[BUF_SIZE];
 
   /* Here we look up the length of the g_dpdk_path string
@@ -319,7 +319,7 @@ static int dpdk_telemetry_socket_init(void) {
 }
 
 static int dpdk_telemetry_shutdown(void) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
   char msg[BUF_SIZE];
   int ret;
 
@@ -338,7 +338,7 @@ static int dpdk_telemetry_shutdown(void) {
 }
 
 static int dpdk_telemetry_read(user_data_t *ud) {
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
   char buffer[BUF_SIZE];
   int bytes = 0, ret;
   char *json_string[MAX_COMMANDS] = {"{\"action\":0,\"command\":"
@@ -378,7 +378,7 @@ static int dpdk_telemetry_read(user_data_t *ud) {
 
 static int dpdk_telemetry_init(void) {
 
-  DEBUG(PLUGIN_NAME ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PLUGIN_NAME ": %s:%d", __func__, __LINE__);
 
   client.s_send = -1;
   client.s_recv = -1;

--- a/src/dpdkevents.c
+++ b/src/dpdkevents.c
@@ -111,7 +111,7 @@ typedef enum {
 #define DPDK_EVENTS_CTX_GET(a) ((dpdk_events_ctx_t *)dpdk_helper_priv_get(a))
 
 #define DPDK_EVENTS_TRACE()                                                    \
-  DEBUG("%s:%s:%d pid=%u", DPDK_EVENTS_PLUGIN, __FUNCTION__, __LINE__, getpid())
+  DEBUG("%s:%s:%d pid=%u", DPDK_EVENTS_PLUGIN, __func__, __LINE__, getpid())
 
 static dpdk_helper_ctx_t *g_hc;
 static dpdk_events_cfg_status g_state;
@@ -497,7 +497,7 @@ static void dpdk_events_gauge_submit(const char *plugin_instance,
 
 static int dpdk_events_link_status_dispatch(dpdk_helper_ctx_t *phc) {
   dpdk_events_ctx_t *ec = DPDK_EVENTS_CTX_GET(phc);
-  DEBUG(DPDK_EVENTS_PLUGIN ": %s:%d ports=%u", __FUNCTION__, __LINE__,
+  DEBUG(DPDK_EVENTS_PLUGIN ": %s:%d ports=%u", __func__, __LINE__,
         ec->nb_ports);
 
   /* dispatch Link Status values to collectd */
@@ -552,7 +552,7 @@ static void dpdk_events_keep_alive_dispatch(dpdk_helper_ctx_t *phc) {
     } else {
       WARNING(DPDK_EVENTS_PLUGIN
               ": %s:%d Core id %u is out of 0 to %u range, skipping",
-              __FUNCTION__, __LINE__, i, INT64_BIT_SIZE * 2);
+              __func__, __LINE__, i, INT64_BIT_SIZE * 2);
       continue;
     }
 
@@ -639,7 +639,7 @@ static int dpdk_events_read(user_data_t *ud) {
     if (ka_ret) {
       ERROR(DPDK_EVENTS_PLUGIN
             ": %s : error %d in dpdk_event_keep_alive_shm_open()",
-            __FUNCTION__, ka_ret);
+            __func__, ka_ret);
     } else
       dpdk_events_keep_alive_dispatch(g_hc);
   }

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -42,7 +42,7 @@
 #define DPDK_STATS_NAME "dpdk_collectd_stats"
 
 #define DPDK_STATS_TRACE()                                                     \
-  DEBUG("%s:%s:%d pid=%u", DPDK_STATS_PLUGIN, __FUNCTION__, __LINE__, getpid())
+  DEBUG("%s:%s:%d pid=%u", DPDK_STATS_PLUGIN, __func__, __LINE__, getpid())
 
 struct dpdk_stats_config_s {
   cdtime_t interval;
@@ -266,7 +266,7 @@ static int dpdk_helper_stats_count_get(dpdk_helper_ctx_t *phc) {
     stats_count += len;
   }
 
-  DPDK_CHILD_LOG("%s:%s:%d stats_count=%d\n", DPDK_STATS_PLUGIN, __FUNCTION__,
+  DPDK_CHILD_LOG("%s:%s:%d stats_count=%d\n", DPDK_STATS_PLUGIN, __func__,
                  __LINE__, stats_count);
 
   return stats_count;
@@ -301,7 +301,7 @@ int dpdk_helper_command_handler(dpdk_helper_ctx_t *phc, enum DPDK_CMD cmd) {
     DPDK_CHILD_LOG(
         DPDK_STATS_PLUGIN
         ":%s:%d not enough space for stats (available=%d, needed=%d)\n",
-        __FUNCTION__, __LINE__, (int)dpdk_stats_get_size(phc), stats_size);
+        __func__, __LINE__, (int)dpdk_stats_get_size(phc), stats_size);
     return -ENOBUFS;
   }
 
@@ -384,7 +384,7 @@ static int dpdk_stats_counters_dispatch(dpdk_helper_ctx_t *phc) {
 
   /* dispatch stats values to collectd */
 
-  DEBUG("%s:%s:%d ports=%u", DPDK_STATS_PLUGIN, __FUNCTION__, __LINE__,
+  DEBUG("%s:%s:%d ports=%u", DPDK_STATS_PLUGIN, __func__, __LINE__,
         ctx->ports_count);
 
   int stats_count = 0;
@@ -429,7 +429,7 @@ static int dpdk_stats_reinit_helper() {
   size_t data_size = sizeof(dpdk_stats_ctx_t) +
                      (ctx->stats_count * DPDK_STATS_CTX_GET_XSTAT_SIZE);
 
-  DEBUG("%s:%d helper reinit (new_size=%" PRIsz ")", __FUNCTION__, __LINE__,
+  DEBUG("%s:%d helper reinit (new_size=%" PRIsz ")", __func__, __LINE__,
         data_size);
 
   dpdk_stats_ctx_t tmp_ctx;

--- a/src/intel_pmu.c
+++ b/src/intel_pmu.c
@@ -215,7 +215,7 @@ static int pmu_config_hw_events(oconfig_item_t *ci, intel_pmu_entity_t *ent) {
 
 static int pmu_config(oconfig_item_t *ci) {
 
-  DEBUG(PMU_PLUGIN ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PMU_PLUGIN ": %s:%d", __func__, __LINE__);
 
   for (int i = 0; i < ci->children_num; i++) {
     int ret = 0;
@@ -257,7 +257,7 @@ static int pmu_config(oconfig_item_t *ci) {
     }
 
     if (ret != 0) {
-      DEBUG(PMU_PLUGIN ": %s:%d ret=%d", __FUNCTION__, __LINE__, ret);
+      DEBUG(PMU_PLUGIN ": %s:%d ret=%d", __func__, __LINE__, ret);
       return ret;
     }
   }
@@ -427,18 +427,18 @@ static void pmu_dispatch_data(intel_pmu_entity_t *ent) {
 
 static int pmu_read(user_data_t *ud) {
   if (ud == NULL) {
-    ERROR(PMU_PLUGIN ": ud is NULL! %s:%d", __FUNCTION__, __LINE__);
+    ERROR(PMU_PLUGIN ": ud is NULL! %s:%d", __func__, __LINE__);
     return -1;
   }
   if (ud->data == NULL) {
-    ERROR(PMU_PLUGIN ": ud->data is NULL! %s:%d", __FUNCTION__, __LINE__);
+    ERROR(PMU_PLUGIN ": ud->data is NULL! %s:%d", __func__, __LINE__);
     return -1;
   }
   intel_pmu_entity_t *ent = (intel_pmu_entity_t *)ud->data;
   int ret;
   struct event *e;
 
-  DEBUG(PMU_PLUGIN ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PMU_PLUGIN ": %s:%d", __func__, __LINE__);
 
   /* read all events only for configured cores */
   for (e = ent->event_list->eventlist; e; e = e->next) {
@@ -703,7 +703,7 @@ static int pmu_read_all_events(void *data, char *name, char *event,
 static int pmu_init(void) {
   int ret;
 
-  DEBUG(PMU_PLUGIN ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PMU_PLUGIN ": %s:%d", __func__, __LINE__);
 
   if (g_ctx.entl == NULL) {
     ERROR(PMU_PLUGIN ": No events were setup in configuration.");
@@ -861,7 +861,7 @@ init_error:
 
 static int pmu_shutdown(void) {
 
-  DEBUG(PMU_PLUGIN ": %s:%d", __FUNCTION__, __LINE__);
+  DEBUG(PMU_PLUGIN ": %s:%d", __func__, __LINE__);
 
   for (intel_pmu_entity_t *ent = g_ctx.entl; ent != NULL;) {
     intel_pmu_entity_t *tmp = ent;

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -859,7 +859,7 @@ static void smi_event_handler(ipmi_con_t __attribute__((unused)) * ipmi,
   unsigned int type = ipmi_event_get_type(event);
   ipmi_domain_t *domain = cb_data;
 
-  DEBUG("%s: Event received: type %u", __FUNCTION__, type);
+  DEBUG("%s: Event received: type %u", __func__, type);
 
   if (type != 0x02)
     /* It's not a standard IPMI event. */

--- a/src/mcelog.c
+++ b/src/mcelog.c
@@ -264,7 +264,7 @@ static int socket_write(socket_adapter_t *self, const char *msg,
 
 static void mcelog_dispatch_notification(notification_t *n) {
   if (!n) {
-    ERROR(MCELOG_PLUGIN ": %s: NULL pointer", __FUNCTION__);
+    ERROR(MCELOG_PLUGIN ": %s: NULL pointer", __func__);
     return;
   }
 
@@ -401,7 +401,7 @@ static int mcelog_dispatch_mem_notifications(const mcelog_memory_rec_t *mr) {
 static int mcelog_submit(const mcelog_memory_rec_t *mr) {
 
   if (!mr) {
-    ERROR(MCELOG_PLUGIN ": %s: NULL pointer", __FUNCTION__);
+    ERROR(MCELOG_PLUGIN ": %s: NULL pointer", __func__);
     return -1;
   }
 
@@ -656,7 +656,7 @@ static int get_memory_machine_checks(void) {
 }
 
 static int mcelog_read(__attribute__((unused)) user_data_t *ud) {
-  DEBUG(MCELOG_PLUGIN ": %s", __FUNCTION__);
+  DEBUG(MCELOG_PLUGIN ": %s", __func__);
 
   if (get_memory_machine_checks() != 0)
     ERROR(MCELOG_PLUGIN ": MACHINE CHECK INFO NOT AVAILABLE");

--- a/src/mdevents.c
+++ b/src/mdevents.c
@@ -41,7 +41,7 @@
 #define DAEMON_NAME "mdadm"
 
 #define MD_EVENTS_ERROR(err_msg, ...)                                          \
-  ERROR(MD_EVENTS_PLUGIN ": %s: " err_msg, __FUNCTION__, ##__VA_ARGS__)
+  ERROR(MD_EVENTS_PLUGIN ": %s: " err_msg, __func__, ##__VA_ARGS__)
 
 // Syslog can be located under different paths on various linux distros;
 // The following two cover the debian-based and redhat distros

--- a/src/mdevents.c
+++ b/src/mdevents.c
@@ -213,9 +213,9 @@ static int md_events_config(const char *key, const char *value) {
 
 static void md_events_handle_regex_error(int rc, regex_t *regex,
                                          const char *func_name) {
-  char buf[MAX_ERROR_MSG] = {};
+  char buf[MAX_ERROR_MSG];
 
-  regerror(rc, regex, buf, MAX_ERROR_MSG);
+  regerror(rc, regex, buf, sizeof(buf));
   DEBUG("%s() failed with '%s'\n", func_name, buf);
 }
 
@@ -284,15 +284,16 @@ static void md_events_copy_match(char *buf, const char *line,
 }
 
 static int md_events_match_regex(regex_t *regex, const char *to_match) {
-  regmatch_t matches[MAX_MATCHES] = {};
+  regmatch_t matches[MAX_MATCHES];
   int status, severity;
-  md_events_event_t event = {};
 
-  status = regexec(regex, to_match, MAX_MATCHES, matches, 0);
+  status = regexec(regex, to_match, STATIC_ARRAY_SIZE(matches), matches, 0);
   if (status) {
     md_events_handle_regex_error(status, regex, "regexec");
     return -1;
   }
+
+  md_events_event_t event = {0};
 
   // each element from matches array contains the indexes (start/end) within
   // the string that we ran regexp on; use them to retrieve the substrings

--- a/src/utils/cmds/cmds_test.c
+++ b/src/utils/cmds/cmds_test.c
@@ -386,7 +386,7 @@ DEF_TEST(parse) {
               "cmd_parse(\"%s\", opts=%p) = "
               "%d (type=%d [%s]); want %d "
               "(type=%d [%s])",
-              parse_data[i].input, parse_data[i].opts, status, cmd.type,
+              parse_data[i].input, (void *)parse_data[i].opts, status, cmd.type,
               CMD_TO_STRING(cmd.type), parse_data[i].expected_status,
               parse_data[i].expected_type,
               CMD_TO_STRING(parse_data[i].expected_type));

--- a/src/utils/dpdk/dpdk.c
+++ b/src/utils/dpdk/dpdk.c
@@ -65,7 +65,7 @@ enum DPDK_HELPER_STATUS {
 };
 
 #define DPDK_HELPER_TRACE(_name)                                               \
-  DEBUG("%s:%s:%d pid=%ld", _name, __FUNCTION__, __LINE__, (long)getpid())
+  DEBUG("%s:%s:%d pid=%ld", _name, __func__, __LINE__, (long)getpid())
 
 struct dpdk_helper_ctx_s {
 
@@ -292,12 +292,12 @@ int dpdk_helper_init(const char *name, size_t data_size,
   size_t shm_size = sizeof(dpdk_helper_ctx_t) + data_size;
 
   if (pphc == NULL) {
-    ERROR("%s:Invalid argument(pphc)", __FUNCTION__);
+    ERROR("%s:Invalid argument(pphc)", __func__);
     return -EINVAL;
   }
 
   if (name == NULL) {
-    ERROR("%s:Invalid argument(name)", __FUNCTION__);
+    ERROR("%s:Invalid argument(name)", __func__);
     return -EINVAL;
   }
 
@@ -417,7 +417,7 @@ static int dpdk_helper_spawn(dpdk_helper_ctx_t *phc) {
 
 static int dpdk_helper_exit(dpdk_helper_ctx_t *phc,
                             enum DPDK_HELPER_STATUS status) {
-  DPDK_CHILD_LOG("%s:%s:%d %s\n", phc->shm_name, __FUNCTION__, __LINE__,
+  DPDK_CHILD_LOG("%s:%s:%d %s\n", phc->shm_name, __func__, __LINE__,
                  dpdk_helper_status_str(status));
 
   close(phc->pipes[1]);
@@ -437,27 +437,27 @@ static int dpdk_helper_exit_command(dpdk_helper_ctx_t *phc,
 
   if (phc->status == DPDK_HELPER_ALIVE_SENDING_EVENTS) {
     phc->status = status;
-    DEBUG("%s:%s:%d %s", phc->shm_name, __FUNCTION__, __LINE__,
+    DEBUG("%s:%s:%d %s", phc->shm_name, __func__, __LINE__,
           dpdk_helper_status_str(status));
 
     int ret = dpdk_helper_command(phc, DPDK_CMD_QUIT, NULL, 0);
     if (ret != 0) {
-      DEBUG("%s:%s:%d kill helper (pid=%lu)", phc->shm_name, __FUNCTION__,
-            __LINE__, (long)phc->pid);
+      DEBUG("%s:%s:%d kill helper (pid=%lu)", phc->shm_name, __func__, __LINE__,
+            (long)phc->pid);
 
       int err = kill(phc->pid, SIGKILL);
       if (err) {
-        ERROR("%s error sending kill to helper: %s", __FUNCTION__, STRERRNO);
+        ERROR("%s error sending kill to helper: %s", __func__, STRERRNO);
       }
     }
   } else {
 
-    DEBUG("%s:%s:%d kill helper (pid=%lu)", phc->shm_name, __FUNCTION__,
-          __LINE__, (long)phc->pid);
+    DEBUG("%s:%s:%d kill helper (pid=%lu)", phc->shm_name, __func__, __LINE__,
+          (long)phc->pid);
 
     int err = kill(phc->pid, SIGKILL);
     if (err) {
-      ERROR("%s error sending kill to helper: %s", __FUNCTION__, STRERRNO);
+      ERROR("%s error sending kill to helper: %s", __func__, STRERRNO);
     }
   }
 
@@ -467,7 +467,7 @@ static int dpdk_helper_exit_command(dpdk_helper_ctx_t *phc,
 static int dpdk_helper_eal_init(dpdk_helper_ctx_t *phc) {
   phc->status = DPDK_HELPER_INITIALIZING_EAL;
   DPDK_CHILD_LOG("%s:%s:%d DPDK_HELPER_INITIALIZING_EAL (start)\n",
-                 phc->shm_name, __FUNCTION__, __LINE__);
+                 phc->shm_name, __func__, __LINE__);
 
   char *argp[DPDK_EAL_ARGC * 2 + 1];
   int argc = 0;
@@ -530,7 +530,7 @@ static int dpdk_helper_eal_init(dpdk_helper_ctx_t *phc) {
   phc->eal_initialized = 1;
 
   DPDK_CHILD_LOG("%s:%s:%d DPDK_HELPER_INITIALIZING_EAL (done)\n",
-                 phc->shm_name, __FUNCTION__, __LINE__);
+                 phc->shm_name, __func__, __LINE__);
 
   return 0;
 }
@@ -545,11 +545,10 @@ static int dpdk_helper_cmd_wait(dpdk_helper_ctx_t *phc, pid_t ppid) {
 
   int ret = sem_timedwait(&phc->sema_cmd_start, &ts);
   DPDK_CHILD_LOG("%s:%s:%d pid=%lu got sema_cmd_start (ret=%d, errno=%d)\n",
-                 phc->shm_name, __FUNCTION__, __LINE__, (long)getpid(), ret,
-                 errno);
+                 phc->shm_name, __func__, __LINE__, (long)getpid(), ret, errno);
 
   if (phc->cmd == DPDK_CMD_QUIT) {
-    DPDK_CHILD_LOG("%s:%s:%d pid=%lu exiting\n", phc->shm_name, __FUNCTION__,
+    DPDK_CHILD_LOG("%s:%s:%d pid=%lu exiting\n", phc->shm_name, __func__,
                    __LINE__, (long)getpid());
     exit(0);
   } else if (ret == -1 && errno == ETIMEDOUT) {
@@ -564,7 +563,7 @@ static int dpdk_helper_cmd_wait(dpdk_helper_ctx_t *phc, pid_t ppid) {
   int val = 0;
   if (sem_getvalue(&phc->sema_cmd_start, &val) == 0)
     DPDK_CHILD_LOG("%s:%s:%d pid=%lu wait sema_cmd_start (value=%d)\n",
-                   phc->shm_name, __FUNCTION__, __LINE__, (long)getpid(), val);
+                   phc->shm_name, __func__, __LINE__, (long)getpid(), val);
 #endif
 
   /* Parent PID change means collectd died so quit the helper process. */
@@ -585,7 +584,7 @@ static int dpdk_helper_cmd_wait(dpdk_helper_ctx_t *phc, pid_t ppid) {
 
     phc->status = DPDK_HELPER_WAITING_ON_PRIMARY;
     DPDK_CHILD_LOG("%s:%s:%d DPDK_HELPER_WAITING_ON_PRIMARY\n", phc->shm_name,
-                   __FUNCTION__, __LINE__);
+                   __func__, __LINE__);
 
     return -1;
   }
@@ -598,7 +597,7 @@ static int dpdk_helper_cmd_wait(dpdk_helper_ctx_t *phc, pid_t ppid) {
     }
     phc->status = DPDK_HELPER_ALIVE_SENDING_EVENTS;
     DPDK_CHILD_LOG("%s:%s:%d DPDK_HELPER_ALIVE_SENDING_EVENTS\n", phc->shm_name,
-                   __FUNCTION__, __LINE__);
+                   __func__, __LINE__);
     return -1;
   }
 
@@ -613,7 +612,7 @@ static int dpdk_helper_worker(dpdk_helper_ctx_t *phc) {
   while (1) {
     if (dpdk_helper_cmd_wait(phc, ppid) == 0) {
       DPDK_CHILD_LOG("%s:%s:%d DPDK command handle (cmd=%d, pid=%lu)\n",
-                     phc->shm_name, __FUNCTION__, __LINE__, phc->cmd,
+                     phc->shm_name, __func__, __LINE__, phc->cmd,
                      (long)getpid());
       phc->cmd_result = dpdk_helper_command_handler(phc, phc->cmd);
     } else {
@@ -623,7 +622,7 @@ static int dpdk_helper_worker(dpdk_helper_ctx_t *phc) {
     /* now kick collectd to get results */
     int err = sem_post(&phc->sema_cmd_complete);
     DPDK_CHILD_LOG("%s:%s:%d post sema_cmd_complete (pid=%lu)\n", phc->shm_name,
-                   __FUNCTION__, __LINE__, (long)getpid());
+                   __func__, __LINE__, (long)getpid());
     if (err) {
       DPDK_CHILD_LOG("dpdk_helper_worker: error posting sema_cmd_complete "
                      "semaphore (%s)\n",
@@ -634,8 +633,7 @@ static int dpdk_helper_worker(dpdk_helper_ctx_t *phc) {
     int val = 0;
     if (sem_getvalue(&phc->sema_cmd_complete, &val) == 0)
       DPDK_CHILD_LOG("%s:%s:%d pid=%lu sema_cmd_complete (value=%d)\n",
-                     phc->shm_name, __FUNCTION__, __LINE__, (long)getpid(),
-                     val);
+                     phc->shm_name, __func__, __LINE__, (long)getpid(), val);
 #endif
 
   } /* while(1) */
@@ -663,14 +661,14 @@ static const char *dpdk_helper_status_str(enum DPDK_HELPER_STATUS status) {
 }
 
 static int dpdk_helper_status_check(dpdk_helper_ctx_t *phc) {
-  DEBUG("%s:%s:%d pid=%u %s", phc->shm_name, __FUNCTION__, __LINE__, getpid(),
+  DEBUG("%s:%s:%d pid=%u %s", phc->shm_name, __func__, __LINE__, getpid(),
         dpdk_helper_status_str(phc->status));
 
   if (phc->status == DPDK_HELPER_GRACEFUL_QUIT) {
     return 0;
   } else if (phc->status == DPDK_HELPER_NOT_INITIALIZED) {
     phc->status = DPDK_HELPER_INITIALIZING;
-    DEBUG("%s:%s:%d DPDK_HELPER_INITIALIZING", phc->shm_name, __FUNCTION__,
+    DEBUG("%s:%s:%d DPDK_HELPER_INITIALIZING", phc->shm_name, __func__,
           __LINE__);
     int err = dpdk_helper_spawn(phc);
     if (err) {
@@ -682,7 +680,7 @@ static int dpdk_helper_status_check(dpdk_helper_ctx_t *phc) {
   pid_t ws = waitpid(phc->pid, NULL, WNOHANG);
   if (ws != 0) {
     phc->status = DPDK_HELPER_INITIALIZING;
-    DEBUG("%s:%s:%d DPDK_HELPER_INITIALIZING", phc->shm_name, __FUNCTION__,
+    DEBUG("%s:%s:%d DPDK_HELPER_INITIALIZING", phc->shm_name, __func__,
           __LINE__);
     int err = dpdk_helper_spawn(phc);
     if (err) {
@@ -733,7 +731,7 @@ int dpdk_helper_command(dpdk_helper_ctx_t *phc, enum DPDK_CMD cmd, int *result,
     return -EINVAL;
   }
 
-  DEBUG("%s:%s:%d pid=%lu, cmd=%d", phc->shm_name, __FUNCTION__, __LINE__,
+  DEBUG("%s:%s:%d pid=%lu, cmd=%d", phc->shm_name, __func__, __LINE__,
         (long)getpid(), cmd);
 
   phc->cmd_wait_time = cmd_wait_time;
@@ -812,8 +810,7 @@ uint64_t strtoull_safe(const char *str, int *err) {
 
   val = strtoull(str, &endptr, 16);
   if (*endptr) {
-    ERROR("%s Failed to parse the value %s, endptr=%c", __FUNCTION__, str,
-          *endptr);
+    ERROR("%s Failed to parse the value %s, endptr=%c", __func__, str, *endptr);
     res = -EINVAL;
   }
   if (err != NULL)
@@ -828,8 +825,8 @@ uint128_t str_to_uint128(const char *str, int len) {
   memset(&lcore_mask, 0, sizeof(lcore_mask));
 
   if (len <= 2 || strncmp(str, "0x", 2) != 0) {
-    ERROR("%s Value %s should be represened in hexadecimal format",
-          __FUNCTION__, str);
+    ERROR("%s Value %s should be represened in hexadecimal format", __func__,
+          str);
     return lcore_mask;
   }
   /* If str is <= 64 bit long ('0x' + 16 chars = 18 chars) then
@@ -871,14 +868,14 @@ uint8_t dpdk_helper_eth_dev_count(void) {
   if (ports == 0) {
     ERROR(
         "%s:%d: No DPDK ports available. Check bound devices to DPDK driver.\n",
-        __FUNCTION__, __LINE__);
+        __func__, __LINE__);
     return ports;
   }
 
   if (ports > RTE_MAX_ETHPORTS) {
     ERROR("%s:%d: Number of DPDK ports (%u) is greater than "
           "RTE_MAX_ETHPORTS=%d. Ignoring extra ports\n",
-          __FUNCTION__, __LINE__, ports, RTE_MAX_ETHPORTS);
+          __func__, __LINE__, ports, RTE_MAX_ETHPORTS);
     ports = RTE_MAX_ETHPORTS;
   }
 

--- a/src/utils/dpdk/dpdk.h
+++ b/src/utils/dpdk/dpdk.h
@@ -85,6 +85,6 @@ uint128_t str_to_uint128(const char *str, int len);
 /* logging functions that should be used in child process */
 #define DPDK_CHILD_LOG(...) fprintf(stdout, __VA_ARGS__)
 #define DPDK_CHILD_TRACE(_name)                                                \
-  fprintf(stdout, "%s:%s:%d pid=%u\n", _name, __FUNCTION__, __LINE__, getpid())
+  fprintf(stdout, "%s:%s:%d pid=%u\n", _name, __func__, __LINE__, getpid())
 
 #endif /* UTILS_DPDK_H */

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -97,8 +97,7 @@
   } while (0)
 #define OVS_DEBUG(fmt, ...)                                                    \
   do {                                                                         \
-    DEBUG("%s:%d:%s(): " fmt, __FILE__, __LINE__, __FUNCTION__,                \
-          ##__VA_ARGS__);                                                      \
+    DEBUG("%s:%d:%s(): " fmt, __FILE__, __LINE__, __func__, ##__VA_ARGS__);    \
   } while (0)
 
 #define OVS_DB_POLL_TIMEOUT 1           /* poll receive timeout (sec) */
@@ -368,14 +367,14 @@ static yajl_gen_status ovs_yajl_gen_val(yajl_gen jgen, yajl_val jval) {
     }
     OVS_YAJL_CALL(yajl_gen_map_close, jgen);
   } else {
-    OVS_ERROR("%s() unsupported value type %d (skip)", __FUNCTION__,
+    OVS_ERROR("%s() unsupported value type %d (skip)", __func__,
               (int)(jval)->type);
     goto yajl_gen_failure;
   }
   return yajl_gen_status_ok;
 
 yajl_gen_failure:
-  OVS_ERROR("%s() error to generate value", __FUNCTION__);
+  OVS_ERROR("%s() error to generate value", __func__);
   return yajl_gen_ret;
 }
 
@@ -1144,7 +1143,7 @@ int ovs_db_send_request(ovs_db_t *pdb, const char *method, const char *params,
       clock_gettime(CLOCK_REALTIME, &ts);
       ts.tv_sec += OVS_DB_SEND_REQ_TIMEOUT;
       if (sem_timedwait(&new_cb->result.sync, &ts) < 0) {
-        OVS_ERROR("%s() no replay received within %d sec", __FUNCTION__,
+        OVS_ERROR("%s() no replay received within %d sec", __func__,
                   OVS_DB_SEND_REQ_TIMEOUT);
         ret = (-1);
       }


### PR DESCRIPTION
This continues https://github.com/collectd/collectd/pull/4243:
* Change _all_ `__FUNCTION__` instances to C99 `__func__`, also in plugins
   * I decided it's safe to do after all because collectd requires C99, and all these changes are to C-files (not C++)
* Fix `-Wpedantic` array/struct initialization warnings in `mdevents.c` plugin modified by above commit
   * This commit is main one needing review
* Fix `-Wpendantic`/`-Wformat` warning in `cmds_test.c`
