### PR TITLE
[collectd 6] Enable `-Wstrict-prototypes`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,7 +114,7 @@ FreeBSD_task:
     - git submodule update -- opentelemetry-proto
   configure_script:
     - ./build.sh
-    - ./configure --disable-perl
+    - ./configure ${DEFAULT_CONFIG_OPTS} --disable-perl
   build_script:
     - make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   tests_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,17 +15,12 @@ clang_pedantic_task:
     # probably always fail
   allow_failures: true
   skip_notifications: true
-  git_submodule_script:
-    - git submodule init -- opentelemetry-proto
-    - git submodule update -- opentelemetry-proto
-  configure_script:
-    - ./build.sh
-    - clang --version
-    - >
-      ./configure CC=clang CXX=clang++
-      $DEFAULT_CONFIG_OPTS
-      CFLAGS='-gdwarf-4 -Wall
+  env:
+    VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
+    CFLAGS: >-
+      -gdwarf-4
       -Wno-error
+      -Wall
       -Wextra
       -Wformat=2
       -Wformat-security
@@ -37,7 +32,6 @@ clang_pedantic_task:
       -Wmissing-prototypes
       -Wimplicit-function-declaration
       -Wmissing-declarations
-      -Wstrict-prototypes
       -Wmissing-noreturn
       -Wshadow
       -Wendif-labels
@@ -47,11 +41,18 @@ clang_pedantic_task:
       -Wdate-time
       -Wnested-externs
       -Wno-typedef-redefinition
-      -Wno-gnu-variable-sized-type-not-at-end'
+      -Wno-gnu-variable-sized-type-not-at-end
+  git_submodule_script:
+    - git submodule init -- opentelemetry-proto
+    - git submodule update -- opentelemetry-proto
+  configure_script:
+    - ./build.sh
+    - clang --version
+    - ./configure CC=clang CXX=clang++ $DEFAULT_CONFIG_OPTS
   build_script:
-    - make -j$(nproc) -sk
+    - make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   tests_script:
-    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j$(nproc) -sk check
+    - make -j$(nproc) check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   always:
     make_check_artifacts:
       path: "**/*.log"
@@ -72,6 +73,7 @@ bleeding_edge_compilers_task:
       CC: clang
       CC: clang-18
       CC: clang-17
+    VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
   git_submodule_script:
     - git submodule init -- opentelemetry-proto
     - git submodule update -- opentelemetry-proto
@@ -85,9 +87,9 @@ bleeding_edge_compilers_task:
       CPPLAGS="$(dpkg-buildflags --get CPPFLAGS)"
       LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"
   build_script:
-    - make -j$(nproc) -sk
+    - make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   tests_script:
-    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j$(nproc) -sk check
+    - make -j$(nproc) check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   always:
     make_check_artifacts:
       path: "**/*.log"
@@ -97,6 +99,8 @@ FreeBSD_task:
     matrix:
       - image_family: freebsd-13-2
   allow_failures: false
+  env:
+    VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
   pkg_install_script:
     - >
       pkg install --yes
@@ -112,9 +116,9 @@ FreeBSD_task:
     - ./build.sh
     - ./configure --disable-perl
   build_script:
-    - make -j$(nproc) -sk
+    - make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   tests_script:
-    - VALGRIND_OPTS="--errors-for-leak-kinds=definite" make -j$(nproc) -sk check
+    - make -j$(nproc) check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   always:
     make_check_artifacts:
       path: "**/*.log"
@@ -139,9 +143,9 @@ MacOS_task:
     - ./build.sh
     - ./configure ${DEFAULT_CONFIG_OPTS}
   build_script:
-    - make -j "${CIRRUS_CPU}" -sk
+    - make -j "${CIRRUS_CPU}" -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   tests_script:
-    - make -j "${CIRRUS_CPU}" -sk check
+    - make -j "${CIRRUS_CPU}" -sk check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
   always:
     make_check_artifacts:
       path: "**/*.log"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,15 +81,15 @@ bleeding_edge_compilers_task:
     - ./build.sh
     - $CC --version
     - >
