### PR TITLE
virt: Drop ATTRIBUTE_UNUSED for virt_eventloop_timeout_cb

### DIFF
--- a/src/virt.c
+++ b/src/virt.c
@@ -2206,8 +2206,9 @@ static int domain_lifecycle_event_cb(__attribute__((unused)) virConnectPtr con_,
   return 0;
 }
 
-static void virt_eventloop_timeout_cb(int timer ATTRIBUTE_UNUSED,
-                                      void *timer_info) {}
+static void
+virt_eventloop_timeout_cb(__attribute__((unused)) int timer,
+                          __attribute__((unused)) void *timer_info) {}
 
 static int register_event_impl(void) {
   if (virEventRegisterDefaultImpl() < 0) {


### PR DESCRIPTION
ATTRIBUTE_UNUSED seems to be never was a public part of the libvirt interface and leads to the following issue with recent libvirt versions were ATTRIBUTE_UNUSED has been renamed to G_GNUC_UNUSED:

```
src/virt.c:2209:49: error: expected ';', ',' or ')' before 'ATTRIBUTE_UNUSED'
 2209 | static void virt_eventloop_timeout_cb(int timer ATTRIBUTE_UNUSED,
      |                                                 ^~~~~~~~~~~~~~~~
src/virt.c: In function 'register_event_impl':
src/virt.c:2222:26: error: 'virt_eventloop_timeout_cb' undeclared (first use in this function)
 2222 |                          virt_eventloop_timeout_cb, NULL, NULL) < 0) {
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~
src/virt.c:2222:26: note: each undeclared identifier is reported only once for each function it appears in
```

Drop ATTRIBUTE_UNUSED here as there is little use from it.

ChangeLog: Fix build with up-to-date libvirt.