### PR TITLE
configure.ac: fix protoc version check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4897,13 +4897,16 @@ AC_PATH_PROG([PROTOC], [protoc])
 have_protoc3="no"
 if test "x$PROTOC" != "x"; then
   AC_MSG_CHECKING([for protoc 3.0.0+])
-  if $PROTOC --version | $EGREP libprotoc.3 >/dev/null; then
-    protoc3="yes (`$PROTOC --version`)"
-    have_protoc3="yes"
-  else
-    protoc3="no (`$PROTOC --version`)"
-  fi
-  AC_MSG_RESULT([$protoc3])
+  AC_SUBST([PROTOC_VERSION], [`$PROTOC --version | cut -d ' ' -f 2`])
+  AX_COMPARE_VERSION([$PROTOC_VERSION],[ge],[3],
+    [
+      have_protoc3="yes"
+      AC_MSG_RESULT([yes ($PROTOC_VERSION)])
+    ],
+    [
+      AC_MSG_RESULT([no ($PROTOC_VERSION)])
+    ]
+  )
 fi
 AM_CONDITIONAL([HAVE_PROTOC3], [test "x$have_protoc3" = "xyes"])
 


### PR DESCRIPTION
The current version check for `3.0.0+` fails to handle cases where protoc is above version `3.0.0` but does not start with a `3`, for example protoc may have a version of `28.1`.

To fix this use `AX_COMPARE_VERSION` to properly compare the version.