### PR TITLE
Fix build due to error in curl_easy_setopt

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -57,7 +57,7 @@ struct web_page_s /* {{{ */
   char *instance;
 
   char *url;
-  int address_family;
+  long address_family;
   char *user;
   char *pass;
   char *credentials;

--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -88,7 +88,7 @@ struct cj_s /* {{{ */
   char *sock;
 
   char *url;
-  int address_family;
+  long address_family;
   char *user;
   char *pass;
   char *credentials;

--- a/src/curl_xml.c
+++ b/src/curl_xml.c
@@ -76,7 +76,7 @@ struct cx_s /* {{{ */
   char *host;
 
   char *url;
-  int address_family;
+  long address_family;
   char *user;
   char *pass;
   char *credentials;


### PR DESCRIPTION
The builds are failing due to error like:

src/curl.c:349:3: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
  349 |   curl_easy_setopt(wp->curl, CURLOPT_IPRESOLVE, wp->address_family);

src/curl_xml.c:740:3: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
  740 |   curl_easy_setopt(db->curl, CURLOPT_IPRESOLVE, db->address_family);

src/curl_json.c:586:3: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
  586 |   curl_easy_setopt(db->curl, CURLOPT_IPRESOLVE, db->address_family);

The error were seen during a rebuild in Ubuntu.

ChangeLog: Fix build failure due to wrong argument type in curl_easy_setopt