-      ./configure CC=$CC
-      $DEFAULT_CONFIG_OPTS
+      ./configure ${DEFAULT_CONFIG_OPTS}
+      CC="$CC"
       CFLAGS="$(dpkg-buildflags --get CFLAGS)"
       CPPLAGS="$(dpkg-buildflags --get CPPFLAGS)"
       LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"
   build_script:
-    - make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
+    - make -j$(nproc) -sk CFLAGS="$(dpkg-buildflags --get CFLAGS) -Werror=strict-prototypes"
   tests_script:
-    - make -j$(nproc) check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
+    - make -j$(nproc) check CFLAGS="$(dpkg-buildflags --get CFLAGS) -Werror=strict-prototypes"
   always:
     make_check_artifacts:
       path: "**/*.log"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,19 @@ jobs:
           - fedora39
           - fedora38
         configure_flags: ['--enable-compatibility-mode']
+        cflags: ['-Wstrict-prototypes']
         include:
           - container_tag: debian12
             configure_flags: '--enable-compatibility-mode --enable-debug'
+            cflags: '-Wstrict-prototypes'
           - container_tag: debian12
+            configure_flags: '--enable-compatibility-mode CC=clang CXX=clang++'
             # By default clang emits DWARF v5, which Valgrind cannot read yet.
             # https://github.com/llvm/llvm-project/issues/56550
-            configure_flags: '--enable-compatibility-mode CC=clang CXX=clang++ CFLAGS=-gdwarf-4'
+            cflags: '-gdwarf-4 -Wstrict-prototypes'
     env:
       CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
+      CFLAGS: ${{ matrix.cflags }}
       # this env var picked up by valgrind during make check phase
       VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,16 +35,16 @@ jobs:
           - fedora39
           - fedora38
         configure_flags: ['--enable-compatibility-mode']
-        cflags: ['-Wstrict-prototypes']
+        cflags: ['']
         include:
           - container_tag: debian12
             configure_flags: '--enable-compatibility-mode --enable-debug'
-            cflags: '-Wstrict-prototypes'
+            cflags: ''
           - container_tag: debian12
             configure_flags: '--enable-compatibility-mode CC=clang CXX=clang++'
             # By default clang emits DWARF v5, which Valgrind cannot read yet.
             # https://github.com/llvm/llvm-project/issues/56550
-            cflags: '-gdwarf-4 -Wstrict-prototypes'
+            cflags: '-gdwarf-4'
     env:
       CONFIGURE_FLAGS: ${{ matrix.configure_flags }}
       CFLAGS: ${{ matrix.cflags }}
@@ -68,12 +68,14 @@ jobs:
       with:
         name: ${{ matrix.container_tag }}
         path: config.log
+    # The configure script relies on the old syntax to check whether functions
+    # exist, so we can't specify `-Wstrict-prototypes` globally.
     - name: Build collectd
-      run: make -j$(nproc) -sk
+      run: make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
     - name: Run make check
       run: |
         set +e
-        make $MAKEFLAGS check
+        make $MAKEFLAGS check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
         echo "$?" >make-check.status
       continue-on-error: true
     - name: Upload log files
@@ -133,11 +135,11 @@ jobs:
         name: ${{ matrix.container_tag }}
         path: config.log
     - name: Build collectd
-      run: make -j$(nproc) -sk
+      run: make -j$(nproc) -sk CFLAGS="${CFLAGS} -Werror=strict-prototypes"
     - name: Run make check
       run: |
         set +e
-        make $MAKEFLAGS check
+        make $MAKEFLAGS check CFLAGS="${CFLAGS} -Werror=strict-prototypes"
         echo "$?" >make-check.status
       continue-on-error: true
     - name: Upload log files

--- a/configure.ac
+++ b/configure.ac
@@ -7062,6 +7062,7 @@ fi
 
 if test "x$with_libcurl" != "xyes"; then
   plugin_write_http="no (libcurl not found)"
