### PR TITLE
src: daemon: fix memory leak in plugin_register_cache_event()

### DIFF
--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -1336,6 +1336,7 @@ EXPORT int plugin_register_cache_event(const char *name,
   if (list_cache_event_num >= 32) {
     P_ERROR("plugin_register_cache_event: Too much cache event callbacks tried "
             "to be registered.");
+    free(name_copy);
     free_userdata(ud);
     return ENOMEM;
   }

--- a/src/write_syslog.c
+++ b/src/write_syslog.c
@@ -591,6 +591,7 @@ static int ws_config_tsd(oconfig_item_t *ci) {
       ERROR("write_syslog plugin: Invalid configuration "
             "option: %s.",
             child->key);
+      ws_callback_free(cb);
       return -1;
     }
   }


### PR DESCRIPTION
Static analyzer detected:
- Memory leak in plugin.c: (strdup(name)) when returning ENOMEM
  due to callback limit (list_cache_event_num >= 32).

Fix:
- Added free(name_copy) before return ENOMEM in the limit check branch.

Impact:
- Prevents memory leak when too many callbacks are registered.
- Matches existing cleanup pattern in other error paths.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov [ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)