### PR TITLE
configure.ac: ensure PERL_BINDINGS_OPTIONS gets the prefix with a correct value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7471,6 +7471,7 @@ AC_SUBST([LOAD_PLUGIN_NETWORK])
 AC_SUBST([LOAD_PLUGIN_CSV])
 
 dnl Perl bindings
+test "x$prefix" = xNONE && prefix=$ac_default_prefix
 PERL_BINDINGS_OPTIONS="PREFIX=${prefix}"
 AC_ARG_WITH(perl-bindings, [AS_HELP_STRING([--with-perl-bindings@<:@=OPTIONS@:>@], [Options passed to "perl Makefile.PL".])],
 [


### PR DESCRIPTION
The generated configure script always gets the prefix with a value of NONE so that files (e.g. .packlist) in buildperl cannot be installed correctly. Try to fix the following error of make uninstall:
./build.sh
...
./configure && make && make install
...
make uninstall
...
/usr/bin/perl -I/opt/collectd ./bindings/perl/uninstall_mod.pl Collectd Collectd is not installed at ./bindings/perl/uninstall_mod.pl line 8. make: *** [Makefile:12003: uninstall-local] Error 2

ChangeLog: Fix build error for make uninstall