### PR TITLE
[collectd 6] gpu_sysman: switch from zeInit() to zesInit()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ AC_CHECK_HEADERS_ONCE([ \
   fs_info.h \
   fshelp.h \
   grp.h \
+  glob.h \
   kstat.h \
   kvm.h \
   libgen.h \

--- a/configure.ac
+++ b/configure.ac
@@ -2111,6 +2111,10 @@ PKG_CHECK_MODULES([LEVEL_ZERO], [level-zero],
   [with_level_zero="no (pkg-config could not find 'level-zero')"]
 )
 
+if ! pkg-config --atleast-version=1.9.4 level-zero; then
+  with_level_zero="no (version $(pkg-config --version level-zero) < 1.9.4)"
+fi
+
 if test "x$with_level_zero" = "xyes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $LEVEL_ZERO_CFLAGS"
@@ -2126,9 +2130,9 @@ if test "x$with_level_zero" = "xyes"; then
   SAVE_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS $LEVEL_ZERO_LIBS"
 
-  AC_CHECK_LIB([ze_loader], zeInit,
+  AC_CHECK_LIB([ze_loader], zesInit,
     [with_level_zero="yes"],
-    [with_level_zero="no (libze_loader symbol 'zeInit' not found)"]
+    [with_level_zero="no (libze_loader symbol 'zesInit' not found)"]
   )
   LDFLAGS="$SAVE_LDFLAGS"
 fi

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -42,21 +42,24 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
 
+/* includes config.h with HAVE_*_H defines, needed by check below */
+#include "collectd.h"
+
+#if HAVE_GLOB_H && HAVE_LIBGEN_H
 /* "dev_file" label (for k8s Intel GPU plugin) and "pci_dev" label
  * (for k8s Intel resource driver) need (POSIX.1-2001/-2008)
  *  glob() + basename() functions.
  */
 #define ADD_DEV_FILE 1
-#if ADD_DEV_FILE
 #include <glob.h>
 #include <libgen.h>
+#else
+#pragma message                                                                \
+    "glob / libgen headers missing => no 'dev_file' / 'pci_dev' labels"
 #endif
 
-#include "collectd.h"
-/* comment avoiding local clang-format conflict with collectd CI one */
 #include "plugin.h"
 #include "utils/common/common.h"
 

--- a/src/gpu_sysman.c
+++ b/src/gpu_sysman.c
@@ -822,7 +822,8 @@ static int gpu_fetch(zes_driver_handle_t *drivers, uint32_t driver_count,
   return retval;
 }
 
-/* Scan Sysman for GPU devices
+/* Scan Sysman for GPU devices:
+ * https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#initialization
  * Return RET_OK for success, (negative) error value otherwise
  */
 static int gpu_init(void) {
@@ -831,6 +832,10 @@ static int gpu_init(void) {
     return RET_OK;
   }
   ze_result_t ret;
+  /* backend versions supporting zesInit(), but older than 23.26.26690.12
+   * still need this env var.
+   */
+  setenv("ZES_ENABLE_SYSMAN", "1", 1);
   if (ret = zesInit(0), ret != ZE_RESULT_SUCCESS) {
     ERROR(PLUGIN_NAME ": Level Zero Sysman init failed => 0x%x", ret);
     return RET_ZES_INIT_FAIL;

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -244,7 +244,8 @@ static ze_result_t dev_args_check(int callbit, const char *name,
   ze_result_t getname(zes_device_handle_t dev, structtype *to_zero) {          \
     ze_result_t ret = dev_args_check(callbit, #getname, dev, to_zero);         \
     if (ret == ZE_RESULT_SUCCESS) {                                            \
-      assert(!to_zero->pNext);                                                 \
+      assert(to_zero->pNext == NULL ||                                         \
+             to_zero->stype == ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES);          \
       memset(to_zero, 0, sizeof(*to_zero));                                    \
       setval;                                                                  \
     }                                                                          \

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -72,6 +72,7 @@
  * - Plugin init, shutdown and re-init works without problems
  */
 
+#define SYSMAN_UNIT_TEST_BUILD 1
 #include "gpu_sysman.c" /* test this */
 
 /* include metric functions + their dependencies directly, instead of
@@ -237,24 +238,6 @@ static ze_result_t dev_args_check(int callbit, const char *name,
   return ZE_RESULT_SUCCESS;
 }
 
-ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t dev, uint32_t *count,
-                                        ze_device_memory_properties_t *props) {
-  ze_result_t ret =
-      dev_args_check(3, "zeDeviceGetMemoryProperties", dev, count);
-  if (ret != ZE_RESULT_SUCCESS)
-    return ret;
-  if (!*count) {
-    *count = 1;
-    return ZE_RESULT_SUCCESS;
-  }
-  *count = 1;
-  if (!props)
-    return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
-  assert(!props->pNext);
-  memset(props, 0, sizeof(*props));
-  return ZE_RESULT_SUCCESS;
-}
-
 /* mock up level-zero sysman device handling API, called during gpu_init() */
 
 #define DEV_GET_SET_STRUCT(callbit, getname, structtype, setval)               \
@@ -268,15 +251,15 @@ ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t dev, uint32_t *count,
     return ret;                                                                \
   }
 
-DEV_GET_SET_STRUCT(4, zesDeviceGetProperties, zes_device_properties_t, )
-DEV_GET_SET_STRUCT(5, zesDevicePciGetProperties, zes_pci_properties_t, )
-DEV_GET_SET_STRUCT(6, zesDeviceGetState, zes_device_state_t,
+DEV_GET_SET_STRUCT(3, zesDeviceGetProperties, zes_device_properties_t, )
+DEV_GET_SET_STRUCT(4, zesDevicePciGetProperties, zes_pci_properties_t, )
+DEV_GET_SET_STRUCT(5, zesDeviceGetState, zes_device_state_t,
                    to_zero->reset = (ZES_RESET_REASON_FLAG_WEDGED |
                                      ZES_RESET_REASON_FLAG_REPAIR))
-DEV_GET_SET_STRUCT(7, zesDeviceGetEccState, zes_device_ecc_properties_t,
+DEV_GET_SET_STRUCT(6, zesDeviceGetEccState, zes_device_ecc_properties_t,
                    to_zero->currentState = ZES_DEVICE_ECC_STATE_ENABLED)
 
-#define INIT_CALL_FUNCS 8
+#define INIT_CALL_FUNCS 7
 #define INIT_CALL_BITS (((uint64_t)1 << INIT_CALL_FUNCS) - 1)
 
 /* ------------------------------------------------------------------------- */

--- a/src/gpu_sysman_test.c
+++ b/src/gpu_sysman_test.c
@@ -158,8 +158,8 @@ static bool call_limit(int callbit, const char *name) {
  */
 
 /* mock up handle values to set & check against */
-#define DRV_HANDLE ((ze_driver_handle_t)(0x123456))
-#define DEV_HANDLE ((ze_device_handle_t)(0xecced))
+#define DRV_HANDLE ((zes_driver_handle_t)(0x123456))
+#define DEV_HANDLE ((zes_device_handle_t)(0xecced))
 #define VAL_HANDLE 0xcaffa
 
 /* driver/device initialization status */
@@ -172,17 +172,17 @@ typedef enum {
 
 static initialized_t initialized = L0_NOT_INITIALIZED;
 
-ze_result_t zeInit(ze_init_flags_t flags) {
-  if (call_limit(0, "zeInit"))
+ze_result_t zesInit(zes_init_flags_t flags) {
+  if (call_limit(0, "zesInit"))
     return ZE_RESULT_ERROR_DEVICE_LOST;
-  if (flags && flags != ZE_INIT_FLAG_GPU_ONLY)
+  if (flags)
     return ZE_RESULT_ERROR_INVALID_ENUMERATION;
   initialized = L0_IS_INITIALIZED;
   return ZE_RESULT_SUCCESS;
 }
 
-ze_result_t zeDriverGet(uint32_t *count, ze_driver_handle_t *handles) {
-  if (call_limit(1, "zeDriverGet"))
+ze_result_t zesDriverGet(uint32_t *count, zes_driver_handle_t *handles) {
+  if (call_limit(1, "zesDriverGet"))
     return ZE_RESULT_ERROR_DEVICE_LOST;
   if (initialized < L0_IS_INITIALIZED)
     return ZE_RESULT_ERROR_UNINITIALIZED;
@@ -200,9 +200,9 @@ ze_result_t zeDriverGet(uint32_t *count, ze_driver_handle_t *handles) {
   return ZE_RESULT_SUCCESS;
 }
 
-ze_result_t zeDeviceGet(ze_driver_handle_t drv, uint32_t *count,
-                        ze_device_handle_t *handles) {
-  if (call_limit(2, "zeDeviceGet"))
+ze_result_t zesDeviceGet(zes_driver_handle_t drv, uint32_t *count,
+                         zes_device_handle_t *handles) {
+  if (call_limit(2, "zesDeviceGet"))
     return ZE_RESULT_ERROR_DEVICE_LOST;
   if (drv != DRV_HANDLE)
     return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
@@ -225,7 +225,7 @@ ze_result_t zeDeviceGet(ze_driver_handle_t drv, uint32_t *count,
 /* mock up level-zero core device handling API, called during gpu_init() */
 
 static ze_result_t dev_args_check(int callbit, const char *name,
-                                  ze_device_handle_t dev, void *type) {
+                                  zes_device_handle_t dev, void *type) {
   if (call_limit(callbit, name))
     return ZE_RESULT_ERROR_DEVICE_LOST;
   if (dev != DEV_HANDLE)
@@ -237,21 +237,10 @@ static ze_result_t dev_args_check(int callbit, const char *name,
   return ZE_RESULT_SUCCESS;
 }
 
-ze_result_t zeDeviceGetProperties(ze_device_handle_t dev,
-                                  ze_device_properties_t *props) {
-  ze_result_t ret = dev_args_check(3, "zeDeviceGetProperties", dev, props);
-  if (ret == ZE_RESULT_SUCCESS) {
-    assert(!props->pNext);
-    memset(props, 0, sizeof(*props));
-    props->type = ZE_DEVICE_TYPE_GPU;
-  }
-  return ret;
-}
-
 ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t dev, uint32_t *count,
                                         ze_device_memory_properties_t *props) {
   ze_result_t ret =
-      dev_args_check(4, "zeDeviceGetMemoryProperties", dev, count);
+      dev_args_check(3, "zeDeviceGetMemoryProperties", dev, count);
   if (ret != ZE_RESULT_SUCCESS)
     return ret;
   if (!*count) {
@@ -279,15 +268,15 @@ ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t dev, uint32_t *count,
     return ret;                                                                \
   }
 
-DEV_GET_SET_STRUCT(5, zesDeviceGetProperties, zes_device_properties_t, )
-DEV_GET_SET_STRUCT(6, zesDevicePciGetProperties, zes_pci_properties_t, )
-DEV_GET_SET_STRUCT(7, zesDeviceGetState, zes_device_state_t,
+DEV_GET_SET_STRUCT(4, zesDeviceGetProperties, zes_device_properties_t, )
+DEV_GET_SET_STRUCT(5, zesDevicePciGetProperties, zes_pci_properties_t, )
+DEV_GET_SET_STRUCT(6, zesDeviceGetState, zes_device_state_t,
                    to_zero->reset = (ZES_RESET_REASON_FLAG_WEDGED |
                                      ZES_RESET_REASON_FLAG_REPAIR))
-DEV_GET_SET_STRUCT(8, zesDeviceGetEccState, zes_device_ecc_properties_t,
+DEV_GET_SET_STRUCT(7, zesDeviceGetEccState, zes_device_ecc_properties_t,
                    to_zero->currentState = ZES_DEVICE_ECC_STATE_ENABLED)
 
-#define INIT_CALL_FUNCS 9
+#define INIT_CALL_FUNCS 8
 #define INIT_CALL_BITS (((uint64_t)1 << INIT_CALL_FUNCS) - 1)
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
ChangeLog: gpu_sysman: switch from zeInit() to zesInit() for Xe KMD support

LevelZero spec v1.5 introduced `zesInit()`, and deprecated `zeInit()`, for initializing Sysman part of L0: https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#initialization

Another motivation for introducing this, is L0 Intel backend supporting the new Xe KMD (for the future GPUs [1]), in addition to earlier i915 KMD (for current Intel GPUs), only when Sysman is initialized with `zesInit()`.

Changing to `zesInit()` requires also dropping use of L0 core API functions, and using only L0 Sysman API ones, which is not an exact match.  Therefore:
* Some of the information logged at plugin init (when GpuInfo option is used) needed to be dropped
* `pci_dev` (PCI device ID) label value needs to be digged from sysfs
* There are also few other minor changes to the logged GPU info

`dev_name` label (matching one used by Intel XPU Manager) is added for user-friendly device name.

(Its name can be changed to OTEL compatible one along with other device specific labels when switching to resources attributes.)

This is on top of another PR, which should be merged before this: #4177.

----

[1] I've tested this with current HW using Xe KMD experimental support for them: https://docs.kernel.org/gpu/rfc/xe.html