### PR TITLE
Added note about sparse data being late in large packets.

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -6340,6 +6340,10 @@ signature):
    </Server>
  </Plugin>
 
+Packets are sent once full.  If data is produced slowly then packets can arrive
+at the server late enough to cause C<FAILURE> notifications about missing
+values.
+
 =over 4
 
 =item B<E<lt>Server> I<Host> [I<Port>]B<E<gt>>


### PR DESCRIPTION
Just a note for the `collectd.conf` man page (in the section for the Network plugin) that data can be late and cause FAILURE notifications if there isn't enough data to fill a packet in time.  It took me a while to figure this out!