### PR TITLE
Fix: for issue 3314 and 3856

### DIFF
--- a/src/smart.c
+++ b/src/smart.c
@@ -151,7 +151,8 @@ static int create_ignorelist_by_serial(ignorelist_t *il) {
         name++;
 
       if (ignorelist_match(ignorelist, name) == 0) {
-        // Allow ignored devices with no serial to carry over to serial ignore list
+        // Allow ignored devices with no serial to carry over to serial ignore
+        // list
         if (!serial)
           serial = name;
         ignorelist_add(ignorelist_by_serial, serial);

--- a/src/smart.c
+++ b/src/smart.c
@@ -150,7 +150,10 @@ static int create_ignorelist_by_serial(ignorelist_t *il) {
       if (name[0] == '/')
         name++;
 
-      if (ignorelist_match(ignorelist, name) == 0 && serial != NULL) {
+      if (ignorelist_match(ignorelist, name) == 0) {
+        // Allow ignored devices with no serial to carry over to serial ignore list
+        if (!serial)
+          serial = name;
         ignorelist_add(ignorelist_by_serial, serial);
       }
     }


### PR DESCRIPTION
ChangeLog: smart plugin:  When UseSerial is enabled, allow configured ignored disk names to be copied to the serial ignore list for devices without serials.

When UseSerial is enabled, the existing code in create_ignorelist_by_serial has a condition that requires the device serial to be non-null to allow the ignore value from the config disk ignore list to carry over to the serial ignore list.

This change allows the config disk ignored value to carry over to the serial ignore list.

Note that without this change, it is not presently possible to ignore loop and raid devices such as /dev/loop1 and /dev/md127, as described in issue 3314.

Fixes #3314 
Fixes #3856 