### PR TITLE
[collectd 6] cache: Provide the first metric value available alongside the first metric time.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -160,6 +160,7 @@ check_PROGRAMS = \
 	test_format_graphite \
 	test_meta_data \
 	test_metric \
+	test_daemon_cache \
 	test_utils_avltree \
 	test_utils_cmds \
 	test_utils_heap \
@@ -358,6 +359,9 @@ if BUILD_AIX
 collectd_tg_LDADD += -lm
 endif
 
+
+test_daemon_cache_SOURCES = src/daemon/utils_cache_test.c
+test_daemon_cache_LDADD = libplugin_mock.la
 
 test_common_SOURCES = \
 	src/utils/common/common_test.c \

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1715,9 +1715,6 @@ EXPORT int plugin_init_all(void) {
   int status;
   int ret = 0;
 
-  /* Init the value cache */
-  uc_init();
-
   if (IS_TRUE(global_option_get("CollectInternalStats"))) {
     record_statistics = true;
     plugin_register_read("collectd", plugin_update_internal_statistics);

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -450,13 +450,13 @@ int uc_get_rate_by_name(const char *name, gauge_t *ret_values) {
       DEBUG("utils_cache: uc_get_rate_by_name: requested metric \"%s\" is in "
             "state \"missing\".",
             name);
-      status = -1;
+      status = EAGAIN;
     } else {
       *ret_values = ce->values_gauge;
     }
   } else {
     DEBUG("utils_cache: uc_get_rate_by_name: No such value: %s", name);
-    status = -1;
+    status = ENOENT;
   }
 
   pthread_mutex_unlock(&cache_lock);

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -465,6 +465,14 @@ int uc_get_rate_by_name(const char *name, gauge_t *ret_values) {
 } /* gauge_t *uc_get_rate_by_name */
 
 int uc_get_rate(metric_t const *m, gauge_t *ret) {
+  if (m == NULL || m->family == NULL || ret == NULL) {
+    return EINVAL;
+  }
+  if (m->family->type == METRIC_TYPE_GAUGE) {
+    *ret = m->value.gauge;
+    return 0;
+  }
+
   strbuf_t buf = STRBUF_CREATE;
   int status = metric_identity(&buf, m);
   if (status != 0) {

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -41,11 +41,14 @@
 typedef struct cache_entry_s {
   char name[6 * DATA_MAX_NAME_LEN];
   gauge_t values_gauge;
-  value_t values_raw;
   /* First observed metric time */
   cdtime_t first_time;
+  /* First observed metric value */
+  value_t first_value;
   /* Last observed metric time (for calculating rates) */
   cdtime_t last_time;
+  /* Last observed metric value (for calculating rates) */
+  value_t last_value;
   /* Time according to the local clock (for purging old entries) */
   cdtime_t last_update;
   /* Interval in which the data is collected
@@ -102,7 +105,7 @@ static cache_entry_t *cache_alloc() {
   }
 
   ce->values_gauge = 0;
-  ce->values_raw = (value_t){.gauge = 0};
+  ce->last_value = (value_t){.gauge = 0};
   ce->history = NULL;
   ce->history_length = 0;
   ce->meta = NULL;
@@ -141,8 +144,9 @@ static int uc_insert(metric_t const *m, char const *key) {
 
   *ce = (cache_entry_t){
       .first_time = m->time,
-      .values_raw = m->value,
+      .first_value = m->value,
       .last_time = m->time,
+      .last_value = m->value,
       .last_update = cdtime(),
       .interval = m->interval,
       .state = STATE_UNKNOWN,
@@ -330,16 +334,23 @@ static int uc_update_metric(metric_t const *m) {
 
   switch (m->family->type) {
   case METRIC_TYPE_COUNTER: {
-    counter_t diff = counter_diff(ce->values_raw.counter, m->value.counter);
+    // Counter overflows and counter resets are signaled to plugins by resetting
+    // "first_time". Since we can't distinguish between an overflow and a
+    // reset, we still provide a non-NAN rate value. In case of a counter
+    // reset, the rate value will likely be unreasonably huge.
+    if (ce->last_value.counter > m->value.counter) {
+      // counter reset
+      ce->first_time = m->time;
+      ce->first_value = m->value;
+    }
+    counter_t diff = counter_diff(ce->last_value.counter, m->value.counter);
     ce->values_gauge =
-        ((double)diff) / (CDTIME_T_TO_DOUBLE(m->time - ce->last_time));
-    ce->values_raw.counter = m->value.counter;
+        ((double)diff) / CDTIME_T_TO_DOUBLE(m->time - ce->last_time);
     break;
   }
 
   case METRIC_TYPE_UNTYPED:
   case METRIC_TYPE_GAUGE: {
-    ce->values_raw.gauge = m->value.gauge;
     ce->values_gauge = m->value.gauge;
     break;
   }
@@ -375,6 +386,7 @@ static int uc_update_metric(metric_t const *m) {
     ce->history_index = (ce->history_index + 1) % ce->history_length;
   }
 
+  ce->last_value = m->value;
   ce->last_time = m->time;
   ce->last_update = cdtime();
   ce->interval = m->interval;
@@ -508,7 +520,7 @@ int uc_get_value_by_name(const char *name, value_t *ret_values) {
     if (ce->state == STATE_MISSING) {
       status = -1;
     } else {
-      *ret_values = ce->values_raw;
+      *ret_values = ce->last_value;
     }
   } else {
     DEBUG("utils_cache: uc_get_value_by_name: No such value: %s", name);
@@ -533,39 +545,42 @@ int uc_get_value(metric_t const *m, value_t *ret) {
   return status;
 } /* value_t *uc_get_value */
 
-static int uc_get_first_time_by_name(const char *name, cdtime_t *ret_time) {
+static uc_first_metric_result_t uc_first_metric_by_name(const char *name) {
   uc_init();
 
   cache_entry_t *ce = NULL;
   int err = c_avl_get(cache_tree, name, (void *)&ce);
   if (err == ENOENT) {
-    DEBUG("utils_cache: uc_get_first_time: No such value: %s", name);
-    return err;
-  } else if (err != 0) {
-    ERROR("utils_cache: uc_get_first_time: c_avl_get(\"%s\") failed: %s", name,
+    DEBUG("utils_cache: uc_first_metric: No such value: \"%s\"", name);
+    return (uc_first_metric_result_t){.err = err};
+  }
+  if (err != 0) {
+    ERROR("utils_cache: uc_first_metric: c_avl_get(\"%s\") failed: %s", name,
           STRERROR(err));
-    return err;
+    return (uc_first_metric_result_t){.err = err};
   }
 
-  *ret_time = ce->first_time;
-  return 0;
+  return (uc_first_metric_result_t){
+      .time = ce->first_time,
+      .value = ce->first_value,
+  };
 }
 
-int uc_get_first_time(metric_t const *m, cdtime_t *ret_time) {
-  strbuf_t buf = STRBUF_CREATE;
-  int err = metric_identity(&buf, m);
+uc_first_metric_result_t uc_first_metric(metric_t const *m) {
+  strbuf_t id = STRBUF_CREATE;
+  int err = metric_identity(&id, m);
   if (err != 0) {
-    ERROR("uc_get_value: metric_identity failed with status %d.", err);
-    STRBUF_DESTROY(buf);
-    return err;
+    ERROR("uc_first_metric: metric_identity failed with status %d.", err);
+    STRBUF_DESTROY(id);
+    return (uc_first_metric_result_t){.err = err};
   }
 
   pthread_mutex_lock(&cache_lock);
-  err = uc_get_first_time_by_name(buf.ptr, ret_time);
+  uc_first_metric_result_t res = uc_first_metric_by_name(id.ptr);
   pthread_mutex_unlock(&cache_lock);
 
-  STRBUF_DESTROY(buf);
-  return err;
+  STRBUF_DESTROY(id);
+  return res;
 }
 
 size_t uc_get_size(void) {
@@ -901,7 +916,7 @@ int uc_iterator_get_values(uc_iter_t *iter, value_t *ret_values) {
   if ((iter == NULL) || (iter->entry == NULL) || (ret_values == NULL))
     return -1;
 
-  *ret_values = iter->entry->values_raw;
+  *ret_values = iter->entry->last_value;
   return 0;
 } /* int uc_iterator_get_values */
 

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -38,7 +38,6 @@
 #define STATE_ERROR 3
 #define STATE_MISSING 15
 
-int uc_init(void);
 int uc_check_timeout(void);
 int uc_update(metric_family_t const *fam);
 

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -48,7 +48,24 @@ value_t *uc_get_value_vl(const data_set_t *ds, const value_list_t *vl);
 
 int uc_get_rate_by_name(const char *name, gauge_t *ret_value);
 
+/* uc_get_rate returns the rate of change for cumulative types (counters) in
+ * `ret_value`. The rate is (approximately) calculcated as:
+ *
+ *   rate = (last_value - prev_value) / (last_time - prev_time)
+ *
+ * Counter overflows are handled correctly. This typically causes counter
+ * resets to result in huge spikes. Unfortunately it is not easily possible to
+ * distinguish between the two. You can determine whether a reset/overflow
+ * occurred by comparing the time returned by `uc_first_metric()` with the
+ * metric time: in an overflow/reset situation, the values are equal.
+ *
+ * For non-cumulative types (gauge), the last value is returned in `ret_value`.
+ *
+ * Returns zero on success, ENOENT if the metric is not in the cache, and
+ * EAGAIN if the metric has state STATE_MISSING.
+ */
 int uc_get_rate(metric_t const *m, gauge_t *ret_value);
+
 int uc_get_value_by_name(const char *name, value_t *ret_value);
 int uc_get_value(metric_t const *m, value_t *ret_value);
 

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -47,12 +47,21 @@ int uc_get_value_by_name_vl(const char *name, value_t **ret_values,
 value_t *uc_get_value_vl(const data_set_t *ds, const value_list_t *vl);
 
 int uc_get_rate_by_name(const char *name, gauge_t *ret_value);
+
 int uc_get_rate(metric_t const *m, gauge_t *ret_value);
 int uc_get_value_by_name(const char *name, value_t *ret_value);
 int uc_get_value(metric_t const *m, value_t *ret_value);
 
-// uc_get_first_time returns the first observed metric time.
-int uc_get_first_time(metric_t const *m, cdtime_t *ret_time);
+typedef struct {
+  cdtime_t time;
+  value_t value;
+  int err;
+} uc_first_metric_result_t;
+
+// uc_first_metric returns the first observed metric value and time.
+// For cumulative metrics (METRIC_TYPE_COUNTER and METRIC_TYPE_FPCOUNTER),
+// counter resets and counter overflows will reset the value.
+uc_first_metric_result_t uc_first_metric(metric_t const *m);
 
 size_t uc_get_size(void);
 int uc_get_names(char ***ret_names, cdtime_t **ret_times, size_t *ret_number);

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -64,8 +64,7 @@ int uc_get_rate_by_name(const char *name, gauge_t *ret_value);
  * authors are discouraged from writing special cases for gauge metrics.
  *
  * Returns zero on success, ENOENT if the metric is not in the cache, and
- * EAGAIN if the metric has state STATE_MISSING.
- */
+ * EAGAIN if the metric has state STATE_MISSING. */
 int uc_get_rate(metric_t const *m, gauge_t *ret_value);
 
 int uc_get_value_by_name(const char *name, value_t *ret_value);
@@ -77,9 +76,9 @@ typedef struct {
   int err;
 } uc_first_metric_result_t;
 
-// uc_first_metric returns the first observed metric value and time.
-// For cumulative metrics (METRIC_TYPE_COUNTER and METRIC_TYPE_FPCOUNTER),
-// counter resets and counter overflows will reset the value.
+/* uc_first_metric returns the first observed metric value and time.
+ * For cumulative metrics (METRIC_TYPE_COUNTER and METRIC_TYPE_FPCOUNTER),
+ * counter resets and counter overflows will reset the value. */
 uc_first_metric_result_t uc_first_metric(metric_t const *m);
 
 size_t uc_get_size(void);

--- a/src/daemon/utils_cache.h
+++ b/src/daemon/utils_cache.h
@@ -59,7 +59,9 @@ int uc_get_rate_by_name(const char *name, gauge_t *ret_value);
  * occurred by comparing the time returned by `uc_first_metric()` with the
  * metric time: in an overflow/reset situation, the values are equal.
  *
- * For non-cumulative types (gauge), the last value is returned in `ret_value`.
+ * For non-cumulative types (gauge), the function takes a short cut and returns
+ * `m->value.gauge` in `ret_value`. Since this is a fast operation, plugin
+ * authors are discouraged from writing special cases for gauge metrics.
  *
  * Returns zero on success, ENOENT if the metric is not in the cache, and
  * EAGAIN if the metric has state STATE_MISSING.

--- a/src/daemon/utils_cache_test.c
+++ b/src/daemon/utils_cache_test.c
@@ -51,6 +51,15 @@ DEF_TEST(uc_get_rate) {
           .want = 2.0,
       },
       {
+          .name = "decreasing gauge",
+          .first_value = (value_t){.gauge = 100.0},
+          .second_value = (value_t){.gauge = 21.5},
+          .first_time = TIME_T_TO_CDTIME_T(100),
+          .second_time = TIME_T_TO_CDTIME_T(110),
+          .type = METRIC_TYPE_GAUGE,
+          .want = 21.5,
+      },
+      {
           .name = "counter",
           .first_value = (value_t){.counter = 42},
           .second_value = (value_t){.counter = 102},

--- a/src/daemon/utils_cache_test.c
+++ b/src/daemon/utils_cache_test.c
@@ -1,0 +1,128 @@
+/**
+ * collectd - src/daemon/utils_cache_test.c
+ * Copyright (C) 2024       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "collectd.h"
+
+#include "daemon/utils_cache.h"
+#include "testing.h"
+#include "utils/common/common.h"
+
+DEF_TEST(uc_get_rate) {
+  struct {
+    char const *name;
+    value_t first_value;
+    value_t second_value;
+    cdtime_t first_time;
+    cdtime_t second_time;
+    metric_type_t type;
+
+    gauge_t want;
+  } cases[] = {
+      {
+          .name = "gauge",
+          .first_value = (value_t){.gauge = 1.0},
+          .second_value = (value_t){.gauge = 2.0},
+          .first_time = TIME_T_TO_CDTIME_T(100),
+          .second_time = TIME_T_TO_CDTIME_T(110),
+          .type = METRIC_TYPE_GAUGE,
+          .want = 2.0,
+      },
+      {
+          .name = "counter",
+          .first_value = (value_t){.counter = 42},
+          .second_value = (value_t){.counter = 102},
+          .first_time = TIME_T_TO_CDTIME_T(100),
+          .second_time = TIME_T_TO_CDTIME_T(110),
+          .type = METRIC_TYPE_COUNTER,
+          .want = (102. - 42.) / (110. - 100.),
+      },
+      {
+          .name = "with 32bit overflow",
+          .first_value = (value_t){.counter = UINT32_MAX - 23},
+          .second_value = (value_t){.counter = 18},
+          .first_time = TIME_T_TO_CDTIME_T(100),
+          .second_time = TIME_T_TO_CDTIME_T(110),
+          .type = METRIC_TYPE_COUNTER,
+          .want = (23. + 18. + 1.) / (110. - 100.),
+      },
+      {
+          .name = "with 64bit overflow",
+          .first_value = (value_t){.counter = UINT64_MAX - 23},
+          .second_value = (value_t){.counter = 18},
+          .first_time = TIME_T_TO_CDTIME_T(100),
+          .second_time = TIME_T_TO_CDTIME_T(110),
+          .type = METRIC_TYPE_COUNTER,
+          .want = (23. + 18. + 1.) / (110. - 100.),
+      },
+  };
+
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
+    printf("## Case %zu: %s\n", i, cases[i].name);
+
+    char name[64];
+    snprintf(name, sizeof(name), "unit.test%zu", i);
+
+    metric_family_t fam = {
+        .name = name,
+        .type = cases[i].type,
+    };
+    metric_t m = {
+        .family = &fam,
+        .time = cases[i].first_time,
+        .value = cases[i].first_value,
+    };
+    fam.metric = (metric_list_t){
+        .ptr = &m,
+        .num = 1,
+    };
+
+    // first value
+    EXPECT_EQ_INT(0, uc_update(&fam));
+    gauge_t got = 0;
+    EXPECT_EQ_INT(0, uc_get_rate(&m, &got));
+    gauge_t want = NAN;
+    if (fam.type == METRIC_TYPE_GAUGE) {
+      want = cases[i].first_value.gauge;
+    }
+    EXPECT_EQ_DOUBLE(want, got);
+
+    // second value
+    m.time = cases[i].second_time;
+    m.value = cases[i].second_value;
+    EXPECT_EQ_INT(0, uc_update(&fam));
+    got = 0;
+    EXPECT_EQ_INT(0, uc_get_rate(&m, &got));
+    EXPECT_EQ_DOUBLE(cases[i].want, got);
+  }
+
+  return 0;
+}
+
+int main(void) {
+  RUN_TEST(uc_get_rate);
+
+  END_TEST;
+}

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -133,8 +133,7 @@ static int format_typed_value(yajl_gen gen, metric_t const *m,
   yajl_gen_map_open(gen);
 
   switch (m->family->type) {
-  case METRIC_TYPE_GAUGE:
-  case METRIC_TYPE_UNTYPED: {
+  case METRIC_TYPE_GAUGE: {
     int status = json_string(gen, "doubleValue");
     if (status != 0)
       return status;
@@ -160,10 +159,10 @@ static int format_typed_value(yajl_gen gen, metric_t const *m,
     }
     break;
   }
-  default: {
-    ERROR("format_typed_value: unknown value type %d.", m->family->type);
+  case METRIC_TYPE_UNTYPED:
+  default:
+    ERROR("format_typed_value: invalid metric type: %d", m->family->type);
     return EINVAL;
-  }
   }
 
   yajl_gen_map_close(gen);

--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -375,11 +375,13 @@ static int format_time_series(yajl_gen gen, metric_t const *m,
     if (!isfinite(m->value.gauge)) {
       return EAGAIN;
     }
+    break;
   case METRIC_TYPE_COUNTER:
     // for cumulative metrics the interval must not be zero.
     if (start.time == m->time) {
       return EAGAIN;
     }
+    break;
   case METRIC_TYPE_UNTYPED:
     ERROR("format_stackdriver: Invalid metric type: %d", m->family->type);
     return EINVAL;

--- a/src/write_redis.c
+++ b/src/write_redis.c
@@ -262,14 +262,13 @@ cleanup:
 }
 
 static bool metric_is_new(metric_t const *m) {
-  cdtime_t first_time = 0;
-  int err = uc_get_first_time(m, &first_time);
-  if (err != 0) {
-    ERROR("write_redis plugin: uc_get_first_time failed: %s", STRERROR(err));
+  uc_first_metric_result_t first = uc_first_metric(m);
+  if (first.err != 0) {
+    ERROR("write_redis plugin: uc_get_first failed: %s", STRERROR(first.err));
     return true;
   }
 
-  return m->time == first_time;
+  return m->time == first.time;
 }
 
 static int wr_write(metric_family_t const *fam, user_data_t *ud) {

--- a/src/write_redis_test.c
+++ b/src/write_redis_test.c
@@ -61,8 +61,6 @@ static void fake_disconnect(wr_node_t *node) {
 static int fake_reconnect(wr_node_t *node) { return 0; }
 
 DEF_TEST(wr_write) {
-  uc_init();
-
   metric_family_t fam = {
       .name = "unit.test",
       .type = METRIC_TYPE_GAUGE,


### PR DESCRIPTION
The *write_stackdriver plugin* uses the first observed time to scale counters so they appear to start from zero. OpenTelemetry calls this [inserting true reset points](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#cumulative-streams-inserting-true-reset-points). The new API returns the first metric time and first metric time in one call for consistency and efficiency.

This PR contains a few other, smaller improvements to the cache:

* A unit test for `uc_insert()` and `uc_get_rate()` has been added.
* The public `uc_init()` function has been removed in favor of automatic initialization. This simplifies using the cache from unit tests.
* The behavior of `uc_get_rate()` has been documented.

ChangeLog: Daemon: The first observed metric value has been added to the metrics cache.