### PR TITLE
Fix lcc_receive

### DIFF
--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -309,7 +309,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
     ptr++;
 
   /* Now copy the message. */
-  strncpy(res.message, ptr, sizeof(res.message));
+  strncpy(res.message, ptr, sizeof(res.message) - 1);
   res.message[sizeof(res.message) - 1] = '\0';
 
   /* Error or no lines follow: We're done. */


### PR DESCRIPTION
Issue #4331 is still present in `main` branch. Here we backport fixing commit from 6.0.

ChangeLog: collectd: The unit has been substracted to pass gcc stringop-truncation warning in lcc_receive function