+  plugin_bind="no (libcurl not found)"
 fi
 if test "x$with_libyajl2" != "xyes"; then
   plugin_write_http="no (libyajl2 not found)"
@@ -7069,6 +7070,15 @@ if test "x$with_libyajl2" != "xyes"; then
 fi
 if test "x$with_libhiredis" != "xyes"; then
   plugin_write_redis="no (libhiredis not found)"
+fi
+
+if test "x$with_libxml2" != "xyes"; then
+  plugin_bind="no (libxml2 not found)"
+  plugin_curl_xml="no (libxml2 not found)"
+fi
+
+if test "x$have_strptime" != "xyes"; then
+  plugin_bind="no (strptime not found)"
 fi
 
 if test "x$with_libyajl" = "xyes"; then

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -240,7 +240,7 @@ static void cap_logger(__attribute__((unused)) void *arg, char const *fmt,
 }
 
 #if defined(MHD_VERSION) && MHD_VERSION >= 0x00090000
-static int cap_open_socket() {
+static int cap_open_socket(void) {
   char service[NI_MAXSERV];
   snprintf(service, sizeof(service), "%hu", httpd_port);
 
@@ -305,7 +305,7 @@ static int cap_open_socket() {
 }
 #endif
 
-static struct MHD_Daemon *cap_start_daemon() {
+static struct MHD_Daemon *cap_start_daemon(void) {
 #if defined(MHD_VERSION) && MHD_VERSION >= 0x00090000
   int fd = cap_open_socket();
   if (fd == -1) {
@@ -368,7 +368,7 @@ static int cap_config(oconfig_item_t *ci) {
   return status;
 }
 
-static int cap_shutdown() {
+static int cap_shutdown(void) {
   if (httpd != NULL) {
     MHD_stop_daemon(httpd);
     httpd = NULL;

--- a/src/connectivity.c
+++ b/src/connectivity.c
@@ -624,7 +624,7 @@ static void connectivity_dispatch_notification(const char *interface,
 }
 
 // NOTE: Caller MUST hold connectivity_data_lock when calling this function
-static void send_interface_status() {
+static void send_interface_status(void) {
   for (interface_list_t *il = interface_list_head; il != NULL;
        il = il->next) /* {{{ */
   {
@@ -642,7 +642,7 @@ static void send_interface_status() {
   statuses_to_send = 0;
 }
 
-static void read_interface_status() /* {{{ */
+static void read_interface_status(void) /* {{{ */
 {
   pthread_mutex_lock(&connectivity_data_lock);
 
@@ -695,7 +695,7 @@ static void *connectivity_dequeue_thread(void *arg) /* {{{ */
   return ((void *)0);
 } /* }}} void *connectivity_dequeue_thread */
 
-static int nl_connect() {
+static int nl_connect(void) {
   struct sockaddr_nl sa_nl = {
       .nl_family = AF_NETLINK,
       .nl_groups = RTMGRP_LINK,
@@ -884,7 +884,7 @@ static int stop_netlink_thread(int shutdown) /* {{{ */
     return thread_status;
 }
 
-static int stop_dequeue_thread() /* {{{ */
+static int stop_dequeue_thread(void) /* {{{ */
 {
   pthread_mutex_lock(&connectivity_threads_lock);
 
@@ -924,7 +924,7 @@ static int stop_dequeue_thread() /* {{{ */
   return status;
 } /* }}} int stop_dequeue_thread */
 
-static int stop_threads() /* {{{ */
+static int stop_threads(void) /* {{{ */
 {
   int status = stop_netlink_thread(1);
   int status2 = stop_dequeue_thread();

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1686,7 +1686,7 @@ EXPORT int plugin_unregister_cache_event(const char *name) {
   return 0;
 }
 
-static void destroy_cache_event_callbacks() {
+static void destroy_cache_event_callbacks(void) {
   for (size_t i = 0; i < list_cache_event_num; i++) {
     cache_event_func_t *cef = &list_cache_event[i];
     if (!cef->callback)

--- a/src/daemon/utils_cache.c
+++ b/src/daemon/utils_cache.c
@@ -95,7 +95,7 @@ static int cache_compare(void const *a, void const *b) {
   return strcmp(ea->name, eb->name);
 } /* int cache_compare */
 
-static cache_entry_t *cache_alloc() {
+static cache_entry_t *cache_alloc(void) {
   cache_entry_t *ce;
 
   ce = calloc(1, sizeof(*ce));

--- a/src/dpdkstat.c
+++ b/src/dpdkstat.c
@@ -102,7 +102,7 @@ dpdk_helper_ctx_t *g_hc = NULL;
 static char g_shm_name[DATA_MAX_NAME_LEN] = DPDK_STATS_NAME;
 static dpdk_stat_cfg_status g_state = DPDK_STAT_STATE_OKAY;
 
-static int dpdk_stats_reinit_helper();
+static int dpdk_stats_reinit_helper(void);
 static void dpdk_stats_default_config(void) {
   dpdk_stats_ctx_t *ec = DPDK_STATS_CTX_GET(g_hc);
 
@@ -421,7 +421,7 @@ static int dpdk_stats_counters_dispatch(dpdk_helper_ctx_t *phc) {
   return 0;
 }
 
-static int dpdk_stats_reinit_helper() {
+static int dpdk_stats_reinit_helper(void) {
   DPDK_STATS_TRACE();
 
   dpdk_stats_ctx_t *ctx = DPDK_STATS_CTX_GET(g_hc);

--- a/src/grpc.cc
+++ b/src/grpc.cc
@@ -524,7 +524,7 @@ private:
  */
 class CollectdServer final {
 public:
-  void Start() {
+  void Start(void) {
     auto auth = grpc::InsecureServerCredentials();
 
     grpc::ServerBuilder builder;
@@ -553,7 +553,7 @@ public:
     server_ = builder.BuildAndStart();
   } /* Start() */
 
-  void Shutdown() { server_->Shutdown(); } /* Shutdown() */
+  void Shutdown(void) { server_->Shutdown(); } /* Shutdown() */
 
 private:
   CollectdImpl collectd_service_;

--- a/src/intel_rdt.c
+++ b/src/intel_rdt.c
@@ -778,7 +778,7 @@ cleanup:
  * RETURN VALUE
  *  0 on success. Negative number on error.
  */
-static int read_pids_data() {
+static int read_pids_data(void) {
 
   if (0 == g_rdt->num_ngroups) {
     DEBUG(RDT_PLUGIN ": read_pids_data: not configured - PIDs read skipped");
@@ -858,7 +858,7 @@ groups_refresh:
  * DESCRIPTION
  *   Initialize pids monitoring for all name groups
  */
-static void rdt_init_pids_monitoring() {
+static void rdt_init_pids_monitoring(void) {
   for (size_t group_idx = 0; group_idx < g_rdt->num_ngroups; group_idx++) {
     /*
      * Each group must have not-null proc_pids array.
@@ -1206,7 +1206,7 @@ static int rdt_config(oconfig_item_t *ci) {
   return 0;
 }
 
-static int read_cores_data() {
+static int read_cores_data(void) {
 
   if (0 == g_rdt->cores.num_cgroups) {
     DEBUG(RDT_PLUGIN ": read_cores_data: not configured - Cores read skipped");
@@ -1257,7 +1257,7 @@ static int rdt_read(__attribute__((unused)) user_data_t *ud) {
   return 0;
 }
 
-static void rdt_init_cores_monitoring() {
+static void rdt_init_cores_monitoring(void) {
   for (size_t i = 0; i < g_rdt->cores.num_cgroups; i++) {
     core_group_t *cg = g_rdt->cores.cgroups + i;
 

--- a/src/intel_rdt_test.c
+++ b/src/intel_rdt_test.c
@@ -91,7 +91,7 @@ int pqos_cap_get_event(const struct pqos_cap *cap,
 /***************************************************************************
  * helper functions
  */
-rdt_ctx_t *stub_rdt_setup() {
+rdt_ctx_t *stub_rdt_setup(void) {
 
   rdt_ctx_t *rdt = calloc(1, sizeof(*rdt));
   struct pqos_cpuinfo *pqos_cpu = calloc(1, sizeof(*pqos_cpu));

--- a/src/ipmi.c
+++ b/src/ipmi.c
@@ -987,7 +987,7 @@ static void *c_ipmi_thread_main(void *user_data) {
   return (void *)0;
 } /* void *c_ipmi_thread_main */
 
-static c_ipmi_instance_t *c_ipmi_init_instance() {
+static c_ipmi_instance_t *c_ipmi_init_instance(void) {
   c_ipmi_instance_t *st;
 
   st = calloc(1, sizeof(*st));

--- a/src/libcollectdclient/network_parse_test.c
+++ b/src/libcollectdclient/network_parse_test.c
@@ -237,7 +237,7 @@ static int nop_writer(lcc_value_list_t const *vl) {
   return 0;
 }
 
-static int test_network_parse() {
+static int test_network_parse(void) {
   int ret = 0;
 
   for (size_t i = 0; i < sizeof(raw_packet_data) / sizeof(raw_packet_data[0]);
@@ -269,7 +269,7 @@ static int test_network_parse() {
   return ret;
 }
 
-static int test_parse_time() {
+static int test_parse_time(void) {
   int ret = 0;
 
   struct {
@@ -317,7 +317,7 @@ static int test_parse_time() {
   return ret;
 }
 
-static int test_parse_string() {
+static int test_parse_string(void) {
   int ret = 0;
 
   struct {
@@ -356,7 +356,7 @@ static int test_parse_string() {
   return ret;
 }
 
-static int test_parse_values() {
+static int test_parse_values(void) {
   int ret = 0;
 
   uint8_t testcase[] = {
@@ -415,7 +415,7 @@ static int test_parse_values() {
 }
 
 #if HAVE_GCRYPT_H
-static int test_verify_sha256() {
+static int test_verify_sha256(void) {
   int ret = 0;
 
   int status = verify_sha256(
@@ -447,7 +447,7 @@ static int test_verify_sha256() {
 #endif
 
 #if HAVE_GCRYPT_H
-static int test_decrypt_aes256() {
+static int test_decrypt_aes256(void) {
   char const *iv_str = "4cbe2a747c9f9dcfa0e66f0c2fa74875";
   uint8_t iv[16] = {0};
   size_t iv_len = sizeof(iv);

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -1005,7 +1005,7 @@ static int qos_filter_cb(const struct nlmsghdr *nlh, void *args) {
   return MNL_CB_OK;
 } /* int qos_filter_cb */
 
-static size_t ir_get_buffer_size() {
+static size_t ir_get_buffer_size(void) {
   if (collect_vf_stats == false) {
     return MNL_SOCKET_BUFFER_SIZE;
   }

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -244,9 +244,9 @@ static int check_ignorelist(const char *dev, const char *type,
         continue;
     } else
 #endif
-        /* i->device == NULL  =>  match all devices */
-        if ((i->device != NULL) && (strcasecmp(i->device, dev) != 0))
-      continue;
+      /* i->device == NULL  =>  match all devices */
+      if ((i->device != NULL) && (strcasecmp(i->device, dev) != 0))
+        continue;
 
     if (strcasecmp(i->type, type) != 0)
       continue;

--- a/src/network_test.c
+++ b/src/network_test.c
@@ -239,7 +239,7 @@ DEF_TEST(parse_packet) {
   return 0;
 }
 
-int main() {
+int main(void) {
   RUN_TEST(parse_packet);
 
   END_TEST;

--- a/src/ovs_events.c
+++ b/src/ovs_events.c
@@ -100,7 +100,7 @@ static int ovs_events_plugin_read(user_data_t *u);
 /* This function is used only by "OVS_EVENTS_CTX_LOCK" define (see above).
  * It always returns 1 when context is locked.
  */
-static int ovs_events_ctx_lock() {
+static int ovs_events_ctx_lock(void) {
   pthread_mutex_lock(&ovs_events_ctx.mutex);
   return 1;
 }
@@ -108,7 +108,7 @@ static int ovs_events_ctx_lock() {
 /* This function is used only by "OVS_EVENTS_CTX_LOCK" define (see above).
  * It always returns 0 when context is unlocked.
  */
-static int ovs_events_ctx_unlock() {
+static int ovs_events_ctx_unlock(void) {
   pthread_mutex_unlock(&ovs_events_ctx.mutex);
   return 0;
 }
@@ -133,7 +133,7 @@ static int ovs_events_config_iface_exists(const char *ifname) {
 /* Get OVS DB select parameter request based on rfc7047,
  * "Transact" & "Select" section
  */
-static char *ovs_events_get_select_params() {
+static char *ovs_events_get_select_params(void) {
   size_t buff_size = 0;
   size_t buff_off = 0;
   char *opt_buff = NULL;
@@ -188,7 +188,7 @@ static char *ovs_events_get_select_params() {
 }
 
 /* Release memory allocated for configuration data */
-static void ovs_events_config_free() {
+static void ovs_events_config_free(void) {
   ovs_events_iface_list_t *del_iface = NULL;
   sfree(ovs_events_ctx.ovs_db_select_params);
   while (ovs_events_ctx.config.ifaces) {
@@ -582,7 +582,7 @@ static void ovs_events_conn_initialize(ovs_db_t *pdb) {
 }
 
 /* OVS DB terminate connection notification callback */
-static void ovs_events_conn_terminate() {
+static void ovs_events_conn_terminate(void) {
   const char msg[] = "OVS DB connection has been lost";
   if (ovs_events_ctx.config.send_notification)
     ovs_events_dispatch_terminate_notification(msg);

--- a/src/ovs_stats.c
+++ b/src/ovs_stats.c
@@ -1268,7 +1268,7 @@ static void ovs_stats_free_bridge_list(bridge_list_t *head) {
 }
 
 /* Handle OVSDB lost connection callback */
-static void ovs_stats_conn_terminate() {
+static void ovs_stats_conn_terminate(void) {
   WARNING("Lost connection to OVSDB server");
   pthread_mutex_lock(&g_stats_lock);
   ovs_stats_free_bridge_list(g_bridge_list_head);

--- a/src/procevent.c
+++ b/src/procevent.c
@@ -663,7 +663,7 @@ static int process_map_refresh(void) {
   return 0;
 }
 
-static int nl_connect() {
+static int nl_connect(void) {
   struct sockaddr_nl sa_nl = {
       .nl_family = AF_NETLINK,
       .nl_groups = CN_IDX_PROC,
@@ -729,7 +729,7 @@ static int set_proc_ev_listen(bool enable) {
 }
 
 // Read from netlink socket and write to ring buffer
-static int read_event() {
+static int read_event(void) {
   int recv_flags = MSG_DONTWAIT;
 
   if (nl_sock == -1)
@@ -903,7 +903,7 @@ static void procevent_dispatch_notification(long pid, gauge_t value,
 }
 
 // Read from ring buffer and dispatch to write plugins
-static void read_ring_buffer() {
+static void read_ring_buffer(void) {
   pthread_mutex_lock(&procevent_data_lock);
 
   // If there's currently nothing to read from the buffer,
@@ -1169,7 +1169,7 @@ static int stop_netlink_thread(int shutdown) /* {{{ */
     return thread_status;
 } /* }}} int stop_netlink_thread */
 
-static int stop_dequeue_thread() /* {{{ */
+static int stop_dequeue_thread(void) /* {{{ */
 {
   pthread_mutex_lock(&procevent_thread_lock);
 
@@ -1205,7 +1205,7 @@ static int stop_dequeue_thread() /* {{{ */
   return status;
 } /* }}} int stop_dequeue_thread */
 
-static int stop_threads() /* {{{ */
+static int stop_threads(void) /* {{{ */
 {
   int status = stop_netlink_thread(1);
   int status2 = stop_dequeue_thread();

--- a/src/redfish_test.c
+++ b/src/redfish_test.c
@@ -45,7 +45,7 @@ int redfish_test_plugin_dispatch_values_mock(value_list_t const *vl) {
   return 0;
 }
 
-static value_list_t *redfish_test_get_last_dispatched_value_list() {
+static value_list_t *redfish_test_get_last_dispatched_value_list(void) {
   return &last_dispatched_value_list;
 }
 

--- a/src/sysevent.c
+++ b/src/sysevent.c
@@ -401,7 +401,7 @@ err:
   return -1;
 }
 
-static int read_socket() {
+static int read_socket(void) {
   int recv_flags = MSG_DONTWAIT;
 
   while (42) {
@@ -608,7 +608,7 @@ static void sysevent_dispatch_notification(const char *message,
     sfree(buf);
 }
 
-static void read_ring_buffer() {
+static void read_ring_buffer(void) {
   pthread_mutex_lock(&sysevent_data_lock);
 
   // If there's currently nothing to read from the buffer,
@@ -862,7 +862,7 @@ static int stop_socket_thread(int shutdown) /* {{{ */
   return status;
 } /* }}} int stop_socket_thread */
 
-static int stop_dequeue_thread() /* {{{ */
+static int stop_dequeue_thread(void) /* {{{ */
 {
   pthread_mutex_lock(&sysevent_thread_lock);
 
@@ -905,7 +905,7 @@ static int stop_dequeue_thread() /* {{{ */
   return status;
 } /* }}} int stop_dequeue_thread */
 
-static int stop_threads() /* {{{ */
+static int stop_threads(void) /* {{{ */
 {
   int status = stop_socket_thread(1);
   int status2 = stop_dequeue_thread();

--- a/src/utils/ovs/ovs.c
+++ b/src/utils/ovs/ovs.c
@@ -218,7 +218,7 @@ static bool ovs_db_poll_is_running(ovs_db_t *pdb) {
 
 /* Generate unique identifier (UID). It is used by OVS DB API
  * to set "id" field for any OVS DB JSON request. */
-static uint64_t ovs_uid_generate() {
+static uint64_t ovs_uid_generate(void) {
   uint64_t new_uid;
   pthread_mutex_lock(&ovs_uid_mutex);
   new_uid = ++ovs_uid;
@@ -607,7 +607,7 @@ static int ovs_db_json_data_process(ovs_db_t *pdb, const char *data,
  */
 
 /* Allocate JSON reader instance */
-static ovs_json_reader_t *ovs_json_reader_alloc() {
+static ovs_json_reader_t *ovs_json_reader_alloc(void) {
   ovs_json_reader_t *jreader = calloc(1, sizeof(*jreader));
   if (jreader == NULL)
     return NULL;

--- a/src/utils/proc_pids/proc_pids_test.c
+++ b/src/utils/proc_pids/proc_pids_test.c
@@ -78,7 +78,7 @@ int stub_procfs_setup(const stub_proc_pid_t *proc_pids_array,
  * RETURN VALUE
  *   system command result
  */
-int stub_procfs_teardown() {
+int stub_procfs_teardown(void) {
   char cmd[256];
   sstrncpy(cmd, "rm -rf ", STATIC_ARRAY_SIZE(cmd));
   strncat(cmd, proc_fs, STATIC_ARRAY_SIZE(cmd) - strlen(cmd) - 1);

--- a/src/utils/strbuf/strbuf.c
+++ b/src/utils/strbuf/strbuf.c
@@ -39,7 +39,7 @@ static size_t strbuf_avail(strbuf_t *buf) {
   return buf->size - (buf->pos + 1);
 }
 
-static size_t strbuf_pagesize() {
+static size_t strbuf_pagesize(void) {
   static size_t cached_pagesize;
 
   if (!cached_pagesize) {

--- a/src/virt.c
+++ b/src/virt.c
@@ -1162,7 +1162,7 @@ static void domain_state_submit_notif(virDomainPtr dom, int state, int reason) {
   submit_notif(dom, severity, msg, "domain_state", NULL);
 }
 
-static int lv_init_ignorelists() {
+static int lv_init_ignorelists(void) {
   if (il_domains == NULL)
     il_domains = ignorelist_create(1);
   if (il_block_devices == NULL)

--- a/src/write_influxdb_udp.c
+++ b/src/write_influxdb_udp.c
@@ -149,7 +149,7 @@ static int bind_socket_to_addr(sockent_t *se, const struct addrinfo *ai) {
   return 0;
 } /* int bind_socket_to_addr */
 
-static sockent_t *sockent_create() {
+static sockent_t *sockent_create(void) {
   sockent_t *se = calloc(1, sizeof(*se));
   if (se == NULL)
     return NULL;

--- a/src/write_kafka.c
+++ b/src/write_kafka.c
@@ -77,7 +77,7 @@ static void kafka_log(const rd_kafka_t *rkt, int level, const char *fac,
 }
 #endif
 
-static rd_kafka_resp_err_t kafka_error() {
+static rd_kafka_resp_err_t kafka_error(void) {
 #if RD_KAFKA_VERSION >= 0x000b00ff
   return rd_kafka_last_error();
 #else

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -651,7 +651,7 @@ static int prom_open_socket(int addrfamily, const char **failed) {
   return fd;
 } /* }}} int prom_open_socket */
 
-static struct MHD_Daemon *prom_start_daemon() {
+static struct MHD_Daemon *prom_start_daemon(void) {
   /* {{{ */
   const char *failed = "(unknown)";
   int fd = prom_open_socket(PF_INET6, &failed);
@@ -684,7 +684,7 @@ static struct MHD_Daemon *prom_start_daemon() {
   return d;
 } /* }}} struct MHD_Daemon *prom_start_daemon */
 #else /* if MHD_VERSION < 0x00090000 */
-static struct MHD_Daemon *prom_start_daemon() {
+static struct MHD_Daemon *prom_start_daemon(void) {
   /* {{{ */
   struct MHD_Daemon *d = MHD_start_daemon(
       MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG, httpd_port,
@@ -731,7 +731,7 @@ static int prom_config(oconfig_item_t *ci) {
   return 0;
 }
 
-static int prom_init() {
+static int prom_init(void) {
   if (prom_metrics == NULL) {
     prom_metrics = c_avl_create((int (*)(const void *, const void *))strcmp);
     if (prom_metrics == NULL) {
@@ -860,7 +860,7 @@ static int prom_missing(metric_family_t const *fam,
   return 0;
 }
 
-static int prom_shutdown() {
+static int prom_shutdown(void) {
   if (httpd != NULL) {
     MHD_stop_daemon(httpd);
     httpd = NULL;
@@ -884,7 +884,7 @@ static int prom_shutdown() {
   return 0;
 }
 
-void module_register() {
+void module_register(void) {
   plugin_register_complex_config("write_prometheus", prom_config);
   plugin_register_init("write_prometheus", prom_init);
   plugin_register_write("write_prometheus", prom_write, /* user data = */ NULL);


### PR DESCRIPTION
In pre-ANSI K&R-style C, functions can use an "initializer list" instead of a "parameter type list". Compilers still support this for backwards compatibility, unfortunately.

One result is that compilers will accept the following prototype:

```c
void foo();
```

Note that this probabaly does not mean what you think it means: this is a function with *an unknown number of arguments* and compilers will happily let you pass anything to it. In other words, the following would be legal:

```c
foo("Hello, World!");
```

This PR changes all (unintentional) uses of empty initializer lists to use `(void)` instead, which expresses what is intended: "this function takes no arguments". It also adds the `-Wstrict-prototypes` CFLAG to prevent backsliding.