### PR TITLE
Fix lcc_receive

### DIFF
--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -309,7 +309,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
     ptr++;
 
   /* Now copy the message. */
-  strncpy(res.message, ptr, sizeof(res.message));
+  strncpy(res.message, ptr, sizeof(res.message) - 1);
   res.message[sizeof(res.message) - 1] = '\0';
 
   /* Error or no lines follow: We're done. */

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -163,7 +163,7 @@ static char *sstrerror(int errnum, char *buf, size_t buflen) {
                 buflen);
     }
   }
-    /* #endif STRERROR_R_CHAR_P */
+  /* #endif STRERROR_R_CHAR_P */
 
 #else
   if (strerror_r(errnum, buf, buflen) != 0) {


### PR DESCRIPTION
ChangeLog: collectd: The unit has been substracted to pass gcc stringop-truncation warning in lcc_receive function

The warning has been observed with gcc v14.2.1