### PR TITLE
format_stackdriver: When JSON generation fails, reset the generator b…

### DIFF
--- a/src/utils/format_stackdriver/format_stackdriver.c
+++ b/src/utils/format_stackdriver/format_stackdriver.c
@@ -623,15 +623,32 @@ int sd_output_register_metric(sd_output_t *out, data_set_t const *ds,
 
 char *sd_output_reset(sd_output_t *out) /* {{{ */
 {
-  sd_output_finalize(out);
+  int err = sd_output_finalize(out);
+  if (err) {
+    goto handle_err;
+  }
 
   unsigned char const *json_buffer = NULL;
-  yajl_gen_get_buf(out->gen, &json_buffer, &(size_t){0});
+  size_t json_buffer_size = 0;
+  err = yajl_gen_get_buf(out->gen, &json_buffer, &json_buffer_size);
+  if (err) {
+    goto handle_err;
+  }
+
   char *ret = strdup((void const *)json_buffer);
+  if (ret == NULL) {
+    err = errno;
+    goto handle_err;
+  }
 
+  /* success */
   reset(out);
-
   return ret;
+
+handle_err:
+  reset(out);
+  errno = err;
+  return NULL;
 } /* }}} char *sd_output_reset */
 
 sd_resource_t *sd_resource_create(char const *type) /* {{{ */

--- a/src/utils/format_stackdriver/format_stackdriver.h
+++ b/src/utils/format_stackdriver/format_stackdriver.h
@@ -62,7 +62,7 @@ int sd_output_register_metric(sd_output_t *out, data_set_t const *ds,
 
 /* sd_output_reset resets the output and returns the previous content of the
  * buffer. It is the caller's responsibility to call free() with the returned
- * pointer. */
+ * pointer. On error errno is set and NULL is returned. */
 char *sd_output_reset(sd_output_t *out);
 
 sd_resource_t *sd_resource_create(char const *type);

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -341,6 +341,11 @@ static int wg_flush_nolock(cdtime_t timeout, wg_callback_t *cb) /* {{{ */
   }
 
   char *payload = sd_output_reset(cb->formatter);
+  if (payload == NULL) {
+    ERROR("write_stackdriver plugin: sd_output_reset failed: %s", STRERRNO);
+    return errno;
+  }
+
   int status = wg_call_timeseries_write(cb, payload);
   wg_reset_buffer(cb);
   return status;


### PR DESCRIPTION
… because it is in an unknown state.

Whenever the JSON generation fails, the code returns early, leaving the generator in an unknown and likely broken state, such as an opened map that we will never close. This happens all throughout the file. This change will reset the generator state in case of an error so that we're back in a well defined state.

Additionally, a free/alloc cycle was replaced with clear+reset, which are much cheaper operations.

This is a cherry-pick of #4268 for collectd 5.12.

ChangeLog: format_stackdriver: An error path that could leave the JSON generator in an undefined state has been fixed.