### PR TITLE
curl_json: recreate easy handles after resolve failures

### DIFF
--- a/src/curl_json.c
+++ b/src/curl_json.c
@@ -118,6 +118,7 @@ typedef unsigned int yajl_len_t;
 #endif
 
 static int cj_read(user_data_t *ud);
+static int cj_init_curl(cj_t *db);
 static void cj_submit_impl(cj_t *db, cj_key_t *key, value_t *value);
 
 /* cj_submit is a function pointer to cj_submit_impl, allowing the unit-test to
@@ -393,6 +394,9 @@ static void cj_free(void *arg) /* {{{ */
     curl_easy_cleanup(db->curl);
   db->curl = NULL;
 
+  sfree(db->credentials);
+  db->curl_errbuf[0] = '\0';
+
   if (db->tree != NULL)
     cj_tree_free(db->tree);
   db->tree = NULL;
@@ -406,7 +410,6 @@ static void cj_free(void *arg) /* {{{ */
   sfree(db->url);
   sfree(db->user);
   sfree(db->pass);
-  sfree(db->credentials);
   sfree(db->cacert);
   sfree(db->post_body);
   curl_slist_free_all(db->headers);
@@ -568,27 +571,48 @@ static int cj_config_add_key(cj_t *db, /* {{{ */
   return 0;
 } /* }}} int cj_config_add_key */
 
