### PR TITLE
[collectd 6, WIP] Fix more GCC "-Wextra" warnings in collectd core

### DIFF
--- a/src/utils/match/match.h
+++ b/src/utils/match/match.h
@@ -82,7 +82,7 @@ typedef struct cu_match_value_s cu_match_value_t;
  *  Creates a new `cu_match_t' object which will use the regular expression
  *  `regex' to match lines, see the `match_apply' method below. If the line
  *  matches, the callback passed in `callback' will be called along with the
- *  pointer `user_pointer'.
+ *  `user_data' pointer.
  *  The string that's passed to the callback depends on the regular expression:
  *  If the regular expression includes a sub-match, i. e. something like
  *    "value=([0-9][0-9]*)"

--- a/src/utils/message_parser/message_parser.c
+++ b/src/utils/message_parser/message_parser.c
@@ -88,7 +88,7 @@ static int start_message_assembly(parser_job_data_t *self) {
     ++(self->message_idx);
 
   /* Resize messages buffer if needed */
-  if (self->message_idx >= self->messages_max_len) {
+  if (self->message_idx >= (int)self->messages_max_len) {
     INFO(UTIL_NAME ": Exceeded message buffer size: %zu",
          self->messages_max_len);
     if (self->resize_message_buffer(self, self->messages_max_len +
@@ -147,8 +147,9 @@ static void end_message_assembly(parser_job_data_t *self) {
   self->message_item_idx = 0;
 }
 
-static int message_assembler(const char *row, char *const *matches,
-                             size_t matches_num, void *user_data) {
+static int message_assembler(__attribute__((unused)) const char *row,
+                             char *const *matches, size_t matches_num,
+                             void *user_data) {
   if (user_data == NULL) {
     ERROR(UTIL_NAME ": Invalid user_data pointer");
     return -1;

--- a/src/utils/proc_pids/proc_pids.c
+++ b/src/utils/proc_pids/proc_pids.c
@@ -116,7 +116,7 @@ int pids_list_clear(pids_list_t *list) {
 int pids_list_contains_pid(pids_list_t *list, const pid_t pid) {
   assert(list);
 
-  for (int i = 0; i < list->size; i++)
+  for (size_t i = 0; i < list->size; i++)
     if (list->pids[i] == pid)
       return 1;
 
@@ -330,14 +330,14 @@ int pids_list_diff(proc_pids_t *proc, pids_list_t *added,
     return pids_list_add_list(removed, proc->prev);
   }
 
-  for (int i = 0; i < proc->prev->size; i++)
+  for (size_t i = 0; i < proc->prev->size; i++)
     if (0 == pids_list_contains_pid(proc->curr, proc->prev->pids[i])) {
       int add_result = pids_list_add_pid(removed, proc->prev->pids[i]);
       if (add_result < 0)
         return add_result;
     }
 
-  for (int i = 0; i < proc->curr->size; i++)
+  for (size_t i = 0; i < proc->curr->size; i++)
     if (0 == pids_list_contains_pid(proc->prev, proc->curr->pids[i])) {
       int add_result = pids_list_add_pid(added, proc->curr->pids[i]);
       if (add_result < 0)


### PR DESCRIPTION
For one of the warnings I filed https://github.com/collectd/collectd/issues/4263 ticket. This PR fixes rest of warnings in collectd core files, shown by `-Wextra -Wno-missing-field-initializers` (latter option is needed, otherwise GCC complains also about `{0}` initializers):
```
$ for i in $(find src/ -mindepth 2 -name '*.c' | grep -v -e _test.c -e _mock.c -e _windows.c); do \
  echo "*** $i ***"; \
  gcc -I. -Isrc -Isrc/daemon -Isrc/libcollectdclient -I/usr/include/dpdk -DHAVE_CONFIG_H \
  -O3 -Werror -Wall -Wextra -Wno-missing-field-initializers -c -o /dev/null $i; \
done
```

There was just one signed vs. unsigned warning for `format_stackdriver.c`. Instead of adding cast just for that, I chose to change `start_value` variables type from `int64_t` -> `counter_t` (`uint64_t`), as those variables are currently only read from, written to, or compared against counters (`derive_t` support was mentioned in TODO, and that is signed though).