### PR TITLE
src/gpu_nvidia.c: Fix a compiler error since cuda-nvml-devel-13

### DIFF
--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -193,10 +193,20 @@ static int nvml_read(void) {
     if (nv_status == NVML_SUCCESS)
       nvml_submit_gauge(ix, dev_name, "fanspeed", NULL, fan_speed);
 
+#if NVML_API_VERSION >= 13
+    nvmlTemperature_t core_temp;
+    memset(&core_temp, 0, sizeof(core_temp));
+    core_temp.version = nvmlTemperature_v1;
+    core_temp.sensorType = NVML_TEMPERATURE_GPU;
+    TRYOPT(nvmlDeviceGetTemperatureV(dev, &core_temp))
+    if (nv_status == NVML_SUCCESS)
+      nvml_submit_gauge(ix, dev_name, "temperature", "core", core_temp.temperature);
+#else
     unsigned int core_temp;
     TRYOPT(nvmlDeviceGetTemperature(dev, NVML_TEMPERATURE_GPU, &core_temp))
     if (nv_status == NVML_SUCCESS)
       nvml_submit_gauge(ix, dev_name, "temperature", "core", core_temp);
+#endif
 
     unsigned int sm_clk_mhz;
     TRYOPT(nvmlDeviceGetClockInfo(dev, NVML_CLOCK_SM, &sm_clk_mhz))


### PR DESCRIPTION
nvmlDeviceGetTemperature() has been deprecated since cuda-nvml-devel-13. so try to fix the compiler error by adding nvmlDeviceGetTemperatureV(). 
```
src/gpu_nvidia.c: In function 'nvml_read':
src/gpu_nvidia.c:197:5: error: 'nvmlDeviceGetTemperature' is deprecated [-Werror=deprecated-declarations]
  197 |     TRYOPT(nvmlDeviceGetTemperature(dev, NVML_TEMPERATURE_GPU, &core_temp))
      |     ^~~~~~
In file included from src/gpu_nvidia.c:27:
/usr/local/cuda-13.1/include/nvml.h:5706:39: note: declared here
 5706 | DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
      |
```