### PR TITLE
src: add NULL check for severity in logparser_config_message

### DIFF
--- a/src/logparser.c
+++ b/src/logparser.c
@@ -285,6 +285,10 @@ static int logparser_config_message(const oconfig_item_t *ci, char *filename,
       ret = cf_util_get_string(child, &parser->def_type_inst);
     else if (strcasecmp("DefaultSeverity", child->key) == 0) {
       ret = cf_util_get_string(child, &severity);
+      if (ret != 0) {
+        ERROR(PLUGIN_NAME ": Error getting DefaultSeverity value");
+        goto error;
+      }
       if (strcasecmp(LOGPARSER_SEV_OK_STR, severity) == 0)
         parser->def_severity = NOTIF_OKAY;
       else if (strcasecmp(LOGPARSER_SEV_WARN_STR, severity) == 0)


### PR DESCRIPTION
Static analyzer detected
After having been assigned to a NULL value at logparser.c:248, pointer 'severity' is dereferenced at logparser.c:288 by calling function 'strcasecmp'.

- Added return value check for cf_util_get_string()
- Prevents potential NULL dereference in strcasecmp()
- Improves error handling consistency

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov [ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)

ChangeLog: src: add NULL check for severity in logparser_config_message