### PR TITLE
fix: Add JVMArg "-Xrs" to java plugin

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -910,6 +910,8 @@
 #</Plugin>
 
 #<Plugin java>
+# # "-Xrs" is needed in order to avoid JVM to trap "QUIT" and "TERM" 
+#	JVMArg "-Xrs"
 #	JVMArg "-verbose:jni"
 #	JVMArg "-Djava.class.path=@prefix@/share/collectd/java/collectd-api.jar"
 #


### PR DESCRIPTION
If JVM traps "QUIT" and "TERM" signal, it terminates collectd process with exit-code=143:

systemd[1]: Stopping collectd.service - Statistics collection and monitoring daemon...
collectd[1134]: [1454.562s][debug][jni,resolve] [Dynamic-linking native method java.lang.Shutdown.beforeHalt ... JNI]
collectd[1134]: [1454.563s][debug][jni,resolve] [Dynamic-linking native method java.lang.Shutdown.halt0 ... JNI]
systemd[1]: collectd.service: Main process exited, code=exited, status=143/n/a
systemd[1]: collectd.service: Failed with result 'exit-code'.
systemd[1]: Stopped collectd.service - Statistics collection and monitoring daemon.

With "-Xrs" collectd terminates correctly.

systemd[1]: Stopping collectd.service - Statistics collection and monitoring daemon...
collectd[1137]: Exiting normally.
collectd[1137]: collectd: Stopping 5 read threads.
collectd[1137]: collectd: Stopping 5 write threads.
collectd[1137]: rrdtool plugin: Shutting down the queue thread.
collectd[1137]: org.collectd.java.GenericJMX.Shutdown ();
systemd[1]: collectd.service: Deactivated successfully.
systemd[1]: Stopped collectd.service - Statistics collection and monitoring daemon.
systemd[1]: collectd.service: Consumed 44.485s CPU time over 1h 6min 13.210s wall clock time, 1.3G memory peak.

ChangeLog: Java plugin: Add "-Xrs" option