+static int cj_recreate_curl(cj_t *db) /* {{{ */
+{
+  if (db == NULL)
+    return -1;
+
+  if (db->curl != NULL)
+    curl_easy_cleanup(db->curl);
+  db->curl = NULL;
+
+  sfree(db->credentials);
+  db->curl_errbuf[0] = '\0';
+
+  return cj_init_curl(db);
+} /* }}} int cj_recreate_curl */
+
 static int cj_init_curl(cj_t *db) /* {{{ */
 {
-  db->curl = curl_easy_init();
-  if (db->curl == NULL) {
+  CURL *curl = curl_easy_init();
+#ifndef HAVE_CURLOPT_USERNAME
+  char *credentials = NULL;
+#endif
+
+  if (curl == NULL) {
     ERROR("curl_json plugin: curl_easy_init failed.");
     return -1;
   }
 
-  curl_easy_setopt(db->curl, CURLOPT_NOSIGNAL, 1L);
-  curl_easy_setopt(db->curl, CURLOPT_WRITEFUNCTION, cj_curl_callback);
-  curl_easy_setopt(db->curl, CURLOPT_WRITEDATA, db);
-  curl_easy_setopt(db->curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
-  curl_easy_setopt(db->curl, CURLOPT_ERRORBUFFER, db->curl_errbuf);
-  curl_easy_setopt(db->curl, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(db->curl, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(db->curl, CURLOPT_IPRESOLVE, db->address_family);
+  db->curl_errbuf[0] = '\0';
+
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cj_curl_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, db);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, COLLECTD_USERAGENT);
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, db->curl_errbuf);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
+  curl_easy_setopt(curl, CURLOPT_IPRESOLVE, db->address_family);
 
   if (db->user != NULL) {
 #ifdef HAVE_CURLOPT_USERNAME
-    curl_easy_setopt(db->curl, CURLOPT_USERNAME, db->user);
-    curl_easy_setopt(db->curl, CURLOPT_PASSWORD,
+    curl_easy_setopt(curl, CURLOPT_USERNAME, db->user);
+    curl_easy_setopt(curl, CURLOPT_PASSWORD,
                      (db->pass == NULL) ? "" : db->pass);
 #else
     size_t credentials_size;
@@ -597,36 +621,47 @@ static int cj_init_curl(cj_t *db) /* {{{ */
     if (db->pass != NULL)
       credentials_size += strlen(db->pass);
 
-    db->credentials = malloc(credentials_size);
-    if (db->credentials == NULL) {
+    credentials = malloc(credentials_size);
+    if (credentials == NULL) {
       ERROR("curl_json plugin: malloc failed.");
+      curl_easy_cleanup(curl);
       return -1;
     }
 
-    snprintf(db->credentials, credentials_size, "%s:%s", db->user,
+    snprintf(credentials, credentials_size, "%s:%s", db->user,
              (db->pass == NULL) ? "" : db->pass);
-    curl_easy_setopt(db->curl, CURLOPT_USERPWD, db->credentials);
+    curl_easy_setopt(curl, CURLOPT_USERPWD, credentials);
 #endif
 
     if (db->digest)
-      curl_easy_setopt(db->curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+      curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
   }
 
-  curl_easy_setopt(db->curl, CURLOPT_SSL_VERIFYPEER, (long)db->verify_peer);
-  curl_easy_setopt(db->curl, CURLOPT_SSL_VERIFYHOST, db->verify_host ? 2L : 0L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (long)db->verify_peer);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, db->verify_host ? 2L : 0L);
   if (db->cacert != NULL)
-    curl_easy_setopt(db->curl, CURLOPT_CAINFO, db->cacert);
+    curl_easy_setopt(curl, CURLOPT_CAINFO, db->cacert);
   if (db->headers != NULL)
-    curl_easy_setopt(db->curl, CURLOPT_HTTPHEADER, db->headers);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, db->headers);
   if (db->post_body != NULL)
-    curl_easy_setopt(db->curl, CURLOPT_POSTFIELDS, db->post_body);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, db->post_body);
 
 #ifdef HAVE_CURLOPT_TIMEOUT_MS
   if (db->timeout >= 0)
-    curl_easy_setopt(db->curl, CURLOPT_TIMEOUT_MS, (long)db->timeout);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, (long)db->timeout);
   else
-    curl_easy_setopt(db->curl, CURLOPT_TIMEOUT_MS,
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS,
                      (long)CDTIME_T_TO_MS(plugin_get_interval()));
+#endif
+
+  db->curl = curl;
+
+#ifdef HAVE_CURLOPT_USERNAME
+  sfree(db->credentials);
+  db->credentials = NULL;
+#else
+  sfree(db->credentials);
+  db->credentials = credentials;
 #endif
 
   return 0;
@@ -883,12 +918,24 @@ static int cj_curl_perform(cj_t *db) /* {{{ */
   long rc;
   char *url;
 
+  if (db->curl == NULL) {
+    status = cj_init_curl(db);
+    if (status != 0)
+      return -1;
+  }
+
+  db->curl_errbuf[0] = '\0';
   curl_easy_setopt(db->curl, CURLOPT_URL, db->url);
 
   status = curl_easy_perform(db->curl);
   if (status != CURLE_OK) {
     ERROR("curl_json plugin: curl_easy_perform failed with status %i: %s (%s)",
           status, db->curl_errbuf, db->url);
+
+    if ((status == CURLE_COULDNT_RESOLVE_HOST) ||
+        (status == CURLE_COULDNT_RESOLVE_PROXY))
+      cj_recreate_curl(db);
+
     return -1;
   }
   if (db->stats != NULL)

--- a/src/curl_json_test.c
+++ b/src/curl_json_test.c
@@ -8,33 +8,158 @@
  *   Florian octo Forster <octo at collectd.org>
  **/
 
+#include <stdarg.h>
+
+#include <curl/curl.h>
+
+#undef curl_easy_getinfo
+#undef curl_easy_setopt
+
+static void test_curl_easy_cleanup(CURL *curl);
+static CURLcode test_curl_easy_getinfo(CURL *curl, CURLINFO info, ...);
+static CURL *test_curl_easy_init(void);
+static CURLcode test_curl_easy_perform(CURL *curl);
+static CURLcode test_curl_easy_setopt(CURL *curl, CURLoption option, ...);
+
+#define curl_easy_cleanup test_curl_easy_cleanup
+#define curl_easy_getinfo test_curl_easy_getinfo
+#define curl_easy_init test_curl_easy_init
+#define curl_easy_perform test_curl_easy_perform
+#define curl_easy_setopt test_curl_easy_setopt
+
 #include "curl_json.c"
 
 #include "testing.h"
 
-static void test_submit(cj_t *db, cj_key_t *key, value_t *value) {
-  /* hack: we repurpose db->curl to store received values. */
-  c_avl_tree_t *values = (void *)db->curl;
+typedef struct {
+  CURLcode perform_result;
+  const char *perform_error;
+  const char *response_body;
+  long response_code;
+} test_curl_spec_t;
 
-  value_t *value_copy = calloc(1, sizeof(*value_copy));
-  memmove(value_copy, value, sizeof(*value_copy));
+typedef struct {
+  int id;
+  int cleanup_calls;
+  int perform_calls;
 
-  assert(c_avl_insert(values, key->path, value_copy) == 0);
+  CURLcode perform_result;
+  const char *perform_error;
+  const char *response_body;
+  long response_code;
+
+  char *url;
+  char *effective_url;
+  char *error_buffer;
+  void *write_data;
+  curl_write_callback write_function;
+
+  bool saw_error_buffer;
+  bool saw_ipresolve;
+  bool saw_timeout_ms;
+  bool saw_url;
+  bool saw_write_data;
+
+  long ipresolve;
+  long timeout_ms;
+} test_curl_handle_t;
+
+static struct {
+  int cleanup_calls;
+  int fail_init_call;
+  int getinfo_calls;
+  int init_calls;
+  int setopt_calls;
+  int unexpected_getinfo_calls;
+  int unexpected_init_calls;
+  int unexpected_setopt_calls;
+
+  test_curl_spec_t specs[8];
+  size_t specs_num;
+  test_curl_handle_t *handles[8];
+} test_curl;
+
+static c_avl_tree_t *submitted_values;
+
+static test_curl_handle_t *test_curl_handle(CURL *curl) {
+  return (test_curl_handle_t *)curl;
 }
 
-static derive_t test_metric(cj_t *db, char const *path) {
-  c_avl_tree_t *values = (void *)db->curl;
+static test_curl_handle_t *test_handle_at(size_t index) {
+  if (index >= STATIC_ARRAY_SIZE(test_curl.handles))
+    return NULL;
+  return test_curl.handles[index];
+}
 
+static void test_curl_reset(void) {
+  for (size_t i = 0; i < STATIC_ARRAY_SIZE(test_curl.handles); i++) {
+    free(test_curl.handles[i]);
+    test_curl.handles[i] = NULL;
+  }
+
+  memset(&test_curl, 0, sizeof(test_curl));
+}
+
+static void test_values_reset(void) {
+  if (submitted_values == NULL)
+    return;
+
+  void *key = NULL;
+  void *value = NULL;
+  while (c_avl_pick(submitted_values, &key, &value) == 0) {
+    /* key belongs to cj_free(). */
+    free(value);
+  }
+  c_avl_destroy(submitted_values);
+  submitted_values = NULL;
+}
+
+static void test_prepare(void) {
+  test_values_reset();
+  test_curl_reset();
+
+  submitted_values = cj_avl_create();
+  assert(submitted_values != NULL);
+}
+
+static void test_submit(cj_t *db, cj_key_t *key, value_t *value) {
+  value_t *value_copy = calloc(1, sizeof(*value_copy));
+
+  assert(db != NULL);
+  assert(key != NULL);
+  assert(value != NULL);
+  assert(submitted_values != NULL);
+  assert(value_copy != NULL);
+
+  *value_copy = *value;
+  assert(c_avl_insert(submitted_values, key->path, value_copy) == 0);
+}
+
+static derive_t test_metric(char const *path) {
   value_t *ret = NULL;
-  if (c_avl_get(values, path, (void *)&ret) == 0) {
+
+  if ((submitted_values != NULL) &&
+      (c_avl_get(submitted_values, path, (void *)&ret) == 0)) {
     return ret->derive;
   }
 
   return -1;
 }
 
-static cj_t *test_setup(char *json, char *key_path) {
+static int test_read(cj_t *db) {
+  user_data_t ud = {
+      .data = db,
+  };
+
+  return cj_read(&ud);
+}
+
+static cj_t *test_parse_setup(char const *json, char const *key_path) {
   cj_t *db = calloc(1, sizeof(*db));
+  yajl_status status;
+
+  assert(db != NULL);
+
   db->yajl = yajl_alloc(&ycallbacks,
 #if HAVE_YAJL_V2
                         /* alloc funcs = */ NULL,
@@ -42,14 +167,14 @@ static cj_t *test_setup(char *json, char *key_path) {
                         /* alloc funcs = */ NULL, NULL,
 #endif
                         /* context = */ (void *)db);
-
-  /* hack; see above. */
-  db->curl = (void *)cj_avl_create();
+  assert(db->yajl != NULL);
 
   cj_key_t *key = calloc(1, sizeof(*key));
+  assert(key != NULL);
   key->path = strdup(key_path);
   key->type = strdup("MAGIC");
-
+  assert(key->path != NULL);
+  assert(key->type != NULL);
   assert(cj_append_key(db, key) == 0);
 
   cj_tree_entry_t root = {0};
@@ -57,34 +182,218 @@ static cj_t *test_setup(char *json, char *key_path) {
   root.tree = db->tree;
   db->state[0].entry = &root;
 
-  cj_curl_callback(json, strlen(json), 1, db);
+  assert(cj_curl_callback((void *)json, 1, strlen(json), db) == strlen(json));
 #if HAVE_YAJL_V2
-  yajl_complete_parse(db->yajl);
+  status = yajl_complete_parse(db->yajl);
 #else
-  yajl_parse_complete(db->yajl);
+  status = yajl_parse_complete(db->yajl);
 #endif
+  assert(status == yajl_status_ok);
 
   db->state[0].entry = NULL;
 
   return db;
 }
 
+static cj_t *test_read_setup(char const *key_path) {
+  cj_t *db = calloc(1, sizeof(*db));
+  cj_key_t *key = calloc(1, sizeof(*key));
+
+  assert(db != NULL);
+  assert(key != NULL);
+
+  db->url = strdup("http://example.invalid:18080/metrics.json");
+  db->instance = strdup("default");
+  db->address_family = CURL_IPRESOLVE_V4;
+  db->timeout = 1234;
+  assert(db->url != NULL);
+  assert(db->instance != NULL);
+
+  key->path = strdup(key_path);
+  key->type = strdup("MAGIC");
+  assert(key->path != NULL);
+  assert(key->type != NULL);
+  assert(cj_append_key(db, key) == 0);
+  assert(cj_init_curl(db) == 0);
+
+  return db;
+}
+
 static void test_teardown(cj_t *db) {
-  c_avl_tree_t *values = (void *)db->curl;
-  db->curl = NULL;
+  if (db == NULL)
+    return;
 
-  void *key;
-  void *value;
-  while (c_avl_pick(values, &key, &value) == 0) {
-    /* key will be freed by cj_free. */
-    free(value);
+  if (db->yajl != NULL) {
+    yajl_free(db->yajl);
+    db->yajl = NULL;
   }
-  c_avl_destroy(values);
 
-  yajl_free(db->yajl);
-  db->yajl = NULL;
-
+  test_values_reset();
   cj_free(db);
+  test_curl_reset();
+}
+
+static CURL *test_curl_easy_init(void) {
+  int call = ++test_curl.init_calls;
+
+  if (test_curl.fail_init_call == call)
+    return NULL;
+
+  if ((size_t)call > STATIC_ARRAY_SIZE(test_curl.handles)) {
+    test_curl.unexpected_init_calls++;
+    return NULL;
+  }
+
+  test_curl_handle_t *handle = calloc(1, sizeof(*handle));
+  assert(handle != NULL);
+
+  handle->id = call;
+  handle->perform_result = CURLE_OK;
+  handle->response_code = 200;
+
+  if ((size_t)call <= test_curl.specs_num) {
+    test_curl_spec_t *spec = &test_curl.specs[call - 1];
+
+    handle->perform_result = spec->perform_result;
+    handle->perform_error = spec->perform_error;
+    handle->response_body = spec->response_body;
+    if (spec->response_code != 0)
+      handle->response_code = spec->response_code;
+  }
+
+  test_curl.handles[call - 1] = handle;
+  return (CURL *)handle;
+}
+
+static CURLcode test_curl_easy_setopt(CURL *curl, CURLoption option, ...) {
+  va_list ap;
+  test_curl_handle_t *handle = test_curl_handle(curl);
+
+  assert(handle != NULL);
+
+  test_curl.setopt_calls++;
+
+  va_start(ap, option);
+  switch (option) {
+  case CURLOPT_NOSIGNAL:
+  case CURLOPT_FOLLOWLOCATION:
+  case CURLOPT_MAXREDIRS:
+  case CURLOPT_HTTPAUTH:
+  case CURLOPT_SSL_VERIFYPEER:
+  case CURLOPT_SSL_VERIFYHOST:
+    (void)va_arg(ap, long);
+    break;
+  case CURLOPT_WRITEFUNCTION:
+    handle->write_function = va_arg(ap, curl_write_callback);
+    break;
+  case CURLOPT_WRITEDATA:
+    handle->write_data = va_arg(ap, void *);
+    handle->saw_write_data = true;
+    break;
+  case CURLOPT_USERAGENT:
+#ifdef HAVE_CURLOPT_USERNAME
+  case CURLOPT_USERNAME:
+  case CURLOPT_PASSWORD:
+#endif
+  case CURLOPT_USERPWD:
+  case CURLOPT_CAINFO:
+  case CURLOPT_POSTFIELDS:
+    (void)va_arg(ap, char *);
+    break;
+  case CURLOPT_ERRORBUFFER:
+    handle->error_buffer = va_arg(ap, char *);
+    handle->saw_error_buffer = true;
+    break;
+  case CURLOPT_HTTPHEADER:
+    (void)va_arg(ap, struct curl_slist *);
+    break;
+  case CURLOPT_IPRESOLVE:
+    handle->ipresolve = va_arg(ap, long);
+    handle->saw_ipresolve = true;
+    break;
+#ifdef HAVE_CURLOPT_TIMEOUT_MS
+  case CURLOPT_TIMEOUT_MS:
+    handle->timeout_ms = va_arg(ap, long);
+    handle->saw_timeout_ms = true;
+    break;
+#endif
+  case CURLOPT_URL:
+    handle->url = va_arg(ap, char *);
+    handle->saw_url = true;
+    break;
+  default:
+    test_curl.unexpected_setopt_calls++;
+    va_end(ap);
+    return CURLE_UNKNOWN_OPTION;
+  }
+  va_end(ap);
+
+  return CURLE_OK;
+}
+
+static CURLcode test_curl_easy_perform(CURL *curl) {
+  test_curl_handle_t *handle = test_curl_handle(curl);
+
+  assert(handle != NULL);
+
+  handle->perform_calls++;
+
+  if (handle->perform_result != CURLE_OK) {
+    if (handle->error_buffer != NULL) {
+      ssnprintf(handle->error_buffer, CURL_ERROR_SIZE, "%s",
+                (handle->perform_error != NULL) ? handle->perform_error
+                                                : "mock perform failure");
+    }
+    return handle->perform_result;
+  }
+
+  if ((handle->write_function != NULL) && (handle->response_body != NULL)) {
+    size_t len = strlen(handle->response_body);
+    size_t written =
+        handle->write_function((void *)handle->response_body, 1, len,
+                               handle->write_data);
+    if (written != len)
+      return CURLE_WRITE_ERROR;
+  }
+
+  return CURLE_OK;
+}
+
+static CURLcode test_curl_easy_getinfo(CURL *curl, CURLINFO info, ...) {
+  va_list ap;
+  test_curl_handle_t *handle = test_curl_handle(curl);
+
+  assert(handle != NULL);
+
+  test_curl.getinfo_calls++;
+
+  va_start(ap, info);
+  switch (info) {
+  case CURLINFO_EFFECTIVE_URL: {
+    char **url = va_arg(ap, char **);
+    *url = (handle->effective_url != NULL) ? handle->effective_url : handle->url;
+  } break;
+  case CURLINFO_RESPONSE_CODE: {
+    long *response_code = va_arg(ap, long *);
+    *response_code = handle->response_code;
+  } break;
+  default:
+    test_curl.unexpected_getinfo_calls++;
+    va_end(ap);
+    return CURLE_UNKNOWN_OPTION;
+  }
+  va_end(ap);
+
+  return CURLE_OK;
+}
+
+static void test_curl_easy_cleanup(CURL *curl) {
+  test_curl_handle_t *handle = test_curl_handle(curl);
+
+  assert(handle != NULL);
+
+  handle->cleanup_calls++;
+  test_curl.cleanup_calls++;
 }
 
 DEF_TEST(parse) {
@@ -97,8 +406,8 @@ DEF_TEST(parse) {
       {"{\"foo\":42,\"bar\":23}", "foo", 42},
       {"{\"foo\":42,\"bar\":23}", "bar", 23},
       /* nested map */
-      {"{\"a\":{\"b\":{\"c\":123}}", "a/b/c", 123},
-      {"{\"x\":{\"y\":{\"z\":789}}", "x/*/z", 789},
+      {"{\"a\":{\"b\":{\"c\":123}}}", "a/b/c", 123},
+      {"{\"x\":{\"y\":{\"z\":789}}}", "x/*/z", 789},
       /* simple array */
       {"[10,11,12,13]", "0", 10},
       {"[10,11,12,13]", "1", 11},
@@ -129,9 +438,10 @@ DEF_TEST(parse) {
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {
-    cj_t *db = test_setup(cases[i].json, cases[i].key_path);
+    test_prepare();
 
-    EXPECT_EQ_INT(cases[i].want, test_metric(db, cases[i].key_path));
+    cj_t *db = test_parse_setup(cases[i].json, cases[i].key_path);
+    EXPECT_EQ_INT(cases[i].want, test_metric(cases[i].key_path));
 
     test_teardown(db);
   }
@@ -139,10 +449,194 @@ DEF_TEST(parse) {
   return 0;
 }
 
+DEF_TEST(recreate_after_resolve_failure) {
+  test_prepare();
+
+  test_curl.specs[0] = (test_curl_spec_t){
+      .perform_result = CURLE_COULDNT_RESOLVE_HOST,
+      .perform_error = "mock resolve failure",
+  };
+  test_curl.specs[1] = (test_curl_spec_t){
+      .perform_result = CURLE_OK,
+      .response_body = "{\"value\":1}",
+      .response_code = 200,
+  };
+  test_curl.specs_num = 2;
+
+  cj_t *db = test_read_setup("value");
+
+  EXPECT_EQ_INT(-1, test_read(db));
+  EXPECT_EQ_INT(2, test_curl.init_calls);
+  EXPECT_EQ_INT(1, test_curl.cleanup_calls);
+  EXPECT_EQ_PTR((void *)test_handle_at(1), db->curl);
+
+  test_curl_handle_t *initial = test_handle_at(0);
+  test_curl_handle_t *replacement = test_handle_at(1);
+  CHECK_NOT_NULL(initial);
+  CHECK_NOT_NULL(replacement);
+
+  EXPECT_EQ_INT(0, test_read(db));
+  EXPECT_EQ_INT(1, test_metric("value"));
+  EXPECT_EQ_INT(1, initial->cleanup_calls);
+  EXPECT_EQ_INT(1, replacement->perform_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_init_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_setopt_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_getinfo_calls);
+
+  test_teardown(db);
+  return 0;
+}
+
+DEF_TEST(recreate_after_proxy_resolve_failure) {
+  test_prepare();
+
+  test_curl.specs[0] = (test_curl_spec_t){
+      .perform_result = CURLE_COULDNT_RESOLVE_PROXY,
+      .perform_error = "mock proxy resolve failure",
+  };
+  test_curl.specs[1] = (test_curl_spec_t){
+      .perform_result = CURLE_OK,
+      .response_body = "{\"value\":1}",
+      .response_code = 200,
+  };
+  test_curl.specs_num = 2;
+
+  cj_t *db = test_read_setup("value");
+
+  EXPECT_EQ_INT(-1, test_read(db));
+  EXPECT_EQ_INT(2, test_curl.init_calls);
+  EXPECT_EQ_INT(1, test_curl.cleanup_calls);
+  EXPECT_EQ_PTR((void *)test_handle_at(1), db->curl);
+
+  test_curl_handle_t *replacement = test_handle_at(1);
+  CHECK_NOT_NULL(replacement);
+
+  EXPECT_EQ_INT(0, test_read(db));
+  EXPECT_EQ_INT(1, test_metric("value"));
+  EXPECT_EQ_INT(1, replacement->perform_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_init_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_setopt_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_getinfo_calls);
+
+  test_teardown(db);
+  return 0;
+}
+
+DEF_TEST(non_resolution_failure_keeps_handle) {
+  test_prepare();
+
+  test_curl.specs[0] = (test_curl_spec_t){
+      .perform_result = CURLE_COULDNT_CONNECT,
+      .perform_error = "mock connect failure",
+  };
+  test_curl.specs_num = 1;
+
+  cj_t *db = test_read_setup("value");
+  void *first_handle = db->curl;
+
+  EXPECT_EQ_INT(-1, test_read(db));
+  EXPECT_EQ_INT(1, test_curl.init_calls);
+  EXPECT_EQ_INT(0, test_curl.cleanup_calls);
+  EXPECT_EQ_PTR(first_handle, db->curl);
+  test_curl_handle_t *initial = test_handle_at(0);
+  CHECK_NOT_NULL(initial);
+  EXPECT_EQ_INT(1, initial->perform_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_init_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_setopt_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_getinfo_calls);
+
+  test_teardown(db);
+  return 0;
+}
+
+DEF_TEST(recreate_failure_recovers_on_next_read) {
+  test_prepare();
+
+  test_curl.specs[0] = (test_curl_spec_t){
+      .perform_result = CURLE_COULDNT_RESOLVE_HOST,
+      .perform_error = "mock resolve failure",
+  };
+  test_curl.specs[2] = (test_curl_spec_t){
+      .perform_result = CURLE_OK,
+      .response_body = "{\"value\":1}",
+      .response_code = 200,
+  };
+  test_curl.specs_num = 3;
+  test_curl.fail_init_call = 2;
+
+  cj_t *db = test_read_setup("value");
+
+  EXPECT_EQ_INT(-1, test_read(db));
+  EXPECT_EQ_INT(2, test_curl.init_calls);
+  EXPECT_EQ_INT(1, test_curl.cleanup_calls);
+  EXPECT_EQ_PTR(NULL, db->curl);
+
+  test_curl.fail_init_call = 0;
+
+  EXPECT_EQ_INT(0, test_read(db));
+  EXPECT_EQ_INT(3, test_curl.init_calls);
+  EXPECT_EQ_PTR((void *)test_handle_at(2), db->curl);
+  test_curl_handle_t *replacement = test_handle_at(2);
+  CHECK_NOT_NULL(replacement);
+  EXPECT_EQ_INT(1, test_metric("value"));
+  EXPECT_EQ_INT(0, test_curl.unexpected_init_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_setopt_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_getinfo_calls);
+
+  test_teardown(db);
+  return 0;
+}
+
+DEF_TEST(recreated_handle_reapplies_options) {
+  test_prepare();
+
+  test_curl.specs[0] = (test_curl_spec_t){
+      .perform_result = CURLE_COULDNT_RESOLVE_HOST,
+      .perform_error = "mock resolve failure",
+  };
+  test_curl.specs[1] = (test_curl_spec_t){
+      .perform_result = CURLE_OK,
+      .response_body = "{\"value\":1}",
+      .response_code = 200,
+  };
+  test_curl.specs_num = 2;
+
+  cj_t *db = test_read_setup("value");
+
+  EXPECT_EQ_INT(-1, test_read(db));
+
+  test_curl_handle_t *replacement = test_handle_at(1);
+  CHECK_NOT_NULL(replacement);
+  OK(replacement->saw_write_data);
+  EXPECT_EQ_PTR(db, replacement->write_data);
+  OK(replacement->saw_error_buffer);
+  EXPECT_EQ_PTR(db->curl_errbuf, replacement->error_buffer);
+  OK(replacement->saw_ipresolve);
+  EXPECT_EQ_INT(CURL_IPRESOLVE_V4, replacement->ipresolve);
+#ifdef HAVE_CURLOPT_TIMEOUT_MS
+  OK(replacement->saw_timeout_ms);
+  EXPECT_EQ_INT(1234, replacement->timeout_ms);
+#endif
+  EXPECT_EQ_INT(0, test_curl.unexpected_init_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_setopt_calls);
+  EXPECT_EQ_INT(0, test_curl.unexpected_getinfo_calls);
+
+  test_teardown(db);
+  return 0;
+}
+
 int main(void) {
   cj_submit = test_submit;
 
   RUN_TEST(parse);
+  RUN_TEST(recreate_after_resolve_failure);
+  RUN_TEST(recreate_after_proxy_resolve_failure);
+  RUN_TEST(non_resolution_failure_keeps_handle);
+  RUN_TEST(recreate_failure_recovers_on_next_read);
+  RUN_TEST(recreated_handle_reapplies_options);
+
+  test_values_reset();
+  test_curl_reset();
 
   END_TEST;
 }


### PR DESCRIPTION
## Summary

`curl_json` can get stuck after a transient DNS or proxy resolution failure.

The plugin keeps one long-lived libcurl easy handle per URL. On affected libcurl versions, if a poll fails with `CURLE_COULDNT_RESOLVE_HOST` or `CURLE_COULDNT_RESOLVE_PROXY`, later polls can continue failing even after the name becomes resolvable again because the same easy handle is reused.

This change recreates the easy handle after those resolution failures, and safely reinitializes it on the next read if handle recreation itself fails.

## Testing

- `make check TESTS=test_plugin_curl_json` in a patched tree: passes
- `make check TESTS=test_plugin_curl_json` in a baseline tree with the new regression: fails as expected
- live smoke test with the system libcurl `7.81.0`: baseline and patched both recover
- live smoke test with locally built libcurl `8.16.0`: baseline stays stuck after the hostname becomes resolvable, patched recovers and resumes submitting metrics

## Notes

- the test harness was refactored to mock libcurl directly rather than reusing `db->curl` for submitted-value storage
- added regression coverage for host and proxy resolution failures, failed reinit recovery, and option reapplication
