### PR TITLE
src: fix memory leak in config parser in write_syslog.c

### DIFF
--- a/src/write_syslog.c
+++ b/src/write_syslog.c
@@ -591,6 +591,7 @@ static int ws_config_tsd(oconfig_item_t *ci) {
       ERROR("write_syslog plugin: Invalid configuration "
             "option: %s.",
             child->key);
+      ws_callback_free(cb);
       return -1;
     }
   }


### PR DESCRIPTION
Static analyzer detected (write_syslog.c:562):
- Memory allocated for `cb` via `calloc()` was lost when returning -1 due to invalid config options (before line 594)

Root cause:
- The function `ws_config_tsd()` could return early on config errors without freeing `cb`, while successful path used `user_data.free_func` for cleanup.

Fix:
- Added explicit cleanup with `ws_callback_free(cb)` before all error returns
- Only one error return path needed fixing (invalid option case)
- Success path still uses automatic cleanup via `user_data.free_func`

Impact:
- Fixes memory leak that could occur on every invalid configuration
- No behavioral changes for valid configurations
- Maintains existing cleanup strategy

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>