### PR TITLE
[collectd 6] gpu_sysman: add PSU and fan metrics support

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -805,6 +805,7 @@
 #   DisableMemory false
 #   DisableMemoryBandwidth false
 #   DisableFabric false
+#   DisableFan false
 #   DisableFrequency false
 #   DisableThrottleTime false
 #   DisableTemperature false

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -809,6 +809,7 @@
 #   DisableThrottleTime false
 #   DisableTemperature false
 #   DisablePower false
+#   DisablePSU false
 #   DisableEngine false
 #   DisableEngineSingle false
 #   DisableErrors false

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3835,6 +3835,10 @@ Disable frequency throttling time metric collection.
 
 Disable power usage metrics collection.
 
+=item B<DisablePSU>
+
+Disable power supply related metrics collection.
+
 =item B<DisableTemperature>
 
 Disable temperature metrics collection.

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -3823,6 +3823,10 @@ Disable memory bandwidth metrics collection.
 
 Disable fabric port metrics collection.
 
+=item B<DisableFan>
+
+Disable metrics collection related to fans.
+
 =item B<DisableFrequency>
 
 Disable actual / requested frequency metrics collection.

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -84,6 +84,7 @@ typedef struct {
   bool membw;
   bool power;
   bool power_ratio; // needs extra Sysman data compared to power
+  bool psu;
   bool ras;
   bool ras_separate;
   bool temp;
@@ -97,6 +98,7 @@ typedef struct {
   char *pci_dev;  // if GpuInfo
   char *dev_file; // if ADD_DEV_FILE
   /* number of types for metrics without allocs */
+  uint32_t psu_count;
   uint32_t ras_count;
   uint32_t temp_count;
   /* number of types for each counter metric */
@@ -154,6 +156,7 @@ static struct {
 #define KEY_DISABLE_MEM "DisableMemory"
 #define KEY_DISABLE_MEMBW "DisableMemoryBandwidth"
 #define KEY_DISABLE_POWER "DisablePower"
+#define KEY_DISABLE_PSU "DisablePSU"
 #define KEY_DISABLE_RAS "DisableErrors"
 #define KEY_DISABLE_RAS_SEPARATE "DisableSeparateErrors"
 #define KEY_DISABLE_TEMP "DisableTemperature"
@@ -232,6 +235,7 @@ static int gpu_config_free(void) {
     FREE_GPU_SAMPLING_ARRAYS(i, frequency);
     FREE_GPU_SAMPLING_ARRAYS(i, memory);
     /* zero rest of counters & free name */
+    gpus[i].psu_count = 0;
     gpus[i].ras_count = 0;
     gpus[i].temp_count = 0;
     free(gpus[i].pci_bdf);
@@ -261,6 +265,7 @@ static unsigned int list_gpu_metrics(const gpu_disable_t *disabled) {
                {disabled->membw, false, "Memory BW"},
                {disabled->power, false, "Power"},
                {disabled->power_ratio, true, "Power ratio"},
+               {disabled->psu, false, "PSU"},
                {disabled->ras, false, "RAS/errors"},
                {disabled->temp, false, "Temperature"},
                {disabled->throttle, false, "Throttle time"}};
@@ -2050,6 +2055,131 @@ static bool gpu_fabrics(gpu_device_t *gpu) {
   return ok;
 }
 
+/* Report metrics for relevant power supplies, return true for success */
+static bool gpu_psus(gpu_device_t *gpu) {
+  uint32_t i, psu_count = 0;
+  zes_device_handle_t dev = gpu->handle;
+  ze_result_t ret = zesDeviceEnumPsus(dev, &psu_count, NULL);
+  if (ret != ZE_RESULT_SUCCESS) {
+    ERROR(PLUGIN_NAME ": failed to get power supply count => 0x%x", ret);
+    return false;
+  }
+  zes_psu_handle_t *psus;
+  psus = scalloc(psu_count, sizeof(*psus));
+  if (ret = zesDeviceEnumPsus(dev, &psu_count, psus),
+      ret != ZE_RESULT_SUCCESS) {
+    ERROR(PLUGIN_NAME ": failed to get %d power supplies => 0x%x", psu_count,
+          ret);
+    free(psus);
+    return false;
+  }
+  if (gpu->psu_count != psu_count) {
+    INFO(PLUGIN_NAME ": Sysman reports %d power supplies", psu_count);
+    gpu->psu_count = psu_count;
+  }
+
+  metric_family_t fam_temp = {
+      .help = "Power supply heatsink temperature (in Celsius) when queried",
+      .name = METRIC_PREFIX "psu_temperature_celsius",
+      .type = METRIC_TYPE_GAUGE,
+  };
+  metric_family_t fam_current = {
+      .help = "Current drawn from power supply (in amperes) when queried",
+      .name = METRIC_PREFIX "psu_current_amperes",
+      .type = METRIC_TYPE_GAUGE,
+  };
+  metric_family_t fam_ratio = {
+      .help = "Power supply current usage ratio (0-1) vs limit",
+      .name = METRIC_PREFIX "psu_current_ratio",
+      .type = METRIC_TYPE_GAUGE,
+  };
+  metric_t metric = {0};
+
+  bool reported_temp = false, reported_current = false, reported_ratio = false,
+       ok = false;
+  for (i = 0; i < psu_count; i++) {
+    zes_psu_properties_t props = {.pNext = NULL};
+    if (ret = zesPsuGetProperties(psus[i], &props), ret != ZE_RESULT_SUCCESS) {
+      ERROR(PLUGIN_NAME ": failed to get power supply %d properties => 0x%x", i,
+            ret);
+      ok = false;
+      break;
+    }
+    zes_psu_state_t state = {.pNext = NULL};
+    if (ret = zesPsuGetState(psus[i], &state), ret != ZE_RESULT_SUCCESS) {
+      ERROR(PLUGIN_NAME ": failed to get power supply %d state => 0x%x", i,
+            ret);
+      ok = false;
+      break;
+    }
+    const char *fan;
+    if (props.haveFan) {
+      if (state.fanFailed) {
+        fan = "failed";
+      } else {
+        fan = "ok";
+      }
+    } else {
+      fan = "no";
+    }
+    metric_label_set(&metric, "fan", fan);
+
+    const char *voltage;
+    switch (state.voltStatus) {
+    case ZES_PSU_VOLTAGE_STATUS_NORMAL:
+      voltage = "ok";
+      break;
+    case ZES_PSU_VOLTAGE_STATUS_OVER:
+      voltage = "over-voltage";
+      break;
+    case ZES_PSU_VOLTAGE_STATUS_UNDER:
+      voltage = "under-voltage";
+      break;
+    case ZES_PSU_VOLTAGE_STATUS_UNKNOWN:
+    default:
+      voltage = "unknown";
+    }
+    metric_label_set(&metric, "voltage", voltage);
+
+    metric_set_subdev(&metric, props.onSubdevice, props.subdeviceId);
+    if (state.temperature != -1) {
+      metric.value.gauge = state.temperature;
+      metric_family_metric_append(&fam_temp, metric);
+      reported_temp = true;
+    }
+    if (state.current != -1) {
+      metric.value.gauge = state.current / 1000.0; /* m-amps as amps */
+      metric_family_metric_append(&fam_current, metric);
+      reported_current = true;
+
+      if (props.ampLimit > 0 && (config.output & OUTPUT_RATIO)) {
+        metric.value.gauge = (double)state.current / props.ampLimit;
+        metric_family_metric_append(&fam_ratio, metric);
+        reported_ratio = true;
+      }
+    }
+    metric_reset(&metric);
+    ok = true;
+  }
+  if (reported_temp) {
+    gpu_submit(gpu, &fam_temp);
+  }
+  if (reported_current) {
+    gpu_submit(gpu, &fam_current);
+    if (reported_ratio) {
+      gpu_submit(gpu, &fam_ratio);
+    }
+  }
+  if (!(reported_temp || reported_current)) {
+    ERROR(PLUGIN_NAME
+          ": neither temperature nor current reported for any of the %d PSUs",
+          psu_count);
+    ok = false;
+  }
+  free(psus);
+  return ok;
+}
+
 /* Report power usage for relevant domains, return true for success */
 static bool gpu_powers(gpu_device_t *gpu) {
   uint32_t i, power_count = 0;
@@ -2461,6 +2591,10 @@ static int gpu_read(void) {
               i);
       disabled->power = true;
     }
+    if (!disabled->psu && !gpu_psus(gpu)) {
+      WARNING(PLUGIN_NAME ": GPU-%d PSU query fail / no PSUs => disabled", i);
+      disabled->psu = true;
+    }
     if (!disabled->ras && !gpu_ras(gpu)) {
       WARNING(PLUGIN_NAME ": GPU-%d errors query fail / no sets => disabled",
               i);
@@ -2479,8 +2613,8 @@ static int gpu_read(void) {
       gpu->disabled.throttle = true;
     }
     if (disabled->engine && disabled->fabric && disabled->freq &&
-        disabled->mem && disabled->membw && disabled->power && disabled->ras &&
-        disabled->temp && disabled->throttle) {
+        disabled->mem && disabled->membw && disabled->power && disabled->psu &&
+        disabled->ras && disabled->temp && disabled->throttle) {
       /* all metrics missing -> disable use of that GPU */
       ERROR(PLUGIN_NAME ": No metrics from GPU-%d, disabling its querying", i);
       disabled->all = true;
@@ -2508,6 +2642,8 @@ static int gpu_config_parse(const char *key, const char *value) {
     config.disabled.membw = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_POWER) == 0) {
     config.disabled.power = IS_TRUE(value);
+  } else if (strcasecmp(key, KEY_DISABLE_PSU) == 0) {
+    config.disabled.psu = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_RAS) == 0) {
     config.disabled.ras = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_RAS_SEPARATE) == 0) {
@@ -2571,13 +2707,11 @@ static int gpu_config_parse(const char *key, const char *value) {
 void module_register(void) {
   /* NOTE: key strings *must* be static */
   static const char *config_keys[] = {
-      KEY_DISABLE_ENGINE,       KEY_DISABLE_ENGINE_SINGLE,
-      KEY_DISABLE_FABRIC,       KEY_DISABLE_FREQ,
-      KEY_DISABLE_MEM,          KEY_DISABLE_MEMBW,
-      KEY_DISABLE_POWER,        KEY_DISABLE_RAS,
-      KEY_DISABLE_RAS_SEPARATE, KEY_DISABLE_TEMP,
-      KEY_DISABLE_THROTTLE,     KEY_METRICS_OUTPUT,
-      KEY_LOG_GPU_INFO,         KEY_SAMPLES};
+      KEY_DISABLE_ENGINE,       KEY_DISABLE_ENGINE_SINGLE, KEY_DISABLE_FABRIC,
+      KEY_DISABLE_FREQ,         KEY_DISABLE_MEM,           KEY_DISABLE_MEMBW,
+      KEY_DISABLE_POWER,        KEY_DISABLE_PSU,           KEY_DISABLE_RAS,
+      KEY_DISABLE_RAS_SEPARATE, KEY_DISABLE_TEMP,          KEY_DISABLE_THROTTLE,
+      KEY_METRICS_OUTPUT,       KEY_LOG_GPU_INFO,          KEY_SAMPLES};
   const int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
   plugin_register_config(PLUGIN_NAME, gpu_config_parse, config_keys,

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -79,6 +79,7 @@ typedef struct {
   bool engine;
   bool engine_single;
   bool fabric;
+  bool fan;
   bool freq;
   bool mem;
   bool membw;
@@ -98,6 +99,7 @@ typedef struct {
   char *pci_dev;  // if GpuInfo
   char *dev_file; // if ADD_DEV_FILE
   /* number of types for metrics without allocs */
+  uint32_t fan_count;
   uint32_t psu_count;
   uint32_t ras_count;
   uint32_t temp_count;
@@ -152,6 +154,7 @@ static struct {
 #define KEY_DISABLE_ENGINE "DisableEngine"
 #define KEY_DISABLE_ENGINE_SINGLE "DisableEngineSingle"
 #define KEY_DISABLE_FABRIC "DisableFabric"
+#define KEY_DISABLE_FAN "DisableFan"
 #define KEY_DISABLE_FREQ "DisableFrequency"
 #define KEY_DISABLE_MEM "DisableMemory"
 #define KEY_DISABLE_MEMBW "DisableMemoryBandwidth"
@@ -235,6 +238,7 @@ static int gpu_config_free(void) {
     FREE_GPU_SAMPLING_ARRAYS(i, frequency);
     FREE_GPU_SAMPLING_ARRAYS(i, memory);
     /* zero rest of counters & free name */
+    gpus[i].fan_count = 0;
     gpus[i].psu_count = 0;
     gpus[i].ras_count = 0;
     gpus[i].temp_count = 0;
@@ -260,6 +264,7 @@ static unsigned int list_gpu_metrics(const gpu_disable_t *disabled) {
     const char *name;
   } names[] = {{disabled->engine, false, "Engine"},
                {disabled->fabric, false, "Fabric port"},
+               {disabled->fan, false, "Fan"},
                {disabled->freq, false, "Frequency"},
                {disabled->mem, false, "Memory"},
                {disabled->membw, false, "Memory BW"},
@@ -2055,6 +2060,118 @@ static bool gpu_fabrics(gpu_device_t *gpu) {
   return ok;
 }
 
+/* Report metrics for relevant fans, return true for success */
+static bool gpu_fans(gpu_device_t *gpu) {
+  uint32_t i, fan_count = 0;
+  zes_device_handle_t dev = gpu->handle;
+  ze_result_t ret = zesDeviceEnumFans(dev, &fan_count, NULL);
+  if (ret != ZE_RESULT_SUCCESS) {
+    ERROR(PLUGIN_NAME ": failed to get fan count => 0x%x", ret);
+    return false;
+  }
+  zes_fan_handle_t *fans;
+  fans = scalloc(fan_count, sizeof(*fans));
+  if (ret = zesDeviceEnumFans(dev, &fan_count, fans),
+      ret != ZE_RESULT_SUCCESS) {
+    ERROR(PLUGIN_NAME ": failed to get %d fans => 0x%x", fan_count, ret);
+    free(fans);
+    return false;
+  }
+  if (gpu->fan_count != fan_count) {
+    INFO(PLUGIN_NAME ": Sysman reports %d fans", fan_count);
+    gpu->fan_count = fan_count;
+  }
+  if (!(config.output & (OUTPUT_RATE | OUTPUT_RATIO))) {
+    ERROR(PLUGIN_NAME ": no fan output variants selected");
+    free(fans);
+    return false;
+  }
+
+  metric_family_t fam_speed = {
+      .help = "Fan speed (in RPMs) when queried",
+      .name = METRIC_PREFIX "fan_speed_rpms",
+      .type = METRIC_TYPE_GAUGE,
+  };
+  metric_family_t fam_ratio = {
+      .help = "Fan speed ratio (0-1) vs max",
+      .name = METRIC_PREFIX "fan_speed_ratio",
+      .type = METRIC_TYPE_GAUGE,
+  };
+  metric_t metric = {0};
+
+  bool reported_ratio = false, reported_speed = false, ok = false;
+  for (i = 0; i < fan_count; i++) {
+    int32_t speed;
+    if (ret = zesFanGetState(fans[i], ZES_FAN_SPEED_UNITS_RPM, &speed),
+        ret != ZE_RESULT_SUCCESS) {
+      ERROR(PLUGIN_NAME ": failed to get fan %d state => 0x%x", i, ret);
+      ok = false;
+      break;
+    }
+    if (speed < 0) {
+      ERROR(PLUGIN_NAME ": invalid or unsupported fan %d speed %d", i, speed);
+      ok = false;
+      break;
+    }
+
+    zes_fan_properties_t props = {.pNext = NULL};
+    if (ret = zesFanGetProperties(fans[i], &props), ret != ZE_RESULT_SUCCESS) {
+      ERROR(PLUGIN_NAME ": failed to get fan %d properties => 0x%x", i, ret);
+      ok = false;
+      break;
+    }
+    zes_fan_config_t conf = {.pNext = NULL};
+    if (ret = zesFanGetConfig(fans[i], &conf), ret != ZE_RESULT_SUCCESS) {
+      ERROR(PLUGIN_NAME ": failed to get fan %d config => 0x%x", i, ret);
+      ok = false;
+      break;
+    }
+    const char *mode;
+    switch (conf.mode) {
+    case ZES_FAN_SPEED_MODE_DEFAULT:
+      mode = "hw-default";
+      break;
+    case ZES_FAN_SPEED_MODE_FIXED:
+      mode = "fixed";
+      break;
+    case ZES_FAN_SPEED_MODE_TABLE:
+      mode = "table";
+      break;
+    default:
+      mode = "unknown";
+    }
+    metric_label_set(&metric, "mode", mode);
+
+    if (props.maxPoints != -1) {
+      char buf[16];
+      snprintf(buf, sizeof(buf), "%d", props.maxPoints);
+      metric_label_set(&metric, "points", buf);
+    }
+    metric_set_subdev(&metric, props.onSubdevice, props.subdeviceId);
+
+    metric.value.gauge = speed;
+    if (config.output & OUTPUT_RATE) {
+      metric_family_metric_append(&fam_speed, metric);
+      reported_speed = true;
+    }
+    if (props.maxRPM > 0 && (config.output & OUTPUT_RATIO)) {
+      metric.value.gauge = (double)speed / props.maxRPM;
+      metric_family_metric_append(&fam_ratio, metric);
+      reported_ratio = true;
+    }
+    metric_reset(&metric);
+    ok = true;
+  }
+  if (reported_speed) {
+    gpu_submit(gpu, &fam_speed);
+  }
+  if (reported_ratio) {
+    gpu_submit(gpu, &fam_ratio);
+  }
+  free(fans);
+  return ok;
+}
+
 /* Report metrics for relevant power supplies, return true for success */
 static bool gpu_psus(gpu_device_t *gpu) {
   uint32_t i, psu_count = 0;
@@ -2581,6 +2698,10 @@ static int gpu_read(void) {
               i);
       disabled->fabric = true;
     }
+    if (!disabled->fan && !gpu_fans(gpu)) {
+      WARNING(PLUGIN_NAME ": GPU-%d fan query fail / no fans => disabled", i);
+      disabled->fan = true;
+    }
     if (!disabled->membw && !gpu_mems_bw(gpu)) {
       WARNING(PLUGIN_NAME ": GPU-%d mem BW query fail / no modules => disabled",
               i);
@@ -2612,9 +2733,10 @@ static int gpu_read(void) {
               i);
       gpu->disabled.throttle = true;
     }
-    if (disabled->engine && disabled->fabric && disabled->freq &&
-        disabled->mem && disabled->membw && disabled->power && disabled->psu &&
-        disabled->ras && disabled->temp && disabled->throttle) {
+    if (disabled->engine && disabled->fabric && disabled->fan &&
+        disabled->freq && disabled->mem && disabled->membw && disabled->power &&
+        disabled->psu && disabled->ras && disabled->temp &&
+        disabled->throttle) {
       /* all metrics missing -> disable use of that GPU */
       ERROR(PLUGIN_NAME ": No metrics from GPU-%d, disabling its querying", i);
       disabled->all = true;
@@ -2634,6 +2756,8 @@ static int gpu_config_parse(const char *key, const char *value) {
     config.disabled.engine_single = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_FABRIC) == 0) {
     config.disabled.fabric = IS_TRUE(value);
+  } else if (strcasecmp(key, KEY_DISABLE_FAN) == 0) {
+    config.disabled.fan = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_FREQ) == 0) {
     config.disabled.freq = IS_TRUE(value);
   } else if (strcasecmp(key, KEY_DISABLE_MEM) == 0) {
@@ -2707,11 +2831,12 @@ static int gpu_config_parse(const char *key, const char *value) {
 void module_register(void) {
   /* NOTE: key strings *must* be static */
   static const char *config_keys[] = {
-      KEY_DISABLE_ENGINE,       KEY_DISABLE_ENGINE_SINGLE, KEY_DISABLE_FABRIC,
-      KEY_DISABLE_FREQ,         KEY_DISABLE_MEM,           KEY_DISABLE_MEMBW,
-      KEY_DISABLE_POWER,        KEY_DISABLE_PSU,           KEY_DISABLE_RAS,
-      KEY_DISABLE_RAS_SEPARATE, KEY_DISABLE_TEMP,          KEY_DISABLE_THROTTLE,
-      KEY_METRICS_OUTPUT,       KEY_LOG_GPU_INFO,          KEY_SAMPLES};
+      KEY_DISABLE_ENGINE,   KEY_DISABLE_ENGINE_SINGLE, KEY_DISABLE_FABRIC,
+      KEY_DISABLE_FAN,      KEY_DISABLE_FREQ,          KEY_DISABLE_MEM,
+      KEY_DISABLE_MEMBW,    KEY_DISABLE_POWER,         KEY_DISABLE_PSU,
+      KEY_DISABLE_RAS,      KEY_DISABLE_RAS_SEPARATE,  KEY_DISABLE_TEMP,
+      KEY_DISABLE_THROTTLE, KEY_METRICS_OUTPUT,        KEY_LOG_GPU_INFO,
+      KEY_SAMPLES};
   const int config_keys_num = STATIC_ARRAY_SIZE(config_keys);
 
   plugin_register_config(PLUGIN_NAME, gpu_config_parse, config_keys,

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -339,6 +339,10 @@ static ze_result_t metric_args_check(int callbit, const char *name,
 #define TEMP_INIT 10
 #define TEMP_INC 5
 
+#define PSU_LIMIT (40 * 1000)
+#define PSU_INIT (PSU_LIMIT / 4)
+#define PSU_INC (PSU_LIMIT / 200)
+
 /* Arguments:
  * - call bit
  * - metric enumaration function name
@@ -573,7 +577,19 @@ ze_result_t zesFabricPortGetThroughput(zes_fabric_port_handle_t handle,
   return ret;
 }
 
-#define QUERY_CALL_FUNCS 27
+/* valid ampLimit is needed for current ratio */
+static zes_psu_properties_t psu_props = {.ampLimit = PSU_LIMIT * 1000,
+                                         .haveFan = true};
+/* multiplied to provide values in milli-amps */
+static zes_psu_state_t psu_stats = {.current = PSU_INIT * 1000,
+                                    .temperature = TEMP_INIT};
+
+ADD_METRIC(27, zesDeviceEnumPsus, zes_psu_handle_t, zesPsuGetProperties,
+           zes_psu_properties_t, psu_props, zesPsuGetState, zes_psu_state_t,
+           psu_stats, psu_stats.current += PSU_INC * 1000,
+           psu_stats.temperature += TEMP_INC)
+
+#define QUERY_CALL_FUNCS 30
 #define QUERY_CALL_BITS (((uint64_t)1 << QUERY_CALL_FUNCS) - 1)
 
 /* ------------------------------------------------------------------------- */
@@ -606,6 +622,9 @@ typedef struct {
 
 #define MEM_RATIO_INIT ((double)MEMORY_INIT / MEMORY_SIZE)
 #define MEM_RATIO_INC ((double)MEMORY_INC / MEMORY_SIZE)
+
+#define PSU_RATIO_INIT ((double)(PSU_INIT) / (PSU_LIMIT))
+#define PSU_RATIO_INC ((double)(PSU_INC) / (PSU_LIMIT))
 
 static metrics_validation_t valid_metrics[] = {
     /* gauge value changes */
@@ -646,6 +665,9 @@ static metrics_validation_t valid_metrics[] = {
      MEM_RATIO_INC, 0, 0.0},
     {"memory_usage_ratio/HBM/system", false, false, MEM_RATIO_INIT,
      MEM_RATIO_INC, 0, 0.0},
+    {"psu_current_amperes", true, false, PSU_INIT, PSU_INC, 0, 0.0},
+    {"psu_current_ratio", true, false, PSU_RATIO_INIT, PSU_RATIO_INC, 0, 0.0},
+    {"psu_temperature_celsius", true, false, TEMP_INIT, TEMP_INC, 0, 0.0},
     {"temperature_celsius", true, false, TEMP_INIT, TEMP_INC, 0, 0.0},
     {"temperature_ratio", true, false, TEMP_RATIO_INIT, TEMP_RATIO_INC, 0, 0.0},
 
@@ -1074,6 +1096,7 @@ static int get_reset_disabled(gpu_disable_t *disabled, bool value, int *mask,
                {"membw", &disabled->membw},
                {"power", &disabled->power},
                {"power_ratio", &disabled->power_ratio},
+               {"psu", &disabled->psu},
                {"errors", &disabled->ras},
                {"temperature", &disabled->temp},
                {"throttle", &disabled->throttle}};

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -343,6 +343,10 @@ static ze_result_t metric_args_check(int callbit, const char *name,
 #define PSU_INIT (PSU_LIMIT / 4)
 #define PSU_INC (PSU_LIMIT / 200)
 
+#define FAN_MAX 6000
+#define FAN_INIT 3000
+#define FAN_INC 200
+
 /* Arguments:
  * - call bit
  * - metric enumaration function name
@@ -589,7 +593,37 @@ ADD_METRIC(27, zesDeviceEnumPsus, zes_psu_handle_t, zesPsuGetProperties,
            psu_stats, psu_stats.current += PSU_INC * 1000,
            psu_stats.temperature += TEMP_INC)
 
-#define QUERY_CALL_FUNCS 30
+static zes_fan_properties_t fan_props = {.maxRPM = FAN_MAX, .maxPoints = 8};
+
+ADD_METRIC(30, zesDeviceEnumFans, zes_fan_handle_t, zesFanGetProperties,
+           zes_fan_properties_t, fan_props, zesFanGetDummyState, int, dummy,
+           dummy = 0, dummy = 0)
+
+/* needed because there's an extra parameter */
+ze_result_t zesFanGetState(zes_fan_handle_t handle, zes_fan_speed_units_t units,
+                           int32_t *speed) {
+  ze_result_t ret = metric_args_check(32, "zesFanGetState", handle, speed);
+  if (ret == ZE_RESULT_SUCCESS) {
+    if (units != ZES_FAN_SPEED_UNITS_RPM) {
+      return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+    static uint32_t fan = FAN_INIT;
+    *speed = fan;
+    fan += FAN_INC;
+  }
+  return ret;
+}
+
+ze_result_t zesFanGetConfig(zes_fan_handle_t handle, zes_fan_config_t *config) {
+  ze_result_t ret = metric_args_check(33, "zesFanGetConfig", handle, config);
+  if (ret == ZE_RESULT_SUCCESS) {
+    assert(!config->pNext);
+    memset(config, 0, sizeof(*config));
+  }
+  return ret;
+}
+
+#define QUERY_CALL_FUNCS 34
 #define QUERY_CALL_BITS (((uint64_t)1 << QUERY_CALL_FUNCS) - 1)
 
 /* ------------------------------------------------------------------------- */
@@ -626,9 +660,14 @@ typedef struct {
 #define PSU_RATIO_INIT ((double)(PSU_INIT) / (PSU_LIMIT))
 #define PSU_RATIO_INC ((double)(PSU_INC) / (PSU_LIMIT))
 
+#define FAN_RATIO_INIT ((double)FAN_INIT / FAN_MAX)
+#define FAN_RATIO_INC ((double)FAN_INC / FAN_MAX)
+
 static metrics_validation_t valid_metrics[] = {
     /* gauge value changes */
     {"all_errors_total", true, false, RAS_INIT, RAS_INC, 0, 0.0},
+    {"fan_speed_ratio", true, false, FAN_RATIO_INIT, FAN_RATIO_INC, 0, 0.0},
+    {"fan_speed_rpms", true, false, FAN_INIT, FAN_INC, 0, 0.0},
     {"frequency_mhz/actual/current/gpu/min", true, true, FREQ_INIT, FREQ_INC, 0,
      0.0},
     {"frequency_mhz/actual/current/gpu/max", true, true, FREQ_INIT, FREQ_INC, 0,
@@ -1089,17 +1128,13 @@ static int get_reset_disabled(gpu_disable_t *disabled, bool value, int *mask,
   struct {
     const char *name;
     bool *flag;
-  } flags[] = {{"engine", &disabled->engine},
-               {"fabric", &disabled->fabric},
-               {"frequency", &disabled->freq},
-               {"memory", &disabled->mem},
-               {"membw", &disabled->membw},
-               {"power", &disabled->power},
-               {"power_ratio", &disabled->power_ratio},
-               {"psu", &disabled->psu},
-               {"errors", &disabled->ras},
-               {"temperature", &disabled->temp},
-               {"throttle", &disabled->throttle}};
+  } flags[] = {
+      {"engine", &disabled->engine},    {"fabric", &disabled->fabric},
+      {"fan", &disabled->fan},          {"frequency", &disabled->freq},
+      {"memory", &disabled->mem},       {"membw", &disabled->membw},
+      {"power", &disabled->power},      {"power_ratio", &disabled->power_ratio},
+      {"psu", &disabled->psu},          {"errors", &disabled->ras},
+      {"temperature", &disabled->temp}, {"throttle", &disabled->throttle}};
   *all = 0;
   int count = 0;
   for (int i = 0; i < (int)STATIC_ARRAY_SIZE(flags); i++) {


### PR DESCRIPTION
ChangeLog: gpu_sysman: add PSU and fan metrics support

I'd rather get these (old commits) in first, and change the names of the new metrics to OTEL naming conventions later as part of PR #4267.

(As name changes have impact also to things outside collectd, and I have not done those other changes yet, due to some of the OTEL name changes still not being final, and relevant parts of the OTEL spec still being in experimental stage...)