### PR TITLE
[collectd 6] format_stackdriver: Add proper error handling to `sd_output_reset()`.

### DIFF
--- a/src/utils/format_stackdriver/format_stackdriver.h
+++ b/src/utils/format_stackdriver/format_stackdriver.h
@@ -60,7 +60,7 @@ int sd_output_register_metric(sd_output_t *out, metric_t const *m);
 
 /* sd_output_reset resets the output and returns the previous content of the
  * buffer. It is the caller's responsibility to call free() with the returned
- * pointer. */
+ * pointer. On error errno is set and NULL is returned. */
 char *sd_output_reset(sd_output_t *out);
 
 sd_resource_t *sd_resource_create(char const *type);

--- a/src/write_stackdriver.c
+++ b/src/write_stackdriver.c
@@ -342,6 +342,11 @@ static int wg_flush_nolock(cdtime_t timeout, wg_callback_t *cb) /* {{{ */
   }
 
   char *payload = sd_output_reset(cb->formatter);
+  if (payload == NULL) {
+    ERROR("write_stackdriver plugin: sd_output_reset failed: %s", STRERRNO);
+    return errno;
+  }
+
   int status = wg_call_timeseries_write(cb, payload);
   wg_reset_buffer(cb);
   return status;


### PR DESCRIPTION
Follow up to  #4268:

> `sd_output_initialize()` can fail and return error without closing map, but its callers do not even check its return value