### PR TITLE
fix: for TypeInstanceOID, PluginOID or HostOID being outside of the direct scope of Values. Fixes bug where collectd discards metrics collected from SNMP tables augmenting another table.

### DIFF
--- a/src/snmp.c
+++ b/src/snmp.c
@@ -179,8 +179,7 @@ static bool csnmp_suffix_within(oid_t const *prefix, oid_t const *full) {
 }
 
 static bool csnmp_suffixes_align(oid_t const *left, oid_t const *right) {
-  return csnmp_suffix_within(left, right) ||
-         csnmp_suffix_within(right, left);
+  return csnmp_suffix_within(left, right) || csnmp_suffix_within(right, left);
 }
 
 static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
@@ -1478,7 +1477,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
 
     /* Update hostname_cell_ptr to point expected suffix */
     if (hostname_cells != NULL) {
-      while ((hostname_cell_ptr != NULL) &&
+      while (
+          (hostname_cell_ptr != NULL) &&
           !csnmp_suffixes_align(&hostname_cell_ptr->suffix, &current_suffix) &&
           (csnmp_oid_compare(&hostname_cell_ptr->suffix, &current_suffix) < 0))
         hostname_cell_ptr = hostname_cell_ptr->next;
@@ -1517,9 +1517,10 @@ static int csnmp_dispatch_table(host_definition_t *host,
     /* Update all the value_cell_ptr to point at the entry with the same
      * trailing partial OID */
     for (i = 0; i < data->values_len; i++) {
-      while ((value_cell_ptr[i] != NULL) &&
-             !csnmp_suffixes_align(&value_cell_ptr[i]->suffix, &current_suffix) &&
-             (csnmp_oid_compare(&value_cell_ptr[i]->suffix, &current_suffix) < 0))
+      while (
+          (value_cell_ptr[i] != NULL) &&
+          !csnmp_suffixes_align(&value_cell_ptr[i]->suffix, &current_suffix) &&
+          (csnmp_oid_compare(&value_cell_ptr[i]->suffix, &current_suffix) < 0))
         value_cell_ptr[i] = value_cell_ptr[i]->next;
 
       if (value_cell_ptr[i] == NULL) {

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -178,6 +178,11 @@ static bool csnmp_suffix_within(oid_t const *prefix, oid_t const *full) {
                             full->oid_len, prefix->oid_len) == 0);
 }
 
+static bool csnmp_suffixes_align(oid_t const *left, oid_t const *right) {
+  return csnmp_suffix_within(left, right) ||
+         csnmp_suffix_within(right, left);
+}
+
 static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
                                oid_t const *o) {
   char oid_str[MAX_OID_LEN][16];

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -156,11 +156,9 @@ static int csnmp_oid_compare(oid_t const *left, oid_t const *right) {
 }
 
 static int csnmp_oid_suffix(oid_t *dst, oid_t const *src, oid_t const *root) {
-  /* Make sure "src" is in "root"s subtree. */
-  if (src->oid_len <= root->oid_len)
-    return EINVAL;
-  if (snmp_oid_ncompare(root->oid, root->oid_len, src->oid, src->oid_len,
-                        /* n = */ root->oid_len) != 0)
+  if ((src->oid_len <= root->oid_len) ||
+      (snmp_oid_ncompare(root->oid, root->oid_len, src->oid, src->oid_len,
+                         root->oid_len) != 0))
     return EINVAL;
 
   memset(dst, 0, sizeof(*dst));
@@ -168,6 +166,16 @@ static int csnmp_oid_suffix(oid_t *dst, oid_t const *src, oid_t const *root) {
   memcpy(dst->oid, &src->oid[root->oid_len],
          dst->oid_len * sizeof(dst->oid[0]));
   return 0;
+}
+
+static bool csnmp_suffix_within(oid_t const *prefix, oid_t const *full) {
+  if (prefix->oid_len == 0)
+    return full->oid_len == 0;
+  if (prefix->oid_len > full->oid_len)
+    return false;
+
+  return (snmp_oid_ncompare(prefix->oid, prefix->oid_len, full->oid,
+                            full->oid_len, prefix->oid_len) == 0);
 }
 
 static int csnmp_oid_to_string(char *buffer, size_t buffer_size,
@@ -1444,6 +1452,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
     /* Update plugin_instance_cell_ptr to point expected suffix */
     if (plugin_instance_cells != NULL) {
       while ((plugin_instance_cell_ptr != NULL) &&
+             !csnmp_suffixes_align(&plugin_instance_cell_ptr->suffix,
+                                   &current_suffix) &&
              (csnmp_oid_compare(&plugin_instance_cell_ptr->suffix,
                                 &current_suffix) < 0))
         plugin_instance_cell_ptr = plugin_instance_cell_ptr->next;
@@ -1453,8 +1463,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
         continue;
       }
 
-      if (csnmp_oid_compare(&plugin_instance_cell_ptr->suffix,
-                            &current_suffix) > 0) {
+      if (!csnmp_suffixes_align(&plugin_instance_cell_ptr->suffix,
+                                &current_suffix)) {
         /* This suffix is missing in the subtree. Indicate this with the
          * "suffix_skipped" flag and try the next instance / suffix. */
         suffix_skipped = 1;
@@ -1463,8 +1473,8 @@ static int csnmp_dispatch_table(host_definition_t *host,
 
     /* Update hostname_cell_ptr to point expected suffix */
     if (hostname_cells != NULL) {
-      while (
-          (hostname_cell_ptr != NULL) &&
+      while ((hostname_cell_ptr != NULL) &&
+          !csnmp_suffixes_align(&hostname_cell_ptr->suffix, &current_suffix) &&
           (csnmp_oid_compare(&hostname_cell_ptr->suffix, &current_suffix) < 0))
         hostname_cell_ptr = hostname_cell_ptr->next;
 
@@ -1473,7 +1483,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
         continue;
       }
 
-      if (csnmp_oid_compare(&hostname_cell_ptr->suffix, &current_suffix) > 0) {
+      if (!csnmp_suffixes_align(&hostname_cell_ptr->suffix, &current_suffix)) {
         /* This suffix is missing in the subtree. Indicate this with the
          * "suffix_skipped" flag and try the next instance / suffix. */
         suffix_skipped = 1;
@@ -1483,6 +1493,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
     /* Update filter_cell_ptr to point expected suffix */
     if (filter_cells != NULL) {
       while ((filter_cell_ptr != NULL) &&
+             !csnmp_suffixes_align(&filter_cell_ptr->suffix, &current_suffix) &&
              (csnmp_oid_compare(&filter_cell_ptr->suffix, &current_suffix) < 0))
         filter_cell_ptr = filter_cell_ptr->next;
 
@@ -1491,7 +1502,7 @@ static int csnmp_dispatch_table(host_definition_t *host,
         continue;
       }
 
-      if (csnmp_oid_compare(&filter_cell_ptr->suffix, &current_suffix) > 0) {
+      if (!csnmp_suffixes_align(&filter_cell_ptr->suffix, &current_suffix)) {
         /* This suffix is missing in the subtree. Indicate this with the
          * "suffix_skipped" flag and try the next instance / suffix. */
         suffix_skipped = 1;
@@ -1501,16 +1512,16 @@ static int csnmp_dispatch_table(host_definition_t *host,
     /* Update all the value_cell_ptr to point at the entry with the same
      * trailing partial OID */
     for (i = 0; i < data->values_len; i++) {
-      while (
-          (value_cell_ptr[i] != NULL) &&
-          (csnmp_oid_compare(&value_cell_ptr[i]->suffix, &current_suffix) < 0))
+      while ((value_cell_ptr[i] != NULL) &&
+             !csnmp_suffixes_align(&value_cell_ptr[i]->suffix, &current_suffix) &&
+             (csnmp_oid_compare(&value_cell_ptr[i]->suffix, &current_suffix) < 0))
         value_cell_ptr[i] = value_cell_ptr[i]->next;
 
       if (value_cell_ptr[i] == NULL) {
         have_more = 0;
         break;
-      } else if (csnmp_oid_compare(&value_cell_ptr[i]->suffix,
-                                   &current_suffix) > 0) {
+      } else if (!csnmp_suffixes_align(&value_cell_ptr[i]->suffix,
+                                       &current_suffix)) {
         /* This suffix is missing in the subtree. Indicate this with the
          * "suffix_skipped" flag and try the next instance / suffix. */
         suffix_skipped = 1;
@@ -1541,17 +1552,17 @@ static int csnmp_dispatch_table(host_definition_t *host,
                                &value_cell_ptr[i]->suffix) == 0);
     }
     assert((type_instance_cell_ptr == NULL) ||
-           (csnmp_oid_compare(&type_instance_cell_ptr->suffix,
-                              &value_cell_ptr[0]->suffix) == 0));
+           csnmp_suffixes_align(&type_instance_cell_ptr->suffix,
+                                &value_cell_ptr[0]->suffix));
     assert((plugin_instance_cell_ptr == NULL) ||
-           (csnmp_oid_compare(&plugin_instance_cell_ptr->suffix,
-                              &value_cell_ptr[0]->suffix) == 0));
+           csnmp_suffixes_align(&plugin_instance_cell_ptr->suffix,
+                                &value_cell_ptr[0]->suffix));
     assert((hostname_cell_ptr == NULL) ||
-           (csnmp_oid_compare(&hostname_cell_ptr->suffix,
-                              &value_cell_ptr[0]->suffix) == 0));
+           csnmp_suffixes_align(&hostname_cell_ptr->suffix,
+                                &value_cell_ptr[0]->suffix));
     assert((filter_cell_ptr == NULL) ||
-           (csnmp_oid_compare(&filter_cell_ptr->suffix,
-                              &value_cell_ptr[0]->suffix) == 0));
+           csnmp_suffixes_align(&filter_cell_ptr->suffix,
+                                &value_cell_ptr[0]->suffix));
 #endif
 
     /* Check the value in filter column */


### PR DESCRIPTION
Fixes: #4387 

csnmp_dispatch_table() only considers rows where every collected column shares the exact same suffix. In a case where the type-instance column produces .1.23 while Value-column produces .1.23.1, the comparison marks every row as “skipped” and nothing is dispatched, even though the agent returned valid data.
Instead of assuming metadata/value suffixes are identical, introduce a helper that treats two suffixes as aligned when either one is a prefix of the other. The driver loop now advances pointers only when the suffix is both “behind” and not aligned, and accepts rows when the shorter index matches the beginning of the longer one. This lets instance columns live elsewhere in the MIB tree while still labelling values correctly.

ChangeLog: SNMP plugin: Dispatch table values when using augmented tables.
