### PR TITLE
add MariaDB to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Features
       Information provided by serial multimeters, such as the `Metex M-4650CR`.
 
     - mysql
-      MySQL server statistics: Commands issued, handlers triggered, thread
+      MariaDB and MySQL server statistics: Commands issued, handlers triggered, thread
       usage, query cache utilization and traffic/octets sent and received.
 
     - netapp


### PR DESCRIPTION
As per discussion in https://github.com/collectd/collectd/issues/4323 . 

I doubt there are any problems with MariaDB. It is the default running in most distros - in Debian since 2017 and on Fedora since 2015 (if I remember correctly). If you are not getting bug reports from Debian/Fedora users, then collectd probably does not have any particular issues with MariaDB. 

ChangeLog: Update the README to include MariaDB.