### PR TITLE
[collectd 6] New plugin (sort of): OpenTelemetry receiver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1747,7 +1747,7 @@ endif
 if BUILD_PLUGIN_OPEN_TELEMETRY
 pkglib_LTLIBRARIES += open_telemetry.la
 open_telemetry_la_SOURCES = \
-	src/open_telemetry.cc \
+	src/open_telemetry.cc src/open_telemetry.h \
 	src/open_telemetry_exporter.cc \
 	src/open_telemetry_receiver.cc \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1747,11 +1747,19 @@ endif
 if BUILD_PLUGIN_OPEN_TELEMETRY_COLLECTOR
 pkglib_LTLIBRARIES += open_telemetry_collector.la
 open_telemetry_collector_la_SOURCES = src/open_telemetry_collector.cc \
-				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
-				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h
-open_telemetry_collector_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS)
-open_telemetry_collector_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS)
-open_telemetry_collector_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS)
+				      opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+				      opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h \
+				      opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
+				      opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h \
+				      opentelemetry/proto/common/v1/common.pb.cc \
+				      opentelemetry/proto/common/v1/common.pb.h \
+				      opentelemetry/proto/metrics/v1/metrics.pb.cc \
+				      opentelemetry/proto/metrics/v1/metrics.pb.h \
+				      opentelemetry/proto/resource/v1/resource.pb.cc \
+				      opentelemetry/proto/resource/v1/resource.pb.h
+open_telemetry_collector_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS) $(BUILD_WITH_LIBPROTOBUF_CPPFLAGS)
+open_telemetry_collector_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS) $(BUILD_WITH_LIBPROTOBUF_LDFLAGS)
+open_telemetry_collector_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS) $(BUILD_WITH_LIBPROTOBUF_LIBS)
 endif
 
 if BUILD_PLUGIN_ORACLE

--- a/Makefile.am
+++ b/Makefile.am
@@ -484,7 +484,7 @@ libformat_influxdb_la_SOURCES = \
 	src/utils/format_influxdb/format_influxdb.c \
 	src/utils/format_influxdb/format_influxdb.h
 
-if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
+if BUILD_PLUGIN_OPEN_TELEMETRY
 noinst_LTLIBRARIES += libformat_open_telemetry.la
 libformat_open_telemetry_la_SOURCES = \
 	src/utils/format_open_telemetry/format_open_telemetry.cc \
@@ -1744,22 +1744,17 @@ openvpn_la_SOURCES = src/openvpn.c
 openvpn_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
-if BUILD_PLUGIN_OPEN_TELEMETRY_COLLECTOR
-pkglib_LTLIBRARIES += open_telemetry_collector.la
-open_telemetry_collector_la_SOURCES = src/open_telemetry_collector.cc \
-				      opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
-				      opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h \
-				      opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc \
-				      opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h \
-				      opentelemetry/proto/common/v1/common.pb.cc \
-				      opentelemetry/proto/common/v1/common.pb.h \
-				      opentelemetry/proto/metrics/v1/metrics.pb.cc \
-				      opentelemetry/proto/metrics/v1/metrics.pb.h \
-				      opentelemetry/proto/resource/v1/resource.pb.cc \
-				      opentelemetry/proto/resource/v1/resource.pb.h
-open_telemetry_collector_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS) $(BUILD_WITH_LIBPROTOBUF_CPPFLAGS)
-open_telemetry_collector_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS) $(BUILD_WITH_LIBPROTOBUF_LDFLAGS)
-open_telemetry_collector_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS) $(BUILD_WITH_LIBPROTOBUF_LIBS)
+if BUILD_PLUGIN_OPEN_TELEMETRY
+pkglib_LTLIBRARIES += open_telemetry.la
+open_telemetry_la_SOURCES = \
+	src/open_telemetry.cc \
+	src/open_telemetry_exporter.cc \
+	src/open_telemetry_receiver.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h
+open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS) $(BUILD_WITH_LIBPROTOBUF_CPPFLAGS)
+open_telemetry_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS) $(BUILD_WITH_LIBPROTOBUF_LDFLAGS)
+open_telemetry_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS) $(BUILD_WITH_LIBPROTOBUF_LIBS) libformat_open_telemetry.la
 endif
 
 if BUILD_PLUGIN_ORACLE
@@ -2377,16 +2372,6 @@ write_mongodb_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBMONGOC_LDFLAGS)
 write_mongodb_la_LIBADD = $(BUILD_WITH_LIBMONGOC_LIBS)
 endif
 
-if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
-pkglib_LTLIBRARIES += write_open_telemetry.la
-write_open_telemetry_la_SOURCES = src/write_open_telemetry.cc \
-				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
-				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h
-write_open_telemetry_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS)
-write_open_telemetry_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS)
-write_open_telemetry_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS) libformat_open_telemetry.la
-endif
-
 if BUILD_PLUGIN_WRITE_PROMETHEUS
 pkglib_LTLIBRARIES += write_prometheus.la
 write_prometheus_la_SOURCES = src/write_prometheus.c
@@ -2535,7 +2520,7 @@ types.pb.cc: $(srcdir)/proto/types.proto
 endif
 endif
 
-if BUILD_PLUGIN_WRITE_OPEN_TELEMETRY
+if BUILD_PLUGIN_OPEN_TELEMETRY
 BUILT_SOURCES += \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
 	opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1744,6 +1744,16 @@ openvpn_la_SOURCES = src/openvpn.c
 openvpn_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 
+if BUILD_PLUGIN_OPEN_TELEMETRY_COLLECTOR
+pkglib_LTLIBRARIES += open_telemetry_collector.la
+open_telemetry_collector_la_SOURCES = src/open_telemetry_collector.cc \
+				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc \
+				  opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h
+open_telemetry_collector_la_CPPFLAGS = $(AM_CPPFLAGS) $(BUILD_WITH_LIBGRPCPP_CPPFLAGS)
+open_telemetry_collector_la_LDFLAGS = $(PLUGIN_LDFLAGS) $(BUILD_WITH_LIBGRPCPP_LDFLAGS)
+open_telemetry_collector_la_LIBADD = $(BUILD_WITH_LIBGRPCPP_LIBS)
+endif
+
 if BUILD_PLUGIN_ORACLE
 pkglib_LTLIBRARIES += oracle.la
 oracle_la_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -2880,6 +2880,37 @@ if test "x$with_libgrpcpp" = "xyes"; then
   AC_LANG_POP(C++)
 fi
 
