### PR TITLE
configure.ac: use pkg-config to find libgcrypt (collectd-6.0)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -649,8 +649,7 @@ libcollectdclient_la_LDFLAGS += -shared -no-undefined
 libcollectdclient_la_LIBADD += -lgnu -lws2_32 -liphlpapi
 endif
 if BUILD_WITH_LIBGCRYPT
-libcollectdclient_la_CPPFLAGS += $(GCRYPT_CPPFLAGS)
-libcollectdclient_la_LDFLAGS += $(GCRYPT_LDFLAGS)
+libcollectdclient_la_CPPFLAGS += $(GCRYPT_CFLAGS)
 libcollectdclient_la_LIBADD += $(GCRYPT_LIBS)
 endif
 
@@ -662,8 +661,7 @@ test_libcollectd_network_parse_CPPFLAGS = \
 	-I$(srcdir)/src/libcollectdclient \
 	-I$(top_builddir)/src/libcollectdclient
 if BUILD_WITH_LIBGCRYPT
-test_libcollectd_network_parse_CPPFLAGS += $(GCRYPT_CPPFLAGS)
-test_libcollectd_network_parse_LDFLAGS = $(GCRYPT_LDFLAGS)
+test_libcollectd_network_parse_CPPFLAGS += $(GCRYPT_CFLAGS)
 test_libcollectd_network_parse_LDADD = $(GCRYPT_LIBS)
 endif
 
@@ -1629,16 +1627,15 @@ if BUILD_WITH_LIBSOCKET
 network_la_LIBADD += -lsocket
 endif
 if BUILD_WITH_LIBGCRYPT
-network_la_CPPFLAGS += $(GCRYPT_CPPFLAGS)
-network_la_LDFLAGS += $(GCRYPT_LDFLAGS)
+network_la_CPPFLAGS += $(GCRYPT_CFLAGS)
 network_la_LIBADD += $(GCRYPT_LIBS)
 endif
 
 test_plugin_network_SOURCES = \
 	src/network_test.c \
 	src/utils_fbhash.c
-test_plugin_network_CPPFLAGS = $(AM_CPPFLAGS) $(GCRYPT_CPPFLAGS)
-test_plugin_network_LDFLAGS = $(PLUGIN_LDFLAGS) $(GCRYPT_LDFLAGS)
+test_plugin_network_CPPFLAGS = $(AM_CPPFLAGS) $(GCRYPT_CFLAGS)
+test_plugin_network_LDFLAGS = $(PLUGIN_LDFLAGS)
 test_plugin_network_LDADD = \
 	libavltree.la \
 	libplugin_mock.la \

--- a/configure.ac
+++ b/configure.ac
@@ -2685,48 +2685,27 @@ AC_SUBST(GANGLIA_LIBS)
 # }}}
 
 # --with-libgcrypt {{{
-GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS"
-GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS"
-GCRYPT_LIBS="$GCRYPT_LIBS"
 AC_ARG_WITH([libgcrypt],
-  [AS_HELP_STRING([--with-libgcrypt@<:@=PREFIX@:>@], [Path to libgcrypt.])],
+  [AS_HELP_STRING([--with-libgcrypt], [Use libgcrypt (default is auto)])],
   [
-    if test -f "$withval" && test -x "$withval"; then
-      with_libgcrypt_config="$withval"
-      with_libgcrypt="yes"
-    else if test -f "$withval/bin/gcrypt-config" && test -x "$withval/bin/gcrypt-config"; then
-      with_libgcrypt_config="$withval/bin/gcrypt-config"
-      with_libgcrypt="yes"
-    else if test -d "$withval"; then
-      GCRYPT_CPPFLAGS="$GCRYPT_CPPFLAGS -I$withval/include"
-      GCRYPT_LDFLAGS="$GCRYPT_LDFLAGS -L$withval/lib"
-      with_libgcrypt="yes"
-    else
-      with_libgcrypt_config="gcrypt-config"
-      with_libgcrypt="$withval"
-    fi; fi; fi
+    with_libgcrypt="$withval"
+    if test "x$withval" = "xno"; then
+      with_libgcrypt="no (disabled on command line)"
+    fi
   ],
-  [
-    with_libgcrypt_config="libgcrypt-config"
-    with_libgcrypt="yes"
-  ]
+  [with_libgcrypt="yes"]
 )
 
-if test "x$with_libgcrypt" = "xyes" && test "x$with_libgcrypt_config" != "x"; then
-  if test "x$GCRYPT_CPPFLAGS" = "x"; then
-    GCRYPT_CPPFLAGS=`"$with_libgcrypt_config" --cflags 2>/dev/null`
-  fi
-
-  if test "x$GCRYPT_LIBS" = "x"; then
-    GCRYPT_LIBS=`"$with_libgcrypt_config" --libs 2>/dev/null`
-  fi
+if test "x$with_libgcrypt" = "xyes"; then
+  PKG_CHECK_MODULES([GCRYPT], [libgcrypt],
+    [],
+    [with_libgcrypt="no (pkg-config could not find libgcrypt)"]
+  )
 fi
 
 SAVE_CPPFLAGS="$CPPFLAGS"
-SAVE_LDFLAGS="$LDFLAGS"
 SAVE_LIBS="$LIBS"
-CPPFLAGS="$CPPFLAGS $GCRYPT_CPPFLAGS"
-LDFLAGS="$LDFLAGS $GCRYPT_LDFLAGS"
+CPPFLAGS="$CPPFLAGS $GCRYPT_CFLAGS"
 LIBS="$LIBS $GCRYPT_LIBS"
 
 if test "x$with_libgcrypt" = "xyes"; then
@@ -2737,18 +2716,16 @@ if test "x$with_libgcrypt" = "xyes"; then
 fi
 
 if test "x$with_libgcrypt" = "xyes"; then
-  AC_CHECK_LIB(gcrypt, gcry_md_hash_buffer,
+  AC_CHECK_FUNC([gcry_md_hash_buffer],
     [with_libgcrypt="yes"],
     [with_libgcrypt="no (symbol gcry_md_hash_buffer not found)"]
   )
 fi
 
 CPPFLAGS="$SAVE_CPPFLAGS"
-LDFLAGS="$SAVE_LDFLAGS"
 LIBS="$SAVE_LIBS"
 
-AC_SUBST([GCRYPT_CPPFLAGS])
-AC_SUBST([GCRYPT_LDFLAGS])
+AC_SUBST([GCRYPT_CFLAGS])
 AC_SUBST([GCRYPT_LIBS])
 AM_CONDITIONAL([BUILD_WITH_LIBGCRYPT], [test "x$with_libgcrypt" = "xyes"])
 # }}}


### PR DESCRIPTION
ChangeLog: configure: use pkg-config rather than libgcrypt-config when searching for libgcrypt

Rebase of #4355 for the `collectd-6.0` branch as requested.