### PR TITLE
fix smart: Fix stack smashing when use incorrect NVME_SMART_CDW10 value

### DIFF
--- a/src/smart.c
+++ b/src/smart.c
@@ -320,9 +320,10 @@ static int smart_read_nvme_disk(const char *dev, char const *name) {
 
   /**
    * Prepare Get Log Page command
-   * Fill following fields (see NVMe 1.4 spec, section 5.14.1)
-   * - Number of DWORDS (bits 27:16) - the struct that will be passed for
-   *   filling has 512 bytes which gives 128 (0x80) DWORDS
+   * Fill following fields (see NVMe 2.1 spec, section 5.1.12)
+   * - Number of DWORDS (bits 31:16) - 0's based value.
+   *   This means that the value will be 0x7F for a 512 byte structure (0x80
+   * DWORD)
    * - Log Page Indentifier (bits 7:0) - for SMART the id is 0x02
    */
 

--- a/src/smart.c
+++ b/src/smart.c
@@ -45,7 +45,7 @@
 #endif
 
 #define O_RDWR 02
-#define NVME_SMART_CDW10 0x00800002
+#define NVME_SMART_CDW10(numdl) (((((numdl) >> 2) - 1) << 16) | 0x00000002)
 #define SHIFT_BYTE_LEFT 256
 #define PLUGIN_NAME "smart"
 struct nvme_admin_cmd {
@@ -331,7 +331,7 @@ static int smart_read_nvme_disk(const char *dev, char const *name) {
                                           .nsid = NVME_NSID_ALL,
                                           .addr = (unsigned long)&smart_log,
                                           .data_len = sizeof(smart_log),
-                                          .cdw10 = NVME_SMART_CDW10});
+                                          .cdw10 = NVME_SMART_CDW10(sizeof(smart_log))});
   if (status < 0) {
     ERROR(PLUGIN_NAME ": ioctl for NVME_IOCTL_ADMIN_CMD failed with %s\n",
           strerror(errno));

--- a/src/smart.c
+++ b/src/smart.c
@@ -326,12 +326,13 @@ static int smart_read_nvme_disk(const char *dev, char const *name) {
    * - Log Page Indentifier (bits 7:0) - for SMART the id is 0x02
    */
 
-  status = ioctl(fd, NVME_IOCTL_ADMIN_CMD,
-                 &(struct nvme_admin_cmd){.opcode = NVME_ADMIN_GET_LOG_PAGE,
-                                          .nsid = NVME_NSID_ALL,
-                                          .addr = (unsigned long)&smart_log,
-                                          .data_len = sizeof(smart_log),
-                                          .cdw10 = NVME_SMART_CDW10(sizeof(smart_log))});
+  status = ioctl(
+      fd, NVME_IOCTL_ADMIN_CMD,
+      &(struct nvme_admin_cmd){.opcode = NVME_ADMIN_GET_LOG_PAGE,
+                               .nsid = NVME_NSID_ALL,
+                               .addr = (unsigned long)&smart_log,
+                               .data_len = sizeof(smart_log),
+                               .cdw10 = NVME_SMART_CDW10(sizeof(smart_log))});
   if (status < 0) {
     ERROR(PLUGIN_NAME ": ioctl for NVME_IOCTL_ADMIN_CMD failed with %s\n",
           strerror(errno));

--- a/src/smart_test.c
+++ b/src/smart_test.c
@@ -56,7 +56,7 @@ int ioctl(int __fd, unsigned long int __request, ...) {
           (struct nvme_additional_smart_log *)addr;
       intel_smart_log->program_fail_cnt.norm = 100;
       return 0;
-    } else if (admin_cmd->cdw10 == NVME_SMART_CDW10) {
+    } else if (admin_cmd->cdw10 == NVME_SMART_CDW10(sizeof(union nvme_smart_log))) {
       // set generic smart attributes
       union nvme_smart_log *smart_log = (union nvme_smart_log *)addr;
       smart_log->data.critical_warning = 0;

--- a/src/smart_test.c
+++ b/src/smart_test.c
@@ -56,7 +56,8 @@ int ioctl(int __fd, unsigned long int __request, ...) {
           (struct nvme_additional_smart_log *)addr;
       intel_smart_log->program_fail_cnt.norm = 100;
       return 0;
-    } else if (admin_cmd->cdw10 == NVME_SMART_CDW10(sizeof(union nvme_smart_log))) {
+    } else if (admin_cmd->cdw10 ==
+               NVME_SMART_CDW10(sizeof(union nvme_smart_log))) {
       // set generic smart attributes
       union nvme_smart_log *smart_log = (union nvme_smart_log *)addr;
       smart_log->data.critical_warning = 0;


### PR DESCRIPTION
ChangeLog:  smart: Fix stack smashing when use incorrect NVME_SMART_CDW10 value

I'm faced that a collectd crash when trying to get a Smart from an NVMe disk
on an arm64 machine. The problem is due to the wrong amount of information being
requested in the ioctl call.


/etc/collectd/collectd.conf

```
<Plugin "smart">
    Disk "nvme0n1"
    IgnoreSelected false
</Plugin>
```

valgrind collectd -f

```
*** stack smashing detected ***: terminated
==861185==
==861185== Process terminating with default action of signal 6 (SIGABRT)
==861185==    at 0x4970A60: __pthread_kill_implementation (pthread_kill.c:44)
==861185==    by 0x492A72B: raise (raise.c:26)
==861185==    by 0x491747B: abort (abort.c:79)
==861185==    by 0x4964AAB: __libc_message (libc_fatal.c:156)
==861185==    by 0x49E7857: __fortify_fail (fortify_fail.c:26)
==861185==    by 0x49E7823: __stack_chk_fail (stack_chk_fail.c:24)
==861185==    by 0x6722117: smart_read_nvme_disk (smart.c:375)
==861185==    by 0x6722897: smart_handle_disk (smart.c:566)
==861185==    by 0x6722897: smart_read (smart.c:628)
==861185==    by 0x11936F: plugin_read_thread (plugin.c:533)
==861185==    by 0x496EE9F: start_thread (pthread_create.c:442)
==861185==    by 0x49D7B1B: thread_start (clone.S:79)
==861185==
```

Fix based according information:

NVM Express® Base Specification, Revision 2.1
Figure 197: Get Log Page – Command Dword 10