+if test "x$with_libgrpcpp" = "xyes"; then
+  AC_MSG_CHECKING([for grpc++_reflection])
+  AC_LANG_PUSH(C++)
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  SAVE_LDFLAGS="$LDFLAGS"
+  SAVE_LIBS="$LIBS"
+  CPPFLAGS="-std=c++11 $with_libgrpcpp_cppflags $GRPCPP_CFLAGS $CPPFLAGS"
+  LDFLAGS="$with_libgrpcpp_ldflags"
+  LIBS="-lgrpc++_reflection $GRPCPP_LIBS"
+  AC_LINK_IFELSE(
+    [
+      AC_LANG_PROGRAM(
+        [[#include <grpc++/ext/proto_server_reflection_plugin.h>]],
+        [[grpc::reflection::InitProtoReflectionServerBuilderPlugin();]]
+      )
+    ],
+    [
+      AC_MSG_RESULT([yes])
+      GRPCPP_LIBS="$LIBS"
+      AC_DEFINE([HAVE_GRPCPP_REFLECTION], [1], [Define if the grpc++_reflection library is available.])
+    ],
+    [
+      AC_MSG_RESULT([no])
+    ]
+  )
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
+  LIBS="$SAVE_LIBS"
+  AC_LANG_POP(C++)
+fi
+
 BUILD_WITH_LIBGRPCPP_CPPFLAGS="-std=c++11 $with_libgrpcpp_cppflags $GRPCPP_CFLAGS"
 BUILD_WITH_LIBGRPCPP_LDFLAGS="$with_libgrpcpp_ldflags"
 BUILD_WITH_LIBGRPCPP_LIBS="$GRPCPP_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -6841,7 +6841,7 @@ plugin_nut="$with_libupsclient"
 plugin_olsrd="yes"
 plugin_onewire="$with_libowcapi"
 plugin_openldap="$with_libldap"
-plugin_open_telemetry_collector="yes"
+plugin_open_telemetry="yes"
 plugin_openvpn="yes"
 plugin_oracle="$with_oracle"
 plugin_ovs_events="no"
@@ -6906,7 +6906,6 @@ plugin_write_influxdb_udp="yes"
 plugin_write_kafka="$with_librdkafka"
 plugin_write_log="no"
 plugin_write_mongodb="$with_libmongoc"
-plugin_write_open_telemetry="yes"
 plugin_write_prometheus="no"
 plugin_write_redis="yes"
 plugin_write_riemann="$with_libriemann_client"
@@ -7177,26 +7176,22 @@ fi
 
 if test "x$GRPC_CPP_PLUGIN" = "x"; then
   plugin_grpc="no (grpc_cpp_plugin not found)"
-  plugin_open_telemetry_collector="no (grpc_cpp_plugin not found)"
-  plugin_write_open_telemetry="no (grpc_cpp_plugin not found)"
+  plugin_open_telemetry="no (grpc_cpp_plugin not found)"
 fi
 if test "x$have_protoc3" != "xyes"; then
   plugin_grpc="no (protoc3 not found)"
-  plugin_open_telemetry_collector="no (protoc3 not found)"
-  plugin_write_open_telemetry="no (protoc3 not found)"
+  plugin_open_telemetry="no (protoc3 not found)"
 fi
 if test "x$with_libprotobuf" != "xyes"; then
   plugin_grpc="no (libprotobuf not found)"
-  plugin_open_telemetry_collector="no (libprotobuf not found)"
-  plugin_write_open_telemetry="no (libprotobuf not found)"
+  plugin_open_telemetry="no (libprotobuf not found)"
 fi
 if test "x$with_libgrpcpp" != "xyes"; then
   plugin_grpc="no (libgrpc++ not found)"
-  plugin_open_telemetry_collector="no (libgrpc++ not found)"
-  plugin_write_open_telemetry="no (libgrpc++ not found)"
+  plugin_open_telemetry="no (libgrpc++ not found)"
 fi
 if test "x$protoc3_optional" = "xno"; then
-  plugin_write_open_telemetry="no (protoc does not support optional fields)"
+  plugin_open_telemetry="no (protoc does not support optional fields)"
 fi
 
 if test "x$have_getifaddrs" = "xyes"; then
@@ -7553,7 +7548,7 @@ AC_PLUGIN([olsrd],               [$plugin_olsrd],             [olsrd statistics]
 AC_PLUGIN([onewire],             [$plugin_onewire],           [OneWire sensor statistics])
 AC_PLUGIN([openldap],            [$plugin_openldap],          [OpenLDAP statistics])
 AC_PLUGIN([openvpn],             [$plugin_openvpn],           [OpenVPN client statistics])
-AC_PLUGIN([open_telemetry_collector], [$plugin_open_telemetry_collector], [OpenTelemetry Collector])
+AC_PLUGIN([open_telemetry],      [$plugin_open_telemetry],    [OpenTelemetry exporter/receiver])
 AC_PLUGIN([oracle],              [$plugin_oracle],            [Oracle plugin])
 AC_PLUGIN([ovs_events],          [$plugin_ovs_events],        [OVS events plugin])
 AC_PLUGIN([ovs_stats],           [$plugin_ovs_stats],         [OVS statistics plugin])
@@ -7618,7 +7613,6 @@ AC_PLUGIN([write_influxdb_udp],  [$plugin_write_influxdb_udp],[Influxdb udp outp
 AC_PLUGIN([write_kafka],         [$plugin_write_kafka],       [Kafka output plugin])
 AC_PLUGIN([write_log],           [$plugin_write_log],         [Log output plugin])
 AC_PLUGIN([write_mongodb],       [$plugin_write_mongodb],     [MongoDB output plugin])
-AC_PLUGIN([write_open_telemetry],[$plugin_write_open_telemetry],[Write OpenTelemetry plugin])
 AC_PLUGIN([write_prometheus],    [$plugin_write_prometheus],  [Prometheus write plugin])
 AC_PLUGIN([write_redis],         [$plugin_write_redis],       [Redis output plugin])
 AC_PLUGIN([write_riemann],       [$plugin_write_riemann],     [Riemann output plugin])
@@ -8001,6 +7995,7 @@ AC_MSG_RESULT([    nut . . . . . . . . . $enable_nut])
 AC_MSG_RESULT([    olsrd . . . . . . . . $enable_olsrd])
 AC_MSG_RESULT([    onewire . . . . . . . $enable_onewire])
 AC_MSG_RESULT([    openldap  . . . . . . $enable_openldap])
+AC_MSG_RESULT([    open_telemetry  . . . $enable_open_telemetry])
 AC_MSG_RESULT([    openvpn . . . . . . . $enable_openvpn])
 AC_MSG_RESULT([    oracle  . . . . . . . $enable_oracle])
 AC_MSG_RESULT([    ovs_events  . . . . . $enable_ovs_events])
@@ -8065,7 +8060,6 @@ AC_MSG_RESULT([    write_influxdb_udp. . $enable_write_influxdb_udp])
 AC_MSG_RESULT([    write_kafka . . . . . $enable_write_kafka])
 AC_MSG_RESULT([    write_log . . . . . . $enable_write_log])
 AC_MSG_RESULT([    write_mongodb . . . . $enable_write_mongodb])
-AC_MSG_RESULT([    write_open_telemetry  $enable_write_open_telemetry])
 AC_MSG_RESULT([    write_prometheus. . . $enable_write_prometheus])
 AC_MSG_RESULT([    write_redis . . . . . $enable_write_redis])
 AC_MSG_RESULT([    write_riemann . . . . $enable_write_riemann])

--- a/configure.ac
+++ b/configure.ac
@@ -6810,6 +6810,7 @@ plugin_nut="$with_libupsclient"
 plugin_olsrd="yes"
 plugin_onewire="$with_libowcapi"
 plugin_openldap="$with_libldap"
+plugin_open_telemetry_collector="yes"
 plugin_openvpn="yes"
 plugin_oracle="$with_oracle"
 plugin_ovs_events="no"
@@ -7145,18 +7146,22 @@ fi
 
 if test "x$GRPC_CPP_PLUGIN" = "x"; then
   plugin_grpc="no (grpc_cpp_plugin not found)"
+  plugin_open_telemetry_collector="no (grpc_cpp_plugin not found)"
   plugin_write_open_telemetry="no (grpc_cpp_plugin not found)"
 fi
 if test "x$have_protoc3" != "xyes"; then
   plugin_grpc="no (protoc3 not found)"
+  plugin_open_telemetry_collector="no (protoc3 not found)"
   plugin_write_open_telemetry="no (protoc3 not found)"
 fi
 if test "x$with_libprotobuf" != "xyes"; then
   plugin_grpc="no (libprotobuf not found)"
+  plugin_open_telemetry_collector="no (libprotobuf not found)"
   plugin_write_open_telemetry="no (libprotobuf not found)"
 fi
 if test "x$with_libgrpcpp" != "xyes"; then
   plugin_grpc="no (libgrpc++ not found)"
+  plugin_open_telemetry_collector="no (libgrpc++ not found)"
   plugin_write_open_telemetry="no (libgrpc++ not found)"
 fi
 if test "x$protoc3_optional" = "xno"; then
@@ -7517,6 +7522,7 @@ AC_PLUGIN([olsrd],               [$plugin_olsrd],             [olsrd statistics]
 AC_PLUGIN([onewire],             [$plugin_onewire],           [OneWire sensor statistics])
 AC_PLUGIN([openldap],            [$plugin_openldap],          [OpenLDAP statistics])
 AC_PLUGIN([openvpn],             [$plugin_openvpn],           [OpenVPN client statistics])
+AC_PLUGIN([open_telemetry_collector], [$plugin_open_telemetry_collector], [OpenTelemetry Collector])
 AC_PLUGIN([oracle],              [$plugin_oracle],            [Oracle plugin])
 AC_PLUGIN([ovs_events],          [$plugin_ovs_events],        [OVS events plugin])
 AC_PLUGIN([ovs_stats],           [$plugin_ovs_stats],         [OVS statistics plugin])

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1339,10 +1339,7 @@
 #    SSLCertificateKeyFile "/path/to/client.key"
 #    VerifyPeer false
 #  </Receiver>
-#  <Exporter "example">
-#    Host "localhost"
-#    Port "4317"
-#  </Exporter>
+#  Exporter "localhost" "4317"
 #</Plugin>
 
 #<Plugin oracle>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1331,6 +1331,16 @@
 #	CollectUserCount false
 #</Plugin>
 
+#<Plugin open_telemetry_collector>
+#  <Listen "0.0.0.0" "4317">
+#    EnableSSL false
+#    SSLCACertificateFile "/path/to/root.pem"
+#    SSLCertificateFile "/path/to/client.pem"
+#    SSLCertificateKeyFile "/path/to/client.key"
+#    VerifyPeer false
+#  </Listen>
+#</Plugin>
+
 #<Plugin oracle>
 #  <Query "out_of_stock">
 #    Statement "SELECT category, COUNT(*) AS value FROM products WHERE in_stock = 0 GROUP BY category"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -182,6 +182,7 @@
 #@BUILD_PLUGIN_OLSRD_TRUE@LoadPlugin olsrd
 #@BUILD_PLUGIN_ONEWIRE_TRUE@LoadPlugin onewire
 #@BUILD_PLUGIN_OPENLDAP_TRUE@LoadPlugin openldap
+#@BUILD_PLUGIN_OPEN_TELEMETRY_TRUE@LoadPlugin open_telemetry
 #@BUILD_PLUGIN_OPENVPN_TRUE@LoadPlugin openvpn
 #@BUILD_PLUGIN_ORACLE_TRUE@LoadPlugin oracle
 #@BUILD_PLUGIN_OVS_EVENTS_TRUE@LoadPlugin ovs_events
@@ -236,7 +237,6 @@
 #@BUILD_PLUGIN_WRITE_KAFKA_TRUE@LoadPlugin write_kafka
 #@BUILD_PLUGIN_WRITE_LOG_TRUE@LoadPlugin write_log
 #@BUILD_PLUGIN_WRITE_MONGODB_TRUE@LoadPlugin write_mongodb
-#@BUILD_PLUGIN_WRITE_OPEN_TELEMETRY_TRUE@LoadPlugin write_open_telemetry
 #@BUILD_PLUGIN_WRITE_PROMETHEUS_TRUE@LoadPlugin write_prometheus
 #@BUILD_PLUGIN_WRITE_REDIS_TRUE@LoadPlugin write_redis
 #@BUILD_PLUGIN_WRITE_RIEMANN_TRUE@LoadPlugin write_riemann
@@ -1331,14 +1331,18 @@
 #	CollectUserCount false
 #</Plugin>
 
-#<Plugin open_telemetry_collector>
-#  <Listen "0.0.0.0" "4317">
+#<Plugin open_telemetry>
+#  <Receiver "0.0.0.0" "4317">
 #    EnableSSL false
 #    SSLCACertificateFile "/path/to/root.pem"
 #    SSLCertificateFile "/path/to/client.pem"
 #    SSLCertificateKeyFile "/path/to/client.key"
 #    VerifyPeer false
-#  </Listen>
+#  </Receiver>
+#  <Exporter "example">
+#    Host "localhost"
+#    Port "4317"
+#  </Exporter>
 #</Plugin>
 
 #<Plugin oracle>
@@ -2078,13 +2082,6 @@
 #		User "auth_user"
 #		Password "auth_passwd"
 #	</Node>
-#</Plugin>
-
-#<Plugin write_open_telemetry>
-#  <Node "example">
-#    Host "localhost"
-#    Port "4317"
-#  </Node>
 #</Plugin>
 
 #<Plugin write_prometheus>

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -1337,9 +1337,14 @@
 #    SSLCACertificateFile "/path/to/root.pem"
 #    SSLCertificateFile "/path/to/client.pem"
 #    SSLCertificateKeyFile "/path/to/client.key"
-#    VerifyPeer false
+#    VerifyPeer true
 #  </Receiver>
-#  Exporter "localhost" "4317"
+#  <Exporter "localhost" "4317">
+#    EnableSSL false
+#    SSLCACertificateFile "/path/to/root.pem"
+#    SSLCertificateFile "/path/to/client.pem"
+#    SSLCertificateKeyFile "/path/to/client.key"
+#  </Exporter>
 #</Plugin>
 
 #<Plugin oracle>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7153,7 +7153,7 @@ can be configured independently from that option. Defaults to B<false>.
 
 =back
 
-=head2 Plugin C<open_telemetry_collector>
+=head2 Plugin C<open_telemetry>
 
 The I<open_telemetry plugin> implements an OpenTelemetry exporter and receiver
 using OTLP. Specifically, it implements a gRPC C<MetricsService> client and
@@ -7169,15 +7169,12 @@ B<Synopsis:>
       SSLCertificateKeyFile "/path/to/client.key"
       VerifyPeer false
     </Receiver>
-    <Exporter "example">
-      Host "localhost"
-      Port "4317"
-    </Exporter>
+    Exporter "localhost" "4317"
   </Plugin>
 
 =over 4
 
-=item B<Receiver> I<Host> I<Port>
+=item B<Receiver> I<Host> [I<Port>]
 
 The B<Receiver> statement sets the network address and port to which to bind.
 Multiple B<Receiver> blocks can be specified to listen on multiple
@@ -7185,6 +7182,9 @@ interfaces/ports. When no B<Receiver> blocks are specified, the plugin will not
 receive any metrics.
 
 The argument I<Host> may be a hostname, an IPv4 address, or an IPv6 address.
+
+The I<Port> argument may be omitted. In that case the default C<"4317"> is
+used.
 
 Optionally, B<Receiver> blocks support the following options:
 
@@ -7212,23 +7212,15 @@ Enabled by default.
 
 =back
 
-=item B<Exporter> I<Name>
+=item B<Exporter> I<Host> [I<Port>]
 
-The plugin can export metrics to multiple collectors by specifying multiple
-B<Exporter> blocks. Within the B<Exporter> blocks, the following options are
-available:
+The B<Exporter> option configures an OTLP export to the given collector
+address. Multiple collectors can be specified using multiple B<Exporter> lines.
 
-=over 4
+The argument I<Host> may be a hostname, an IPv4 address, or an IPv6 address.
 
-=item B<Host> I<Address>
-
-Hostname or address to connect to. Defaults to C<localhost>.
-
-=item B<Port> I<Service>
-
-Service name or port number to connect to. Defaults to C<4317>.
-
-=back
+The I<Port> argument may be omitted. In that case the default C<"4317"> is
+used.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7192,7 +7192,7 @@ Optionally, B<Receiver> blocks support the following options:
 
 =item B<EnableSSL> I<false>|I<true>
 
-Whether to enable SSL for incoming connections. Default: false.
+Whether to enable SSL for incoming connections. Default: I<false>.
 
 =item B<SSLCACertificateFile> I<Filename>
 
@@ -7221,6 +7221,25 @@ The argument I<Host> may be a hostname, an IPv4 address, or an IPv6 address.
 
 The I<Port> argument may be omitted. In that case the default C<"4317"> is
 used.
+
+Optionally, B<Exporter> blocks support the following options:
+
+=over 4
+
+=item B<EnableSSL> I<false>|I<true>
+
+Whether to require SSL when connecting. Default: I<false>.
+
+=item B<SSLCACertificateFile> I<Filename>
+
+=item B<SSLCertificateFile> I<Filename>
+
+=item B<SSLCertificateKeyFile> I<Filename>
+
+Filenames specifying SSL certificate and key material to be used with SSL
+connections.
+
+=back
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7211,7 +7211,7 @@ connections.
 =item B<VerifyPeer> B<true>|B<false>
 
 When enabled, a valid client certificate is required to connect to the server.
-When disabled, a client certifiacte is not requested and any unsolicited client
+When disabled, a client certificate is not requested and any unsolicited client
 certificate is accepted.
 Enabled by default.
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7155,21 +7155,38 @@ can be configured independently from that option. Defaults to B<false>.
 
 =head2 Plugin C<open_telemetry_collector>
 
-The I<open_telemetry_collector plugin> implements an OpenTelemetry Collector.
-Specifically, it implements a gRPC C<MetricsService>.
+The I<open_telemetry plugin> implements an OpenTelemetry exporter and receiver
+using OTLP. Specifically, it implements a gRPC C<MetricsService> client and
+server.
+
+B<Synopsis:>
+
+  <Plugin open_telemetry>
+    <Receiver "0.0.0.0" "4317">
+      EnableSSL false
+      SSLCACertificateFile "/path/to/root.pem"
+      SSLCertificateFile "/path/to/client.pem"
+      SSLCertificateKeyFile "/path/to/client.key"
+      VerifyPeer false
+    </Receiver>
+    <Exporter "example">
+      Host "localhost"
+      Port "4317"
+    </Exporter>
+  </Plugin>
 
 =over 4
 
-=item B<Listen> I<Host> I<Port>
+=item B<Receiver> I<Host> I<Port>
 
-The B<Listen> statement sets the network address and port to which to bind.
-Multiple B<Listen> blocks can be specified to listen on multiple
-interfaces/ports. When no B<Listen> blocks are specified, it defaults to
-B<0.0.0.0:4317>.
+The B<Receiver> statement sets the network address and port to which to bind.
+Multiple B<Receiver> blocks can be specified to listen on multiple
+interfaces/ports. When no B<Receiver> blocks are specified, the plugin will not
+receive any metrics.
 
 The argument I<Host> may be a hostname, an IPv4 address, or an IPv6 address.
 
-Optionally, B<Listen> blocks support the following options:
+Optionally, B<Receiver> blocks support the following options:
 
 =over 4
 
@@ -7192,6 +7209,24 @@ When enabled, a valid client certificate is required to connect to the server.
 When disabled, a client certifiacte is not requested and any unsolicited client
 certificate is accepted.
 Enabled by default.
+
+=back
+
+=item B<Exporter> I<Name>
+
+The plugin can export metrics to multiple collectors by specifying multiple
+B<Exporter> blocks. Within the B<Exporter> blocks, the following options are
+available:
+
+=over 4
+
+=item B<Host> I<Address>
+
+Hostname or address to connect to. Defaults to C<localhost>.
+
+=item B<Port> I<Service>
+
+Service name or port number to connect to. Defaults to C<4317>.
 
 =back
 
@@ -11192,35 +11227,6 @@ number.
 Sets the information used when authenticating to a I<MongoDB> database. The
 fields are optional (in which case no authentication is attempted), but if you
 want to use authentication all three fields must be set.
-
-=back
-
-=head2 Plugin C<write_open_telemetry>
-
-The I<write_open_telemetry plugin> will export metrics to an I<OpenTelemetry
-collector> using the gRPC based OTLP protocol.
-
-B<Synopsis:>
-
- <Plugin "write_open_telemetry">
-   <Node "default">
-     Host "localhost"
-     Port "4317"
-   </Node>
- </Plugin>
-
-The plugin can export metrics to multiple collectors by specifying multiple
-B<Node> blocks. Within the B<Node> blocks, the following options are available:
-
-=over 4
-
-=item B<Host> I<Address>
-
-Hostname or address to connect to. Defaults to C<localhost>.
-
-=item B<Port> I<Service>
-
-Service name or port number to connect to. Defaults to C<4317>.
 
 =back
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7153,6 +7153,50 @@ can be configured independently from that option. Defaults to B<false>.
 
 =back
 
+=head2 Plugin C<open_telemetry_collector>
+
+The I<open_telemetry_collector plugin> implements an OpenTelemetry Collector.
+Specifically, it implements a gRPC C<MetricsService>.
+
+=over 4
+
+=item B<Listen> I<Host> I<Port>
+
+The B<Listen> statement sets the network address and port to which to bind.
+Multiple B<Listen> blocks can be specified to listen on multiple
+interfaces/ports. When no B<Listen> blocks are specified, it defaults to
+B<0.0.0.0:4317>.
+
+The argument I<Host> may be a hostname, an IPv4 address, or an IPv6 address.
+
+Optionally, B<Listen> blocks support the following options:
+
+=over 4
+
+=item B<EnableSSL> I<false>|I<true>
+
+Whether to enable SSL for incoming connections. Default: false.
+
+=item B<SSLCACertificateFile> I<Filename>
+
+=item B<SSLCertificateFile> I<Filename>
+
+=item B<SSLCertificateKeyFile> I<Filename>
+
+Filenames specifying SSL certificate and key material to be used with SSL
+connections.
+
+=item B<VerifyPeer> B<true>|B<false>
+
+When enabled, a valid client certificate is required to connect to the server.
+When disabled, a client certifiacte is not requested and any unsolicited client
+certificate is accepted.
+Enabled by default.
+
+=back
+
+=back
+
 =head2 Plugin C<oracle>
 
 The "oracle" plugin uses the Oracle® Call Interface I<(OCI)> to connect to an

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -7167,9 +7167,14 @@ B<Synopsis:>
       SSLCACertificateFile "/path/to/root.pem"
       SSLCertificateFile "/path/to/client.pem"
       SSLCertificateKeyFile "/path/to/client.key"
-      VerifyPeer false
+      VerifyPeer true
     </Receiver>
-    Exporter "localhost" "4317"
+    <Exporter "localhost" "4317">
+      EnableSSL false
+      SSLCACertificateFile "/path/to/root.pem"
+      SSLCertificateFile "/path/to/client.pem"
+      SSLCertificateKeyFile "/path/to/client.key"
+    </Exporter>
   </Plugin>
 
 =over 4

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -523,13 +523,13 @@ int uc_get_value_by_name(const char *name, value_t *ret_values) {
 
     /* remove missing values from getval */
     if (ce->state == STATE_MISSING) {
-      status = -1;
+      status = EAGAIN;
     } else {
       *ret_values = ce->last_value;
     }
   } else {
     DEBUG("utils_cache: uc_get_value_by_name: No such value: %s", name);
-    status = -1;
+    status = ENOENT;
   }
 
   pthread_mutex_unlock(&cache_lock);
@@ -739,7 +739,7 @@ int uc_get_history_by_name(const char *name, gauge_t *ret_history,
   status = c_avl_get(cache_tree, name, (void *)&ce);
   if (status != 0) {
     pthread_mutex_unlock(&cache_lock);
-    return -ENOENT;
+    return ENOENT;
   }
   /* Check if there are enough values available. If not, increase the buffer
    * size. */
@@ -749,7 +749,7 @@ int uc_get_history_by_name(const char *name, gauge_t *ret_history,
     tmp = realloc(ce->history, sizeof(*ce->history) * num_steps);
     if (tmp == NULL) {
       pthread_mutex_unlock(&cache_lock);
-      return -ENOMEM;
+      return ENOMEM;
     }
 
     for (size_t i = ce->history_length; i < num_steps; i++)

--- a/src/open_telemetry.cc
+++ b/src/open_telemetry.cc
@@ -1,0 +1,70 @@
+/**
+ * collectd - src/open_telemetry.cc
+ * Copyright (C) 2024       Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+extern "C" {
+#include "collectd.h"
+
+#include "daemon/configfile.h"
+#include "daemon/plugin.h"
+}
+
+int exporter_config(oconfig_item_t *ci);
+int receiver_config(oconfig_item_t *ci);
+
+static int ot_config(oconfig_item_t *ci) {
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (strcasecmp("Exporter", child->key) == 0) {
+      int err = exporter_config(child);
+      if (err) {
+        ERROR("open_telemetry plugin: Configuring exporter failed "
+              "with status %d",
+              err);
+        return err;
+      }
+    } else if (strcasecmp("Receiver", child->key) == 0) {
+      int err = receiver_config(child);
+      if (err) {
+        ERROR("open_telemetry plugin: Configuring receiver failed "
+              "with status %d",
+              err);
+        return err;
+      }
+    } else {
+      ERROR("open_telemetry plugin: invalid config option: \"%s\"", child->key);
+      return EINVAL;
+    }
+  }
+
+  return 0;
+}
+
+extern "C" {
+void module_register(void) {
+  plugin_register_complex_config("open_telemetry", ot_config);
+}
+}

--- a/src/open_telemetry.h
+++ b/src/open_telemetry.h
@@ -1,5 +1,5 @@
 /**
- * collectd - src/open_telemetry.cc
+ * collectd - src/open_telemetry.h
  * Copyright (C) 2024       Florian octo Forster
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,46 +24,19 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
-extern "C" {
-#include "collectd.h"
+#ifndef OPEN_TELEMETRY_H
+#define OPEN_TELEMETRY_H 1
 
+extern "C" {
+#include "daemon/collectd.h"
 #include "daemon/configfile.h"
-#include "daemon/plugin.h"
 }
 
-#include "open_telemetry.h"
+#include <grpc++/grpc++.h>
 
-static int ot_config(oconfig_item_t *ci) {
-  for (int i = 0; i < ci->children_num; i++) {
-    oconfig_item_t *child = ci->children + i;
+int exporter_config(oconfig_item_t *ci);
+int receiver_config(oconfig_item_t *ci);
 
-    if (strcasecmp("Exporter", child->key) == 0) {
-      int err = exporter_config(child);
-      if (err) {
-        ERROR("open_telemetry plugin: Configuring exporter failed "
-              "with status %d",
-              err);
-        return err;
-      }
-    } else if (strcasecmp("Receiver", child->key) == 0) {
-      int err = receiver_config(child);
-      if (err) {
-        ERROR("open_telemetry plugin: Configuring receiver failed "
-              "with status %d",
-              err);
-        return err;
-      }
-    } else {
-      ERROR("open_telemetry plugin: invalid config option: \"%s\"", child->key);
-      return EINVAL;
-    }
-  }
+int config_get_file(oconfig_item_t const *ci, grpc::string *out);
 
-  return 0;
-}
-
-extern "C" {
-void module_register(void) {
-  plugin_register_complex_config("open_telemetry", ot_config);
-}
-}
+#endif

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -313,8 +313,8 @@ static grpc::Status dispatch_resource_metrics(ResourceMetrics rm) {
  */
 class OTMetricsService : public MetricsService::Service {
 public:
-  grpc::Status Export(grpc::ClientContext *context,
-                      const ExportMetricsServiceRequest &req,
+  grpc::Status Export(grpc::ServerContext *context,
+                      const ExportMetricsServiceRequest *req,
                       ExportMetricsServiceResponse *resp) {
     for (auto rm : req.resource_metrics()) {
       grpc::Status s = dispatch_resource_metrics(rm);

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -480,11 +480,12 @@ static int otelcol_config_listen(oconfig_item_t *ci) {
     }
   }
 
-  ssl_opts->pem_key_cert_pairs.push_back(pkcp);
-  if (use_ssl)
+  if (use_ssl) {
+    ssl_opts->pem_key_cert_pairs.push_back(pkcp);
     listener.ssl = ssl_opts;
-  else
+  } else {
     delete (ssl_opts);
+  }
 
   listeners.push_back(listener);
   return 0;

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -73,7 +73,7 @@ struct Listener {
   grpc::SslServerCredentialsOptions *ssl;
 };
 static std::vector<Listener> listeners;
-static grpc::string default_addr("0.0.0.0:50051");
+static grpc::string default_addr("0.0.0.0:4317");
 
 /*
  * helper functions

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -173,7 +173,6 @@ static grpc::Status unmarshal_data_point(NumberDataPoint dp,
       // (#4266)
       // fam->type = METRIC_TYPE_FPCOUNTER;
       // m.value.fpcounter = dp.as_double();
-      fam->type = METRIC_TYPE_COUNTER;
       m.value.counter = offset.counter + (counter_t)dp.as_double();
       break;
     }
@@ -181,7 +180,6 @@ static grpc::Status unmarshal_data_point(NumberDataPoint dp,
     break;
   case NumberDataPoint::kAsInt:
     if (is_cumulative) {
-      fam->type = METRIC_TYPE_COUNTER;
       m.value.counter = offset.counter + (counter_t)dp.as_int();
       break;
     }
@@ -270,6 +268,7 @@ static grpc::Status dispatch_metric(Metric mpb, label_set_t resource,
     break;
   }
   case Metric::kSum: {
+    fam.type = METRIC_TYPE_COUNTER;
     grpc::Status s = unmarshal_sum_metric(mpb.sum(), &fam);
     if (!s.ok()) {
       metric_family_metric_reset(&fam);

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -1,0 +1,483 @@
+/**
+ * collectd - src/grpc.cc
+ * Copyright (C) 2015-2016 Sebastian Harl
+ * Copyright (C) 2016-2024 Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Sebastian Harl <sh at tokkee.org>
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+extern "C" {
+#include "daemon/collectd.h"
+#include "daemon/metric.h"
+#include "daemon/utils_cache.h"
+#include "utils/common/common.h"
+}
+
+#include <fstream>
+#include <vector>
+
+#include <grpc++/grpc++.h>
+
+#include "opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
+#include "opentelemetry/proto/common/v1/common.pb.h"
+#include "opentelemetry/proto/metrics/v1/metrics.pb.h"
+#include "opentelemetry/proto/resource/v1/resource.pb.h"
+
+using opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;
+using opentelemetry::proto::collector::metrics::v1::
+    ExportMetricsServiceResponse;
+using opentelemetry::proto::collector::metrics::v1::MetricsService;
+using opentelemetry::proto::common::v1::AnyValue;
+using opentelemetry::proto::common::v1::KeyValue;
+using opentelemetry::proto::metrics::v1::Gauge;
+using opentelemetry::proto::metrics::v1::Metric;
+using opentelemetry::proto::metrics::v1::NumberDataPoint;
+using opentelemetry::proto::metrics::v1::ResourceMetrics;
+using opentelemetry::proto::metrics::v1::Sum;
+using opentelemetry::proto::resource::v1::Resource;
+
+/*
+ * private types
+ */
+
+struct Listener {
+  grpc::string addr;
+  grpc::string port;
+
+  grpc::SslServerCredentialsOptions *ssl;
+};
+static std::vector<Listener> listeners;
+static grpc::string default_addr("0.0.0.0:50051");
+
+/*
+ * helper functions
+ */
+static grpc::string read_file(const char *filename) {
+  std::ifstream f;
+  grpc::string s, content;
+
+  f.open(filename);
+  if (!f.is_open()) {
+    ERROR("open_telemetry_collector: Failed to open '%s'", filename);
+    return "";
+  }
+
+  while (std::getline(f, s)) {
+    content += s;
+    content.push_back('\n');
+  }
+  f.close();
+  return content;
+} /* read_file */
+
+/*
+ * proto conversion
+ */
+static grpc::Status wrap_error(int err) {
+  if (!err) {
+    return grpc::Status::OK;
+  }
+  return grpc::Status(grpc::StatusCode::INTERNAL, "wrapped internal error");
+}
+
+static grpc::Status unmarshal_label_pair(KeyValue kv, label_set_t *labels) {
+  switch (kv.value().value_case()) {
+  case AnyValue::kStringValue:
+    return wrap_error(label_set_add(labels, kv.key().c_str(),
+                                    kv.value().string_value().c_str()));
+  case AnyValue::kBoolValue:
+    return wrap_error(label_set_add(
+        labels, kv.key().c_str(), kv.value().bool_value() ? "true" : "false"));
+  case AnyValue::kIntValue: {
+    char buf[64] = {0};
+    snprintf(buf, sizeof(buf), "%" PRId64, kv.value().int_value());
+    return wrap_error(label_set_add(labels, kv.key().c_str(), buf));
+  }
+  case AnyValue::kDoubleValue: {
+    char buf[64] = {0};
+    snprintf(buf, sizeof(buf), GAUGE_FORMAT, kv.value().double_value());
+    return wrap_error(label_set_add(labels, kv.key().c_str(), buf));
+  }
+  case AnyValue::kArrayValue:
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "array labels are not supported");
+  case AnyValue::kKvlistValue:
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "key/value list labels are not supported");
+  case AnyValue::kBytesValue:
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "byte labels are not supported");
+  default:
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        "unexpected label value type");
+  }
+}
+
+static grpc::Status unmarshal_data_point(NumberDataPoint dp,
+                                         metric_family_t *fam,
+                                         bool is_cumulative) {
+  metric_t m = {
+      .time = NS_TO_CDTIME_T(dp.time_unix_nano()),
+  };
+
+  switch (dp.value_case()) {
+  case NumberDataPoint::kAsDouble:
+// TODO(octo): enable once floating point counters have been merged (#4266)
+#if 0
+    if (is_cumulative) {
+      fam->type = METRIC_TYPE_FPCOUNTER;
+      m.value.fpcounter = dp.as_double();
+      break;
+    }
+#endif
+    m.value.gauge = dp.as_double();
+    break;
+  case NumberDataPoint::kAsInt:
+    if (is_cumulative) {
+      fam->type = METRIC_TYPE_COUNTER;
+      m.value.counter = (counter_t)dp.as_int();
+      break;
+    }
+    m.value.gauge = (gauge_t)dp.as_int();
+    break;
+  default:
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        "unexpected data point value type");
+  }
+
+  for (auto kv : dp.attributes()) {
+    grpc::Status s = unmarshal_label_pair(kv, &m.label);
+    if (!s.ok()) {
+      metric_reset(&m);
+      return s;
+    }
+  }
+
+  // TODO(octo): get the first metric time from the cache and detect counter
+  // resets.
+  // TODO(octo): when aggregation temporality == AGGREGATION_TEMPORALITY_DELTA,
+  // get the previous value from the cache and add to it.
+
+  int err = metric_family_metric_append(fam, m);
+
+  metric_reset(&m);
+  return wrap_error(err);
+}
+
+static grpc::Status unmarshal_gauge_metric(Gauge g, metric_family_t *fam) {
+  for (auto db : g.data_points()) {
+    grpc::Status s = unmarshal_data_point(db, fam, false);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  return grpc::Status::OK;
+}
+
+static grpc::Status unmarshal_sum_metric(Sum s, metric_family_t *fam) {
+  // TODO(octo): check is_monotonic and aggregation temporality
+  for (auto db : s.data_points()) {
+    grpc::Status s = unmarshal_data_point(db, fam, true);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  return grpc::Status::OK;
+}
+
+static grpc::Status dispatch_metric(Metric mpb, label_set_t resource) {
+  metric_family_t fam = {
+      .name = (char *)mpb.name().c_str(),
+      .help = (char *)mpb.description().c_str(),
+      .unit = (char *)mpb.unit().c_str(),
+      .resource = resource,
+  };
+
+  switch (mpb.data_case()) {
+  case Metric::kGauge: {
+    fam.type = METRIC_TYPE_GAUGE;
+    grpc::Status s = unmarshal_gauge_metric(mpb.gauge(), &fam);
+    if (!s.ok()) {
+      metric_family_metric_reset(&fam);
+      return s;
+    }
+    break;
+  }
+  case Metric::kSum: {
+    grpc::Status s = unmarshal_sum_metric(mpb.sum(), &fam);
+    if (!s.ok()) {
+      metric_family_metric_reset(&fam);
+      return s;
+    }
+    break;
+  }
+  case Metric::kHistogram:
+  case Metric::kExponentialHistogram:
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "histogram metrics are not supported");
+  case Metric::kSummary:
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "summary metrics are not supported");
+  default:
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        "unexpected data type");
+  }
+
+  int err = plugin_dispatch_metric_family(&fam);
+
+  metric_family_metric_reset(&fam);
+  return wrap_error(err);
+}
+
+static grpc::Status unmarshal_resource(Resource rpb, label_set_t *resource) {
+  for (auto kv : rpb.attributes()) {
+    grpc::Status s = unmarshal_label_pair(kv, resource);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  return grpc::Status::OK;
+}
+
+static grpc::Status dispatch_resource_metrics(ResourceMetrics rm) {
+  label_set_t resource = {0};
+
+  grpc::Status s = unmarshal_resource(rm.resource(), &resource);
+  if (!s.ok()) {
+    return s;
+  }
+
+  for (auto sm : rm.scope_metrics()) {
+    for (auto m : sm.metrics()) {
+      grpc::Status s = dispatch_metric(m, resource);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+  }
+
+  label_set_reset(&resource);
+  return grpc::Status::OK;
+}
+
+/*
+ * OpenTelemetry MetricsService
+ */
+class OTMetricsService : public MetricsService::Service {
+public:
+  grpc::Status Export(grpc::ClientContext *context,
+                      const ExportMetricsServiceRequest &req,
+                      ExportMetricsServiceResponse *resp) {
+    for (auto rm : req.resource_metrics()) {
+      grpc::Status s = dispatch_resource_metrics(rm);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "Export is not implemented yet");
+  }
+};
+
+/*
+ * gRPC server implementation
+ */
+class CollectorServer final {
+public:
+  void Start() {
+    auto auth = grpc::InsecureServerCredentials();
+
+    grpc::ServerBuilder builder;
+
+    if (listeners.empty()) {
+      builder.AddListeningPort(default_addr, auth);
+      INFO("open_telemetry_collector: Listening on %s", default_addr.c_str());
+    } else {
+      for (auto l : listeners) {
+        grpc::string addr = l.addr + ":" + l.port;
+
+        auto use_ssl = grpc::string("");
+        auto a = auth;
+        if (l.ssl != nullptr) {
+          use_ssl = grpc::string(" (SSL enabled)");
+          a = grpc::SslServerCredentials(*l.ssl);
+        }
+
+        builder.AddListeningPort(addr, a);
+        INFO("open_telemetry_collector: Listening on %s%s", addr.c_str(),
+             use_ssl.c_str());
+      }
+    }
+
+    builder.RegisterService(&metrics_service);
+
+    server = builder.BuildAndStart();
+  }
+
+  void Shutdown() { server->Shutdown(); }
+
+private:
+  OTMetricsService metrics_service;
+
+  std::unique_ptr<grpc::Server> server;
+};
+
+static CollectorServer *server = nullptr;
+
+/*
+ * collectd plugin interface
+ */
+extern "C" {
+static int otelcol_config_listen(oconfig_item_t *ci) {
+  if ((ci->values_num != 2) || (ci->values[0].type != OCONFIG_TYPE_STRING) ||
+      (ci->values[1].type != OCONFIG_TYPE_STRING)) {
+    ERROR("open_telemetry_collector: The `%s` config option needs exactly "
+          "two string argument (address and port).",
+          ci->key);
+    return -1;
+  }
+
+  auto listener = Listener();
+  listener.addr = grpc::string(ci->values[0].value.string);
+  listener.port = grpc::string(ci->values[1].value.string);
+  listener.ssl = nullptr;
+
+  auto ssl_opts = new grpc::SslServerCredentialsOptions(
+      GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY);
+  grpc::SslServerCredentialsOptions::PemKeyCertPair pkcp = {};
+  bool use_ssl = false;
+
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (!strcasecmp("EnableSSL", child->key)) {
+      if (cf_util_get_boolean(child, &use_ssl)) {
+        ERROR("open_telemetry_collector: Option `%s` expects a boolean value",
+              child->key);
+        return -1;
+      }
+    } else if (!strcasecmp("SSLCACertificateFile", child->key)) {
+      char *certs = NULL;
+      if (cf_util_get_string(child, &certs)) {
+        ERROR("open_telemetry_collector: Option `%s` expects a string value",
+              child->key);
+        return -1;
+      }
+      ssl_opts->pem_root_certs = read_file(certs);
+    } else if (!strcasecmp("SSLCertificateKeyFile", child->key)) {
+      char *key = NULL;
+      if (cf_util_get_string(child, &key)) {
+        ERROR("open_telemetry_collector: Option `%s` expects a string value",
+              child->key);
+        return -1;
+      }
+      pkcp.private_key = read_file(key);
+    } else if (!strcasecmp("SSLCertificateFile", child->key)) {
+      char *cert = NULL;
+      if (cf_util_get_string(child, &cert)) {
+        ERROR("open_telemetry_collector: Option `%s` expects a string value",
+              child->key);
+        return -1;
+      }
+      pkcp.cert_chain = read_file(cert);
+    } else if (!strcasecmp("VerifyPeer", child->key)) {
+      bool verify = false;
+      if (cf_util_get_boolean(child, &verify)) {
+        return -1;
+      }
+      ssl_opts->client_certificate_request =
+          verify ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
+                 : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
+    } else {
+      WARNING(
+          "open_telemetry_collector: Option `%s` not allowed in <%s> block.",
+          child->key, ci->key);
+    }
+  }
+
+  ssl_opts->pem_key_cert_pairs.push_back(pkcp);
+  if (use_ssl)
+    listener.ssl = ssl_opts;
+  else
+    delete (ssl_opts);
+
+  listeners.push_back(listener);
+  return 0;
+} /* otelcol_config_listen() */
+
+static int otelcol_config(oconfig_item_t *ci) {
+  for (int i = 0; i < ci->children_num; i++) {
+    oconfig_item_t *child = ci->children + i;
+
+    if (!strcasecmp("Listen", child->key)) {
+      if (otelcol_config_listen(child)) {
+        return -1;
+      }
+    }
+
+    else {
+      WARNING("open_telemetry_collector: Option `%s` not allowed here.",
+              child->key);
+    }
+  }
+
+  return 0;
+} /* otelcol_config() */
+
+static int otelcol_init(void) {
+  if (server) {
+    return 0;
+  }
+
+  server = new CollectorServer();
+  if (!server) {
+    ERROR("open_telemetry_collector: Failed to create server");
+    return -1;
+  }
+
+  server->Start();
+  return 0;
+} /* otelcol_init() */
+
+static int otelcol_shutdown(void) {
+  if (!server)
+    return 0;
+
+  server->Shutdown();
+
+  delete server;
+  server = nullptr;
+
+  return 0;
+} /* otelcol_shutdown() */
+
+void module_register(void) {
+  plugin_register_complex_config("open_telemetry_collector", otelcol_config);
+  plugin_register_init("open_telemetry_collector", otelcol_init);
+  plugin_register_shutdown("open_telemetry_collector", otelcol_shutdown);
+} /* module_register() */
+} /* extern "C" */

--- a/src/open_telemetry_collector.cc
+++ b/src/open_telemetry_collector.cc
@@ -37,6 +37,9 @@ extern "C" {
 #include <vector>
 
 #include <grpc++/grpc++.h>
+#if HAVE_GRPCPP_REFLECTION
+#include <grpc++/ext/proto_server_reflection_plugin.h>
+#endif
 
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
@@ -370,6 +373,9 @@ public:
 class CollectorServer final {
 public:
   void Start() {
+#if HAVE_GRPCPP_REFLECTION
+    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+#endif
     auto auth = grpc::InsecureServerCredentials();
 
     grpc::ServerBuilder builder;

--- a/src/open_telemetry_exporter.cc
+++ b/src/open_telemetry_exporter.cc
@@ -38,11 +38,12 @@ extern "C" {
 }
 
 #include <fstream>
-
 #include <grpc++/grpc++.h>
 
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
 #include "utils/format_open_telemetry/format_open_telemetry.h"
+
+#include "open_telemetry.h"
 
 #ifndef OT_DEFAULT_PORT
 #define OT_DEFAULT_PORT "4317"

--- a/src/open_telemetry_exporter.cc
+++ b/src/open_telemetry_exporter.cc
@@ -1,6 +1,6 @@
 /**
- * collectd - src/write_open_telemetry.cc
- * Copyright (C) 2023       Florian octo Forster
+ * collectd - src/open_telemetry_exporter.cc
+ * Copyright (C) 2023-2024  Florian octo Forster
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@
 extern "C" {
 #include "collectd.h"
 
-#include "plugin.h"
+#include "daemon/plugin.h"
 #include "utils/common/common.h"
 
 #include "utils/resource_metrics/resource_metrics.h"
@@ -196,7 +196,7 @@ static int ot_write(metric_family_t const *fam, user_data_t *user_data) {
   return 0;
 }
 
-static int ot_config_node(oconfig_item_t *ci) {
+int exporter_config(oconfig_item_t *ci) {
   ot_callback_t *cb = (ot_callback_t *)calloc(1, sizeof(*cb));
   if (cb == NULL) {
     ERROR("write_open_telemetry plugin: calloc failed.");
@@ -253,24 +253,4 @@ static int ot_config_node(oconfig_item_t *ci) {
   ot_callback_decref(cb);
   STRBUF_DESTROY(callback_name);
   return 0;
-}
-
-static int ot_config(oconfig_item_t *ci) {
-  for (int i = 0; i < ci->children_num; i++) {
-    oconfig_item_t *child = ci->children + i;
-
-    if (strcasecmp("Node", child->key) == 0)
-      ot_config_node(child);
-    else {
-      ERROR("write_open_telemetry plugin: Invalid configuration "
-            "option: %s.",
-            child->key);
-    }
-  }
-
-  return 0;
-}
-
-void module_register(void) {
-  plugin_register_complex_config("write_open_telemetry", ot_config);
 }

--- a/src/open_telemetry_exporter.cc
+++ b/src/open_telemetry_exporter.cc
@@ -149,6 +149,7 @@ static void ot_callback_decref(void *data) {
   sfree(cb->port);
 
   delete cb->ssl_opts;
+  cb->ssl_opts = NULL;
 
   pthread_mutex_unlock(&cb->mu);
   pthread_mutex_destroy(&cb->mu);

--- a/src/open_telemetry_exporter.cc
+++ b/src/open_telemetry_exporter.cc
@@ -187,7 +187,7 @@ static int ot_write(metric_family_t const *fam, user_data_t *user_data) {
   return 0;
 }
 
-static int config_get_file(oconfig_item_t const *ci, grpc::string *out) {
+int config_get_file(oconfig_item_t const *ci, grpc::string *out) {
   char *path = NULL;
   int err = cf_util_get_string(ci, &path);
   if (err) {
@@ -223,7 +223,7 @@ int exporter_config(oconfig_item_t *ci) {
   ot_callback_t *cb = (ot_callback_t *)calloc(1, sizeof(*cb));
   if (cb == NULL) {
     ERROR("open_telemetry plugin: calloc failed.");
-    return -1;
+    return ENOMEM;
   }
 
   cb->reference_count = 1;

--- a/src/open_telemetry_exporter.cc
+++ b/src/open_telemetry_exporter.cc
@@ -24,17 +24,6 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
-/* write_open_telemetry plugin configuration example
- *
- * <Plugin write_open_telemetry>
- *   <Node "name">
- *     Host "localhost"
- *     Port "8080"
- *     Path "/v1/metrics"
- *   </Node>
- * </Plugin>
- */
-
 extern "C" {
 #include "collectd.h"
 
@@ -103,7 +92,7 @@ static int export_metrics(ot_callback_t *cb) {
   grpc::Status status = cb->stub->Export(&context, *req, &resp);
 
   if (!status.ok()) {
-    ERROR("write_open_telemetry plugin: Exporting metrics failed: %s",
+    ERROR("open_telemetry plugin: Exporting metrics failed: %s",
           status.error_message().c_str());
     return -1;
   }
@@ -111,8 +100,7 @@ static int export_metrics(ot_callback_t *cb) {
   if (resp.has_partial_success() &&
       resp.partial_success().rejected_data_points() > 0) {
     auto ps = resp.partial_success();
-    NOTICE("write_open_telemetry plugin: %" PRId64
-           " data points were rejected: %s",
+    NOTICE("open_telemetry plugin: %" PRId64 " data points were rejected: %s",
            ps.rejected_data_points(), ps.error_message().c_str());
   }
 
@@ -199,7 +187,7 @@ static int ot_write(metric_family_t const *fam, user_data_t *user_data) {
 int exporter_config(oconfig_item_t *ci) {
   ot_callback_t *cb = (ot_callback_t *)calloc(1, sizeof(*cb));
   if (cb == NULL) {
-    ERROR("write_open_telemetry plugin: calloc failed.");
+    ERROR("open_telemetry plugin: calloc failed.");
     return -1;
   }
 
@@ -219,9 +207,7 @@ int exporter_config(oconfig_item_t *ci) {
     else if (strcasecmp("Port", child->key) == 0)
       status = cf_util_get_service(child, &cb->port);
     else {
-      ERROR("write_open_telemetry plugin: Invalid configuration "
-            "option: %s.",
-            child->key);
+      ERROR("open_telemetry plugin: invalid config option: %s.", child->key);
       status = -1;
     }
 
@@ -232,7 +218,7 @@ int exporter_config(oconfig_item_t *ci) {
   }
 
   strbuf_t callback_name = STRBUF_CREATE;
-  strbuf_printf(&callback_name, "write_open_telemetry/%s", cb->name);
+  strbuf_printf(&callback_name, "open_telemetry/%s", cb->name);
 
   user_data_t user_data = {
       .data = cb,

--- a/src/open_telemetry_receiver.cc
+++ b/src/open_telemetry_receiver.cc
@@ -47,6 +47,8 @@ extern "C" {
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 #include "opentelemetry/proto/resource/v1/resource.pb.h"
 
+#include "open_telemetry.h"
+
 #ifndef OT_DEFAULT_PORT
 #define OT_DEFAULT_PORT "4317"
 #endif
@@ -426,9 +428,6 @@ static void receiver_install_callbacks(void) {
 
   done = true;
 }
-
-// config_get_file is implemented in src/open_telemetry_exporter.cc
-int config_get_file(oconfig_item_t const *ci, grpc::string *out);
 
 /*
  * collectd plugin interface

--- a/src/open_telemetry_receiver.cc
+++ b/src/open_telemetry_receiver.cc
@@ -80,7 +80,6 @@ struct Listener {
   grpc::SslServerCredentialsOptions *ssl;
 };
 static std::vector<Listener> listeners;
-static grpc::string default_addr("0.0.0.0:4317");
 
 /*
  * helper functions

--- a/src/open_telemetry_receiver.cc
+++ b/src/open_telemetry_receiver.cc
@@ -176,11 +176,8 @@ static grpc::Status unmarshal_data_point(NumberDataPoint dp,
   switch (dp.value_case()) {
   case NumberDataPoint::kAsDouble:
     if (is_cumulative) {
-      // TODO(octo): enable once floating point counters have been merged
-      // (#4266)
-      // fam->type = METRIC_TYPE_FPCOUNTER;
-      // m.value.fpcounter = dp.as_double();
-      m.value.counter = offset.counter + (counter_t)dp.as_double();
+      fam->type = METRIC_TYPE_FPCOUNTER;
+      m.value.fpcounter = dp.as_double();
       break;
     }
     m.value.gauge = dp.as_double();


### PR DESCRIPTION
This PR adds an gRPC server to collectd, implementing the OpenTelemetry `MetricsService`. This allows collectd to receive metrics via OTLP, for example from the OpenTelemetry Collector.

This new code and the *write_open_telemetry* plugin have been merged into one plugin, called "open_telemetry". Users can enable the exporter, the receiver, or both using the config file, just like they could in the *network plugin* in collectd 5.

**Known limitations:**

* Non-monotonic sums are rejected. We could either convert them to "gauge" or re-introduce "derive" metrics to get them to work.
* Counter resets are not yet detected. Mostly because this needs additional code in the "cache" and this PR is already quite large.
* Histograms, exponential histograms, and summary metrics are rejected.

ChangeLog: OpenTelemetry plugin: This new plugin provides the ability to export as well as receive metrics via OTLP. It supersedes the *write_open_telemetry plugin*.