### PR TITLE
Build system: Honour runstatedir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -284,7 +284,7 @@ collectd_SOURCES += src/daemon/cmd.c
 endif
 
 if BUILD_FEATURE_DAEMON
-collectd_CPPFLAGS += -DPIDFILE='"${localstatedir}/run/${PACKAGE_NAME}.pid"'
+collectd_CPPFLAGS += -DPIDFILE='"${runstatedir}/${PACKAGE_NAME}.pid"'
 endif
 
 # The daemon needs to call sg_init, so we need to link it against libstatgrab,
@@ -2493,7 +2493,7 @@ endif
 endif
 
 install-exec-hook:
-	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run
+	$(mkinstalldirs) $(DESTDIR)$(runstatedir)
 	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/lib/$(PACKAGE_NAME)
 	$(mkinstalldirs) $(DESTDIR)$(localstatedir)/log
 	$(mkinstalldirs) $(DESTDIR)$(sysconfdir)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.60])
+dnl Compatibility with Autoconf < 2.70.
+AC_SUBST([runstatedir], ['${localstatedir}/run'])
 AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
 AC_CONFIG_SRCDIR(src/target_set.c)
 AC_CONFIG_HEADERS(src/config.h)

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -13,7 +13,7 @@
 #Hostname    "localhost"
 #FQDNLookup   true
 #BaseDir     "@localstatedir@/lib/@PACKAGE_NAME@"
-#PIDFile     "@localstatedir@/run/@PACKAGE_NAME@.pid"
+#PIDFile     "@runstatedir@/@PACKAGE_NAME@.pid"
 #PluginDir   "@libdir@/@PACKAGE_NAME@"
 #TypesDB     "@prefix@/share/@PACKAGE_NAME@/types.db"
 
@@ -734,7 +734,7 @@
 #</Plugin>
 
 #<Plugin email>
-#	SocketFile "@localstatedir@/run/@PACKAGE_NAME@-email"
+#	SocketFile "@runstatedir@/@PACKAGE_NAME@-email"
 #	SocketGroup "collectd"
 #	SocketPerms "0770"
 #	MaxConns 5

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -8082,8 +8082,8 @@ In this case please file a bug report with the collectd team.
 =item B<Socket> I<Path>
 
 Configures the path to the UNIX domain socket to be used when connecting to the
-daemon. By default C<${localstatedir}/run/pdns.controlsocket> will be used for
-an authoritative server and C<${localstatedir}/run/pdns_recursor.controlsocket>
+daemon. By default C<${runstatedir}/pdns.controlsocket> will be used for
+an authoritative server and C<${runstatedir}/pdns_recursor.controlsocket>
 will be used for the recursor.
 
 =back


### PR DESCRIPTION
Autoconf 2.70 introduced a `--runstatedir` option, with this comment:

```
  This defaults to ‘${localstatedir}/run’.  It can be used, for
  instance, to place per-process temporary runtime files (such as pid
  files) into ‘/run’ instead of ‘/var/run’.
```

On systems where `/var/run` is just a compatibility symlink, it would be nice to be able to configure collectd to use `/run` directly rather than relying on that.

This command-line option is only available when `configure` was built with Autoconf >= 2.70.

ChangeLog: Build system: Honour the "--runstatedir" configure option.