### PR TITLE
Clang: Fix build failure

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -470,7 +470,10 @@ static int bind_parse_generic_name_value(const char *xpath_expression, /* {{{ */
     return -1;
   }
 
+#if COLLECT_DEBUG
   int num_entries = 0;
+#endif
+
   /* Iterate over all matching nodes. */
   for (int i = 0; xpathObj->nodesetval && (i < xpathObj->nodesetval->nodeNr);
        i++) {
@@ -510,8 +513,11 @@ static int bind_parse_generic_name_value(const char *xpath_expression, /* {{{ */
       }
 
       status = (*list_callback)(name, value, current_time, user_data);
+
+#if COLLECT_DEBUG
       if (status == 0)
         num_entries++;
+#endif
 
       xmlFree(name);
     }
@@ -549,7 +555,10 @@ static int bind_parse_generic_value_list(const char *xpath_expression, /* {{{ */
     return -1;
   }
 
+#if COLLECT_DEBUG
   int num_entries = 0;
+#endif
+
   /* Iterate over all matching nodes. */
   for (int i = 0; xpathObj->nodesetval && (i < xpathObj->nodesetval->nodeNr);
        i++) {
@@ -572,8 +581,11 @@ static int bind_parse_generic_value_list(const char *xpath_expression, /* {{{ */
         continue;
 
       status = (*list_callback)(node_name, value, current_time, user_data);
+
+#if COLLECT_DEBUG
       if (status == 0)
         num_entries++;
+#endif
     }
   }
 
@@ -609,7 +621,10 @@ static int bind_parse_generic_name_attr_value_list(
     return -1;
   }
 
+#if COLLECT_DEBUG
   int num_entries = 0;
+#endif
+
   /* Iterate over all matching nodes. */
   for (int i = 0; xpathObj->nodesetval && (i < xpathObj->nodesetval->nodeNr);
        i++) {
@@ -641,8 +656,11 @@ static int bind_parse_generic_name_attr_value_list(
       }
 
       status = (*list_callback)(attr_name, value, current_time, user_data);
+
+#if COLLECT_DEBUG
       if (status == 0)
         num_entries++;
+#endif
 
       xmlFree(attr_name);
     }


### PR DESCRIPTION
Clang complains about a variable being unused because in the non-debug builds, we don't end up using its value. This commit fixes it.

Addresses: #4305 